### PR TITLE
feat: gate per-run telemetry CSV behind developerMode

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -569,20 +569,32 @@ class MOTIONConnector(QObject):
         self._runlog_handler = run_handler
         self._runlog_active = True
 
-        # Initialize CSV telemetry log (same basename as run log)
-        try:
-            self._runlog_csv_file = open(
-                self._runlog_csv_path, "w", newline="", encoding="utf-8"
+        # Initialize CSV telemetry log (same basename as run log).
+        # Telemetry CSVs are a developer artifact: clinical users have no
+        # use for raw tcm/tcl/pdc samples, so only emit them when
+        # developerMode is on (issue #43). _write_runlog_csv_sample and
+        # _stop_runlog already short-circuit on a None writer/file.
+        if self._app_config.get("developerMode", False):
+            try:
+                self._runlog_csv_file = open(
+                    self._runlog_csv_path, "w", newline="", encoding="utf-8"
+                )
+                self._runlog_csv_writer = csv.writer(self._runlog_csv_file)
+                self._runlog_csv_writer.writerow(
+                    ["timestamp", "unix_ms", "tcm", "tcl", "pdc"]
+                )
+                self._runlog_csv_file.flush()
+            except Exception as e:
+                logger.error(f"Failed to open run CSV log: {e}")
+                self._runlog_csv_file = None
+                self._runlog_csv_writer = None
+        else:
+            logger.debug(
+                "[RUNLOG] telemetry CSV skipped (developerMode disabled)"
             )
-            self._runlog_csv_writer = csv.writer(self._runlog_csv_file)
-            self._runlog_csv_writer.writerow(
-                ["timestamp", "unix_ms", "tcm", "tcl", "pdc"]
-            )
-            self._runlog_csv_file.flush()
-        except Exception as e:
-            logger.error(f"Failed to open run CSV log: {e}")
             self._runlog_csv_file = None
             self._runlog_csv_writer = None
+            self._runlog_csv_path = None
 
         # --- Gather version info for header ---
         # SDK version (MOTION SDK / sensor SDK)


### PR DESCRIPTION
Closes #43

## Summary
- Gate creation of the per-run telemetry CSV (`run-<subject>_<ts>.csv` in `output_base/run-logs/`) behind `appConfig.developerMode` at `motion_connector.py:572-597`.
- When developer mode is off, the writer is set to `None` and downstream `_write_runlog_csv_sample`/`_stop_runlog` already no-op safely.
- The sibling per-run `.log` file is intentionally NOT gated — it's a structured event log used for clinical support, not telemetry.

## Test plan
- [ ] Run a scan with `developerMode: false` — no `run-*.csv` is created in `app-logs/run-logs/`; the `.log` file is still produced.
- [ ] Run a scan with `developerMode: true` — telemetry CSV is created and populated as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)