### PR TITLE
feat(reduced-mode): disable autoupdater in reduced mode

### DIFF
--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -779,6 +779,9 @@ Item {
                     }
                     FieldRow {
                         label: "Updates"
+                        // Hidden in reduced (clinical) mode — no user-driven
+                        // self-update flow in that mode; see issue #96.
+                        visible: !root.reducedMode
                         ActionButton {
                             id: updateCheckBtn
                             text: "Check for Updates"

--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -98,10 +98,12 @@ Rectangle {
         }
     }
 
-    // Auto-check on creation (after a brief delay to let the app settle)
+    // Auto-check on creation (after a brief delay to let the app settle).
+    // Skipped in reduced (clinical) mode — see issue #96; the connector's
+    // checkForUpdates() slot also no-ops in that mode as defence in depth.
     Timer {
         interval: 3000
-        running: true
+        running: MOTIONInterface.appConfig.reducedMode !== true
         repeat: false
         onTriggered: MOTIONInterface.checkForUpdates()
     }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2947,7 +2947,15 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot()
     def checkForUpdates(self):
-        """Check GitHub releases for a newer version (runs in a background thread)."""
+        """Check GitHub releases for a newer version (runs in a background thread).
+
+        Skipped entirely in reduced (clinical) mode — the simplified clinical
+        UI must not surface user-driven self-update flows or make outbound
+        network calls. See issue #96.
+        """
+        if self._app_config.get("reducedMode", False):
+            logger.info("Update check skipped: reduced mode is enabled")
+            return
         t = threading.Thread(target=self._check_for_updates_worker, daemon=True)
         t.start()
 


### PR DESCRIPTION
Closes #96

## Summary
- Skip the network call in `MOTIONConnector.checkForUpdates()` when `reducedMode` is enabled (`motion_connector.py:2948`).
- Stop the auto-check `Timer` in `UpdateBanner.qml` from firing in reduced mode.
- Hide the manual "Check for Updates" row in `SettingsModal.qml`'s About card (mirrors the existing pattern used for other developer surfaces).

Defense in depth: both the trigger (auto + manual) and the network call are gated, so a clinical user can't kick off an update from any path.

## Test plan
- [ ] Launch with `reducedMode: true` in `config/app_config.json` — no update banner appears at startup, "Check for Updates" row is hidden in Settings.
- [ ] Launch with `reducedMode: false` — banner Timer fires after 3s as before, "Check for Updates" row visible and functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)