### PR TITLE
test(raw_csv_save): target installed config, log-based scan-complete, payload integrity

### DIFF
--- a/tests/hil_helpers.py
+++ b/tests/hil_helpers.py
@@ -120,9 +120,61 @@ _PANEL_BUTTON_LABELS = (
     "Start", "Scan\nSettings", "Notes", "Check", "History", "Settings",
 )
 
-_APP_CONFIG_PATH = (
+_REPO_APP_CONFIG_PATH = (
     Path(__file__).resolve().parent.parent / "config" / "app_config.json"
 )
+
+
+def _from_source_mode() -> bool:
+    return os.environ.get("OPENWATER_FROM_SOURCE", "").lower() in (
+        "1", "true", "yes",
+    )
+
+
+def _resolve_app_config_path() -> Path:
+    """Return the app_config.json the running/about-to-run bloodflow app
+    actually reads.
+
+    From-source mode reads ``<repo>/config/app_config.json`` (cwd is
+    PROJECT_ROOT when ``python main.py`` is launched). The packaged
+    PyInstaller exe reads ``<exe-dir>/_internal/config/app_config.json``
+    — its own bundled copy, NOT the repo's. Tests that write to the
+    wrong file silently no-op against the running exe and the
+    snapshot-and-restore dance leaves an alien value on disk afterward.
+
+    Resolution order:
+      1. ``OPENWATER_APP_CONFIG`` env var (explicit override).
+      2. From-source mode  → repo config.
+      3. ``OPENWATER_EXE`` env var → its sibling ``_internal/config``.
+      4. Latest installed exe via the same glob set as conftest's
+         ``_find_exe``  → its sibling ``_internal/config``.
+      5. Fall back to the repo config (tests that don't run an exe
+         still need somewhere to read/write).
+    """
+    explicit = os.environ.get("OPENWATER_APP_CONFIG", "")
+    if explicit and Path(explicit).exists():
+        return Path(explicit)
+    if _from_source_mode():
+        return _REPO_APP_CONFIG_PATH
+    candidates: list[str] = []
+    env_exe = os.environ.get("OPENWATER_EXE", "")
+    if env_exe and os.path.exists(env_exe):
+        candidates.append(env_exe)
+    else:
+        import glob as _glob
+        for pattern in (
+            r"C:\Users\*\Documents\OpenMotion\**\OpenWaterApp.exe",
+            r"C:\Users\*\Desktop\**\OpenWaterApp.exe",
+            r"C:\Program Files\**\OpenWaterApp.exe",
+            r"C:\Program Files (x86)\**\OpenWaterApp.exe",
+        ):
+            candidates.extend(_glob.glob(pattern, recursive=True))
+    if candidates:
+        latest = max(candidates, key=os.path.getmtime)
+        bundled = Path(latest).parent / "_internal" / "config" / "app_config.json"
+        if bundled.exists():
+            return bundled
+    return _REPO_APP_CONFIG_PATH
 
 
 # ─────────────────────────────────────────────
@@ -153,7 +205,7 @@ def read_app_config_value(key: str, default: Any = None) -> Any:
     """Return the value of ``key`` in app_config.json, or ``default``
     if the key is absent or the file is missing/unreadable."""
     try:
-        with _APP_CONFIG_PATH.open(encoding="utf-8") as fh:
+        with _resolve_app_config_path().open(encoding="utf-8") as fh:
             return json.load(fh).get(key, default)
     except Exception:
         return default
@@ -163,14 +215,15 @@ def write_app_config_value(key: str, value: Any) -> None:
     """Persist ``key=value`` to app_config.json. Logs a warning on
     failure rather than raising — config IO shouldn't take a test
     down."""
+    path = _resolve_app_config_path()
     try:
-        with _APP_CONFIG_PATH.open(encoding="utf-8") as fh:
+        with path.open(encoding="utf-8") as fh:
             cfg = json.load(fh)
         cfg[key] = value
-        with _APP_CONFIG_PATH.open("w", encoding="utf-8") as fh:
+        with path.open("w", encoding="utf-8") as fh:
             json.dump(cfg, fh, indent=2)
     except Exception as e:
-        log.warning(f"  Failed to persist {key}={value}: {e}")
+        log.warning(f"  Failed to persist {key}={value} at {path}: {e}")
 
 
 def force_app_config_value(key: str, value: Any) -> Any:
@@ -954,3 +1007,87 @@ def dismiss_signal_quality_modal() -> bool:
         f"  Modal detected via {detected_via} but Dismiss button not found"
     )
     return False
+
+
+# ─────────────────────────────────────────────
+# Raw histogram CSV payload validation
+# ─────────────────────────────────────────────
+#
+# The SDK ships ``data-processing/check_csv.py`` which scans a raw
+# histogram CSV for three integrity violations:
+#   * ``bad_sum`` - any row whose ``sum`` column != EXPECTED_SUM
+#     (2,457,606 = 1024 bins × 2400 photons/bin baseline)
+#   * ``frame_id_skipped`` - non-monotonic frame_id sequencing modulo 256
+#   * ``bad_frame_cam_count`` - frames missing one or more camera rows
+#
+# The SDK module's directory has a dash (``data-processing``), so it
+# isn't importable as a package; load it by file path. The function
+# itself prints results and returns ``None``, so we capture stdout and
+# look for the literal ``[PASS]`` it emits on success. We surface the
+# captured output on failure so the operator sees exactly which row(s)
+# tripped which check.
+
+_SDK_CHECK_CSV_PATH = Path(
+    os.environ.get(
+        "OPENWATER_CHECK_CSV",
+        Path(__file__).resolve().parent.parent.parent
+        / "openmotion-sdk" / "data-processing" / "check_csv.py",
+    )
+)
+
+
+_CHECK_CSV_COUNT_RE = re.compile(
+    r"^\s+(bad_sum|frame_id_skipped|bad_frame_cam_count):\s+(\d+)\s*$",
+    re.MULTILINE,
+)
+
+
+def validate_raw_csv_payload(csv_path: Path) -> tuple[dict[str, int], str]:
+    """Run the SDK's ``check_csv_integrity`` against ``csv_path``.
+
+    Returns ``(counts, captured_stdout)`` where ``counts`` is the
+    per-error-class tally the SDK printed:
+
+        {"bad_sum": int, "frame_id_skipped": int, "bad_frame_cam_count": int}
+
+    The caller decides what's a hard fail vs an acceptable artifact —
+    e.g. ``bad_frame_cam_count == 1`` is normal at the truncation
+    boundary (SDK closes the raw CSV mid-frame, leaving one partial
+    frame with fewer cam rows), so the *raw-CSV* test treats that as
+    OK while still demanding ``bad_sum == 0`` and
+    ``frame_id_skipped == 0``. Setup/IO failures surface as
+    ``counts == {}`` with the failure message in the second slot.
+    """
+    import importlib.util
+    import io
+    import contextlib
+
+    if not _SDK_CHECK_CSV_PATH.exists():
+        return {}, (
+            f"SDK check_csv.py not found at {_SDK_CHECK_CSV_PATH}. "
+            f"Set OPENWATER_CHECK_CSV to its absolute path, or check the "
+            f"openmotion-sdk repo is alongside openmotion-bloodflow-app."
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        "openwater_sdk_check_csv", str(_SDK_CHECK_CSV_PATH)
+    )
+    if spec is None or spec.loader is None:
+        return {}, f"Could not load module spec from {_SDK_CHECK_CSV_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if not hasattr(mod, "check_csv_integrity"):
+        return {}, (
+            f"{_SDK_CHECK_CSV_PATH} loaded but has no "
+            f"``check_csv_integrity`` symbol — SDK API changed?"
+        )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        try:
+            mod.check_csv_integrity(str(csv_path))
+        except Exception as e:
+            return {}, f"{type(e).__name__}: {e}\n{buf.getvalue()}"
+    out = buf.getvalue()
+    counts = {m.group(1): int(m.group(2)) for m in _CHECK_CSV_COUNT_RE.finditer(out)}
+    return counts, out

--- a/tests/test_raw_csv_save.py
+++ b/tests/test_raw_csv_save.py
@@ -22,19 +22,22 @@ Lifecycle
      (so the Scan Settings panel button is visible).
   4. Launch the app, calibrate panel buttons, wait for CONNECTED.
   5. Open Settings, scroll to the Developer section, toggle
-     ``Save raw CSV`` ON via the UI, type ``120`` into
+     ``Save raw CSV`` ON via the UI, type ``30`` into
      ``Raw CSV duration``, escape out.
-  6. Open Scan Settings, set duration to 3 minutes, escape out.
+  6. Open Scan Settings, set duration to 1 minute, escape out.
   7. Click Start, wait for the auto-opened Session Notes modal
      (signals scan completion).
   8. Diff the data directory before/after the scan to find the
      three new CSVs (canonical + left/right raw). Assert:
-       - canonical CSV's ``timestamp_s`` column spans ~180 s ± tol
-       - both ``*_raw.csv`` files span ~120 s ± tol
+       - canonical CSV's ``timestamp_s`` column spans ~60 s ± tol
+       - both ``*_raw.csv`` files span ~30 s ± tol
+       - both ``*_raw.csv`` files pass the SDK
+         ``check_csv_integrity`` payload check (per-row sum,
+         frame_id sequencing, equal cam count per frame)
   9. Always (in ``finally``): restore the original config values
      and relaunch so the bench is clean for whatever runs next.
 
-Marked ``release``: ~7 min wall-clock total (3 min scan + camera
+Marked ``release``: ~3-4 min wall-clock total (1 min scan + camera
 config + setup/teardown). Don't run in the dev-tier HIL set.
 """
 
@@ -68,6 +71,7 @@ from hil_helpers import (
     find_app_log,
     read_app_config_value,
     recalibrate_panel_buttons,
+    validate_raw_csv_payload,
     wait_for_pattern,
     write_app_config_value,
 )
@@ -79,12 +83,12 @@ pytestmark = pytest.mark.release
 
 # Wall-clock budgets
 APP_CONNECT_TIMEOUT = 60
-SESSION_NOTES_TIMEOUT = 360  # camera config (~75s) + 3-min scan + buffer
+SESSION_NOTES_TIMEOUT = 200  # camera config (~75s) + 1-min scan + buffer
 
 # Test parameters (also baked into the assertions below)
-SCAN_DURATION_SEC      = 180   # 3 min, set in Scan Settings
-RAW_CSV_DURATION_SEC   = 120   # 2 min, typed into Settings → Developer
-DURATION_TOLERANCE_SEC = 12    # how far off the timestamps can drift
+SCAN_DURATION_SEC      = 60    # 1 min, set in Scan Settings
+RAW_CSV_DURATION_SEC   = 30    # 30 s, typed into Settings → Developer
+DURATION_TOLERANCE_SEC = 8     # how far off the timestamps can drift
 
 # Column name in both raw and canonical CSVs.
 _TIMESTAMP_COL = "timestamp_s"
@@ -508,11 +512,56 @@ def require_focus_via_ensure_visible() -> None:
         pytest.fail("App window not visible — cannot type into duration fields")
 
 
+# When the scan workflow completes, motion_connector logs:
+#   "Saved scan notes to <path>"
+# at the same moment the Session Notes modal auto-opens. The modal is
+# the visible signal to the operator; the log line is the structured
+# signal we trust here, since UIA window walks fail intermittently
+# under the bench's display configuration ("UIA window not found"
+# warnings during multi-minute waits) and would let scan completion
+# slip past detection. Belt-and-suspenders: also poll UIA so a
+# non-default app build that doesn't emit that exact log line still
+# gets caught.
+_SCAN_COMPLETE_RE = re.compile(r"Saved scan notes to ", re.IGNORECASE)
+
+
 def _wait_for_session_notes_modal(timeout: int) -> bool:
-    """Poll UIA for a 'Session Notes' string. The modal auto-opens
-    when the SDK fires the scan-complete callback."""
+    """Return True once the scan workflow signals completion.
+
+    Two parallel signals; whichever fires first wins:
+      - app log carries "Saved scan notes to <path>" — emitted by
+        motion_connector at scan completion, simultaneous with the
+        Session Notes modal opening.
+      - UIA descendants surface a "Session Notes" text — works when
+        Qt's a11y bridge is cooperating.
+
+    The log path is captured up-front (before Start was clicked) so we
+    only consider lines written during this scan, not a stale entry
+    from a prior session.
+    """
+    log_path = find_app_log()
+    log_offset = log_path.stat().st_size if log_path else 0
+    if log_path is not None:
+        log.info(
+            f"  scan-complete watch: tailing {log_path.name} "
+            f"from byte {log_offset}"
+        )
+
     deadline = time.time() + timeout
     while time.time() < deadline:
+        # Log signal — cheap, deterministic, no UIA round-trips.
+        if log_path is not None and log_path.exists():
+            try:
+                with log_path.open("r", encoding="utf-8", errors="replace") as fh:
+                    fh.seek(log_offset)
+                    chunk = fh.read()
+                    log_offset += len(chunk.encode("utf-8", errors="replace"))
+                    if _SCAN_COMPLETE_RE.search(chunk):
+                        log.info("  scan complete via app-log 'Saved scan notes to'")
+                        return True
+            except Exception as e:
+                log.warning(f"  log tail failed: {e}")
+        # UIA signal — secondary, in case the log line ever changes.
         try:
             win = uia_window()
             for elem in win.descendants():
@@ -521,10 +570,11 @@ def _wait_for_session_notes_modal(timeout: int) -> bool:
                 except Exception:
                     continue
                 if "session notes" in txt:
+                    log.info("  scan complete via UIA 'Session Notes' text")
                     return True
         except Exception:
             pass
-        time.sleep(2)
+        time.sleep(1)
     return False
 
 
@@ -797,17 +847,65 @@ class TestRawCsvSave:
             # protects against a build where the truncation didn't fire
             # at all and all three CSVs ran to full scan duration but
             # within the absolute tolerance happened to look OK.
-            assert left_span  < canonical_span - 30, (
+            assert left_span  < canonical_span - 15, (
                 f"Left raw CSV span ({left_span:.1f} s) should be at "
-                f"least 30 s shorter than canonical ({canonical_span:.1f} s); "
+                f"least 15 s shorter than canonical ({canonical_span:.1f} s); "
                 f"raw truncation likely didn't fire."
             )
-            assert right_span < canonical_span - 30, (
+            assert right_span < canonical_span - 15, (
                 f"Right raw CSV span ({right_span:.1f} s) should be at "
-                f"least 30 s shorter than canonical ({canonical_span:.1f} s); "
+                f"least 15 s shorter than canonical ({canonical_span:.1f} s); "
                 f"raw truncation likely didn't fire."
             )
             log.info("  PASS: all three CSVs span their expected durations")
+
+            # ─── Payload integrity (per-row sum + frame sequencing + cam count)
+            #
+            # We assert tightly on the two checks that SHOULD always be
+            # zero on a healthy scan:
+            #   * bad_sum:           every row's histogram sums to the
+            #                        configured photon-count constant.
+            #   * frame_id_skipped:  no dropped frames (mod-256 rollover
+            #                        is normal and not flagged).
+            #
+            # We allow ``bad_frame_cam_count <= 1`` because the SDK
+            # closes raw CSVs mid-frame at the truncation boundary,
+            # leaving exactly one partial frame with fewer cam rows.
+            # Anything beyond that points at real frame loss during
+            # the scan.
+            for label in ("left_raw", "right_raw"):
+                path = scan_files[label]
+                log.info(f"  validating payload of {path.name}")
+                counts, output = validate_raw_csv_payload(path)
+                assert counts, (
+                    f"{path.name}: SDK check_csv setup failed.\n"
+                    f"{output.strip()}"
+                )
+                bad_sum     = counts.get("bad_sum", -1)
+                fid_skipped = counts.get("frame_id_skipped", -1)
+                bad_cams    = counts.get("bad_frame_cam_count", -1)
+                assert bad_sum == 0, (
+                    f"{path.name}: {bad_sum} row(s) failed the "
+                    f"per-row histogram sum check.\n"
+                    f"--- check_csv output ---\n{output.strip()}"
+                )
+                assert fid_skipped == 0, (
+                    f"{path.name}: {fid_skipped} frame_id(s) dropped "
+                    f"during the scan.\n"
+                    f"--- check_csv output ---\n{output.strip()}"
+                )
+                assert bad_cams <= 1, (
+                    f"{path.name}: {bad_cams} frame(s) had a wrong "
+                    f"cam_id count. Up to 1 partial frame is expected "
+                    f"at the truncation boundary; this run shows more, "
+                    f"which suggests real frame loss.\n"
+                    f"--- check_csv output ---\n{output.strip()}"
+                )
+                log.info(
+                    f"    {path.name}: PASS "
+                    f"(bad_sum={bad_sum}, frame_id_skipped={fid_skipped}, "
+                    f"bad_frame_cam_count={bad_cams})"
+                )
 
         finally:
             # ─── Step 9 (cleanup): restore original config on disk ───


### PR DESCRIPTION
## Summary

Three fixes to `tests/test_raw_csv_save.py` (#105) so it works against the packaged 1.1.0-dev.3 install on the bench:

- **`hil_helpers._resolve_app_config_path()`** — read/write helpers now target the installed exe's bundled `_internal/config/app_config.json`, not the repo's. Without this, `developerMode`/`reducedMode` writes were silent no-ops against the running exe.
- **Log-based scan-complete signal** — `_wait_for_session_notes_modal` tails the app log for `Saved scan notes to`, with the existing UIA walk kept as fallback. Avoids "UIA window not found" hiccups timing the test out at 360 s.
- **Payload integrity check** — step 8 now runs the SDK's `check_csv_integrity` on each raw CSV via `validate_raw_csv_payload()` (importlib loads `data-processing/check_csv.py`). Asserts `bad_sum == 0`, `frame_id_skipped == 0`, `bad_frame_cam_count <= 1` (boundary partial frame is normal at truncation).

Test parameters shortened: 60 s scan / 30 s raw CSV / 200 s timeout. Wall-clock dropped from ~7 min to ~3 min.

## Test plan

- [x] Test passes end-to-end on the bench (`1 passed in 157.45s`)
- [x] Both raw CSVs validate clean: `bad_sum=0, frame_id_skipped=0, bad_frame_cam_count=0`
- [x] Canonical span 59.98 s, raw spans 30.00 / 30.03 s — both within ±8 s tolerance
- [x] Run-to-run: one transient TextField-commit flake observed; immediate retry passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)