### PR TITLE
fix(bloodflow-app): preserve scan mask through sensor reconnects (#127)

### DIFF
--- a/components/SensorView.qml
+++ b/components/SensorView.qml
@@ -157,31 +157,30 @@ Rectangle {
     // Initialize fan status when component loads
     Component.onCompleted: {
         updateFanStatus()
-        resetCamerasWhenDisconnected()
     }
-    
+
     // Update fan status only when THIS side's connected flag actually
     // toggles. Listening to the connector's connectionStatusChanged
     // would fire on every state transition of every handle, causing
     // each SensorView to re-poll its fan whenever the OTHER side moved.
+    //
+    // Do NOT zero ``sensorActive`` on disconnect — the per-circle color
+    // bindings above already AND with ``root.sensorConnected``, so the
+    // circles gray themselves out automatically while disconnected. The
+    // old reset destroyed the source-of-truth pattern, and since no one
+    // restores it on reconnect, the circles stayed gray forever after
+    // a console power cycle even though the dropdown still showed the
+    // selected pattern (issue #127).
     onSensorConnectedChanged: {
         updateFanStatus()
-        resetCamerasWhenDisconnected()
     }
-    
+
     // Helper function to update fan status
     function updateFanStatus() {
         if (connector && sensorConnected) {
             root.fanOn = connector.getFanControlStatus(root.sensorSide)
         } else {
             root.fanOn = false
-        }
-    }
-    
-    // Helper function to reset cameras when sensor disconnects
-    function resetCamerasWhenDisconnected() {
-        if (!sensorConnected) {
-            root.sensorActive = [false, false, false, false, false, false, false, false]
         }
     }
 }

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -43,6 +43,14 @@ Rectangle {
     property int leftMask: 0x99   // default "Outer"
     property int rightMask: 0x00
 
+    // Track whether the cfg-default mask has been applied this session, per
+    // side. Once true, sensor reconnects (e.g. console power cycle) leave
+    // the current mask alone instead of clobbering the user's Scan Settings
+    // choice with cfg.leftMask / cfg.rightMask (issue #127). Set true when
+    // defaults are applied OR the user picks a mask in ScanSettingsModal.
+    property bool _leftMaskInitialApplied: false
+    property bool _rightMaskInitialApplied: false
+
     property string sessionId: MOTIONInterface.userLabel || ""
 
     // Duration from scan time modal
@@ -88,8 +96,14 @@ Rectangle {
         var cfg      = MOTIONInterface.appConfig;
         var defLeft  = reducedMode ? (cfg.reducedModeLeftMask  !== undefined ? cfg.reducedModeLeftMask  : 0xC3) : (cfg.leftMask  !== undefined ? cfg.leftMask  : 0x99);
         var defRight = reducedMode ? (cfg.reducedModeRightMask !== undefined ? cfg.reducedModeRightMask : 0xC3) : (cfg.rightMask !== undefined ? cfg.rightMask : 0x99);
-        if (MOTIONInterface.leftSensorConnected)  leftMask  = defLeft;
-        if (MOTIONInterface.rightSensorConnected) rightMask = defRight;
+        if (MOTIONInterface.leftSensorConnected && !_leftMaskInitialApplied) {
+            leftMask = defLeft;
+            _leftMaskInitialApplied = true;
+        }
+        if (MOTIONInterface.rightSensorConnected && !_rightMaskInitialApplied) {
+            rightMask = defRight;
+            _rightMaskInitialApplied = true;
+        }
         if (cfg.autoConfigureOnStartup !== false &&
                 (MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected)) {
             flashDefaultCameras();
@@ -282,6 +296,12 @@ Rectangle {
             bloodFlow.durationSec = dur
             bloodFlow.leftMask = newLeftMask
             bloodFlow.rightMask = newRightMask
+            // A user-driven selection counts as "initial applied" so that
+            // a later sensor reconnect cannot overwrite it with the cfg
+            // default (issue #127). Covers the edge case where the user
+            // edits Scan Settings before sensors first enumerate.
+            bloodFlow._leftMaskInitialApplied = true
+            bloodFlow._rightMaskInitialApplied = true
         }
     }
 
@@ -455,8 +475,21 @@ Rectangle {
                         var cfg      = MOTIONInterface.appConfig;
                         var defLeft  = bloodFlow.reducedMode ? (cfg.reducedModeLeftMask  !== undefined ? cfg.reducedModeLeftMask  : 0xC3) : (cfg.leftMask  !== undefined ? cfg.leftMask  : 0x99);
                         var defRight = bloodFlow.reducedMode ? (cfg.reducedModeRightMask !== undefined ? cfg.reducedModeRightMask : 0xC3) : (cfg.rightMask !== undefined ? cfg.rightMask : 0x99);
-                        if (MOTIONInterface.leftSensorConnected)  bloodFlow.leftMask  = defLeft;
-                        if (MOTIONInterface.rightSensorConnected) bloodFlow.rightMask = defRight;
+                        // First connect this session per side: apply cfg
+                        // default. Subsequent reconnects (e.g. console power
+                        // cycle) preserve whatever's already in *Mask —
+                        // either the cfg default already adopted earlier or
+                        // the user's Scan Settings choice (issue #127). The
+                        // re-flash below still runs because the FPGA loses
+                        // its camera-enable state on power cycle.
+                        if (MOTIONInterface.leftSensorConnected && !bloodFlow._leftMaskInitialApplied) {
+                            bloodFlow.leftMask  = defLeft;
+                            bloodFlow._leftMaskInitialApplied = true;
+                        }
+                        if (MOTIONInterface.rightSensorConnected && !bloodFlow._rightMaskInitialApplied) {
+                            bloodFlow.rightMask = defRight;
+                            bloodFlow._rightMaskInitialApplied = true;
+                        }
                         if (cfg.autoConfigureOnStartup !== false)
                             flashDefaultCameras()
                     }


### PR DESCRIPTION
## Summary

Two related bugs both surface on console power-cycle, both bundled here:

**1. `bloodFlow.leftMask` / `rightMask` reset to cfg default on every reconnect** (`pages/BloodFlow.qml`)

`onSignalConnected` was resetting the masks to `cfg.leftMask` / `cfg.rightMask` on every sensor reconnect. Since both config defaults are `102` (`0x66` = "Middle"), any power cycle silently overwrote the user's Scan Settings choice — and re-flashed Middle to the FPGAs. Contradicts the issue #40 modal-preservation work: the modal kept its selection through transient USB drops, but the page-level masks (the source of truth that `setInitialSelection` reads on next open) were clobbered out from under it.

Gate the cfg-default application on a per-side `_*MaskInitialApplied` flag. Set on (a) first apply at page-load, (b) first auto-apply on connect, and (c) user selection in `ScanSettingsModal`. Once set, sensor reconnects no longer touch the mask. Re-flash still happens on every reconnect (the FPGA loses camera-enable state on power cycle), but now pushes the *current* mask rather than overwriting it.

**2. `SensorView` blue circles stay gray after reconnect** (`components/SensorView.qml`)

`resetCamerasWhenDisconnected` zeroed `root.sensorActive` every time the side disconnected, but nothing restored it on reconnect. After a power cycle the dropdown still showed the selected pattern (preserved by issue #40), but every circle was gray because the view's copy of the pattern had been wiped and the modal only writes back through `setInitialSelection` on open-from-closed. Commit `2d46280` already added per-circle `sensorActive[N] && root.sensorConnected` color guards, which gray the circles out while disconnected, so the reset was destructive without being necessary. Removed.

Fixes #127.

## Test plan
- [ ] Power on console, open Bloodflow, open Scan Settings, set Left = "Outer" / Right = "Far"
- [ ] Power cycle the console
- [ ] After reconnect: Scan Settings still shows Outer / Far in the dropdowns, **and the blue circles match the selected pattern**, selectors enabled
- [ ] Auto-flash log shows Outer / Far masks being pushed to the FPGAs (not Middle)
- [ ] Initial-connect regression: starting Bloodflow with no prior selection still adopts the configured defaults from `app_config.json`
- [ ] Disconnect-only regression: with sensor disconnected, the SensorView is greyed (`opacity 0.4`, red-ish border) and circles are gray — same as before

> Not verifiable on the dev machine without hardware — needs HIL re-test against issue #127 repro steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)