### PR TITLE
Differentiated orange lights in dev-mode CQ modal (#128)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ OpenWaterApp*.zip
 /run-logs/
 
 .claude/
+.superpowers/
 tests/scan_data/*
 tests/run-logs/*
 tests/test_logs/*

--- a/components/AppTheme.qml
+++ b/components/AppTheme.qml
@@ -39,11 +39,13 @@ QtObject {
     readonly property color textLink:      dark ? "#4A90E2" : "#2060C0"
 
     // ── accent colours (same in both modes) ───────────────────────
-    readonly property color accentBlue:   "#4A90E2"
-    readonly property color accentGreen:  "#2ECC71"
-    readonly property color accentRed:    "#E74C3C"
-    readonly property color accentYellow: "#F1C40F"
-    readonly property color accentOrange: "#E67E22"
+    readonly property color accentBlue:          "#4A90E2"
+    readonly property color accentGreen:         "#2ECC71"
+    readonly property color accentRed:           "#E74C3C"
+    readonly property color accentYellow:        "#F1C40F"
+    readonly property color accentOrange:        "#E67E22"
+    readonly property color accentOrangeAmbient: "#9A4012"
+    readonly property color accentOrangeContact: "#F4A460"
 
     // ── status / indicators ───────────────────────────────────────
     readonly property color statusGreen:  "#2ECC71"

--- a/components/CameraDot.qml
+++ b/components/CameraDot.qml
@@ -14,9 +14,7 @@ import QtQuick.Controls as Controls
  *      modal      : the ContactQualityModal root (required — used to
  *                   call cameraStatus / cameraWarningTypes / cameraTooltip
  *                   and to read developerMode)
- *      size       : pixel size of the dot (default 18). Must be even —
- *                   the split-render geometry assumes an even width so
- *                   the two halves meet exactly at the centerline.
+ *      size       : pixel size of the dot (default 18).
  */
 Item {
     id: root
@@ -63,10 +61,11 @@ Item {
         border.width: 1
     }
 
-    // Split case — two clipped half-rects inset 1px on every edge so
-    // they don't overdraw the outer Rectangle's 1px border. The outer
-    // Rectangle owns the rounded border and clips its children to the
-    // circular shape.
+    // Split case — horizontal sharp-transition gradient. Qt 6's
+    // Rectangle.gradient respects radius, so the fill is naturally
+    // clipped to the circular shape. (Two clipped child rects don't
+    // work — Rectangle's clip:true uses rectangular bounds, not the
+    // rounded outline.)
     Rectangle {
         id: splitFrame
         anchors.fill: parent
@@ -74,21 +73,12 @@ Item {
         radius: parent.width / 2
         border.color: "black"
         border.width: 1
-        color: "transparent"
-        clip: true
-
-        Rectangle {
-            x: 1; y: 1
-            width: (parent.width - 2) / 2
-            height: parent.height - 2
-            color: theme.accentOrangeAmbient
-        }
-        Rectangle {
-            x: parent.width / 2
-            y: 1
-            width: (parent.width - 2) / 2
-            height: parent.height - 2
-            color: theme.accentOrangeContact
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+            GradientStop { position: 0.0;    color: theme.accentOrangeAmbient }
+            GradientStop { position: 0.4999; color: theme.accentOrangeAmbient }
+            GradientStop { position: 0.5001; color: theme.accentOrangeContact }
+            GradientStop { position: 1.0;    color: theme.accentOrangeContact }
         }
     }
 

--- a/components/CameraDot.qml
+++ b/components/CameraDot.qml
@@ -14,7 +14,9 @@ import QtQuick.Controls as Controls
  *      modal      : the ContactQualityModal root (required — used to
  *                   call cameraStatus / cameraWarningTypes / cameraTooltip
  *                   and to read developerMode)
- *      size       : pixel size of the dot (default 18)
+ *      size       : pixel size of the dot (default 18). Must be even —
+ *                   the split-render geometry assumes an even width so
+ *                   the two halves meet exactly at the centerline.
  */
 Item {
     id: root
@@ -43,8 +45,9 @@ Item {
         if (status === "inactive") return "#666666"
         // status === "bad" past this point
         if (!modal.developerMode)  return "#E67E22"
-        if (hasAmbient && !isSplit) return theme.accentOrangeAmbient
-        if (hasContact && !isSplit) return theme.accentOrangeContact
+        if (isSplit)                return theme.accentOrangeAmbient  // unused at render time (splitFrame handles it); kept so singleColor is never undefined
+        if (hasAmbient)             return theme.accentOrangeAmbient
+        if (hasContact)             return theme.accentOrangeContact
         // Unknown / future typeKey — fall back to dark orange.
         return theme.accentOrangeAmbient
     }

--- a/components/CameraDot.qml
+++ b/components/CameraDot.qml
@@ -1,0 +1,99 @@
+import QtQuick 6.0
+import QtQuick.Controls as Controls
+
+/*  CameraDot — single per-camera contact-quality indicator.
+ *
+ *  Used in ContactQualityModal sensor diagrams. Encapsulates the
+ *  status/type lookup and renders either a solid circular dot or
+ *  a vertical-split dot (dark left, light right) for the dev-mode
+ *  "ambient + contact both fired" case (#128).
+ *
+ *  API:
+ *      side       : "left" | "right"
+ *      camIndex1  : 1..8
+ *      modal      : the ContactQualityModal root (required — used to
+ *                   call cameraStatus / cameraWarningTypes / cameraTooltip
+ *                   and to read developerMode)
+ *      size       : pixel size of the dot (default 18)
+ */
+Item {
+    id: root
+
+    property string side
+    property int    camIndex1
+    required property var modal
+    property int    size: 18
+
+    width: size
+    height: size
+
+    AppTheme { id: theme }
+
+    readonly property string status: modal.cameraStatus(side, camIndex1)
+    readonly property var    types: status === "bad" && modal.developerMode
+                                    ? modal.cameraWarningTypes(side, camIndex1)
+                                    : []
+    readonly property bool   hasAmbient: types.indexOf("ambient_light") >= 0
+    readonly property bool   hasContact: types.indexOf("poor_contact") >= 0
+    readonly property bool   isSplit:    hasAmbient && hasContact
+
+    readonly property color singleColor: {
+        if (status === "good")     return "#A3E4A1"
+        if (status === "checking") return "#666666"
+        if (status === "inactive") return "#666666"
+        // status === "bad" past this point
+        if (!modal.developerMode)  return "#E67E22"
+        if (hasAmbient && !isSplit) return theme.accentOrangeAmbient
+        if (hasContact && !isSplit) return theme.accentOrangeContact
+        // Unknown / future typeKey — fall back to dark orange.
+        return theme.accentOrangeAmbient
+    }
+
+    // Solid case (no split) — single coloured circle.
+    Rectangle {
+        anchors.fill: parent
+        visible: !root.isSplit
+        radius: parent.width / 2
+        color: root.singleColor
+        border.color: "black"
+        border.width: 1
+    }
+
+    // Split case — two clipped half-rects inset 1px on every edge so
+    // they don't overdraw the outer Rectangle's 1px border. The outer
+    // Rectangle owns the rounded border and clips its children to the
+    // circular shape.
+    Rectangle {
+        id: splitFrame
+        anchors.fill: parent
+        visible: root.isSplit
+        radius: parent.width / 2
+        border.color: "black"
+        border.width: 1
+        color: "transparent"
+        clip: true
+
+        Rectangle {
+            x: 1; y: 1
+            width: (parent.width - 2) / 2
+            height: parent.height - 2
+            color: theme.accentOrangeAmbient
+        }
+        Rectangle {
+            x: parent.width / 2
+            y: 1
+            width: (parent.width - 2) / 2
+            height: parent.height - 2
+            color: theme.accentOrangeContact
+        }
+    }
+
+    MouseArea {
+        id: hover
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.NoButton
+    }
+    Controls.ToolTip.visible: hover.containsMouse
+    Controls.ToolTip.text: modal.cameraTooltip(side, camIndex1)
+}

--- a/components/CameraDot.qml
+++ b/components/CameraDot.qml
@@ -48,7 +48,8 @@ Item {
         if (isSplit)                return theme.accentOrangeAmbient  // unused at render time (splitFrame handles it); kept so singleColor is never undefined
         if (hasAmbient)             return theme.accentOrangeAmbient
         if (hasContact)             return theme.accentOrangeContact
-        // Unknown / future typeKey — fall back to dark orange.
+        // Unknown / future typeKey — fall back to dark orange and warn.
+        console.warn("CameraDot: unknown typeKey(s)", types, "for", side, camIndex1)
         return theme.accentOrangeAmbient
     }
 

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -474,6 +474,52 @@ Item {
                 }
             }
 
+            // Per-camera dot color legend (#128). Developer mode only —
+            // RUO operators just see a single orange and don't need this.
+            RowLayout {
+                visible: root.developerMode
+                         && (root.state_ === "ok" || root.state_ === "warnings")
+                Layout.alignment: Qt.AlignHCenter
+                spacing: 18
+
+                RowLayout {
+                    spacing: 6
+                    Rectangle { width: 10; height: 10; radius: 5
+                        color: theme.accentOrangeAmbient
+                        border.color: "black"; border.width: 1 }
+                    Text { text: "ambient"; color: theme.textSecondary; font.pixelSize: 11 }
+                }
+                RowLayout {
+                    spacing: 6
+                    Rectangle { width: 10; height: 10; radius: 5
+                        color: theme.accentOrangeContact
+                        border.color: "black"; border.width: 1 }
+                    Text { text: "contact"; color: theme.textSecondary; font.pixelSize: 11 }
+                }
+                RowLayout {
+                    spacing: 6
+                    Item {
+                        width: 10; height: 10
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: 5
+                            border.color: "black"; border.width: 1
+                            color: "transparent"
+                            clip: true
+                            Rectangle { x: 1; y: 1
+                                width: (parent.width - 2) / 2
+                                height: parent.height - 2
+                                color: theme.accentOrangeAmbient }
+                            Rectangle { x: parent.width / 2; y: 1
+                                width: (parent.width - 2) / 2
+                                height: parent.height - 2
+                                color: theme.accentOrangeContact }
+                        }
+                    }
+                    Text { text: "both"; color: theme.textSecondary; font.pixelSize: 11 }
+                }
+            }
+
             Item {
                 Layout.fillHeight: true
                 Layout.fillWidth: true

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -191,6 +191,21 @@ Item {
         return "good"
     }
 
+    // Returns the deduped typeKey array for a camera's active warnings.
+    // Empty when the camera has no warnings. Used by CameraDot (#128)
+    // to decide between single-color and split rendering in dev mode.
+    function cameraWarningTypes(side, camIndex1) {
+        var prefix = (side === "left") ? "L" : "R"
+        var label = prefix + camIndex1
+        var types = []
+        for (var i = 0; i < entries.length; ++i) {
+            if (entries[i].camera === label
+                    && types.indexOf(entries[i].typeKey) === -1)
+                types.push(entries[i].typeKey)
+        }
+        return types
+    }
+
     function cameraTooltip(side, camIndex1) {
         var prefix = (side === "left") ? "L" : "R"
         var label = prefix + camIndex1

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -224,14 +224,6 @@ Item {
         return lines.join("\n")
     }
 
-    function cameraColor(side, camIndex1) {
-        var st = cameraStatus(side, camIndex1)
-        if (st === "good")     return "#A3E4A1"  // pale green
-        if (st === "bad")      return "#E67E22"  // strong orange
-        if (st === "checking") return "#666666"
-        return "#666666"
-    }
-
     function cameraEnabled(side, camIndex1) {
         // Camera 1 maps to bit 7 ... camera 8 maps to bit 0.
         var bit = 8 - camIndex1
@@ -411,45 +403,21 @@ Item {
                             Layout.alignment: Qt.AlignHCenter
                             property int cs: 18
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 1); border.color: "black"; border.width: 1
-                                MouseArea { id: lh1; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh1.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 1) }
+                            CameraDot { side: "left"; camIndex1: 1; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 8); border.color: "black"; border.width: 1
-                                MouseArea { id: lh2; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh2.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 8) }
+                            CameraDot { side: "left"; camIndex1: 8; modal: root; size: parent.cs }
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 2); border.color: "black"; border.width: 1
-                                MouseArea { id: lh3; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh3.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 2) }
+                            CameraDot { side: "left"; camIndex1: 2; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 7); border.color: "black"; border.width: 1
-                                MouseArea { id: lh4; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh4.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 7) }
+                            CameraDot { side: "left"; camIndex1: 7; modal: root; size: parent.cs }
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 3); border.color: "black"; border.width: 1
-                                MouseArea { id: lh5; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh5.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 3) }
+                            CameraDot { side: "left"; camIndex1: 3; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 6); border.color: "black"; border.width: 1
-                                MouseArea { id: lh6; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh6.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 6) }
+                            CameraDot { side: "left"; camIndex1: 6; modal: root; size: parent.cs }
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 4); border.color: "black"; border.width: 1
-                                MouseArea { id: lh7; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh7.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 4) }
+                            CameraDot { side: "left"; camIndex1: 4; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("left", 5); border.color: "black"; border.width: 1
-                                MouseArea { id: lh8; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: lh8.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 5) }
+                            CameraDot { side: "left"; camIndex1: 5; modal: root; size: parent.cs }
 
                             Item {}
                             Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
@@ -481,45 +449,21 @@ Item {
                             Layout.alignment: Qt.AlignHCenter
                             property int cs: 18
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 1); border.color: "black"; border.width: 1
-                                MouseArea { id: rh1; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh1.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 1) }
+                            CameraDot { side: "right"; camIndex1: 1; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 8); border.color: "black"; border.width: 1
-                                MouseArea { id: rh2; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh2.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 8) }
+                            CameraDot { side: "right"; camIndex1: 8; modal: root; size: parent.cs }
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 2); border.color: "black"; border.width: 1
-                                MouseArea { id: rh3; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh3.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 2) }
+                            CameraDot { side: "right"; camIndex1: 2; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 7); border.color: "black"; border.width: 1
-                                MouseArea { id: rh4; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh4.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 7) }
+                            CameraDot { side: "right"; camIndex1: 7; modal: root; size: parent.cs }
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 3); border.color: "black"; border.width: 1
-                                MouseArea { id: rh5; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh5.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 3) }
+                            CameraDot { side: "right"; camIndex1: 3; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 6); border.color: "black"; border.width: 1
-                                MouseArea { id: rh6; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh6.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 6) }
+                            CameraDot { side: "right"; camIndex1: 6; modal: root; size: parent.cs }
 
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 4); border.color: "black"; border.width: 1
-                                MouseArea { id: rh7; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh7.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 4) }
+                            CameraDot { side: "right"; camIndex1: 4; modal: root; size: parent.cs }
                             Item {}
-                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
-                                color: cameraColor("right", 5); border.color: "black"; border.width: 1
-                                MouseArea { id: rh8; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
-                                Controls.ToolTip.visible: rh8.containsMouse; Controls.ToolTip.text: cameraTooltip("right", 5) }
+                            CameraDot { side: "right"; camIndex1: 5; modal: root; size: parent.cs }
 
                             Item {}
                             Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -498,22 +498,15 @@ Item {
                 }
                 RowLayout {
                     spacing: 6
-                    Item {
-                        width: 10; height: 10
-                        Rectangle {
-                            anchors.fill: parent
-                            radius: 5
-                            border.color: "black"; border.width: 1
-                            color: "transparent"
-                            clip: true
-                            Rectangle { x: 1; y: 1
-                                width: (parent.width - 2) / 2
-                                height: parent.height - 2
-                                color: theme.accentOrangeAmbient }
-                            Rectangle { x: parent.width / 2; y: 1
-                                width: (parent.width - 2) / 2
-                                height: parent.height - 2
-                                color: theme.accentOrangeContact }
+                    Rectangle {
+                        width: 10; height: 10; radius: 5
+                        border.color: "black"; border.width: 1
+                        gradient: Gradient {
+                            orientation: Gradient.Horizontal
+                            GradientStop { position: 0.0;    color: theme.accentOrangeAmbient }
+                            GradientStop { position: 0.4999; color: theme.accentOrangeAmbient }
+                            GradientStop { position: 0.5001; color: theme.accentOrangeContact }
+                            GradientStop { position: 1.0;    color: theme.accentOrangeContact }
                         }
                     }
                     Text { text: "both"; color: theme.textSecondary; font.pixelSize: 11 }

--- a/docs/superpowers/plans/2026-05-21-128-differentiated-orange-lights.md
+++ b/docs/superpowers/plans/2026-05-21-128-differentiated-orange-lights.md
@@ -1,0 +1,559 @@
+# Differentiated Orange Lights — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In developer mode, color-code the Contact Quality modal's per-camera dots by warning type (dark orange = ambient_light, light orange = poor_contact, vertical split = both), with a small legend below the sensor diagrams. RUO / reduced mode is unchanged.
+
+**Architecture:** A new `components/CameraDot.qml` encapsulates a single dot's render logic (single color or two clipped half-rects for the split case). `ContactQualityModal.qml` replaces its 16 inline dot `Rectangle` blocks with `CameraDot` instances, adds a `cameraWarningTypes(side, camIndex1)` helper, removes the now-unused `cameraColor`, and renders the legend strip below the sensor `RowLayout`. Two new color tokens (`accentOrangeAmbient`, `accentOrangeContact`) live in `AppTheme.qml`. No SDK changes; warning typeKeys (`"ambient_light"`, `"poor_contact"`) are already distinct on the wire.
+
+**Tech Stack:** QML 6.0 + Qt Quick Controls (PyQt6). Manual UI verification only — no QML test harness exists in this repo and adding one is out of scope for this feature.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-128-differentiated-orange-lights-design.md`
+
+---
+
+## Working branch
+
+Already on `feature/128-differentiated-orange-lights` (off `next`). All commits in this plan land on that branch. The spec is already committed (commit `068ee8a`).
+
+---
+
+## File map
+
+- **Create** `components/CameraDot.qml` — single dot rendering, ~50 LOC.
+- **Modify** `components/AppTheme.qml` — add two color tokens.
+- **Modify** `components/ContactQualityModal.qml` — add `cameraWarningTypes` helper, replace 16 inline `Rectangle` dot blocks with `CameraDot` instances, remove `cameraColor`, add the legend strip.
+
+---
+
+## Task 1 — Add the two color tokens to `AppTheme.qml`
+
+**Files:**
+- Modify: `components/AppTheme.qml`
+
+Standalone, zero-risk addition. Lands first so subsequent tasks can reference the tokens.
+
+- [ ] **Step 1: Add the two tokens next to the existing `accentOrange`**
+
+Open `components/AppTheme.qml`. Find the accent-colors block (around lines 41–47):
+
+```qml
+    // ── accent colours (same in both modes) ───────────────────────
+    readonly property color accentBlue:   "#4A90E2"
+    readonly property color accentGreen:  "#2ECC71"
+    readonly property color accentRed:    "#E74C3C"
+    readonly property color accentYellow: "#F1C40F"
+    readonly property color accentOrange: "#E67E22"
+```
+
+Replace it with:
+
+```qml
+    // ── accent colours (same in both modes) ───────────────────────
+    readonly property color accentBlue:          "#4A90E2"
+    readonly property color accentGreen:         "#2ECC71"
+    readonly property color accentRed:           "#E74C3C"
+    readonly property color accentYellow:        "#F1C40F"
+    readonly property color accentOrange:        "#E67E22"
+    readonly property color accentOrangeAmbient: "#9A4012"
+    readonly property color accentOrangeContact: "#F4A460"
+```
+
+- [ ] **Step 2: Syntax-check by launching the app briefly**
+
+Run:
+```powershell
+cd C:\Users\ethan\Projects\openmotion-bloodflow-app
+python -c "from PyQt6.QtQml import QQmlEngine; e = QQmlEngine(); print('QML engine ok')"
+```
+Expected: `QML engine ok`. This doesn't load the QML file but proves PyQt6 is healthy; the real load check happens once the app opens in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/AppTheme.qml
+git commit -m "feat(bloodflow-app): add ambient/contact orange tokens to AppTheme (#128)"
+```
+
+---
+
+## Task 2 — Add `cameraWarningTypes` helper to `ContactQualityModal.qml`
+
+**Files:**
+- Modify: `components/ContactQualityModal.qml`
+
+Pure-JS function, no consumers yet. Lands as its own commit so the bigger restructuring in Task 4 only contains the wiring change.
+
+- [ ] **Step 1: Add the helper next to `cameraStatus`**
+
+Open `components/ContactQualityModal.qml`. Find `cameraStatus` (around line 181). Immediately after the closing `}` of `cameraStatus` (around line 192, before `cameraTooltip` starts at line 194), insert:
+
+```qml
+    // Returns the deduped typeKey array for a camera's active warnings.
+    // Empty when the camera has no warnings. Used by CameraDot (#128)
+    // to decide between single-color and split rendering in dev mode.
+    function cameraWarningTypes(side, camIndex1) {
+        var prefix = (side === "left") ? "L" : "R"
+        var label = prefix + camIndex1
+        var types = []
+        for (var i = 0; i < entries.length; ++i) {
+            if (entries[i].camera === label
+                    && types.indexOf(entries[i].typeKey) === -1)
+                types.push(entries[i].typeKey)
+        }
+        return types
+    }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/ContactQualityModal.qml
+git commit -m "feat(bloodflow-app): cameraWarningTypes helper on CQ modal (#128)"
+```
+
+---
+
+## Task 3 — Create `components/CameraDot.qml`
+
+**Files:**
+- Create: `components/CameraDot.qml`
+
+Self-contained new component. Not wired in by anything yet — wiring happens in Task 4.
+
+- [ ] **Step 1: Create the file**
+
+Write `components/CameraDot.qml` with this exact content:
+
+```qml
+import QtQuick 6.0
+import QtQuick.Controls as Controls
+
+/*  CameraDot — single per-camera contact-quality indicator.
+ *
+ *  Used in ContactQualityModal sensor diagrams. Encapsulates the
+ *  status/type lookup and renders either a solid circular dot or
+ *  a vertical-split dot (dark left, light right) for the dev-mode
+ *  "ambient + contact both fired" case (#128).
+ *
+ *  API:
+ *      side       : "left" | "right"
+ *      camIndex1  : 1..8
+ *      modal      : the ContactQualityModal root (required — used to
+ *                   call cameraStatus / cameraWarningTypes / cameraTooltip
+ *                   and to read developerMode)
+ *      size       : pixel size of the dot (default 18)
+ */
+Item {
+    id: root
+
+    property string side
+    property int    camIndex1
+    required property var modal
+    property int    size: 18
+
+    width: size
+    height: size
+
+    AppTheme { id: theme }
+
+    readonly property string status: modal.cameraStatus(side, camIndex1)
+    readonly property var    types: status === "bad" && modal.developerMode
+                                    ? modal.cameraWarningTypes(side, camIndex1)
+                                    : []
+    readonly property bool   hasAmbient: types.indexOf("ambient_light") >= 0
+    readonly property bool   hasContact: types.indexOf("poor_contact") >= 0
+    readonly property bool   isSplit:    hasAmbient && hasContact
+
+    readonly property color singleColor: {
+        if (status === "good")     return "#A3E4A1"
+        if (status === "checking") return "#666666"
+        if (status === "inactive") return "#666666"
+        // status === "bad" past this point
+        if (!modal.developerMode)  return "#E67E22"
+        if (hasAmbient && !isSplit) return theme.accentOrangeAmbient
+        if (hasContact && !isSplit) return theme.accentOrangeContact
+        // Unknown / future typeKey — fall back to dark orange.
+        return theme.accentOrangeAmbient
+    }
+
+    // Solid case (no split) — single coloured circle.
+    Rectangle {
+        anchors.fill: parent
+        visible: !root.isSplit
+        radius: parent.width / 2
+        color: root.singleColor
+        border.color: "black"
+        border.width: 1
+    }
+
+    // Split case — two clipped half-rects inset 1px on every edge so
+    // they don't overdraw the outer Rectangle's 1px border. The outer
+    // Rectangle owns the rounded border and clips its children to the
+    // circular shape.
+    Rectangle {
+        id: splitFrame
+        anchors.fill: parent
+        visible: root.isSplit
+        radius: parent.width / 2
+        border.color: "black"
+        border.width: 1
+        color: "transparent"
+        clip: true
+
+        Rectangle {
+            x: 1; y: 1
+            width: (parent.width - 2) / 2
+            height: parent.height - 2
+            color: theme.accentOrangeAmbient
+        }
+        Rectangle {
+            x: parent.width / 2
+            y: 1
+            width: (parent.width - 2) / 2
+            height: parent.height - 2
+            color: theme.accentOrangeContact
+        }
+    }
+
+    MouseArea {
+        id: hover
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.NoButton
+    }
+    Controls.ToolTip.visible: hover.containsMouse
+    Controls.ToolTip.text: modal.cameraTooltip(side, camIndex1)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/CameraDot.qml
+git commit -m "feat(bloodflow-app): CameraDot component for differentiated CQ indicators (#128)"
+```
+
+---
+
+## Task 4 — Wire `CameraDot` into `ContactQualityModal.qml` and remove `cameraColor`
+
+**Files:**
+- Modify: `components/ContactQualityModal.qml`
+
+The big visible step. Replaces 16 inline `Rectangle` blocks (8 per sensor) with `CameraDot` instances and deletes the now-unused `cameraColor` function.
+
+- [ ] **Step 1: Delete `cameraColor`**
+
+In `components/ContactQualityModal.qml`, find `cameraColor` (around lines 212–218):
+
+```qml
+    function cameraColor(side, camIndex1) {
+        var st = cameraStatus(side, camIndex1)
+        if (st === "good")     return "#A3E4A1"  // pale green
+        if (st === "bad")      return "#E67E22"  // strong orange
+        if (st === "checking") return "#666666"
+        return "#666666"
+    }
+```
+
+Delete the entire function (the block above, including its closing `}`). All color-decision logic now lives in `CameraDot.singleColor`.
+
+- [ ] **Step 2: Replace the left-sensor `GridLayout` body**
+
+Find the left-sensor `GridLayout` (around lines 394–444). Replace its body — keep the outer `GridLayout { columns: 3 … property int cs: 18 ` and its closing `}` — but swap the 16 dot `Rectangle` blocks for `CameraDot` instances. The full replacement:
+
+```qml
+                        GridLayout {
+                            columns: 3; columnSpacing: 16; rowSpacing: 8
+                            Layout.alignment: Qt.AlignHCenter
+                            property int cs: 18
+
+                            CameraDot { side: "left"; camIndex1: 1; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "left"; camIndex1: 8; modal: root; size: parent.cs }
+
+                            CameraDot { side: "left"; camIndex1: 2; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "left"; camIndex1: 7; modal: root; size: parent.cs }
+
+                            CameraDot { side: "left"; camIndex1: 3; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "left"; camIndex1: 6; modal: root; size: parent.cs }
+
+                            CameraDot { side: "left"; camIndex1: 4; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "left"; camIndex1: 5; modal: root; size: parent.cs }
+
+                            Item {}
+                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
+                                color: "#FFD700"; border.color: "black"; border.width: 1 }
+                            Item {}
+                        }
+```
+
+The yellow connector dot at the bottom stays as a plain `Rectangle` — it's not a contact-quality indicator and is out of scope.
+
+- [ ] **Step 3: Replace the right-sensor `GridLayout` body**
+
+Find the right-sensor `GridLayout` (around lines 464–513). Apply the same swap with `side: "right"` and identical camera indices:
+
+```qml
+                        GridLayout {
+                            columns: 3; columnSpacing: 16; rowSpacing: 8
+                            Layout.alignment: Qt.AlignHCenter
+                            property int cs: 18
+
+                            CameraDot { side: "right"; camIndex1: 1; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "right"; camIndex1: 8; modal: root; size: parent.cs }
+
+                            CameraDot { side: "right"; camIndex1: 2; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "right"; camIndex1: 7; modal: root; size: parent.cs }
+
+                            CameraDot { side: "right"; camIndex1: 3; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "right"; camIndex1: 6; modal: root; size: parent.cs }
+
+                            CameraDot { side: "right"; camIndex1: 4; modal: root; size: parent.cs }
+                            Item {}
+                            CameraDot { side: "right"; camIndex1: 5; modal: root; size: parent.cs }
+
+                            Item {}
+                            Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
+                                color: "#FFD700"; border.color: "black"; border.width: 1 }
+                            Item {}
+                        }
+```
+
+- [ ] **Step 4: Launch the app and verify default rendering**
+
+Run:
+```powershell
+cd C:\Users\ethan\Projects\openmotion-bloodflow-app
+python main.py
+```
+
+In the app:
+1. Open the Contact Quality modal (e.g., via the Check button on the BloodFlow page, or trigger a live scan).
+2. With no warnings active, confirm all dots render green (the same `#A3E4A1` as before).
+3. Hover a dot — the tooltip should still show the camera label (e.g., `"L3"`) just like before.
+
+If you see a missing-component error in the terminal (`CameraDot is not a type`), QML can't find the new file — check that `components/CameraDot.qml` was committed in Task 3 and is in the same `components/` directory as `ContactQualityModal.qml`. QML auto-discovers sibling components by filename.
+
+If the app crashes with `Cannot assign to non-existent property "modal"`, the `required property var modal` line was dropped — restore it in `CameraDot.qml`.
+
+Close the app cleanly (don't `Ctrl+C` — use the window close button) so any pending writes flush.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/ContactQualityModal.qml
+git commit -m "refactor(bloodflow-app): replace inline CQ dots with CameraDot, drop cameraColor (#128)"
+```
+
+---
+
+## Task 5 — Add the legend strip
+
+**Files:**
+- Modify: `components/ContactQualityModal.qml`
+
+Inserted below the sensor `RowLayout`, inside the same `ColumnLayout`. Developer mode only.
+
+- [ ] **Step 1: Locate the insertion point**
+
+In `components/ContactQualityModal.qml`, find the sensor `RowLayout` that contains both sensor cards (it starts around line 371 with `RowLayout { visible: root.state_ === "ok" || root.state_ === "warnings"` and ends around line 516 with its closing `}`).
+
+Immediately *after* that `RowLayout`'s closing `}` and *before* the `Item { Layout.fillHeight: true … }` spacer (around line 518), insert the legend strip:
+
+```qml
+            // Per-camera dot color legend (#128). Developer mode only —
+            // RUO operators just see a single orange and don't need this.
+            RowLayout {
+                visible: root.developerMode
+                         && (root.state_ === "ok" || root.state_ === "warnings")
+                Layout.alignment: Qt.AlignHCenter
+                spacing: 18
+
+                RowLayout {
+                    spacing: 6
+                    Rectangle { width: 10; height: 10; radius: 5
+                        color: theme.accentOrangeAmbient
+                        border.color: "black"; border.width: 1 }
+                    Text { text: "ambient"; color: theme.textSecondary; font.pixelSize: 11 }
+                }
+                RowLayout {
+                    spacing: 6
+                    Rectangle { width: 10; height: 10; radius: 5
+                        color: theme.accentOrangeContact
+                        border.color: "black"; border.width: 1 }
+                    Text { text: "contact"; color: theme.textSecondary; font.pixelSize: 11 }
+                }
+                RowLayout {
+                    spacing: 6
+                    Item {
+                        width: 10; height: 10
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: 5
+                            border.color: "black"; border.width: 1
+                            color: "transparent"
+                            clip: true
+                            Rectangle { x: 1; y: 1
+                                width: (parent.width - 2) / 2
+                                height: parent.height - 2
+                                color: theme.accentOrangeAmbient }
+                            Rectangle { x: parent.width / 2; y: 1
+                                width: (parent.width - 2) / 2
+                                height: parent.height - 2
+                                color: theme.accentOrangeContact }
+                        }
+                    }
+                    Text { text: "both"; color: theme.textSecondary; font.pixelSize: 11 }
+                }
+            }
+```
+
+- [ ] **Step 2: Launch the app to verify the legend appears in dev mode**
+
+Make sure developer mode is on. Open `config/app_config.json` and confirm:
+```json
+"developerMode": true,
+```
+
+(If the key doesn't exist, add it inside the top-level object.)
+
+Run:
+```powershell
+python main.py
+```
+
+Open the Contact Quality modal. After the initial "checking" state transitions to `"ok"`, you should see the three-swatch legend (ambient / contact / both) horizontally centered below the sensor diagrams.
+
+If the legend doesn't show, check:
+- `developerMode` is `true` in `config/app_config.json`.
+- The legend's `visible` binding includes both `"ok"` and `"warnings"` states.
+
+- [ ] **Step 3: Verify the legend is hidden in non-dev mode**
+
+Stop the app. Edit `config/app_config.json` and set:
+```json
+"developerMode": false,
+```
+
+Run `python main.py`. Open the CQ modal. The three sensor-diagram dots should render and the legend should be absent.
+
+Restore `developerMode: true` afterwards.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ContactQualityModal.qml
+git commit -m "feat(bloodflow-app): per-camera dot legend in CQ modal (dev mode) (#128)"
+```
+
+---
+
+## Task 6 — End-to-end manual verification
+
+**Files:**
+- None modified — verification + fix-up only.
+
+Drive each color case and confirm rendering. This task does not commit unless a defect is found and fixed.
+
+- [ ] **Step 1: Verify each color state in developer mode**
+
+Ensure `"developerMode": true` in `config/app_config.json`. Launch the app and open the Contact Quality modal during a live scan (so that real warnings can flow through).
+
+Three cases per the spec's Testing section — drive each via a real hardware condition that produces the corresponding warning. (Either on the bench by manipulating ambient light / sensor seating, or via an injection harness — see fallback in Step 2 below.)
+
+For each case, confirm:
+
+| Triggered condition           | Expected dot rendering                                      |
+|-------------------------------|-------------------------------------------------------------|
+| `ambient_light` only on L3    | Dot L3 is dark orange (`#9A4012`)                          |
+| `poor_contact` only on L3     | Dot L3 is light orange (`#F4A460`)                         |
+| Both on L3                    | Dot L3 is split: dark left half, light right half           |
+| No warnings                   | All dots green                                              |
+| L3 not in calibration mask    | Dot L3 is gray, no type colors apply                        |
+
+Tooltip on hover continues to name the typeKey ("Ambient light (X.X DN)", "Poor contact (…)") for each.
+
+- [ ] **Step 2: Fallback if hardware can't trigger both warning types on demand**
+
+If you can't reliably drive `poor_contact` on the bench, inject a synthetic warning by attaching to the running app's `MOTIONInterface` from a Python REPL **in the same process** is not possible from outside. Instead, temporarily add a debug keybinding inside `ContactQualityModal.qml` to inject test warnings:
+
+In `components/ContactQualityModal.qml`, add this temporary block inside the `Rectangle { id: panel … }` (e.g., just before the existing `Keys.onReleased`):
+
+```qml
+        // TEMP #128 verification — remove before merging.
+        Keys.onPressed: function(event) {
+            if (!root.developerMode) return
+            if (event.modifiers !== Qt.ControlModifier) return
+            if (event.key === Qt.Key_1) {
+                root.addWarning("L3", "ambient_light", "Ambient light", 4.2)
+                event.accepted = true
+            } else if (event.key === Qt.Key_2) {
+                root.addWarning("L3", "poor_contact", "Poor contact", 0.0)
+                event.accepted = true
+            } else if (event.key === Qt.Key_3) {
+                root.addWarning("L3", "ambient_light", "Ambient light", 4.2)
+                root.addWarning("L3", "poor_contact", "Poor contact", 0.0)
+                event.accepted = true
+            } else if (event.key === Qt.Key_0) {
+                root.clearWarning("L3", "ambient_light")
+                root.clearWarning("L3", "poor_contact")
+                event.accepted = true
+            }
+        }
+```
+
+Then with the modal focused: `Ctrl+1` adds ambient only, `Ctrl+2` adds contact only, `Ctrl+3` adds both, `Ctrl+0` clears L3.
+
+Walk through the four key combos. Verify dot L3 changes color/render exactly as the spec describes.
+
+**Important:** Remove the temporary `Keys.onPressed` block before committing. Do not include the keybinding in any commit.
+
+- [ ] **Step 3: Verify non-dev mode regression**
+
+Stop the app. Set `"developerMode": false` in `config/app_config.json`. Run `python main.py`. Drive any "bad" condition (real or via temporarily re-adding the keybinding — but again, do not commit it). Confirm every "bad" dot renders the existing `#E67E22` regardless of type. Legend is hidden.
+
+Restore `developerMode: true` after the regression check.
+
+- [ ] **Step 4: Verify there are no leftover debug blocks**
+
+Run:
+```bash
+git diff main components/ContactQualityModal.qml | grep -i "TEMP\|Keys.onPressed.*ambient_light"
+```
+Expected: no output. If anything appears, remove the debug block and re-stage.
+
+- [ ] **Step 5: Final state check**
+
+Run:
+```bash
+git status
+git log --oneline 068ee8a..HEAD
+```
+
+You should see four feature commits on top of the spec commit (`068ee8a`):
+1. `feat(bloodflow-app): add ambient/contact orange tokens to AppTheme (#128)`
+2. `feat(bloodflow-app): cameraWarningTypes helper on CQ modal (#128)`
+3. `feat(bloodflow-app): CameraDot component for differentiated CQ indicators (#128)`
+4. `refactor(bloodflow-app): replace inline CQ dots with CameraDot, drop cameraColor (#128)`
+5. `feat(bloodflow-app): per-camera dot legend in CQ modal (dev mode) (#128)`
+
+The branch is ready for review. Do not merge to `next` per the milestone workflow — this branch will be merged into `next-next` alongside `feature/132-…` once both features land.
+
+---
+
+## YAGNI reminder
+
+Resist while implementing:
+- Animating the color transition. Snap is what the existing green/orange/gray does today.
+- Refactoring the sensor diagrams (the surrounding `RowLayout`, the `GridLayout`, the yellow connector dot). Scope is the per-camera dot rendering only.
+- Changing the modal panel border to also encode warning type. Border stays generic `accentOrange`.
+- Adding light-mode-specific oranges. Current pair reads on both; defer if light-mode QA flags it.
+- Adding automated UI tests. No QML test harness exists in this repo; introducing one is its own project.

--- a/docs/superpowers/specs/2026-05-21-128-differentiated-orange-lights-design.md
+++ b/docs/superpowers/specs/2026-05-21-128-differentiated-orange-lights-design.md
@@ -1,0 +1,315 @@
+# Differentiated Orange Lights — Design Spec
+
+**Date:** 2026-05-21
+**Issue:** openmotion-bloodflow-app#128
+**Feature:** In developer mode, the Contact Quality modal's per-camera dots color-encode *which* warning type each camera tripped: dark orange for `ambient_light`, light orange for `poor_contact`, and a vertical dark/light split when both fire on the same camera. A small legend strip below the sensor diagrams names the colors. RUO / reduced mode is unchanged — every "bad" camera stays the existing single orange.
+
+---
+
+## Background
+
+Today every per-camera dot in `components/ContactQualityModal.qml` is one of four colors driven by `cameraStatus(side, camIndex1)`:
+
+| Status     | Color (hex)   | Source                         |
+|------------|---------------|--------------------------------|
+| `good`     | `#A3E4A1`     | Pale green, inline             |
+| `bad`      | `#E67E22`     | Strong orange, inline (same as `theme.accentOrange`) |
+| `checking` | `#666666`     | Gray, inline                   |
+| `inactive` | `#666666`     | Gray, inline                   |
+
+`bad` collapses two distinct conditions into one color. The connector already emits warnings with distinct `typeKey` values (`"ambient_light"` and `"poor_contact"` — `motion_connector.py:2657, 2673`) and the modal stores them in `entries[]`. Today's UI just throws that distinction away at render time.
+
+The two warnings have different operator responses:
+- **`ambient_light`** — lift the sensor / dim the room. Optical hygiene.
+- **`poor_contact`** — reseat the sensor on the head. Physical placement.
+
+When a dev is debugging a flaky bench setup, knowing *which* failure mode is firing across the eight cameras determines whether they reach for a blackout cloth or re-seat the headset. The current undifferentiated orange forces them to hover each dot in turn.
+
+The modal has 16 nearly-identical inline `Rectangle` dot blocks (8 cameras × 2 sensors) — already past the threshold where extracting a component is the cleaner path.
+
+---
+
+## Requirements
+
+| #  | Requirement |
+|----|-------------|
+| R1 | A new `components/CameraDot.qml` encapsulates a single dot's color + hover + tooltip rendering. Takes `side`, `camIndex1`, `modal` (the parent `ContactQualityModal`), and an optional `size`. |
+| R2 | `ContactQualityModal.qml` replaces its 16 inline `Rectangle` dot blocks with `CameraDot { … }` instantiations. Per-camera tooltip behavior is preserved. |
+| R3 | `components/AppTheme.qml` defines two new tokens: `accentOrangeAmbient = "#9A4012"` and `accentOrangeContact = "#F4A460"`. Existing `accentOrange = "#E67E22"` is unchanged and still used by the modal's panel border. |
+| R4 | When `developerMode` is true *and* the camera is `bad`: dot color is `accentOrangeAmbient` if only `ambient_light` is present, `accentOrangeContact` if only `poor_contact` is present, and a vertical split (dark left half, light right half) if both are present. |
+| R5 | When `developerMode` is false *and* the camera is `bad`: dot color falls back to the existing `#E67E22`. No split rendering. The legend strip is hidden. |
+| R6 | A legend strip is inserted below the sensor `RowLayout`, visible only when `developerMode && (state_ === "ok" || state_ === "warnings")`. Three entries: an ambient swatch + label, a contact swatch + label, a split swatch + label "both". Minimal chrome — no card / background. |
+| R7 | If a future third `typeKey` lands (not `"ambient_light"` or `"poor_contact"`), `CameraDot` falls back to single dark-orange and logs at debug level once per render. The change here must not actively break in that case. |
+| R8 | A new `cameraWarningTypes(side, camIndex1)` helper on `ContactQualityModal` returns a deduped array of typeKeys present for that camera. The existing `cameraColor(side, camIndex1)` is removed — `CameraDot` computes its own color from `cameraStatus` + `cameraWarningTypes` internally, and the inline `cameraColor` callers go away when the 16 dot blocks are replaced. No external callers exist (verified by grep). |
+
+---
+
+## Architecture
+
+### `components/AppTheme.qml`
+
+Add two color tokens alongside the existing `accentOrange`:
+
+```qml
+readonly property color accentOrange:        "#E67E22"   // unchanged
+readonly property color accentOrangeAmbient: "#9A4012"   // NEW — dev-mode ambient_light
+readonly property color accentOrangeContact: "#F4A460"   // NEW — dev-mode poor_contact
+```
+
+### `components/CameraDot.qml` — new file
+
+```qml
+import QtQuick 6.0
+import QtQuick.Controls as Controls
+
+Item {
+    id: root
+    property string side
+    property int camIndex1
+    required property var modal
+    property int size: 18
+
+    width: size; height: size
+
+    AppTheme { id: theme }
+
+    readonly property string status: modal.cameraStatus(side, camIndex1)
+    readonly property var    types: status === "bad" && modal.developerMode
+                                    ? modal.cameraWarningTypes(side, camIndex1)
+                                    : []
+
+    readonly property bool   isSplit: types.indexOf("ambient_light") >= 0
+                                      && types.indexOf("poor_contact") >= 0
+
+    readonly property color  singleColor: {
+        if (status === "good")     return "#A3E4A1"
+        if (status === "checking") return "#666666"
+        if (status === "inactive") return "#666666"
+        // status === "bad" past this point
+        if (!modal.developerMode)  return "#E67E22"
+        if (types.indexOf("ambient_light") >= 0 && !isSplit)
+            return theme.accentOrangeAmbient
+        if (types.indexOf("poor_contact") >= 0 && !isSplit)
+            return theme.accentOrangeContact
+        // Unknown / future typeKey — fall back to dark orange.
+        return theme.accentOrangeAmbient
+    }
+
+    // Solid case (no split)
+    Rectangle {
+        anchors.fill: parent
+        visible: !root.isSplit
+        radius: parent.width / 2
+        color: root.singleColor
+        border.color: "black"
+        border.width: 1
+    }
+
+    // Split case — two clipped half-rects inside a circular outline
+    Rectangle {
+        anchors.fill: parent
+        visible: root.isSplit
+        radius: parent.width / 2
+        border.color: "black"
+        border.width: 1
+        color: "transparent"
+        clip: true
+
+        Rectangle {
+            width: parent.width / 2; height: parent.height
+            anchors.left: parent.left
+            color: theme.accentOrangeAmbient
+        }
+        Rectangle {
+            width: parent.width / 2; height: parent.height
+            anchors.right: parent.right
+            color: theme.accentOrangeContact
+        }
+    }
+
+    MouseArea {
+        id: hover
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.NoButton
+    }
+    Controls.ToolTip.visible: hover.containsMouse
+    Controls.ToolTip.text: modal.cameraTooltip(side, camIndex1)
+}
+```
+
+Split rendering uses two clipped child Rectangles rather than a `LinearGradient`. Two reasons: (a) sharp vertical transition at 50% is trivially exact with anchored half-rects, (b) `LinearGradient` on a `Rectangle` with `radius` antialiases the gradient edge, which gets fuzzy at 18px.
+
+Implementation note: a child `Rectangle` anchored flush to the outer Rectangle's edge will overdraw the outer's border. Inset the child rects by `border.width` (1px) on each side that touches the outer border, or layer the border on top with a higher-z transparent overlay. Either works; pick whichever reads cleaner once on screen.
+
+### `components/ContactQualityModal.qml`
+
+**Replace the 16 inline dot blocks.** Each row in the existing 3-column grid currently looks like:
+
+```qml
+Rectangle { width: parent.cs; height: parent.cs; radius: parent.cs/2
+    color: cameraColor("left", 1); border.color: "black"; border.width: 1
+    MouseArea { id: lh1; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
+    Controls.ToolTip.visible: lh1.containsMouse; Controls.ToolTip.text: cameraTooltip("left", 1) }
+```
+
+Becomes:
+
+```qml
+CameraDot { side: "left"; camIndex1: 1; modal: root; size: parent.cs }
+```
+
+The grid layout stays identical (3-column with empty `Item {}` spacers and the yellow connector dot at the bottom — out of scope).
+
+**Add `cameraWarningTypes` helper** next to the existing `cameraStatus` function:
+
+```qml
+function cameraWarningTypes(side, camIndex1) {
+    var prefix = (side === "left") ? "L" : "R"
+    var label = prefix + camIndex1
+    var types = []
+    for (var i = 0; i < entries.length; ++i) {
+        if (entries[i].camera === label
+                && types.indexOf(entries[i].typeKey) === -1)
+            types.push(entries[i].typeKey)
+    }
+    return types
+}
+```
+
+`entries.length` is ≤16 (one entry per camera per typeKey), so the linear scan is fine.
+
+**Remove `cameraColor`.** Once `CameraDot` replaces the inline Rectangles, nothing calls `cameraColor` anymore (the legend uses theme tokens directly). Grep confirms no external callers. Delete the function rather than leaving it as dead code.
+
+**Add the legend strip** below the sensor `RowLayout`, inside the same `ColumnLayout`:
+
+```qml
+RowLayout {
+    visible: root.developerMode
+             && (root.state_ === "ok" || root.state_ === "warnings")
+    Layout.alignment: Qt.AlignHCenter
+    spacing: 18
+
+    RowLayout { spacing: 6
+        Rectangle { width: 10; height: 10; radius: 5
+            color: theme.accentOrangeAmbient
+            border.color: "black"; border.width: 1
+        }
+        Text { text: "ambient"; color: theme.textSecondary; font.pixelSize: 11 }
+    }
+    RowLayout { spacing: 6
+        Rectangle { width: 10; height: 10; radius: 5
+            color: theme.accentOrangeContact
+            border.color: "black"; border.width: 1
+        }
+        Text { text: "contact"; color: theme.textSecondary; font.pixelSize: 11 }
+    }
+    RowLayout { spacing: 6
+        // Reuse the same split-render approach as CameraDot.
+        Item { width: 10; height: 10
+            Rectangle { anchors.fill: parent; radius: 5
+                border.color: "black"; border.width: 1
+                color: "transparent"; clip: true
+                Rectangle { width: parent.width/2; height: parent.height
+                    anchors.left: parent.left
+                    color: theme.accentOrangeAmbient
+                }
+                Rectangle { width: parent.width/2; height: parent.height
+                    anchors.right: parent.right
+                    color: theme.accentOrangeContact
+                }
+            }
+        }
+        Text { text: "both"; color: theme.textSecondary; font.pixelSize: 11 }
+    }
+}
+```
+
+Inline rather than extracted because the legend is rendered exactly once.
+
+---
+
+## Data Flow
+
+```
+motion_connector.py
+  └─ emits contactQualityWarning(camera, typeKey, typeText, value)
+       (typeKey ∈ {"ambient_light", "poor_contact"})
+
+BloodFlow.qml
+  └─ contactQualityModal.addWarning(camera, typeKey, typeText, value)
+
+ContactQualityModal.qml
+  └─ entries[] gets {camera, typeKey, typeText, value}
+  └─ state_ → "warnings"
+
+CameraDot.qml (per-camera, on entries change)
+  └─ status = modal.cameraStatus(side, camIndex1)        // good/bad/checking/inactive
+  └─ if (status === "bad" && modal.developerMode):
+        types = modal.cameraWarningTypes(side, camIndex1) // ["ambient_light"], ["poor_contact"], or both
+        if both → render split (two clipped half-Rectangles)
+        else    → render solid (singleColor)
+  └─ else → render solid (existing color logic)
+```
+
+---
+
+## Edge Cases
+
+- **Non-developer mode:** `singleColor` returns existing `#E67E22` for any `bad`; `isSplit` is always false (gated on `developerMode`); legend's `visible` is false. Net behavior = today.
+- **`addWarning` upserts:** the existing implementation already dedupes by `(camera, typeKey)`. `cameraWarningTypes` dedupes again defensively (cheap, ≤16 entries).
+- **Unknown future `typeKey`:** `singleColor` falls back to `accentOrangeAmbient` (dark orange) and `isSplit` requires both `"ambient_light"` *and* `"poor_contact"` specifically, so the unknown type can't accidentally trigger a split. Visually the dev sees a dark-orange dot whose tooltip names the unknown type. No silent breakage.
+- **Camera mask changes mid-scan:** `cameraStatus` already returns `"inactive"` first; `CameraDot.singleColor` short-circuits on `inactive` and never reaches the types-based branches.
+- **Modal panel border:** `theme.accentOrange` stays the panel border color when `state_ === "warnings"`. Border is a generic "warnings exist" indicator and intentionally does not encode type. Out of scope for this issue.
+- **Dark mode toggle:** the new tokens are not mode-dependent (orange reads on both backgrounds). If a future light-mode pass wants different oranges, add the conditional to `AppTheme` then; not needed now.
+
+---
+
+## Testing
+
+### Manual verification (golden path)
+
+1. Launch the app from source on the `feature/128-differentiated-orange-lights` branch with `"developerMode": true` in `config/app_config.json`.
+2. Open the Contact Quality modal (either via Check button or trigger a live scan with warnings). With no warnings present, confirm: all dots green, **no legend visible** (because `state_ === "checking"` momentarily, then `"ok"` shows legend per R6 — verify it appears in both `ok` and `warnings`).
+3. Drive synthetic warnings via the connector or a test script. Three cases per camera:
+   - **Ambient only** — `MOTIONInterface.contactQualityWarning.emit("L3", "ambient_light", "Ambient light", 4.2)`. Dot L3 → dark orange.
+   - **Contact only** — same with `"poor_contact"`. Dot L3 → light orange.
+   - **Both** — emit both. Dot L3 → vertical split, dark left / light right.
+4. Verify the legend strip displays the same three swatches under the sensor diagrams.
+5. Hover each dot. Tooltip text is unchanged from today.
+
+### Manual verification (non-dev fallback)
+
+6. Flip `"developerMode": false`. Restart app. Repeat step 3. Every "bad" dot is `#E67E22` regardless of type. Legend is hidden.
+
+### Regression net (optional)
+
+The current test suite (`tests/`) does not exercise CQ modal rendering. Adding a pixmap-diff harness for this one feature is more scaffolding than the change is worth. A lightweight QML helper that asserts `cameraWarningTypes` returns the expected results for synthetic entry sets is cheap if you want a regression net; not included in scope by default.
+
+---
+
+## Implementation Order
+
+Single repo (bloodflow-app), small scope, no SDK changes. Order:
+
+1. **Add theme tokens.** `accentOrangeAmbient` and `accentOrangeContact` in `components/AppTheme.qml`. One commit.
+2. **Add `cameraWarningTypes` helper.** Pure-JS function in `ContactQualityModal.qml`; safe to land before the rest because nothing calls it yet. One commit.
+3. **Create `components/CameraDot.qml`.** New file, self-contained. Not yet wired in. One commit.
+4. **Wire `CameraDot` into the modal.** Replace all 16 inline `Rectangle` blocks. One commit.
+5. **Add the legend strip.** One commit.
+6. **Manual verification** per the test plan above. Fix anything that surfaces, then PR.
+
+Each step is small, individually verifiable, and reversible.
+
+---
+
+## YAGNI / Out of Scope
+
+- **Animation on color transitions.** Snap is fine; the dot already snaps between green/orange/gray today.
+- **Tooltip text changes.** Existing text already names the type (e.g. `"Ambient light (3.7 DN)"`); the new colors add a second-channel cue, not a replacement.
+- **Modal panel border differentiation.** Border stays generic `accentOrange` — it's a "warnings exist" indicator, not a type indicator.
+- **Other UI surfaces.** Per the brainstorming confirmation, dots are the only place this lives. No live-scan banner / BloodFlow page badge / etc.
+- **Per-sensor (aggregate) version of the indicator.** Per-camera matches both the existing dot model and the issue text reading.
+- **SDK changes.** `typeKey` is already distinct on the wire; nothing to plumb.
+- **Light-mode-specific orange palette.** Current pair reads on both backgrounds; if light-mode QA dislikes it, defer to a separate change.
+- **Automated regression test.** Not included by default; cheap to add later if regression risk justifies it.


### PR DESCRIPTION
## Summary

In developer mode, the Contact Quality modal's per-camera dots now color-encode which warning each camera tripped, instead of every "bad" camera being the same orange. Closes #128.

- **`ambient_light` only** → dark orange (`#9A4012`)
- **`poor_contact` only** → light orange (`#F4A460`)
- **Both on one camera** → vertical split (dark left half, light right half), rendered via `Rectangle.gradient` so the rounded shape is respected
- **Non-developer mode / RUO** → unchanged single `#E67E22` for any bad camera, no legend
- **Future unknown typeKey** → falls back to dark orange + `console.warn` to flag it for whoever added the new typeKey

A small legend strip under the sensor diagrams (dev mode only) names the three colors so the convention is self-documenting.

### Files

- `components/AppTheme.qml` — two new color tokens (`accentOrangeAmbient`, `accentOrangeContact`); existing `accentOrange` unchanged and still drives the modal panel border.
- `components/CameraDot.qml` (new, ~100 lines) — encapsulates one dot: status lookup, type-aware color, gradient-based split rendering, hover tooltip.
- `components/ContactQualityModal.qml` — added `cameraWarningTypes(side, camIndex1)` helper; replaced 16 inline `Rectangle` dot blocks (8 per sensor × 2 sensors) with `CameraDot` instances; removed dead `cameraColor` function; added the dev-mode legend strip. Net -56 lines in the modal.

Spec: `docs/superpowers/specs/2026-05-21-128-differentiated-orange-lights-design.md`
Plan: `docs/superpowers/plans/2026-05-21-128-differentiated-orange-lights.md`

## Integration note

Per the 1.1.2 milestone workflow, this branch is intended to be merged into `next-next` alongside #132 once both are reviewed — not directly into `next`. The PR is opened against `next` for review surface only.

## Test plan

- [ ] With `developerMode: true`, open the Contact Quality modal. Confirm:
  - [ ] Legend strip appears under the sensor diagrams (ambient / contact / both swatches).
  - [ ] Driving an `ambient_light`-only warning on a camera turns its dot dark orange.
  - [ ] Driving a `poor_contact`-only warning turns its dot light orange.
  - [ ] Driving both warnings on the same camera shows a properly split circle (left dark, right light) — **not** two side-by-side rectangles.
- [ ] Hover behavior unchanged — tooltip still names the warning type(s) and DN value.
- [ ] With `developerMode: false`, drive any warning. Confirm dot is the existing single `#E67E22` and the legend is hidden.
- [ ] Confirm modal panel border is still the generic `accentOrange` (no per-type encoding on the border).
- [ ] Confirm yellow connector dot at the bottom of each sensor grid is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)