### PR TITLE
ci(hil): bypass PowerShell execution policy on the self-hosted runner

### DIFF
--- a/.github/workflows/hil-tests.yml
+++ b/.github/workflows/hil-tests.yml
@@ -41,7 +41,13 @@ jobs:
     timeout-minutes: 240
     defaults:
       run:
-        shell: pwsh
+        # Windows PowerShell 5.1 with -ExecutionPolicy Bypass — the
+        # self-hosted runner has the OS default Restricted policy, which
+        # rejects unsigned .ps1 files. Bypass is scoped to this single
+        # invocation, so it doesn't persist on the runner.
+        # `pwsh` (PowerShell 7+) isn't installed on the runner, so we
+        # can't use the cleaner `shell: pwsh` here.
+        shell: powershell -ExecutionPolicy Bypass -File {0}
 
     env:
       # SHELLY_IP_ADDRESS is provided by the self-hosted runner's session


### PR DESCRIPTION
## Summary
- Tweak the HIL workflow's shell line from \`powershell\` to \`powershell -ExecutionPolicy Bypass -File {0}\`.
- Latest HIL run on \`main\` died with: \`cannot be loaded because running scripts is disabled on this system. SecurityError: PSSecurityException\`. That's the runner's OS-default \`Restricted\` execution policy rejecting the temp \`.ps1\` files Actions writes for each step.
- Bypass is scoped to the single invocation so it doesn't permanently relax security on the runner machine.

## Test plan
- [ ] Merge.
- [ ] Manually re-dispatch HIL: \`gh workflow run hil-tests.yml --repo OpenwaterHealth/openmotion-bloodflow-app -f test_set=dev\`.
- [ ] Confirm the resolve step actually executes past the \`UnauthorizedAccess\` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)