### PR TITLE
remove singleton from blood flow app

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from PyQt6.QtCore import qInstallMessageHandler, QtMsgType
 from qasync import QEventLoop
 
 from motion_connector import MOTIONConnector
+from omotion.Interface import MOTIONInterface
 from utils.single_instance import check_single_instance, cleanup_single_instance
 from version import get_version
 from utils.resource_path import resource_path
@@ -178,7 +179,9 @@ def main():
     if my_args.advanced_sensors:
         app_config["advancedSensors"] = True
 
+    interface = MOTIONInterface()
     connector = MOTIONConnector(
+        interface=interface,
         advanced_sensors=app_config.get("advancedSensors", True),
         force_laser_fail=app_config.get("forceLaserFail", False),
         camera_temp_alert_threshold_c=app_config.get("cameraTempAlertThresholdC", 105),

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -26,7 +26,7 @@ import string
 import platform
 import socket
 
-from motion_singleton import motion_interface
+from omotion.Interface import MOTIONInterface
 
 from omotion.config import (
     DEBUG_FLAG_USB_PRINTF,
@@ -135,6 +135,7 @@ class MOTIONConnector(QObject):
 
     def __init__(
         self,
+        interface: MOTIONInterface,
         config_dir="config",
         parent=None,
         advanced_sensors=False,
@@ -148,7 +149,7 @@ class MOTIONConnector(QObject):
         power_off_unused_cameras=False,
     ):
         super().__init__(parent)
-        self._interface = motion_interface
+        self._interface = interface
         self._advanced_sensors = advanced_sensors
         self._force_laser_fail = force_laser_fail
         self._camera_temp_alert_threshold_c = float(camera_temp_alert_threshold_c)
@@ -166,7 +167,7 @@ class MOTIONConnector(QObject):
 
         # Check if console and sensor are connected
         console_connected, left_sensor_connected, right_sensor_connected = (
-            motion_interface.is_device_connected()
+            self._interface.is_device_connected()
         )
 
         self._leftSensorConnected = left_sensor_connected
@@ -467,7 +468,7 @@ class MOTIONConnector(QObject):
 
         # Console firmware version (from console module) :contentReference[oaicite:5]{index=5}
         try:
-            fw_ver = motion_interface.console_module.get_version()
+            fw_ver = self._interface.console_module.get_version()
         except Exception as e:
             fw_ver = f"ERROR({e})"
 
@@ -629,8 +630,8 @@ class MOTIONConnector(QObject):
             # Console information
             if self._consoleConnected:
                 try:
-                    fw_version = motion_interface.console_module.get_version()
-                    hw_id = motion_interface.console_module.get_hardware_id()
+                    fw_version = self._interface.console_module.get_version()
+                    hw_id = self._interface.console_module.get_hardware_id()
                     device_id = base58.b58encode(bytes.fromhex(hw_id)).decode()
                     run_logger.info(
                         f"Console - Firmware: {fw_version}, Device ID: {device_id}"
@@ -643,7 +644,7 @@ class MOTIONConnector(QObject):
             # Left sensor information
             if self._leftSensorConnected:
                 try:
-                    sensor = motion_interface.sensors.get("left")
+                    sensor = self._interface.sensors.get("left")
                     if sensor is not None:
                         fw_version = sensor.get_version()
                         hw_id = sensor.get_hardware_id()
@@ -661,7 +662,7 @@ class MOTIONConnector(QObject):
             # Right sensor information
             if self._rightSensorConnected:
                 try:
-                    sensor = motion_interface.sensors.get("right")
+                    sensor = self._interface.sensors.get("right")
                     if sensor is not None:
                         fw_version = sensor.get_version()
                         hw_id = sensor.get_hardware_id()
@@ -773,13 +774,13 @@ class MOTIONConnector(QObject):
             self._schedule_sensor_init("right")
         elif desc == "CONSOLE":
             self._consoleConnected = True
-            if motion_interface.console_module.tec_voltage(self._tec_voltage_default):
+            if self._interface.console_module.tec_voltage(self._tec_voltage_default):
                 logger.info(f"Console TEC voltage set to {self._tec_voltage_default}V")
             else:
                 logger.error(
                     f"Failed to set console TEC voltage to {self._tec_voltage_default}V"
                 )
-            if motion_interface.console_module.set_fan_speed(fan_speed=100):
+            if self._interface.console_module.set_fan_speed(fan_speed=100):
                 logger.info("Console fan speed set to 50%")
             else:
                 logger.error("Failed to set console fan speed")
@@ -1110,9 +1111,9 @@ class MOTIONConnector(QObject):
     def queryConsoleInfo(self):
         """Fetch and emit device information."""
         try:
-            fw_version = motion_interface.console_module.get_version()
+            fw_version = self._interface.console_module.get_version()
             logger.info(f"Version: {fw_version}")
-            hw_id = motion_interface.console_module.get_hardware_id()
+            hw_id = self._interface.console_module.get_hardware_id()
             device_id = base58.b58encode(bytes.fromhex(hw_id)).decode()
             self.consoleDeviceInfoReceived.emit(fw_version, device_id)
             logger.info(
@@ -1537,7 +1538,7 @@ class MOTIONConnector(QObject):
         """
 
         try:
-            v, i, p, t, ok = motion_interface.console_module.tec_status()
+            v, i, p, t, ok = self._interface.console_module.tec_status()
 
             R_TH = (
                 1 / ((float(v) / (V_REF / 2 * R_3)) - 1 / R_3 + 1 / R_1) - R_2
@@ -1596,12 +1597,12 @@ class MOTIONConnector(QObject):
           { "ok": False, "error": "..." }
         """
         try:
-            pdu = motion_interface.console_module.read_pdu_mon()
+            pdu = self._interface.console_module.read_pdu_mon()
             if pdu is None:
                 logger.error("PDU MON: no data")
                 return {"ok": False, "error": "no data"}
 
-            temp1, temp2, temp3 = motion_interface.console_module.get_temperatures()
+            temp1, temp2, temp3 = self._interface.console_module.get_temperatures()
 
             # Cache for QML bindings
             self._pdu_raws = list(pdu.raws)
@@ -1704,7 +1705,7 @@ class MOTIONConnector(QObject):
 
             if target == "CONSOLE":
                 fpga_data, fpga_data_len = (
-                    motion_interface.console_module.read_i2c_packet(
+                    self._interface.console_module.read_i2c_packet(
                         mux_index=mux_idx,
                         channel=channel,
                         device_addr=i2c_addr,
@@ -1735,7 +1736,7 @@ class MOTIONConnector(QObject):
             if state not in valid_states:
                 logger.error(f"Invalid RGB state value: {state}")
                 return
-            if motion_interface.console_module.set_rgb_led(state) == state:
+            if self._interface.console_module.set_rgb_led(state) == state:
                 logger.info(f"RGB state set to: {state}")
             else:
                 logger.error(f"Failed to set RGB state to: {state}")
@@ -1746,7 +1747,7 @@ class MOTIONConnector(QObject):
     def queryRGBState(self):
         """Fetch and emit RGB state."""
         try:
-            state = motion_interface.console_module.get_rgb_led()
+            state = self._interface.console_module.get_rgb_led()
             state_text = {0: "Off", 1: "IND1", 2: "IND2", 3: "IND3"}.get(
                 state, "Unknown"
             )
@@ -1758,7 +1759,7 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot(result=QVariant)
     def queryTriggerConfig(self):
-        trigger_setting = motion_interface.console_module.get_trigger_json()
+        trigger_setting = self._interface.console_module.get_trigger_json()
         if trigger_setting:
             if isinstance(trigger_setting, str):
                 updateTrigger = json.loads(trigger_setting)
@@ -1779,7 +1780,7 @@ class MOTIONConnector(QObject):
         try:
             json_trigger_data = json.loads(triggerjson)
 
-            trigger_setting = motion_interface.console_module.set_trigger_json(
+            trigger_setting = self._interface.console_module.set_trigger_json(
                 data=json_trigger_data
             )
             if trigger_setting:
@@ -1803,7 +1804,7 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot(result=bool)
     def startTrigger(self):
-        success = motion_interface.console_module.start_trigger()
+        success = self._interface.console_module.start_trigger()
         if success:
             self._trigger_state = "ON"
             self.triggerStateChanged.emit()
@@ -1812,7 +1813,7 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot()
     def stopTrigger(self):
-        motion_interface.console_module.stop_trigger()
+        self._interface.console_module.stop_trigger()
         self._trigger_state = "OFF"
         self.triggerStateChanged.emit()
         self._stop_runlog()
@@ -1822,7 +1823,7 @@ class MOTIONConnector(QObject):
     def getFsyncCount(self):
         """Get the Fsync count from the console."""
         try:
-            fsync_count = motion_interface.console_module.get_fsync_pulsecount()
+            fsync_count = self._interface.console_module.get_fsync_pulsecount()
             logger.info(f"Fsync Count: {fsync_count}")
             return fsync_count
         except Exception as e:
@@ -1833,7 +1834,7 @@ class MOTIONConnector(QObject):
     def getLsyncCount(self):
         """Get the Fsync count from the console."""
         try:
-            lsync_count = motion_interface.console_module.get_lsync_pulsecount()
+            lsync_count = self._interface.console_module.get_lsync_pulsecount()
             logger.debug(f"Lsync Count: {lsync_count}")
             return lsync_count
         except Exception as e:
@@ -1893,10 +1894,10 @@ class MOTIONConnector(QObject):
 
             # Get all sensors (left and right)
             sensors = []
-            if self._leftSensorConnected and "left" in motion_interface.sensors:
-                sensors.append(("left", motion_interface.sensors["left"]))
-            if self._rightSensorConnected and "right" in motion_interface.sensors:
-                sensors.append(("right", motion_interface.sensors["right"]))
+            if self._leftSensorConnected and "left" in self._interface.sensors:
+                sensors.append(("left", self._interface.sensors["left"]))
+            if self._rightSensorConnected and "right" in self._interface.sensors:
+                sensors.append(("right", self._interface.sensors["right"]))
 
             if not sensors:
                 logger.warning("No sensors connected, cannot read camera UIDs")
@@ -2055,7 +2056,7 @@ class MOTIONConnector(QObject):
                 logger.error(f"{sensor_tag.capitalize()} sensor not connected")
                 return
 
-            sensor = motion_interface.sensors[sensor_tag]
+            sensor = self._interface.sensors[sensor_tag]
             if sensor is None:
                 logger.error(f"{sensor_tag.capitalize()} sensor object is None")
                 return
@@ -2075,7 +2076,7 @@ class MOTIONConnector(QObject):
                 logger.error(f"Invalid target for sensor info query: {target}")
                 return
 
-            gyro = motion_interface.sensors[sensor_tag].imu_get_gyroscope()
+            gyro = self._interface.sensors[sensor_tag].imu_get_gyroscope()
             logger.info(f"Gyro  (raw): X={gyro[0]}, Y={gyro[1]}, Z={gyro[2]}")
             self.gyroscopeSensorUpdated.emit(gyro[0], gyro[1], gyro[2])
         except Exception as e:
@@ -2086,13 +2087,13 @@ class MOTIONConnector(QObject):
         """reset hardware Sensor device."""
         try:
             if target == "CONSOLE":
-                if motion_interface.console_module.soft_reset():
+                if self._interface.console_module.soft_reset():
                     logger.info("Software Reset Sent")
                 else:
                     logger.error("Failed to send Software Reset")
             elif target == "SENSOR_LEFT" or target == "SENSOR_RIGHT":
                 sensor_tag = "left" if target == "SENSOR_LEFT" else "right"
-                if motion_interface.sensors[sensor_tag].soft_reset():
+                if self._interface.sensors[sensor_tag].soft_reset():
                     logger.info("Software Reset Sent")
                 else:
                     logger.error("Failed to send Software Reset")
@@ -2116,7 +2117,7 @@ class MOTIONConnector(QObject):
                 logger.error(f"{sensor_tag.capitalize()} sensor not connected")
                 return
 
-            sensor = motion_interface.sensors[sensor_tag]
+            sensor = self._interface.sensors[sensor_tag]
             if sensor is None:
                 logger.error(f"{sensor_tag.capitalize()} sensor object is None")
                 return
@@ -2144,7 +2145,7 @@ class MOTIONConnector(QObject):
                 logger.error(f"{sensor_tag.capitalize()} sensor not connected")
                 return
 
-            sensor = motion_interface.sensors[sensor_tag]
+            sensor = self._interface.sensors[sensor_tag]
             if sensor is None:
                 logger.error(f"{sensor_tag.capitalize()} sensor object is None")
                 return
@@ -2581,9 +2582,9 @@ class MOTIONConnector(QObject):
 
     def connect_signals(self):
         """Connect LIFUInterface signals to QML."""
-        motion_interface.signal_connect.connect(self.on_connected)
-        motion_interface.signal_disconnect.connect(self.on_disconnected)
-        motion_interface.signal_data_received.connect(self.on_data_received)
+        self._interface.signal_connect.connect(self.on_connected)
+        self._interface.signal_disconnect.connect(self.on_disconnected)
+        self._interface.signal_data_received.connect(self.on_data_received)
         self.safetyTripDuringCaptureRequested.connect(
             self._on_safety_trip_during_capture
         )
@@ -2625,7 +2626,7 @@ class MOTIONConnector(QObject):
 
     @property
     def interface(self):
-        return motion_interface
+        return self._interface
 
 
 # --- worker to run visualiztion ---

--- a/motion_singleton.py
+++ b/motion_singleton.py
@@ -1,6 +1,0 @@
-# motion_singleton.py
-from omotion.Interface import MOTIONInterface
-
-motion_interface, console_connected, left_sensor, right_sensor = (
-    MOTIONInterface.acquire_motion_interface()
-)


### PR DESCRIPTION
Do you mind if we whack the singleton part in the blood flow app? Since it instantiates the interface on import, it can be hard to sequence life cycle management functions like the logging