### PR TITLE
Update to laser safety values and C_max

### DIFF
--- a/config/laser_params.json
+++ b/config/laser_params.json
@@ -40,5 +40,19 @@
     "i2cAddr": 65,
     "offset": 8,
     "dataToSend": [229, 32]
+  },
+  {
+    "muxIdx": 1,
+    "channel": 7,
+    "i2cAddr": 65,
+    "offset": 4,
+    "dataToSend": [110, 13, 0, 0]
+  },
+  {
+    "muxIdx": 1,
+    "channel": 6,
+    "i2cAddr": 65,
+    "offset": 4,
+    "dataToSend": [110, 13, 0, 0]
   }
 ]

--- a/processing/visualize_bloodflow.py
+++ b/processing/visualize_bloodflow.py
@@ -48,8 +48,8 @@ class VisualizeBloodflow:
         [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]], dtype=float))
     C_max: np.ndarray = field(default_factory=lambda: np.array(
-        [[0.2, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.2],
-         [0.2, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.2]], dtype=float))
+        [[0.4, 0.4, 0.45, 0.55, 0.55, 0.45, 0.4, 0.4],
+         [0.4, 0.4, 0.45, 0.55, 0.55, 0.45, 0.4, 0.4]], dtype=float))
 
     # Internals (populated after compute)
     _BFI: Optional[np.ndarray] = field(default=None, init=False)


### PR DESCRIPTION
Updating laser pulse width threshold to override FPGA default values so that in case laser safety starts working it won't immediately switch off the laser. Updating C_max values used for blood flow plotting so that BFI values on static phantom don't come back negative.