### PR TITLE
fix(bloodflow-app): unwedge ScanRunner from late SDK callbacks (#124)

### DIFF
--- a/pages/scan/CaptureDataTask.qml
+++ b/pages/scan/CaptureDataTask.qml
@@ -23,11 +23,26 @@ QtObject {
     property var _onProg: null
     property var _onDone: null
 
+    function _disconnectHandlers() {
+        // Tear down any handlers left connected by a previous ``run()``.
+        // Without this, a previous run's ``_onDone`` stays wired to
+        // ``connector.captureFinished`` if the user clicks Stop+Start before
+        // the SDK's ``_on_complete`` fires; when that late signal finally
+        // arrives it re-emits ``finished`` on this task and re-enters the
+        // ScanRunner state machine after it has already torn down (issue
+        // #124). The ScanRunner ``_done`` guard catches the late re-entry,
+        // but disconnecting at the source avoids the cycle entirely.
+        if (_onLog)  { try { connector.captureLog.disconnect(_onLog)   } catch(e) {} _onLog  = null }
+        if (_onProg) { try { connector.captureProgress.disconnect(_onProg) } catch(e) {} _onProg = null }
+        if (_onDone) { try { connector.captureFinished.disconnect(_onDone) } catch(e) {} _onDone = null }
+    }
+
     function run() {
         if (!connector || !connector.startCapture) {
             finished(false, "Connector missing startCapture()")
             return
         }
+        _disconnectHandlers()
         started()
         progress(25)
         log("Preparing capture…")

--- a/pages/scan/ContactQualityCheckTask.qml
+++ b/pages/scan/ContactQualityCheckTask.qml
@@ -18,11 +18,20 @@ QtObject {
 
     property var _onDone: null
 
+    function _disconnectHandlers() {
+        // See CaptureDataTask._disconnectHandlers — same rationale (issue #124).
+        if (_onDone) {
+            try { connector.contactQualityCheckFinished.disconnect(_onDone) } catch(e) {}
+            _onDone = null
+        }
+    }
+
     function run() {
         if (!connector || !connector.runContactQualityCheck) {
             finished(false, "Connector missing runContactQualityCheck()")
             return
         }
+        _disconnectHandlers()
         started()
         progress(50)
         log("Running contact quality check…")

--- a/pages/scan/FlashSensorsTask.qml
+++ b/pages/scan/FlashSensorsTask.qml
@@ -17,6 +17,13 @@ QtObject {
     property var _onProg: null
     property var _onDone: null
 
+    function _disconnectHandlers() {
+        // See CaptureDataTask._disconnectHandlers — same rationale (issue #124).
+        if (_onLog)  { try { connector.configLog.disconnect(_onLog)   } catch(e) {} _onLog  = null }
+        if (_onProg) { try { connector.configProgress.disconnect(_onProg) } catch(e) {} _onProg = null }
+        if (_onDone) { try { connector.configFinished.disconnect(_onDone) } catch(e) {} _onDone = null }
+    }
+
     function run() {
         if (!connector || !connector.startConfigureCameraSensors) {
             console.log("FlashSensorsTask: connector missing startConfigureCameraSensors()")
@@ -24,6 +31,7 @@ QtObject {
             return
         }
 
+        _disconnectHandlers()
         started()
         progress(5)
         log("Configuring sensors/FPGA… (mask=0x" + leftCameraMask.toString(16).toUpperCase() + ")")

--- a/pages/scan/ScanRunner.qml
+++ b/pages/scan/ScanRunner.qml
@@ -99,7 +99,14 @@ QtObject {
         }
         onProgress: function(pct) { runner.progressUpdate(pct) }
         onLog: function(line) { runner.messageOut(line) }
+        // Guard against late-fire (issue #124): a connector signal that was
+        // pending when an earlier cycle's ``_finish`` ran can still arrive
+        // and propagate ``finished`` here. Without the guard, the handler
+        // mutates ``_stage`` and re-enters ``_finish``, which then bails on
+        // ``_done`` — leaving the runner wedged in a non-idle stage so the
+        // next ``start()`` is silently rejected.
         onFinished: function(ok, err) {
+            if (runner._done) return
             runner.flashWatchdog.stop()
             if (!ok) { runner._finish(false, err, "", ""); return }
             runner.setTriggerLaserTask.run()
@@ -121,6 +128,7 @@ QtObject {
         onProgress: function(pct) { runner.progressUpdate(pct) }
         onLog: function(line) { runner.messageOut(line) }
         onFinished: function(ok, err) {
+            if (runner._done) return
             runner.setTriggerWatchdog.stop()
             if (!ok) { runner._finish(false, err, "", ""); return }
             if (runner.mode === "check") {
@@ -149,6 +157,7 @@ QtObject {
         onProgress: function(pct) { runner.progressUpdate(pct) }
         onLog: function(line) { runner.messageOut(line) }
         onFinished: function(ok, err) {
+            if (runner._done) return
             if (!ok) { runner._finish(false, err, "", ""); return }
             runner._stage = "post"
             runner.stageUpdate("Scan complete")
@@ -169,6 +178,7 @@ QtObject {
         onProgress: function(pct) { runner.progressUpdate(pct) }
         onLog: function(line) { runner.messageOut(line) }
         onFinished: function(ok, err) {
+            if (runner._done) return
             runner.checkWatchdog.stop()
             runner._finish(ok, err, "", "")
         }


### PR DESCRIPTION
## Summary

Two interacting defects let \`ScanRunner\` stall in a non-idle \`_stage\` so a subsequent \`start()\` would silently return, leaving \`beginScanNow\`'s \`scanning=true\` never cleared — Stop button stuck after a power cycle when no scan is actually running. Clicking Stop in that state opens Session Notes showing the *previous* scan's \"Scan stopped — duration: 00:00:51\" line because \`scanNotes\` is still populated from the prior \`_on_complete\`.

**1) Stale-handler leak in the three task QObjects** (\`CaptureDataTask.qml\`, \`FlashSensorsTask.qml\`, \`ContactQualityCheckTask.qml\`). Each \`run()\` reassigned the \`_onLog\` / \`_onProg\` / \`_onDone\` property vars and connected the new handlers, but never disconnected the prior run's. If the user clicked Stop+Start before the SDK's \`_on_complete\` fired, run #1's \`_onDone\` stayed wired to \`connector.captureFinished\` and re-emitted \`finished()\` on the task when the late signal finally arrived.

**2) No late-fire guard in \`ScanRunner.qml\`'s task \`onFinished\` handlers**. \`captureTask.onFinished\` in particular set \`runner._stage = \"post\"\` *before* calling \`_finish\`, which then bailed on \`_done=true\` — leaving \`_stage\` wedged at \"post\". \`start()\` rejects anything but \`_stage===\"idle\"\`, so the next \`beginScanNow\`'s \`scanRunner.start()\` was a silent no-op while \`scanning=true\` had already been set.

**Fix**
- Added \`_disconnectHandlers()\` to all three task files; \`run()\` calls it before reconnecting so a fresh cycle never inherits stale connections.
- Added \`if (runner._done) return\` to all four \`onFinished\` handlers (flash / set-trigger / capture / check) in \`ScanRunner\` so any late callback that slips through can't mutate state on an already-torn-down runner.

Fixes #124.

## Test plan
- [ ] Power on console, open Bloodflow, click Start, then hammer the Start/Stop button rapidly while the scan is in progress
- [ ] Let the original scan unwind / SDK \`_on_complete\` fire
- [ ] Power-cycle the console
- [ ] After reconnect, click Start: scan should actually start (flash → set trigger → start_scan in log), Stop button responsive
- [ ] Negative: do the same without the hammering — confirm normal Start/Stop still works, Notes modal opens with correct content on Stop
- [ ] Contact-quality quick-check path (Check button) still works after rapid clicks

> Not verifiable on the dev machine without hardware — needs HIL re-test against #124 repro steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)