### PR TITLE
refactor(scan-files): accept new naming (drop _corrected, add _raw); writer side in SDK

### DIFF
--- a/DATA_STRUCTURES.md
+++ b/DATA_STRUCTURES.md
@@ -263,14 +263,33 @@ CONSOLE_CONNECTED (2) ──► READY (3) ──► RUNNING (4)
 
 ### 4.9 Scan File Naming Convention
 
+Current convention (issue #44 — applied SDK-side; the app reads both):
+
 ```
-scan_{subjectId}_{YYYYMMDD_HHMMSS}_{side}_mask{XX}.csv   # histogram data
-scan_{subjectId}_{YYYYMMDD_HHMMSS}_notes.txt              # scan notes
-scan_{subjectId}_{YYYYMMDD_HHMMSS}_bfi_results.csv        # computed BFI/BVI
+{YYYYMMDD_HHMMSS}_{subjectId}.csv                              # post-processed BFI/BVI scan output
+{YYYYMMDD_HHMMSS}_{subjectId}_{side}_mask{XX}_raw.csv          # raw histogram data (when writeRawCsv=True)
+{YYYYMMDD_HHMMSS}_{subjectId}_telemetry.csv                    # per-frame telemetry log
+{YYYYMMDD_HHMMSS}_{subjectId}_notes.txt                        # scan notes
+{YYYYMMDD_HHMMSS}_{subjectId}_bfi_results.csv                  # legacy results CSV (visualize_bloodflow path)
 ```
 
-**Structure type:** Filesystem directory listing, glob-matched  
-**Access pattern:** `get_scan_list()` globs for `scan_*_notes.txt`, extracts `{subjectId}_{timestamp}`, sorts by timestamp descending.
+Notes on the suffixes:
+- The post-processed output **no longer carries a ``_corrected`` suffix**. The plain ``.csv`` IS the normal output.
+- Raw histogram captures append ``_raw`` to make their purpose explicit. The ``_raw`` suffix is added only when ``writeRawCsv=True``.
+
+Legacy formats still accepted on read for back-compat with historical scans on disk:
+
+```
+{YYYYMMDD_HHMMSS}_{subjectId}_corrected.csv                    # legacy post-processed output
+{YYYYMMDD_HHMMSS}_{subjectId}_{side}_mask{XX}.csv              # legacy raw histogram (no _raw suffix)
+scan_{subjectId}_{YYYYMMDD_HHMMSS}_corrected.csv               # original "scan_" prefixed format
+scan_{subjectId}_{YYYYMMDD_HHMMSS}_{side}_mask{XX}.csv
+scan_{subjectId}_{YYYYMMDD_HHMMSS}_notes.txt
+scan_{subjectId}_{YYYYMMDD_HHMMSS}_bfi_results.csv
+```
+
+**Structure type:** Filesystem directory listing, glob-matched.
+**Access pattern:** `get_scan_list()` globs ``*_corrected.csv`` plus any ``\d{8}_\d{6}_*.csv`` that is not an aux file (``_left_mask``, ``_right_mask``, ``_telemetry``, ``_bfi_results``, etc.). `get_scan_details()` looks up the post-processed CSV under the new no-suffix name first, then falls back to the legacy ``_corrected.csv`` name; raw files are looked up with the ``_raw`` suffix first, then without.
 
 ### 4.10 Real-Time Correction State (Per-Camera)
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1096,28 +1096,56 @@ class MOTIONConnector(QObject):
     def get_scan_list(self):
         """Return sorted list of scan IDs.
 
-        Supports two filename formats:
-          New: {YYYYMMDD_HHMMSS}_{sessionId}_corrected.csv
-          Old: scan_{sessionId}_{YYYYMMDD_HHMMSS}_corrected.csv
+        Supports three filename formats for the post-processed (BFI/BVI)
+        scan output:
+
+          Current: {YYYYMMDD_HHMMSS}_{sessionId}.csv          (no suffix)
+          Legacy:  {YYYYMMDD_HHMMSS}_{sessionId}_corrected.csv
+          Legacy:  scan_{sessionId}_{YYYYMMDD_HHMMSS}_corrected.csv
+
+        The ``_corrected`` suffix was dropped in issue #44 — the post-
+        processed CSV no longer carries it. We still glob for legacy
+        ``_corrected.csv`` files so historical scans on disk remain
+        visible in the History modal.
         """
         base_path = Path(self._directory)
         if not base_path.exists():
             return []
 
-        ids = []
+        # Sub-suffixes that distinguish auxiliary scan files from the
+        # primary post-processed CSV. Any *.csv whose stem ends with
+        # one of these is NOT the per-scan output file.
+        aux_suffix_re = re.compile(
+            r"_(?:left|right)_mask[0-9A-Fa-f]+(?:_raw)?$"
+            r"|_telemetry$"
+            r"|_bfi_results$"
+            r"|_(?:left|right)_mask[0-9A-Fa-f]+_(?:bfi|signal)$"
+        )
+
+        ids = set()
+
+        # Legacy: explicit "_corrected.csv" suffix.
         for f in base_path.glob("*_corrected.csv"):
             if not f.is_file():
                 continue
-            stem = f.stem  # strip ".csv" → "..._corrected"
-            if not stem.endswith("_corrected"):
-                continue
-            stem = stem[:-10]  # strip "_corrected"
-
+            stem = f.stem[:-10]  # strip "_corrected"
             if stem.startswith("scan_"):
-                # Old format: scan_{sessionId}_{ts}
-                stem = stem[5:]
+                stem = stem[5:]  # legacy "scan_" prefix
+            ids.add(stem)
 
-            ids.append(stem)
+        # Current: no "_corrected" suffix. Match files that start with
+        # the new YYYYMMDD_HHMMSS_* pattern and are not aux files.
+        for f in base_path.glob("*.csv"):
+            if not f.is_file():
+                continue
+            stem = f.stem
+            if not re.match(r"^\d{8}_\d{6}_", stem):
+                continue
+            if stem.endswith("_corrected"):
+                continue  # already handled above
+            if aux_suffix_re.search(stem):
+                continue
+            ids.add(stem)
 
         def ts_key(s):
             # New format starts with YYYYMMDD (8 digits)
@@ -1135,8 +1163,22 @@ class MOTIONConnector(QObject):
         scan_id is either:
           New format: 'YYYYMMDD_HHMMSS_userLabel'
           Old format: 'userLabel_YYYYMMDD_HHMMSS'
+
+        The post-processed CSV is looked up first under the current
+        no-suffix convention, then under the legacy ``_corrected.csv``
+        name. Raw histogram files are looked up first with a ``_raw``
+        suffix (current convention from issue #44) and then without
+        (legacy).
         """
         base = Path(self._directory)
+
+        def _first_match(*patterns):
+            """Return the first existing file across the given globs."""
+            for pat in patterns:
+                hit = next(base.glob(pat), None)
+                if hit is not None:
+                    return hit
+            return None
 
         # Detect format by checking if it starts with a date
         if re.match(r'^\d{8}_\d{6}_', scan_id):
@@ -1145,18 +1187,38 @@ class MOTIONConnector(QObject):
             ts = parts[0] + "_" + parts[1]
             subject = parts[2] if len(parts) > 2 else ""
             notes_path = base / f"{scan_id}_notes.txt"
-            left      = next(base.glob(f"{scan_id}_left_mask*.csv"), None)
-            right     = next(base.glob(f"{scan_id}_right_mask*.csv"), None)
-            corrected = next(base.glob(f"{scan_id}_corrected.csv"), None)
+            left      = _first_match(
+                f"{scan_id}_left_mask*_raw.csv",
+                f"{scan_id}_left_mask*.csv",
+            )
+            right     = _first_match(
+                f"{scan_id}_right_mask*_raw.csv",
+                f"{scan_id}_right_mask*.csv",
+            )
+            # Current convention is no suffix; fall back to legacy
+            # ``_corrected.csv`` for scans collected before issue #44.
+            corrected = _first_match(
+                f"{scan_id}.csv",
+                f"{scan_id}_corrected.csv",
+            )
         else:
             # Old format: userLabel_YYYYMMDD_HHMMSS
             parts = scan_id.split("_", 1)
             subject = parts[0]
             ts = parts[1] if len(parts) > 1 else ""
             notes_path = base / f"scan_{scan_id}_notes.txt"
-            left      = next(base.glob(f"scan_{scan_id}_left_mask*.csv"), None)
-            right     = next(base.glob(f"scan_{scan_id}_right_mask*.csv"), None)
-            corrected = next(base.glob(f"scan_{scan_id}_corrected.csv"), None)
+            left      = _first_match(
+                f"scan_{scan_id}_left_mask*_raw.csv",
+                f"scan_{scan_id}_left_mask*.csv",
+            )
+            right     = _first_match(
+                f"scan_{scan_id}_right_mask*_raw.csv",
+                f"scan_{scan_id}_right_mask*.csv",
+            )
+            corrected = _first_match(
+                f"scan_{scan_id}.csv",
+                f"scan_{scan_id}_corrected.csv",
+            )
 
         left_mask = ""
         right_mask = ""
@@ -2768,12 +2830,17 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot(str, result=bool)
     def visualize_corrected(self, corrected_csv: str) -> bool:
-        """Plot BFI/BVI from a _corrected.csv using plot_corrected_scan from the SDK."""
+        """Plot BFI/BVI from a post-processed scan CSV using
+        plot_corrected_scan from the SDK. Slot name kept for QML
+        back-compat; the input CSV no longer requires a ``_corrected``
+        suffix (see issue #44)."""
         return self._launch_correct_viz(corrected_csv, mode="bfi")
 
     @pyqtSlot(str, result=bool)
     def visualize_corrected_signal(self, corrected_csv: str) -> bool:
-        """Plot contrast/mean from a _corrected.csv using plot_corrected_scan from the SDK."""
+        """Plot contrast/mean from a post-processed scan CSV using
+        plot_corrected_scan from the SDK. Slot name kept for QML
+        back-compat (see ``visualize_corrected`` and issue #44)."""
         return self._launch_correct_viz(corrected_csv, mode="signal")
 
     def _launch_correct_viz(self, corrected_csv: str, mode: str) -> bool:
@@ -3072,11 +3139,12 @@ class _CorrectVizWorker(QObject):
             df = pd.read_csv(self.corrected_csv)
             if "timestamp_s" not in df.columns:
                 raise ValueError(
-                    "'timestamp_s' column not found — is this a _corrected.csv file?"
+                    "'timestamp_s' column not found — is this a "
+                    "post-processed scan CSV?"
                 )
             active_sides = mod._requested_sides(df, "both")
             if not active_sides:
-                raise ValueError("No camera data found in corrected CSV.")
+                raise ValueError("No camera data found in scan CSV.")
 
             reduced = mod._is_reduced_mode(df)
             if reduced:

--- a/processing/plot_corrected_scan.py
+++ b/processing/plot_corrected_scan.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """
-Plot BFI and BVI from a _corrected.csv file produced by the OpenMOTION SDK.
+Plot BFI and BVI from a post-processed scan CSV produced by the
+OpenMOTION SDK.
+
+The script name still uses ``plot_corrected_scan`` for back-compat
+with the bundled SDK copy (loaded by name from
+``motion_connector._load_plot_corrected_scan``). As of issue #44 the
+post-processed scan CSV no longer carries a ``_corrected`` suffix,
+but the script accepts any CSV that has a ``timestamp_s`` column and
+the BFI/BVI per-camera or per-side columns documented below.
 
 Supports two CSV formats:
 
@@ -30,7 +38,7 @@ Optional secondary figure (--show-signal) adds mean, std, and contrast
 
 Usage
 -----
-    python plot_corrected_scan.py --csv path/to/_corrected.csv
+    python plot_corrected_scan.py --csv path/to/scan.csv
     python plot_corrected_scan.py --csv scan.csv --show-signal --save
 """
 
@@ -143,8 +151,13 @@ def _requested_sides(df: pd.DataFrame, requested: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Plot OpenMOTION corrected scan CSV")
-    p.add_argument("--csv", required=True, help="Path to the _corrected.csv file")
+    p = argparse.ArgumentParser(
+        description="Plot OpenMOTION post-processed scan CSV (BFI/BVI)"
+    )
+    p.add_argument(
+        "--csv", required=True,
+        help="Path to the post-processed scan CSV file",
+    )
     p.add_argument(
         "--sides", choices=["left", "right", "both"], default="both",
         help="Which sensor side(s) to plot (default: both)",
@@ -306,7 +319,7 @@ def main() -> None:
     print(f"  {len(df)} rows, {len(df.columns)} columns")
 
     if "timestamp_s" not in df.columns:
-        print("ERROR: 'timestamp_s' column not found — is this a _corrected.csv?",
+        print("ERROR: 'timestamp_s' column not found — is this a post-processed scan CSV?",
               file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
Refs #44. Reader-side companion to OpenwaterHealth/openmotion-sdk#45 (which is the actual writer change).

## Summary
The actual filename writers for `_corrected.csv` and per-side raw histogram CSVs live in `openmotion-sdk` (`omotion/ScanWorkflow.py`), not in this repo. This PR teaches the bloodflow-app to *accept* the new naming convention while staying back-compat with existing on-disk scans.

- `motion_connector.get_scan_list` (`motion_connector.py:1095-1158`) now globs both legacy `*_corrected.csv` and new `\d{8}_\d{6}_*.csv`, excluding aux files.
- `motion_connector.get_scan_details` (`motion_connector.py:1160-1221`) does new-first-then-legacy lookup for both the post-processed CSV and the raw per-side files.
- Slot docstrings + one error message updated (`motion_connector.py:2832-2843`, `:3137`).
- `processing/plot_corrected_scan.py` docstring, `--csv` help, and `timestamp_s` error reworded.
- `DATA_STRUCTURES.md` section 4.9 rewritten — new convention is documented as primary, legacy formats listed as still-accepted-on-read.

## Decisions worth flagging
- **Back-compat:** readers accept BOTH conventions. Existing `_corrected.csv` scans on disk remain visible in History and remain visualizable. No file migration. Once the SDK PR ships and the legacy reader paths are no longer needed for any in-the-wild data, the fallbacks can be removed in a follow-up.
- **Did NOT rename `processing/plot_corrected_scan.py`** — it's loaded by exact filename via `importlib.util.spec_from_file_location` (with a dev-mode fallback to the SDK checkout). Renaming would break that path.
- **Internal QML names like `correctedPath` and `visualize_corrected*` slots** left alone — same back-compat reason; cosmetic rename is a separate concern.

## Test plan
- [ ] Existing scans on disk (`*_corrected.csv` + per-side `*_left_maskFF.csv` etc.) appear in the History modal and visualize correctly.
- [ ] Once openmotion-sdk#45 lands, new scans (`{ts}_{subject}.csv` + `*_raw.csv` per side) also appear and visualize correctly.
- [ ] `processing/plot_corrected_scan.py --csv <new-style.csv>` runs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)