### PR TITLE
Real-time plot viewer (Saleae-style replacement for EmbeddedRealtimePlot)

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -24,6 +24,7 @@ Item {
 
     function open() {
         refreshScans()
+        console.warn("[History] opened — " + scans.length + " scan(s) listed")
         root.visible = true
     }
     function close() {
@@ -100,7 +101,8 @@ Item {
             Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
             MouseArea {
                 id: xArea; anchors.fill: parent; hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor; onClicked: root.close()
+                cursorShape: Qt.PointingHandCursor
+                onClicked: { console.warn("[History] close (✕) clicked"); root.close() }
             }
         }
 
@@ -135,7 +137,10 @@ Item {
                         color: parent.hovered ? theme.accentBlue : theme.bgInput
                         border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                     }
-                    onClicked: Qt.openUrlExternally("file:///" + MOTIONInterface.directory)
+                    onClicked: {
+                        console.warn("[History] Open Folder clicked → " + MOTIONInterface.directory)
+                        Qt.openUrlExternally("file:///" + MOTIONInterface.directory)
+                    }
                 }
 
                 Button {
@@ -151,7 +156,10 @@ Item {
                         color: parent.hovered ? theme.accentBlue : theme.bgInput
                         border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                     }
-                    onClicked: refreshScans()
+                    onClicked: {
+                        console.warn("[History] Refresh clicked")
+                        refreshScans()
+                    }
                 }
             }
 
@@ -228,6 +236,7 @@ Item {
                     }
                     onCurrentIndexChanged: {
                         if (currentIndex >= 0 && currentIndex < scans.length) {
+                            console.warn("[History] scan selected [" + currentIndex + "] " + scans[currentIndex])
                             try { selected = MOTIONInterface.get_scan_details(scans[currentIndex]) || {} }
                             catch (e) { selected = {} }
                         } else { selected = {} }
@@ -307,6 +316,7 @@ Item {
                                 border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                             }
                             onClicked: {
+                                console.warn("[History] Visualize BFI/BVI (legacy) clicked → " + (scans[scanPicker.currentIndex] || "?"))
                                 root.visualizing = true
                                 MOTIONInterface.visualize_bloodflow(selected.leftPath || "", selected.rightPath || "", 0.0, 0.0, false)
                             }
@@ -329,6 +339,7 @@ Item {
                                 border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                             }
                             onClicked: {
+                                console.warn("[History] Visualize Contrast/Mean (legacy) clicked → " + (scans[scanPicker.currentIndex] || "?"))
                                 root.visualizing = true
                                 MOTIONInterface.visualize_bloodflow(selected.leftPath || "", selected.rightPath || "", 0.0, 0.0, true)
                             }
@@ -350,6 +361,7 @@ Item {
                                 border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                             }
                             onClicked: {
+                                console.warn("[History] Visualize BFI/BVI clicked → " + (selected.correctedPath || "?"))
                                 root.visualizing = true
                                 MOTIONInterface.visualize_corrected(selected.correctedPath || "")
                             }
@@ -372,6 +384,7 @@ Item {
                                 border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                             }
                             onClicked: {
+                                console.warn("[History] Visualize Contrast/Mean clicked → " + (selected.correctedPath || "?"))
                                 root.visualizing = true
                                 MOTIONInterface.visualize_corrected_signal(selected.correctedPath || "")
                             }
@@ -399,6 +412,7 @@ Item {
                                 border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                             }
                             onClicked: {
+                                console.warn("[History] View in plot → clicked → " + (scans[scanPicker.currentIndex] || "?"))
                                 MOTIONInterface.loadPastScan(scans[scanPicker.currentIndex] || "")
                                 root.close()
                             }

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -376,7 +376,11 @@ Item {
                             text: "View in plot →"
                             visible: MOTIONInterface.appConfig.useNewPlotViewer === true
                             Layout.fillWidth: true; Layout.preferredHeight: 36
-                            enabled: scans.length > 0 && currentIndex >= 0
+                            // `currentIndex` lives on scanPicker (the ComboBox)
+                            // — referencing it bare here resolves to undefined
+                            // at the root scope and `undefined >= 0` is false,
+                            // which left this button perma-greyed.
+                            enabled: scans.length > 0 && scanPicker.currentIndex >= 0
                             hoverEnabled: enabled
                             contentItem: Text {
                                 text: parent.text; font.pixelSize: 13
@@ -388,7 +392,7 @@ Item {
                                 border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                             }
                             onClicked: {
-                                MOTIONInterface.loadPastScan(scans[currentIndex] || "")
+                                MOTIONInterface.loadPastScan(scans[scanPicker.currentIndex] || "")
                                 root.close()
                             }
                         }

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -289,7 +289,11 @@ Item {
 
                         Button {
                             text: "Visualize BFI/BVI (legacy)"
-                            visible: MOTIONInterface.appConfig.developerMode ? true : false
+                            // Phase 4: matplotlib popouts stay reachable via
+                            // developerMode fallback while useNewPlotViewer is
+                            // off, hidden once the new viewer is the default.
+                            visible: MOTIONInterface.appConfig.developerMode === true
+                                     && MOTIONInterface.appConfig.useNewPlotViewer !== true
                             Layout.fillWidth: true; Layout.preferredHeight: 36
                             enabled: !!(selected.leftPath || selected.rightPath)
                             hoverEnabled: enabled
@@ -310,7 +314,8 @@ Item {
 
                         Button {
                             text: "Visualize Contrast/Mean (legacy)"
-                            visible: MOTIONInterface.appConfig.developerMode ? true : false
+                            visible: MOTIONInterface.appConfig.developerMode === true
+                                     && MOTIONInterface.appConfig.useNewPlotViewer !== true
                             Layout.fillWidth: true; Layout.preferredHeight: 36
                             enabled: !!(selected.leftPath || selected.rightPath)
                             hoverEnabled: enabled
@@ -331,6 +336,7 @@ Item {
 
                         Button {
                             text: "Visualize BFI/BVI"
+                            visible: MOTIONInterface.appConfig.useNewPlotViewer !== true
                             Layout.fillWidth: true; Layout.preferredHeight: 36
                             enabled: !!(selected.correctedPath)
                             hoverEnabled: enabled
@@ -352,6 +358,7 @@ Item {
                         Button {
                             text: "Visualize Contrast/Mean"
                             visible: MOTIONInterface.appConfig.reducedMode !== true
+                                     && MOTIONInterface.appConfig.useNewPlotViewer !== true
                             Layout.fillWidth: true; Layout.preferredHeight: 36
                             enabled: !!(selected.correctedPath)
                             hoverEnabled: enabled

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -370,6 +370,29 @@ Item {
                             }
                         }
 
+                        // New plot viewer — opens the past scan inside the
+                        // BloodFlow page's PlotViewer instead of a popout.
+                        Button {
+                            text: "View in plot →"
+                            visible: MOTIONInterface.appConfig.useNewPlotViewer === true
+                            Layout.fillWidth: true; Layout.preferredHeight: 36
+                            enabled: scans.length > 0 && currentIndex >= 0
+                            hoverEnabled: enabled
+                            contentItem: Text {
+                                text: parent.text; font.pixelSize: 13
+                                color: parent.enabled ? theme.textSecondary : theme.textTertiary
+                                horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                            }
+                            background: Rectangle {
+                                color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
+                                border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                            }
+                            onClicked: {
+                                MOTIONInterface.loadPastScan(scans[currentIndex] || "")
+                                root.close()
+                            }
+                        }
+
                         Item { Layout.fillHeight: true }
                     }
                 }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -219,7 +219,9 @@ Item {
             // autoscale-derived range — clinicians care about "what's
             // it reading right now", not the y-axis extent. paintTick
             // is a dependency so the text refreshes at the throttled
-            // rate.
+            // rate. Junk last-frame values are filtered at the SDK side
+            // (BfiBviStage NaN's anything outside [-2, 10) exclusive),
+            // so the absolute-last sample is safe to read directly.
             text: {
                 void cell.paintTick  // dependency
                 if (!cell.source) return cell.metric.toUpperCase() + "  --"

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -25,14 +25,13 @@ Item {
     property color frameColor: "#444444"
     property color bgColor: "#1A1A1A"
 
-    // ── Derived ────────────────────────────────────────────────────────
-    readonly property real tHi: source ? source.liveEdge : 0
-    readonly property real tLo: Math.max(0, tHi - windowSeconds)
-
     // ── Repaint plumbing ───────────────────────────────────────────────
-    onTHiChanged: traceCanvas.requestPaint()
+    // liveEdge is a plain Python @property with no notify signal — QML
+    // can't bind to it. Instead, samplesAppended drives the repaint,
+    // and onPaint reads source.liveEdge directly each time.
     onWidthChanged: traceCanvas.requestPaint()
     onHeightChanged: traceCanvas.requestPaint()
+    onSourceChanged: traceCanvas.requestPaint()
 
     Connections {
         target: cell.source
@@ -62,15 +61,20 @@ Item {
 
             if (!cell.source) return
 
+            // Read liveEdge fresh each paint — it has no notify signal so
+            // we can't cache it in a QML binding.
+            var tHi = cell.source.liveEdge
+            var tLo = Math.max(0, tHi - cell.windowSeconds)
+            var dt = tHi - tLo
+            if (dt <= 0) return
+
             var maxPts = Math.max(50, Math.floor(width * 2))
             var pts = cell.source.points_for_window(
                 cell.side, cell.camId, cell.metric,
-                cell.tLo, cell.tHi, maxPts
+                tLo, tHi, maxPts
             )
             if (pts.length < 2) return
 
-            var dt = cell.tHi - cell.tLo
-            if (dt <= 0) return
             var dy = cell.yMax - cell.yMin
             if (dy <= 0) return
 
@@ -81,7 +85,7 @@ Item {
                 var t = pts[i][0]
                 var v = pts[i][1]
                 if (!isFinite(v)) continue
-                var x = ((t - cell.tLo) / dt) * width
+                var x = ((t - tLo) / dt) * width
                 var y = height - ((v - cell.yMin) / dy) * height
                 if (i === 0) ctx.moveTo(x, y)
                 else ctx.lineTo(x, y)

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -1,0 +1,103 @@
+import QtQuick 6.0
+
+// Phase 2a — single-trace Canvas bound to one (side, cam_id, metric) key
+// on a ScanDataSource. No pan/zoom, no crosshair, no axis labels —
+// those land in Phase 2b. The cell tracks the live edge of the source
+// and renders the last `windowSeconds` of samples, strided to at most
+// 2 * width samples per paint.
+Item {
+    id: cell
+
+    // ── Inputs ─────────────────────────────────────────────────────────
+    property var source: null            // ScanDataSource (Python QObject) or null
+    property string side: "left"
+    property int    camId: 0
+    property string metric: "bfi"
+    property real   windowSeconds: 15
+
+    // Display bounds — Phase 2a uses fixed [yMin, yMax]; Phase 2b adds
+    // autoscale / per-cell fit.
+    property real yMin: 0.0
+    property real yMax: 10.0
+
+    // Visual — inline for Phase 2a, theme integration in Phase 2b.
+    property color traceColor: "#E74C3C"
+    property color frameColor: "#444444"
+    property color bgColor: "#1A1A1A"
+
+    // ── Derived ────────────────────────────────────────────────────────
+    readonly property real tHi: source ? source.liveEdge : 0
+    readonly property real tLo: Math.max(0, tHi - windowSeconds)
+
+    // ── Repaint plumbing ───────────────────────────────────────────────
+    onTHiChanged: traceCanvas.requestPaint()
+    onWidthChanged: traceCanvas.requestPaint()
+    onHeightChanged: traceCanvas.requestPaint()
+
+    Connections {
+        target: cell.source
+        ignoreUnknownSignals: true
+        function onSamplesAppended(s, c, m, n) {
+            if (s === cell.side && c === cell.camId && m === cell.metric)
+                traceCanvas.requestPaint()
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: cell.bgColor
+        border.color: cell.frameColor
+        border.width: 1
+        radius: 4
+    }
+
+    Canvas {
+        id: traceCanvas
+        anchors.fill: parent
+        anchors.margins: 4
+
+        onPaint: {
+            var ctx = getContext("2d")
+            ctx.clearRect(0, 0, width, height)
+
+            if (!cell.source) return
+
+            var maxPts = Math.max(50, Math.floor(width * 2))
+            var pts = cell.source.points_for_window(
+                cell.side, cell.camId, cell.metric,
+                cell.tLo, cell.tHi, maxPts
+            )
+            if (pts.length < 2) return
+
+            var dt = cell.tHi - cell.tLo
+            if (dt <= 0) return
+            var dy = cell.yMax - cell.yMin
+            if (dy <= 0) return
+
+            ctx.beginPath()
+            ctx.lineWidth = 1.5
+            ctx.strokeStyle = cell.traceColor
+            for (var i = 0; i < pts.length; i++) {
+                var t = pts[i][0]
+                var v = pts[i][1]
+                if (!isFinite(v)) continue
+                var x = ((t - cell.tLo) / dt) * width
+                var y = height - ((v - cell.yMin) / dy) * height
+                if (i === 0) ctx.moveTo(x, y)
+                else ctx.lineTo(x, y)
+            }
+            ctx.stroke()
+        }
+    }
+
+    // Cell label — top-left, identifies which (side, cam, metric) this is.
+    Text {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.margins: 8
+        text: cell.side.toUpperCase() + " " + (cell.camId + 1) + " · " + cell.metric.toUpperCase()
+        color: "#CCCCCC"
+        font.pixelSize: 11
+        font.family: "Roboto Mono"
+    }
+}

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -14,11 +14,13 @@ Item {
     property int    camId: 0
     property real   windowSeconds: 15
 
-    // Time-axis state — when followLive=true, the cell tracks
-    // source.liveEdge for the window's right edge. When false, the
-    // window is pinned at [windowStartT, windowStartT + windowSeconds].
+    // Time-axis state — when followLive=true, the cell tracks the
+    // viewer's per-tick liveEdge snapshot (NOT source.liveEdge directly,
+    // so every cell sees the same value for a given paintTick). When
+    // false, the window is pinned at [windowStartT, windowStartT + windowSeconds].
     property bool followLive: true
     property real windowStartT: 0.0
+    property real liveEdgeSnapshot: 0.0
 
     // Primary trace
     property string metric: "bfi"
@@ -116,12 +118,12 @@ Item {
 
             if (!cell.source) return
 
-            // Window boundaries — followLive locks tHi to source.liveEdge
-            // (live edge advancing); otherwise the window stays pinned
-            // at the user-set [windowStartT, windowStartT + windowSeconds].
-            // liveEdge is read fresh each paint — it has no notify signal.
+            // Window boundaries — followLive locks tHi to the viewer's
+            // per-tick snapshot (synced across every cell); otherwise the
+            // window stays pinned at the user-set
+            // [windowStartT, windowStartT + windowSeconds].
             var tHi = cell.followLive
-                ? cell.source.liveEdge
+                ? cell.liveEdgeSnapshot
                 : cell.windowStartT + cell.windowSeconds
             var tLo = tHi - cell.windowSeconds
             var dt = tHi - tLo
@@ -189,7 +191,7 @@ Item {
 
         function _currentTHi() {
             if (cell.followLive)
-                return cell.source ? cell.source.liveEdge : 0
+                return cell.liveEdgeSnapshot
             return cell.windowStartT + cell.windowSeconds
         }
 

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -215,14 +215,31 @@ Item {
         }
         Text {
             visible: cell.width >= 80
-            text: cell.metric.toUpperCase() + "  " + cell.yMin.toFixed(2) + " – " + cell.yMax.toFixed(2)
+            // Show the most recent sample value rather than the
+            // autoscale-derived range — clinicians care about "what's
+            // it reading right now", not the y-axis extent. paintTick
+            // is a dependency so the text refreshes at the throttled
+            // rate.
+            text: {
+                void cell.paintTick  // dependency
+                if (!cell.source) return cell.metric.toUpperCase() + "  --"
+                var v = cell.source.value_at(cell.side, cell.camId, cell.metric, cell.liveEdgeSnapshot)
+                return cell.metric.toUpperCase() + "  "
+                       + (isFinite(v) ? v.toFixed(2) : "--")
+            }
             color: cell.traceColor
             font.pixelSize: 10
             font.family: "Roboto Mono"
         }
         Text {
             visible: cell.width >= 80 && cell.secondaryMetric.length > 0
-            text: cell.secondaryMetric.toUpperCase() + "  " + cell.secondaryYMin.toFixed(2) + " – " + cell.secondaryYMax.toFixed(2)
+            text: {
+                void cell.paintTick
+                if (!cell.source) return cell.secondaryMetric.toUpperCase() + "  --"
+                var v = cell.source.value_at(cell.side, cell.camId, cell.secondaryMetric, cell.liveEdgeSnapshot)
+                return cell.secondaryMetric.toUpperCase() + "  "
+                       + (isFinite(v) ? v.toFixed(2) : "--")
+            }
             color: cell.secondaryColor
             font.pixelSize: 10
             font.family: "Roboto Mono"

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -12,16 +12,23 @@ Item {
     property var source: null            // ScanDataSource (Python QObject) or null
     property string side: "left"
     property int    camId: 0
-    property string metric: "bfi"
     property real   windowSeconds: 15
 
-    // Display bounds — Phase 2a uses fixed [yMin, yMax]; Phase 2b adds
-    // autoscale / per-cell fit.
+    // Primary trace
+    property string metric: "bfi"
     property real yMin: 0.0
     property real yMax: 10.0
+    property color traceColor: theme.statusBlue
+
+    // Secondary trace (optional) — set secondaryMetric to a non-empty
+    // string to render a second overlaid trace with its own y-mapping.
+    // Used for BFI+BVI / Mean+Contrast paired display modes.
+    property string secondaryMetric: ""
+    property real secondaryYMin: 0.0
+    property real secondaryYMax: 10.0
+    property color secondaryColor: theme.statusBlue
 
     // Visual — defaults pulled from AppTheme; can be overridden per-cell.
-    property color traceColor: theme.statusBlue
     property color frameColor: theme.borderSubtle
     property color bgColor: theme.bgPanel
 
@@ -39,9 +46,37 @@ Item {
         target: cell.source
         ignoreUnknownSignals: true
         function onSamplesAppended(s, c, m, n) {
-            if (s === cell.side && c === cell.camId && m === cell.metric)
+            if (s !== cell.side || c !== cell.camId) return
+            if (m === cell.metric || m === cell.secondaryMetric)
                 traceCanvas.requestPaint()
         }
+    }
+
+    // Render one trace inside the current Canvas context using the given
+    // metric/color/yMin/yMax. Defined as a JS function on the cell so
+    // both primary and secondary draws share it.
+    function _drawTrace(ctx, metricName, color, yMinVal, yMaxVal,
+                       tLo, tHi, dt, maxPts, w, h) {
+        if (!metricName || metricName.length === 0) return
+        var pts = cell.source.points_for_window(
+            cell.side, cell.camId, metricName, tLo, tHi, maxPts
+        )
+        if (pts.length < 2) return
+        var dy = yMaxVal - yMinVal
+        if (dy <= 0) return
+        ctx.beginPath()
+        ctx.lineWidth = 1.5
+        ctx.strokeStyle = color
+        for (var i = 0; i < pts.length; i++) {
+            var t = pts[i][0]
+            var v = pts[i][1]
+            if (!isFinite(v)) continue
+            var x = ((t - tLo) / dt) * w
+            var y = h - ((v - yMinVal) / dy) * h
+            if (i === 0) ctx.moveTo(x, y)
+            else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
     }
 
     Rectangle {
@@ -83,61 +118,44 @@ Item {
             if (dt <= 0) return
 
             var maxPts = Math.max(50, Math.floor(width * 2))
-            var pts = cell.source.points_for_window(
-                cell.side, cell.camId, cell.metric,
-                tLo, tHi, maxPts
-            )
-            if (pts.length < 2) return
 
-            var dy = cell.yMax - cell.yMin
-            if (dy <= 0) return
-
-            ctx.beginPath()
-            ctx.lineWidth = 1.5
-            ctx.strokeStyle = cell.traceColor
-            for (var i = 0; i < pts.length; i++) {
-                var t = pts[i][0]
-                var v = pts[i][1]
-                if (!isFinite(v)) continue
-                var x = ((t - tLo) / dt) * width
-                var y = height - ((v - cell.yMin) / dy) * height
-                if (i === 0) ctx.moveTo(x, y)
-                else ctx.lineTo(x, y)
-            }
-            ctx.stroke()
+            cell._drawTrace(ctx, cell.metric, cell.traceColor,
+                            cell.yMin, cell.yMax,
+                            tLo, tHi, dt, maxPts, width, height)
+            cell._drawTrace(ctx, cell.secondaryMetric, cell.secondaryColor,
+                            cell.secondaryYMin, cell.secondaryYMax,
+                            tLo, tHi, dt, maxPts, width, height)
         }
     }
 
-    // Cell label — top-left, identifies which (side, cam, metric) this is.
-    Text {
+    // Cell label — top-left, camera identity plus per-metric range labels
+    // colored to match each trace. When secondaryMetric is empty, only
+    // the primary metric row is shown.
+    Column {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.margins: 8
-        text: cell.side.toUpperCase() + " " + (cell.camId + 1) + " · " + cell.metric.toUpperCase()
-        color: theme.textSecondary
-        font.pixelSize: 11
-        font.family: "Roboto Mono"
-    }
+        spacing: 1
 
-    // Y-axis bound labels — hidden when cell is too narrow to fit them.
-    Text {
-        visible: cell.width >= 80
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.margins: 8
-        text: cell.yMax.toFixed(2)
-        color: theme.textTertiary
-        font.pixelSize: 10
-        font.family: "Roboto Mono"
-    }
-    Text {
-        visible: cell.width >= 80
-        anchors.bottom: parent.bottom
-        anchors.right: parent.right
-        anchors.margins: 8
-        text: cell.yMin.toFixed(2)
-        color: theme.textTertiary
-        font.pixelSize: 10
-        font.family: "Roboto Mono"
+        Text {
+            text: cell.side.toUpperCase() + " " + (cell.camId + 1)
+            color: theme.textSecondary
+            font.pixelSize: 11
+            font.family: "Roboto Mono"
+        }
+        Text {
+            visible: cell.width >= 80
+            text: cell.metric.toUpperCase() + "  " + cell.yMin.toFixed(2) + " – " + cell.yMax.toFixed(2)
+            color: cell.traceColor
+            font.pixelSize: 10
+            font.family: "Roboto Mono"
+        }
+        Text {
+            visible: cell.width >= 80 && cell.secondaryMetric.length > 0
+            text: cell.secondaryMetric.toUpperCase() + "  " + cell.secondaryYMin.toFixed(2) + " – " + cell.secondaryYMax.toFixed(2)
+            color: cell.secondaryColor
+            font.pixelSize: 10
+            font.family: "Roboto Mono"
+        }
     }
 }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -297,4 +297,43 @@ Item {
             wheel.accepted = true
         }
     }
+
+    // ── Touch pinch-zoom ───────────────────────────────────────────────
+    // Mouse wheel is mouse-only — touch devices (Surface, etc.) need a
+    // pinch handler. Single-finger drag still flows through the
+    // MouseArea above (Qt auto-translates one touch to mouse events).
+    // The handler snapshots windowSeconds and the anchor at pinch
+    // start, then computes newSec = baseSec / scale so the pinch
+    // gesture's cumulative scale maps smoothly to the visible window.
+    PinchHandler {
+        id: pinchZoom
+        target: null  // we drive the viewer manually via setWindow
+
+        property real _baseWindowSeconds: 0
+        property real _baseTLo: 0
+        property real _anchorRatio: 0.5
+
+        onActiveChanged: {
+            if (active && cell.width > 0) {
+                _baseWindowSeconds = cell.windowSeconds
+                _baseTLo = panZoomArea._currentTHi() - cell.windowSeconds
+                _anchorRatio = Math.max(0, Math.min(1, centroid.position.x / cell.width))
+                // Keyboard focus back to viewer on any touch interaction.
+                if (cell.panZoomTarget) cell.panZoomTarget.forceActiveFocus()
+            }
+        }
+
+        onScaleChanged: {
+            if (!active || !cell.panZoomTarget || cell.width <= 0) return
+            // Pinch out (scale > 1) = zoom in (smaller window); pinch
+            // in (scale < 1) = zoom out. Matches platform conventions.
+            var newSec = pinchZoom._baseWindowSeconds / scale
+            var anchorT = pinchZoom._baseTLo
+                          + pinchZoom._anchorRatio * pinchZoom._baseWindowSeconds
+            cell.panZoomTarget.setWindow(
+                anchorT - pinchZoom._anchorRatio * newSec,
+                newSec
+            )
+        }
+    }
 }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -46,6 +46,10 @@ Item {
     // windowSeconds across all cells.
     property var panZoomTarget: null
 
+    // Crosshair: NaN means hide. The viewer broadcasts the same value
+    // to every cell so the vertical line stays synced across the grid.
+    property real cursorT: NaN
+
     AppTheme { id: theme }
 
     // ── Repaint plumbing ───────────────────────────────────────────────
@@ -59,6 +63,10 @@ Item {
     onWidthChanged: traceCanvas.requestPaint()
     onHeightChanged: traceCanvas.requestPaint()
     onSourceChanged: traceCanvas.requestPaint()
+    // Note: cursorT changes do NOT trigger a direct repaint — that
+    // would spam paints on every mouse-move event. Instead the viewer
+    // sets _dirty on cursorAt() so the next paintThrottle tick
+    // (≤ 33 ms) repaints with the new crosshair position.
 
     // Render one trace inside the current Canvas context using the given
     // metric/color/yMin/yMax. Defined as a JS function on the cell so
@@ -143,6 +151,31 @@ Item {
             cell._drawTrace(ctx, cell.secondaryMetric, cell.secondaryColor,
                             cell.secondaryYMin, cell.secondaryYMax,
                             tLo, tHi, dt, maxPts, width, height)
+
+            // Dropout marker — vertical red bar at the recorded
+            // dropout time for this (side, cam).
+            var dropT = cell.source.dropped_at_for(cell.side, cell.camId)
+            if (isFinite(dropT) && dropT >= tLo && dropT <= tHi) {
+                var dropX = ((dropT - tLo) / dt) * width
+                ctx.strokeStyle = theme.accentRed
+                ctx.lineWidth = 2
+                ctx.beginPath()
+                ctx.moveTo(Math.floor(dropX) + 0.5, 0)
+                ctx.lineTo(Math.floor(dropX) + 0.5, height)
+                ctx.stroke()
+            }
+
+            // Crosshair — vertical line at cursorT (broadcast by the
+            // viewer so every cell stays in sync on hover).
+            if (isFinite(cell.cursorT) && cell.cursorT >= tLo && cell.cursorT <= tHi) {
+                var crossX = ((cell.cursorT - tLo) / dt) * width
+                ctx.strokeStyle = theme.textTertiary
+                ctx.lineWidth = 1
+                ctx.beginPath()
+                ctx.moveTo(Math.floor(crossX) + 0.5, 0)
+                ctx.lineTo(Math.floor(crossX) + 0.5, height)
+                ctx.stroke()
+            }
         }
     }
 
@@ -188,6 +221,7 @@ Item {
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton
         cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+        hoverEnabled: true
 
         // Drag snapshot — captured at press so the drag is computed
         // against a fixed origin instead of accumulating per-move
@@ -201,20 +235,41 @@ Item {
             return cell.windowStartT + cell.windowSeconds
         }
 
+        function _cursorTFromMouseX(mx) {
+            var tHiNow = panZoomArea._currentTHi()
+            var tLoNow = tHiNow - cell.windowSeconds
+            return tLoNow + (mx / cell.width) * cell.windowSeconds
+        }
+
         onPressed: function(mouse) {
             panZoomArea._dragStartX = mouse.x
             panZoomArea._dragStartWindowStartT = panZoomArea._currentTHi() - cell.windowSeconds
         }
 
         onPositionChanged: function(mouse) {
-            if (!pressed || !cell.panZoomTarget || cell.width <= 0) return
-            // Drag right = scroll back in time = windowStartT decreases.
-            var dx = mouse.x - panZoomArea._dragStartX
-            var dt = (dx / cell.width) * cell.windowSeconds
-            cell.panZoomTarget.setWindow(
-                panZoomArea._dragStartWindowStartT - dt,
-                cell.windowSeconds
-            )
+            if (pressed) {
+                if (!cell.panZoomTarget || cell.width <= 0) return
+                // Drag right = scroll back in time = windowStartT decreases.
+                var dx = mouse.x - panZoomArea._dragStartX
+                var dt = (dx / cell.width) * cell.windowSeconds
+                cell.panZoomTarget.setWindow(
+                    panZoomArea._dragStartWindowStartT - dt,
+                    cell.windowSeconds
+                )
+            } else {
+                // Hover: broadcast cursor time to the viewer.
+                if (cell.panZoomTarget && cell.width > 0)
+                    cell.panZoomTarget.cursorAt(panZoomArea._cursorTFromMouseX(mouse.x))
+            }
+        }
+
+        onEntered: {
+            if (cell.panZoomTarget && cell.width > 0)
+                cell.panZoomTarget.cursorAt(panZoomArea._cursorTFromMouseX(mouseX))
+        }
+
+        onExited: {
+            if (cell.panZoomTarget) cell.panZoomTarget.cursorAt(NaN)
         }
 
         onWheel: function(wheel) {

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -129,13 +129,11 @@ Item {
             var dt = tHi - tLo
             if (dt <= 0) return
 
-            // Cap at ~3× cell pixel width so decimation only kicks in for
-            // very-long windows. Below this threshold every sample is
-            // drawn — avoids stride-aliasing flicker as the window scrolls
-            // one sample at a time. When decimation IS needed (long
-            // windows, e.g. 5 min × 40 fps = 12 000 samples), the source
-            // mean-bins instead of stride-subsampling.
-            var maxPts = Math.max(50, Math.floor(width * 3))
+            // 1 sample per pixel — mean-binning at the source smooths
+            // the scroll, so we don't need the headroom of × 2 / × 3 to
+            // avoid aliasing. Smaller maxPts = less Python→QML data per
+            // paint = snappier feel under load.
+            var maxPts = Math.max(50, Math.floor(width))
 
             cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -132,13 +132,12 @@ Item {
             var dt = tHi - tLo
             if (dt <= 0) return
 
-            // Cap at ~3× cell pixel width. A typical 15 s window at 40 Hz
-            // is 600 samples; for any reasonable cell width × 3 stays
-            // above that, so decimation never kicks in for the common
-            // case and every raw sample is drawn — smoothest possible.
-            // Decimation (with mean-binning) only engages for very long
-            // windows where some smoothing is acceptable anyway.
-            var maxPts = Math.max(50, Math.floor(width * 3))
+            // 1 sample per pixel. Source-side smoothing (overlap-mean
+            // with 3-stride kernel) handles the anti-aliasing, so we
+            // don't need the headroom of × 3 to dodge decimation. Cuts
+            // per-paint Python→QML data volume 3× → restores 30 Hz
+            // paint cadence.
+            var maxPts = Math.max(50, Math.floor(width))
 
             cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -189,7 +189,11 @@ Item {
         spacing: 1
 
         Text {
-            text: cell.side.toUpperCase() + " " + (cell.camId + 1)
+            // cam_id = -1 is the side-averaged stream fed by the SDK's
+            // SideAveragingStage in reduced mode. Label it as "AVG".
+            text: cell.camId === -1
+                ? cell.side.toUpperCase() + " AVG"
+                : cell.side.toUpperCase() + " " + (cell.camId + 1)
             color: theme.textSecondary
             font.pixelSize: 11
             font.family: "Roboto Mono"

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -129,9 +129,13 @@ Item {
             var dt = tHi - tLo
             if (dt <= 0) return
 
-            // 1 sample per pixel is plenty for a smooth trace and halves
-            // the per-paint Python→QML data volume vs the spec's 2×.
-            var maxPts = Math.max(50, Math.floor(width))
+            // Cap at ~3× cell pixel width so decimation only kicks in for
+            // very-long windows. Below this threshold every sample is
+            // drawn — avoids stride-aliasing flicker as the window scrolls
+            // one sample at a time. When decimation IS needed (long
+            // windows, e.g. 5 min × 40 fps = 12 000 samples), the source
+            // mean-bins instead of stride-subsampling.
+            var maxPts = Math.max(50, Math.floor(width * 3))
 
             cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -61,6 +61,18 @@ Item {
             var ctx = getContext("2d")
             ctx.clearRect(0, 0, width, height)
 
+            // Midline gridline — always drawn for visual reference, even
+            // when no source is bound. Skipped for very narrow cells.
+            if (width >= 60) {
+                ctx.strokeStyle = cell.frameColor
+                ctx.lineWidth = 1
+                ctx.beginPath()
+                var midY = Math.floor(height / 2) + 0.5  // crisp 1px line
+                ctx.moveTo(0, midY)
+                ctx.lineTo(width, midY)
+                ctx.stroke()
+            }
+
             if (!cell.source) return
 
             // Read liveEdge fresh each paint — it has no notify signal so
@@ -104,6 +116,28 @@ Item {
         text: cell.side.toUpperCase() + " " + (cell.camId + 1) + " · " + cell.metric.toUpperCase()
         color: theme.textSecondary
         font.pixelSize: 11
+        font.family: "Roboto Mono"
+    }
+
+    // Y-axis bound labels — hidden when cell is too narrow to fit them.
+    Text {
+        visible: cell.width >= 80
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.margins: 8
+        text: cell.yMax.toFixed(2)
+        color: theme.textTertiary
+        font.pixelSize: 10
+        font.family: "Roboto Mono"
+    }
+    Text {
+        visible: cell.width >= 80
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.margins: 8
+        text: cell.yMin.toFixed(2)
+        color: theme.textTertiary
+        font.pixelSize: 10
         font.family: "Roboto Mono"
     }
 }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -132,12 +132,13 @@ Item {
             var dt = tHi - tLo
             if (dt <= 0) return
 
-            // 1 sample per pixel. Source-side smoothing (overlap-mean
-            // with 3-stride kernel) handles the anti-aliasing, so we
-            // don't need the headroom of × 3 to dodge decimation. Cuts
-            // per-paint Python→QML data volume 3× → restores 30 Hz
-            // paint cadence.
-            var maxPts = Math.max(50, Math.floor(width))
+            // 0.5 samples per pixel. Source-side stride-aligned causal
+            // smoothing makes the visual quality robust to lower output
+            // counts. Halving maxPts (vs width × 1) lets decimation
+            // saturate at ~3 s of scan instead of ~6 s, cutting the
+            // ramp-up paint-throttle gap in half and giving us a lower
+            // steady-state per-paint marshalling cost.
+            var maxPts = Math.max(50, Math.floor(width * 0.5))
 
             cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -38,6 +38,12 @@ Item {
     property color frameColor: theme.borderSubtle
     property color bgColor: theme.bgPanel
 
+    // DVR target — set to PlotViewer; cell calls .setWindow(startT, sec)
+    // on pan/zoom interactions. Cell itself owns no time-axis state;
+    // viewer is the single source of truth for windowStartT / followLive /
+    // windowSeconds across all cells.
+    property var panZoomTarget: null
+
     AppTheme { id: theme }
 
     // ── Repaint plumbing ───────────────────────────────────────────────
@@ -160,6 +166,64 @@ Item {
             color: cell.secondaryColor
             font.pixelSize: 10
             font.family: "Roboto Mono"
+        }
+    }
+
+    // ── Pan + wheel-zoom MouseArea ─────────────────────────────────────
+    // Top of z-order (last sibling) so it captures mouse events from
+    // the underlying Canvas + label children. Wheel zooms around the
+    // cursor x; click-drag pans the time axis. Both apply globally via
+    // panZoomTarget.setWindow(...) so every cell in the grid stays in
+    // sync. Sets followLive=false on any interaction.
+    MouseArea {
+        id: panZoomArea
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+
+        // Drag snapshot — captured at press so the drag is computed
+        // against a fixed origin instead of accumulating per-move
+        // floating-point drift.
+        property real _dragStartX: 0
+        property real _dragStartWindowStartT: 0
+
+        function _currentTHi() {
+            if (cell.followLive)
+                return cell.source ? cell.source.liveEdge : 0
+            return cell.windowStartT + cell.windowSeconds
+        }
+
+        onPressed: function(mouse) {
+            panZoomArea._dragStartX = mouse.x
+            panZoomArea._dragStartWindowStartT = panZoomArea._currentTHi() - cell.windowSeconds
+        }
+
+        onPositionChanged: function(mouse) {
+            if (!pressed || !cell.panZoomTarget || cell.width <= 0) return
+            // Drag right = scroll back in time = windowStartT decreases.
+            var dx = mouse.x - panZoomArea._dragStartX
+            var dt = (dx / cell.width) * cell.windowSeconds
+            cell.panZoomTarget.setWindow(
+                panZoomArea._dragStartWindowStartT - dt,
+                cell.windowSeconds
+            )
+        }
+
+        onWheel: function(wheel) {
+            if (!cell.panZoomTarget || cell.width <= 0) {
+                wheel.accepted = false
+                return
+            }
+            // Up = zoom in (smaller window); down = zoom out.
+            var factor = wheel.angleDelta.y > 0 ? 0.8 : 1.25
+            var ratio = Math.max(0, Math.min(1, wheel.x / cell.width))
+            var tHiNow = panZoomArea._currentTHi()
+            var tLoNow = tHiNow - cell.windowSeconds
+            var anchorT = tLoNow + ratio * cell.windowSeconds
+            var newSec = cell.windowSeconds * factor
+            var newStart = anchorT - ratio * newSec
+            cell.panZoomTarget.setWindow(newStart, newSec)
+            wheel.accepted = true
         }
     }
 }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -20,10 +20,12 @@ Item {
     property real yMin: 0.0
     property real yMax: 10.0
 
-    // Visual — inline for Phase 2a, theme integration in Phase 2b.
-    property color traceColor: "#E74C3C"
-    property color frameColor: "#444444"
-    property color bgColor: "#1A1A1A"
+    // Visual — defaults pulled from AppTheme; can be overridden per-cell.
+    property color traceColor: theme.statusBlue
+    property color frameColor: theme.borderSubtle
+    property color bgColor: theme.bgPanel
+
+    AppTheme { id: theme }
 
     // ── Repaint plumbing ───────────────────────────────────────────────
     // liveEdge is a plain Python @property with no notify signal — QML
@@ -100,7 +102,7 @@ Item {
         anchors.left: parent.left
         anchors.margins: 8
         text: cell.side.toUpperCase() + " " + (cell.camId + 1) + " · " + cell.metric.toUpperCase()
-        color: "#CCCCCC"
+        color: theme.textSecondary
         font.pixelSize: 11
         font.family: "Roboto Mono"
     }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -129,7 +129,9 @@ Item {
             var dt = tHi - tLo
             if (dt <= 0) return
 
-            var maxPts = Math.max(50, Math.floor(width * 2))
+            // 1 sample per pixel is plenty for a smooth trace and halves
+            // the per-paint Python→QML data volume vs the spec's 2×.
+            var maxPts = Math.max(50, Math.floor(width))
 
             cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -101,6 +101,9 @@ Item {
         anchors.margins: 4
 
         onPaint: {
+            // [LAG-DIAG] Time the per-cell paint. Log when > 15 ms;
+            // 8 active cells × >15 ms each would blow the 33 ms tick budget.
+            var _paintT0 = Date.now()
             var ctx = getContext("2d")
             ctx.clearRect(0, 0, width, height)
 
@@ -143,6 +146,12 @@ Item {
             cell._drawTrace(ctx, cell.secondaryMetric, cell.secondaryColor,
                             cell.secondaryYMin, cell.secondaryYMax,
                             tLo, tHi, dt, maxPts, width, height)
+
+            var _paintMs = Date.now() - _paintT0
+            if (_paintMs > 15) {
+                console.warn("[LAG-DIAG] PlotCell paint took " + _paintMs +
+                             " ms (" + cell.side + "/cam" + cell.camId + ")")
+            }
         }
     }
 

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -35,22 +35,16 @@ Item {
     AppTheme { id: theme }
 
     // ── Repaint plumbing ───────────────────────────────────────────────
-    // liveEdge is a plain Python @property with no notify signal — QML
-    // can't bind to it. Instead, samplesAppended drives the repaint,
-    // and onPaint reads source.liveEdge directly each time.
+    // Repaints are throttled by the parent PlotViewer: it owns a 33 ms
+    // dirty-flagged Timer that ticks `paintTick` whenever any
+    // samplesAppended arrived. Binding paintTick here triggers exactly
+    // one repaint per parent tick — caps cell-paint rate to ~30 Hz and
+    // keeps all cells visually in lockstep.
+    property int paintTick: 0
+    onPaintTickChanged: traceCanvas.requestPaint()
     onWidthChanged: traceCanvas.requestPaint()
     onHeightChanged: traceCanvas.requestPaint()
     onSourceChanged: traceCanvas.requestPaint()
-
-    Connections {
-        target: cell.source
-        ignoreUnknownSignals: true
-        function onSamplesAppended(s, c, m, n) {
-            if (s !== cell.side || c !== cell.camId) return
-            if (m === cell.metric || m === cell.secondaryMetric)
-                traceCanvas.requestPaint()
-        }
-    }
 
     // Render one trace inside the current Canvas context using the given
     // metric/color/yMin/yMax. Defined as a JS function on the cell so

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -248,6 +248,10 @@ Item {
         onPressed: function(mouse) {
             panZoomArea._dragStartX = mouse.x
             panZoomArea._dragStartWindowStartT = panZoomArea._currentTHi() - cell.windowSeconds
+            // Pull keyboard focus back to the viewer — if the user just
+            // clicked into a text input elsewhere, this restores the
+            // shortcut bindings on the next click into the plot grid.
+            if (cell.panZoomTarget) cell.panZoomTarget.forceActiveFocus()
         }
 
         onPositionChanged: function(mouse) {

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -129,11 +129,13 @@ Item {
             var dt = tHi - tLo
             if (dt <= 0) return
 
-            // 1 sample per pixel — mean-binning at the source smooths
-            // the scroll, so we don't need the headroom of × 2 / × 3 to
-            // avoid aliasing. Smaller maxPts = less Python→QML data per
-            // paint = snappier feel under load.
-            var maxPts = Math.max(50, Math.floor(width))
+            // Cap at ~3× cell pixel width. A typical 15 s window at 40 Hz
+            // is 600 samples; for any reasonable cell width × 3 stays
+            // above that, so decimation never kicks in for the common
+            // case and every raw sample is drawn — smoothest possible.
+            // Decimation (with mean-binning) only engages for very long
+            // windows where some smoothing is acceptable anyway.
+            var maxPts = Math.max(50, Math.floor(width * 3))
 
             cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -14,6 +14,12 @@ Item {
     property int    camId: 0
     property real   windowSeconds: 15
 
+    // Time-axis state — when followLive=true, the cell tracks
+    // source.liveEdge for the window's right edge. When false, the
+    // window is pinned at [windowStartT, windowStartT + windowSeconds].
+    property bool followLive: true
+    property real windowStartT: 0.0
+
     // Primary trace
     property string metric: "bfi"
     property real yMin: 0.0
@@ -104,10 +110,14 @@ Item {
 
             if (!cell.source) return
 
-            // Read liveEdge fresh each paint — it has no notify signal so
-            // we can't cache it in a QML binding.
-            var tHi = cell.source.liveEdge
-            var tLo = Math.max(0, tHi - cell.windowSeconds)
+            // Window boundaries — followLive locks tHi to source.liveEdge
+            // (live edge advancing); otherwise the window stays pinned
+            // at the user-set [windowStartT, windowStartT + windowSeconds].
+            // liveEdge is read fresh each paint — it has no notify signal.
+            var tHi = cell.followLive
+                ? cell.source.liveEdge
+                : cell.windowStartT + cell.windowSeconds
+            var tLo = tHi - cell.windowSeconds
             var dt = tHi - tLo
             if (dt <= 0) return
 

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -101,9 +101,6 @@ Item {
         anchors.margins: 4
 
         onPaint: {
-            // [LAG-DIAG] Time the per-cell paint. Log when > 15 ms;
-            // 8 active cells × >15 ms each would blow the 33 ms tick budget.
-            var _paintT0 = Date.now()
             var ctx = getContext("2d")
             ctx.clearRect(0, 0, width, height)
 
@@ -146,12 +143,6 @@ Item {
             cell._drawTrace(ctx, cell.secondaryMetric, cell.secondaryColor,
                             cell.secondaryYMin, cell.secondaryYMax,
                             tLo, tHi, dt, maxPts, width, height)
-
-            var _paintMs = Date.now() - _paintT0
-            if (_paintMs > 15) {
-                console.warn("[LAG-DIAG] PlotCell paint took " + _paintMs +
-                             " ms (" + cell.side + "/cam" + cell.camId + ")")
-            }
         }
     }
 

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -70,16 +70,17 @@ Item {
 
     // Render one trace inside the current Canvas context using the given
     // metric/color/yMin/yMax. Defined as a JS function on the cell so
-    // both primary and secondary draws share it.
+    // both primary and secondary draws share it. Returns the number of
+    // points actually painted so the profile HUD can sum across cells.
     function _drawTrace(ctx, metricName, color, yMinVal, yMaxVal,
                        tLo, tHi, dt, maxPts, w, h) {
-        if (!metricName || metricName.length === 0) return
+        if (!metricName || metricName.length === 0) return 0
         var pts = cell.source.points_for_window(
             cell.side, cell.camId, metricName, tLo, tHi, maxPts
         )
-        if (pts.length < 2) return
+        if (pts.length < 2) return 0
         var dy = yMaxVal - yMinVal
-        if (dy <= 0) return
+        if (dy <= 0) return 0
         ctx.beginPath()
         ctx.lineWidth = 1.5
         ctx.strokeStyle = color
@@ -93,6 +94,7 @@ Item {
             else ctx.lineTo(x, y)
         }
         ctx.stroke()
+        return pts.length
     }
 
     Rectangle {
@@ -109,6 +111,14 @@ Item {
         anchors.margins: 4
 
         onPaint: {
+            // Profile-HUD timing: only sample wall-time when the HUD is
+            // visible to keep clinical-build paint hot path identical.
+            var profOn = cell.panZoomTarget
+                         && cell.panZoomTarget.recordCellPaint
+                         && cell.panZoomTarget._hudVisible
+            var profT0 = profOn ? Date.now() : 0
+            var profPts = 0
+
             var ctx = getContext("2d")
             ctx.clearRect(0, 0, width, height)
 
@@ -124,7 +134,10 @@ Item {
                 ctx.stroke()
             }
 
-            if (!cell.source) return
+            if (!cell.source) {
+                if (profOn) cell.panZoomTarget.recordCellPaint(Date.now() - profT0, 0)
+                return
+            }
 
             // Window boundaries — followLive locks tHi to the viewer's
             // per-tick snapshot (synced across every cell); otherwise the
@@ -145,10 +158,10 @@ Item {
             // steady-state per-paint marshalling cost.
             var maxPts = Math.max(50, Math.floor(width * 0.5))
 
-            cell._drawTrace(ctx, cell.metric, cell.traceColor,
+            profPts += cell._drawTrace(ctx, cell.metric, cell.traceColor,
                             cell.yMin, cell.yMax,
                             tLo, tHi, dt, maxPts, width, height)
-            cell._drawTrace(ctx, cell.secondaryMetric, cell.secondaryColor,
+            profPts += cell._drawTrace(ctx, cell.secondaryMetric, cell.secondaryColor,
                             cell.secondaryYMin, cell.secondaryYMax,
                             tLo, tHi, dt, maxPts, width, height)
 
@@ -176,6 +189,8 @@ Item {
                 ctx.lineTo(Math.floor(crossX) + 0.5, height)
                 ctx.stroke()
             }
+
+            if (profOn) cell.panZoomTarget.recordCellPaint(Date.now() - profT0, profPts)
         }
     }
 

--- a/components/PlotScrubber.qml
+++ b/components/PlotScrubber.qml
@@ -1,0 +1,107 @@
+import QtQuick 6.0
+
+// Bottom timeline showing the full scan extent (0 → liveEdge) with the
+// visible window highlighted as a draggable inset. Click outside the
+// inset jumps the window so the click lands at its centre; drag the
+// inset to pan.
+//
+// Inputs come from PlotViewer; setWindow callback applies the change.
+// Cell-side scroll-and-zoom keep working as before — the scrubber is
+// an alternative pan UI, not the only one.
+Item {
+    id: scrubber
+
+    AppTheme { id: theme }
+
+    // ── Inputs ─────────────────────────────────────────────────────────
+    property real fullScanDuration: 0      // = liveEdgeSnapshot
+    property real windowStartT: 0
+    property real windowSeconds: 15
+    property bool followLive: true
+
+    // ── Output ─────────────────────────────────────────────────────────
+    signal panRequested(real startT)
+
+    // Effective span the scrubber covers — at least one full window
+    // wide so the inset never gets clipped to zero width at scan start.
+    readonly property real _span: Math.max(scrubber.fullScanDuration, scrubber.windowSeconds)
+    readonly property real _insetX: scrubber._span > 0
+        ? scrubber.width * (scrubber.windowStartT / scrubber._span)
+        : 0
+    readonly property real _insetW: scrubber._span > 0
+        ? Math.max(8, scrubber.width * (scrubber.windowSeconds / scrubber._span))
+        : 0
+
+    // ── Background ─────────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: theme.bgPanel
+        border.color: theme.borderSubtle
+        border.width: 1
+        radius: 4
+    }
+
+    // Visible-window inset — translucent so the scrubber background
+    // remains visible underneath, indicating the proportion of the
+    // full scan that the inset covers.
+    Rectangle {
+        id: windowInset
+        x: scrubber._insetX
+        width: scrubber._insetW
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.topMargin: 2
+        anchors.bottomMargin: 2
+        color: scrubber.followLive ? theme.statusBlue : theme.accentOrange
+        opacity: 0.35
+        radius: 3
+    }
+
+    // Right-edge "live" indicator — small bright tick at liveEdge so
+    // the user can see the head of the recording at a glance.
+    Rectangle {
+        x: scrubber._span > 0
+            ? Math.min(scrubber.width - 2, scrubber.width * (scrubber.fullScanDuration / scrubber._span))
+            : 0
+        width: 2
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        color: theme.statusGreen
+        visible: scrubber.fullScanDuration > 0
+    }
+
+    // ── Interaction ────────────────────────────────────────────────────
+    MouseArea {
+        anchors.fill: parent
+        cursorShape: _dragging ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+
+        property bool _dragging: false
+        property real _dragStartX: 0
+        property real _dragStartWindowT: 0
+
+        onPressed: function(mouse) {
+            var insetLeft = scrubber._insetX
+            var insetRight = insetLeft + scrubber._insetW
+            if (mouse.x >= insetLeft && mouse.x <= insetRight) {
+                // Grab the inset — pan it.
+                _dragging = true
+                _dragStartX = mouse.x
+                _dragStartWindowT = scrubber.windowStartT
+            } else if (scrubber._span > 0 && scrubber.width > 0) {
+                // Click outside: jump the window so the clicked time
+                // lands at the centre of the visible window.
+                var clickT = (mouse.x / scrubber.width) * scrubber._span
+                scrubber.panRequested(Math.max(0, clickT - scrubber.windowSeconds / 2))
+            }
+        }
+
+        onReleased: _dragging = false
+
+        onPositionChanged: function(mouse) {
+            if (!_dragging || scrubber.width <= 0 || scrubber._span <= 0) return
+            var dx = mouse.x - _dragStartX
+            var dT = (dx / scrubber.width) * scrubber._span
+            scrubber.panRequested(Math.max(0, _dragStartWindowT + dT))
+        }
+    }
+}

--- a/components/PlotScrubber.qml
+++ b/components/PlotScrubber.qml
@@ -18,6 +18,10 @@ Item {
     property real windowStartT: 0
     property real windowSeconds: 15
     property bool followLive: true
+    // Item that should regain keyboard focus when the scrubber is
+    // clicked — set to the PlotViewer root so keyboard shortcuts
+    // resume after the user has clicked into another widget.
+    property var focusTarget: null
 
     // ── Output ─────────────────────────────────────────────────────────
     signal panRequested(real startT)
@@ -80,6 +84,9 @@ Item {
         property real _dragStartWindowT: 0
 
         onPressed: function(mouse) {
+            // Restore keyboard focus to the viewer so shortcuts resume
+            // working after the user clicked into a text field.
+            if (scrubber.focusTarget) scrubber.focusTarget.forceActiveFocus()
             var insetLeft = scrubber._insetX
             var insetRight = insetLeft + scrubber._insetW
             if (mouse.x >= insetLeft && mouse.x <= insetRight) {

--- a/components/PlotToolbar.qml
+++ b/components/PlotToolbar.qml
@@ -20,6 +20,13 @@ Item {
     property int windowSeconds: 15
     property bool autoScale: true
     property bool followLive: true
+    // True iff a LiveScanSource exists in MOTIONConnector — lets the
+    // Back-to-live button stay enabled when the viewer is showing a
+    // past scan so the user can return to the live edge in one click.
+    property bool liveSourceAvailable: false
+
+    readonly property bool _viewerOnPast: scanSource !== null
+                                          && scanSource.live === false
 
     // ── Outputs ────────────────────────────────────────────────────────
     signal displayModeRequested(string mode)
@@ -57,8 +64,14 @@ Item {
 
         Button {
             id: backToLiveBtn
-            visible: !toolbar.followLive
-            text: "● Back to live"
+            // Visible when:
+            //   - viewer is on a past source AND a live source is held
+            //     in the background (button switches sources), OR
+            //   - viewer is on the live source but the visible window
+            //     is pinned (button resumes tracking the live edge).
+            visible: (toolbar._viewerOnPast && toolbar.liveSourceAvailable)
+                     || (!toolbar._viewerOnPast && !toolbar.followLive)
+            text: toolbar._viewerOnPast ? "← Back to live scan" : "● Back to live"
             // Material-style accent — uses the same red as BFI traces for
             // visual urgency: "you're not seeing live data right now".
             palette.buttonText: theme.accentRed

--- a/components/PlotToolbar.qml
+++ b/components/PlotToolbar.qml
@@ -13,20 +13,21 @@ Item {
 
     // ── Inputs ─────────────────────────────────────────────────────────
     property var scanSource: null
-    property string metric: "bvi"
+    // displayMode pairs metrics: "bfi_bvi" overlays BFI + BVI on each
+    // cell; "mean_contrast" overlays Mean + Contrast. Matches the
+    // legacy plot's showBfiBvi toggle.
+    property string displayMode: "bfi_bvi"
     property int windowSeconds: 15
     property bool autoScale: true
 
     // ── Outputs ────────────────────────────────────────────────────────
-    signal metricRequested(string m)
+    signal displayModeRequested(string mode)
     signal windowSecondsRequested(int s)
     signal autoScaleToggled(bool enabled)
 
-    readonly property var _metricOptions: [
-        { value: "bfi",      label: "BFI" },
-        { value: "bvi",      label: "BVI" },
-        { value: "mean",     label: "Mean" },
-        { value: "contrast", label: "Contrast" }
+    readonly property var _displayModeOptions: [
+        { value: "bfi_bvi",       label: "BFI / BVI" },
+        { value: "mean_contrast", label: "Mean / Contrast" }
     ]
     readonly property var _windowOptions: [
         { value: 5,  label: "5 s" },
@@ -53,23 +54,23 @@ Item {
         }
 
         Text {
-            text: "Metric:"
+            text: "Show:"
             color: theme.textTertiary
             font.pixelSize: 11
         }
         ComboBox {
-            id: metricCombo
-            Layout.preferredWidth: 110
-            model: toolbar._metricOptions
+            id: displayModeCombo
+            Layout.preferredWidth: 160
+            model: toolbar._displayModeOptions
             textRole: "label"
             valueRole: "value"
             currentIndex: {
-                for (var i = 0; i < toolbar._metricOptions.length; i++) {
-                    if (toolbar._metricOptions[i].value === toolbar.metric) return i
+                for (var i = 0; i < toolbar._displayModeOptions.length; i++) {
+                    if (toolbar._displayModeOptions[i].value === toolbar.displayMode) return i
                 }
-                return 1  // default BVI
+                return 0  // default BFI/BVI
             }
-            onActivated: toolbar.metricRequested(toolbar._metricOptions[currentIndex].value)
+            onActivated: toolbar.displayModeRequested(toolbar._displayModeOptions[currentIndex].value)
         }
 
         Text {

--- a/components/PlotToolbar.qml
+++ b/components/PlotToolbar.qml
@@ -24,6 +24,11 @@ Item {
     // Back-to-live button stay enabled when the viewer is showing a
     // past scan so the user can return to the live edge in one click.
     property bool liveSourceAvailable: false
+    // Profile-HUD toggle — the checkbox is hidden in non-developer
+    // builds so clinical users never see it. The viewer reads
+    // `showProfiling` for HUD visibility.
+    property bool developerMode: false
+    property bool showProfiling: false
 
     readonly property bool _viewerOnPast: scanSource !== null
                                           && scanSource.live === false
@@ -33,6 +38,7 @@ Item {
     signal windowSecondsRequested(int s)
     signal autoScaleToggled(bool enabled)
     signal backToLiveRequested()
+    signal showProfilingToggled(bool enabled)
 
     readonly property var _displayModeOptions: [
         { value: "bfi_bvi",       label: "BFI / BVI" },
@@ -123,6 +129,18 @@ Item {
             text: "Autoscale"
             checked: toolbar.autoScale
             onToggled: toolbar.autoScaleToggled(checked)
+        }
+
+        CheckBox {
+            id: profilingCheck
+            // Dev-only — clinical users never see the profiler toggle.
+            // The viewer additionally gates HUD visibility on
+            // developerMode, so toggling this in a non-dev build (e.g.
+            // via QML inspector) still leaves the HUD off.
+            visible: toolbar.developerMode
+            text: "Profiler"
+            checked: toolbar.showProfiling
+            onToggled: toolbar.showProfilingToggled(checked)
         }
 
         Item { Layout.fillWidth: true }  // pushes everything left

--- a/components/PlotToolbar.qml
+++ b/components/PlotToolbar.qml
@@ -1,0 +1,104 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+
+// Phase 2b-i — top toolbar for PlotViewer. Stateless: inputs are read from
+// parent, outputs are signals the parent applies to its own state. Phase
+// 2b-ii adds "Back to live" + Phase 2b-iii adds "Open scan..." buttons.
+Item {
+    id: toolbar
+    implicitHeight: bar.implicitHeight + 8
+
+    AppTheme { id: theme }
+
+    // ── Inputs ─────────────────────────────────────────────────────────
+    property var scanSource: null
+    property string metric: "bvi"
+    property int windowSeconds: 15
+    property bool autoScale: true
+
+    // ── Outputs ────────────────────────────────────────────────────────
+    signal metricRequested(string m)
+    signal windowSecondsRequested(int s)
+    signal autoScaleToggled(bool enabled)
+
+    readonly property var _metricOptions: [
+        { value: "bfi",      label: "BFI" },
+        { value: "bvi",      label: "BVI" },
+        { value: "mean",     label: "Mean" },
+        { value: "contrast", label: "Contrast" }
+    ]
+    readonly property var _windowOptions: [
+        { value: 5,  label: "5 s" },
+        { value: 15, label: "15 s" },
+        { value: 30, label: "30 s" },
+        { value: 60, label: "1 min" },
+        { value: 300, label: "5 min" }
+    ]
+
+    RowLayout {
+        id: bar
+        anchors.fill: parent
+        anchors.margins: 4
+        spacing: 16
+
+        Text {
+            text: toolbar.scanSource
+                ? "● Live · " + (toolbar.scanSource.live ? "LiveScanSource" : "PastScanSource")
+                : "○ No active scan source"
+            color: theme.textSecondary
+            font.pixelSize: 12
+            font.family: "Roboto Mono"
+            Layout.preferredWidth: 260
+        }
+
+        Text {
+            text: "Metric:"
+            color: theme.textTertiary
+            font.pixelSize: 11
+        }
+        ComboBox {
+            id: metricCombo
+            Layout.preferredWidth: 110
+            model: toolbar._metricOptions
+            textRole: "label"
+            valueRole: "value"
+            currentIndex: {
+                for (var i = 0; i < toolbar._metricOptions.length; i++) {
+                    if (toolbar._metricOptions[i].value === toolbar.metric) return i
+                }
+                return 1  // default BVI
+            }
+            onActivated: toolbar.metricRequested(toolbar._metricOptions[currentIndex].value)
+        }
+
+        Text {
+            text: "Window:"
+            color: theme.textTertiary
+            font.pixelSize: 11
+        }
+        ComboBox {
+            id: windowCombo
+            Layout.preferredWidth: 90
+            model: toolbar._windowOptions
+            textRole: "label"
+            valueRole: "value"
+            currentIndex: {
+                for (var i = 0; i < toolbar._windowOptions.length; i++) {
+                    if (toolbar._windowOptions[i].value === toolbar.windowSeconds) return i
+                }
+                return 1  // default 15s
+            }
+            onActivated: toolbar.windowSecondsRequested(toolbar._windowOptions[currentIndex].value)
+        }
+
+        CheckBox {
+            id: autoScaleCheck
+            text: "Autoscale"
+            checked: toolbar.autoScale
+            onToggled: toolbar.autoScaleToggled(checked)
+        }
+
+        Item { Layout.fillWidth: true }  // pushes everything left
+    }
+}

--- a/components/PlotToolbar.qml
+++ b/components/PlotToolbar.qml
@@ -19,11 +19,13 @@ Item {
     property string displayMode: "bfi_bvi"
     property int windowSeconds: 15
     property bool autoScale: true
+    property bool followLive: true
 
     // ── Outputs ────────────────────────────────────────────────────────
     signal displayModeRequested(string mode)
     signal windowSecondsRequested(int s)
     signal autoScaleToggled(bool enabled)
+    signal backToLiveRequested()
 
     readonly property var _displayModeOptions: [
         { value: "bfi_bvi",       label: "BFI / BVI" },
@@ -51,6 +53,16 @@ Item {
             font.pixelSize: 12
             font.family: "Roboto Mono"
             Layout.preferredWidth: 260
+        }
+
+        Button {
+            id: backToLiveBtn
+            visible: !toolbar.followLive
+            text: "● Back to live"
+            // Material-style accent — uses the same red as BFI traces for
+            // visual urgency: "you're not seeing live data right now".
+            palette.buttonText: theme.accentRed
+            onClicked: toolbar.backToLiveRequested()
         }
 
         Text {

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -1,0 +1,56 @@
+import QtQuick 6.0
+import QtQuick.Layouts 6.0
+import OpenMotion 1.0
+
+// Phase 2a — single-cell shell that binds to MOTIONInterface.currentScanSource
+// and shows ONE PlotCell for left/0/bfi. Phase 2b grows this into a full
+// GridLayout with per-camera cells + toolbar + scrubber.
+Rectangle {
+    id: viewer
+    color: "#0E0E0E"
+    radius: 8
+    border.color: "#2A2A2A"
+    border.width: 1
+
+    // ── Inputs ─────────────────────────────────────────────────────────
+    // Reduced mode is consumed by Phase 2b for layout selection. Stored
+    // here now so the BloodFlow.qml wiring matches Phase 2b's contract.
+    property bool reducedMode: false
+
+    // ── Source subscription ────────────────────────────────────────────
+    // currentScanSource is a notify-bound pyqtProperty on MOTIONConnector.
+    // It updates at every scan start (new LiveScanSource) and will update
+    // again when Phase 2b's loadPastScan installs a PastScanSource.
+    readonly property var scanSource: MOTIONInterface.currentScanSource
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 12
+        spacing: 8
+
+        // Header — temporary; replaced by PlotToolbar.qml in Phase 2b.
+        Text {
+            Layout.fillWidth: true
+            text: viewer.scanSource
+                ? "● Live · " + (viewer.scanSource.live ? "LiveScanSource" : "PastScanSource")
+                : "○ No active scan source"
+            color: "#CCCCCC"
+            font.pixelSize: 12
+            font.family: "Roboto Mono"
+        }
+
+        PlotCell {
+            id: cell
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            source: viewer.scanSource
+            side: "left"
+            camId: 0
+            metric: "bfi"
+            windowSeconds: 15
+            yMin: 0.0
+            yMax: 10.0
+            traceColor: "#E74C3C"
+        }
+    }
+}

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -21,11 +21,20 @@ Rectangle {
     property bool reducedMode: false   // honored in Phase 2b-ii
 
     // ── State (owned here; pushed to every cell) ───────────────────────
-    property string metric: "bvi"
-    property real windowSeconds: 15
-    property real yMin: 0.0
-    property real yMax: 10.0
+    // displayMode: "bfi_bvi" overlays BFI+BVI on each cell;
+    // "mean_contrast" overlays Mean+Contrast. Each metric has its own
+    // y-axis mapping (primary*/secondary*) so the two traces don't
+    // squash each other when their ranges differ wildly.
+    property string displayMode: "bfi_bvi"
+    property int windowSeconds: 15
     property bool autoScale: true
+
+    // Independent y-axis bounds per metric — kept here so every cell
+    // shares the same scale.
+    property real primaryYMin: 0.0
+    property real primaryYMax: 10.0
+    property real secondaryYMin: 0.0
+    property real secondaryYMax: 10.0
 
     // ── Source subscription ────────────────────────────────────────────
     readonly property var scanSource: MOTIONInterface.currentScanSource
@@ -74,9 +83,18 @@ Rectangle {
         return theme.statusBlue
     }
 
-    // Autoscale tick — 1 Hz. Calls into the source's compute_bounds_for_metric
-    // (Phase 2b-i Task 1) and pushes the result into the viewer's yMin/yMax,
-    // which propagates to every cell via property binding.
+    // ── Display-mode pair resolution ───────────────────────────────────
+    // Maps the displayMode toggle to the primary/secondary metric pair
+    // pushed to every cell.
+    readonly property var _displayPair: {
+        if (viewer.displayMode === "mean_contrast")
+            return { primary: "mean", secondary: "contrast" }
+        return { primary: "bfi", secondary: "bvi" }
+    }
+
+    // Autoscale tick — 1 Hz. Computes bounds for both metrics in the
+    // current display pair and pushes them into the viewer's per-metric
+    // ranges, which propagate to every cell via property bindings.
     Timer {
         interval: 1000
         running: viewer.autoScale && viewer.scanSource !== null
@@ -84,10 +102,15 @@ Rectangle {
         triggeredOnStart: true
         onTriggered: {
             if (!viewer.scanSource) return
-            var b = viewer.scanSource.compute_bounds_for_metric(viewer.metric)
-            if (b && typeof b.yMin === "number" && typeof b.yMax === "number") {
-                viewer.yMin = b.yMin
-                viewer.yMax = b.yMax
+            var bp = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.primary)
+            if (bp && typeof bp.yMin === "number" && typeof bp.yMax === "number") {
+                viewer.primaryYMin = bp.yMin
+                viewer.primaryYMax = bp.yMax
+            }
+            var bs = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.secondary)
+            if (bs && typeof bs.yMin === "number" && typeof bs.yMax === "number") {
+                viewer.secondaryYMin = bs.yMin
+                viewer.secondaryYMax = bs.yMax
             }
         }
     }
@@ -100,11 +123,11 @@ Rectangle {
         PlotToolbar {
             Layout.fillWidth: true
             scanSource: viewer.scanSource
-            metric: viewer.metric
+            displayMode: viewer.displayMode
             windowSeconds: viewer.windowSeconds
             autoScale: viewer.autoScale
 
-            onMetricRequested: function(m) { viewer.metric = m }
+            onDisplayModeRequested: function(mode) { viewer.displayMode = mode }
             onWindowSecondsRequested: function(s) { viewer.windowSeconds = s }
             onAutoScaleToggled: function(enabled) { viewer.autoScale = enabled }
         }
@@ -127,11 +150,15 @@ Rectangle {
                     source: viewer.scanSource
                     side: modelData.side
                     camId: modelData.camId
-                    metric: viewer.metric
                     windowSeconds: viewer.windowSeconds
-                    yMin: viewer.yMin
-                    yMax: viewer.yMax
-                    traceColor: viewer._traceColorForMetric(viewer.metric)
+                    metric: viewer._displayPair.primary
+                    yMin: viewer.primaryYMin
+                    yMax: viewer.primaryYMax
+                    traceColor: viewer._traceColorForMetric(viewer._displayPair.primary)
+                    secondaryMetric: viewer._displayPair.secondary
+                    secondaryYMin: viewer.secondaryYMin
+                    secondaryYMax: viewer.secondaryYMax
+                    secondaryColor: viewer._traceColorForMetric(viewer._displayPair.secondary)
                 }
             }
         }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -134,7 +134,13 @@ Rectangle {
     function setWindow(startT, seconds) {
         _ensureFrozen()
         viewer.windowSeconds = Math.max(_minWindowSeconds, Math.min(_maxWindowSeconds, seconds))
-        viewer.windowStartT = Math.max(0, startT)
+        // Cap startT so the window can't extend past the live edge —
+        // otherwise the scrubber inset slides off into empty future
+        // space when the user keeps dragging right. Lower bound 0
+        // (scan start); upper bound puts the rightmost data at the
+        // right edge of the visible plot.
+        var maxStart = Math.max(0, viewer.liveEdgeSnapshot - viewer.windowSeconds)
+        viewer.windowStartT = Math.max(0, Math.min(maxStart, startT))
         viewer._dirty = true
     }
 
@@ -264,7 +270,16 @@ Rectangle {
                 viewer._recomputeAutoscale()
             }
             onWindowSecondsRequested: function(s) {
-                viewer.windowSeconds = s
+                // Route through setWindow so the off-edge cap re-applies
+                // — expanding from 5 s to 60 s while paused near liveEdge
+                // would otherwise push the right edge past liveEdge.
+                // When followLive, setWindow's _ensureFrozen snapshots
+                // the current view first, preserving the visual position.
+                if (viewer.followLive) {
+                    viewer.windowSeconds = s
+                } else {
+                    viewer.setWindow(viewer.windowStartT, s)
+                }
                 viewer._dirty = true
                 console.info("[Plot] windowSeconds → " + s + " s")
             }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -2,9 +2,10 @@ import QtQuick 6.0
 import QtQuick.Layouts 6.0
 import OpenMotion 1.0
 
-// Phase 2a — single-cell shell that binds to MOTIONInterface.currentScanSource
-// and shows ONE PlotCell for left/0/bfi. Phase 2b grows this into a full
-// GridLayout with per-camera cells + toolbar + scrubber.
+// Phase 2b-i — multi-cell viewer. Always renders 16 cells (2 sides × 8 cams).
+// Inactive cameras just render an empty Canvas + label; no per-mask branching.
+// Reduced-mode 2-cell layout is Phase 2b-ii. Toolbar + autoscale arrive in
+// Task 5; the current header text is the Phase 2a placeholder.
 Rectangle {
     id: viewer
     anchors.fill: parent
@@ -16,29 +17,41 @@ Rectangle {
     AppTheme { id: theme }
 
     // ── Inputs ─────────────────────────────────────────────────────────
-    // Reduced mode is consumed by Phase 2b for layout selection. Stored
-    // here now so the BloodFlow.qml wiring matches Phase 2b's contract.
-    property bool reducedMode: false
+    property bool reducedMode: false   // honored in Phase 2b-ii
+
+    // ── State (owned here; pushed to every cell) ───────────────────────
+    property string metric: "bvi"
+    property real windowSeconds: 15
+    property real yMin: 0.0
+    property real yMax: 10.0
 
     // ── Source subscription ────────────────────────────────────────────
-    // currentScanSource is a notify-bound pyqtProperty on MOTIONConnector.
-    // It updates at every scan start (new LiveScanSource) and will update
-    // again when Phase 2b's loadPastScan installs a PastScanSource.
     readonly property var scanSource: MOTIONInterface.currentScanSource
 
-    // Phase 2a: show the first active camera from the user's mask config
-    // so the single cell renders SOMETHING regardless of mask choice.
-    // Phase 2b expands to a full per-camera grid driven by both masks.
-    readonly property var _firstActive: {
-        var lm = (MOTIONInterface.appConfig.leftMask  || 0) & 0xFF
-        var rm = (MOTIONInterface.appConfig.rightMask || 0) & 0xFF
-        for (var i = 0; i < 8; i++) {
-            if (lm & (1 << i)) return { side: "left",  cam: i }
+    // ── Grid model ─────────────────────────────────────────────────────
+    // 16 entries in row-major order matching the layout grid:
+    //   row 0: L1 L2 L3 L4
+    //   row 1: L5 L6 L7 L8
+    //   row 2: R1 R2 R3 R4
+    //   row 3: R5 R6 R7 R8
+    readonly property var _cellModel: {
+        var entries = []
+        var sides = ["left", "right"]
+        for (var s = 0; s < sides.length; s++) {
+            for (var c = 0; c < 8; c++) {
+                entries.push({ side: sides[s], camId: c })
+            }
         }
-        for (var j = 0; j < 8; j++) {
-            if (rm & (1 << j)) return { side: "right", cam: j }
-        }
-        return { side: "left", cam: 0 }
+        return entries
+    }
+
+    // ── Trace color per metric ─────────────────────────────────────────
+    function _traceColorForMetric(m) {
+        if (m === "bfi")      return theme.accentRed
+        if (m === "bvi")      return theme.statusBlue
+        if (m === "mean")     return theme.accentOrange
+        if (m === "contrast") return theme.accentYellow
+        return theme.statusBlue
     }
 
     ColumnLayout {
@@ -46,34 +59,42 @@ Rectangle {
         anchors.margins: 12
         spacing: 8
 
-        // Header — temporary; replaced by PlotToolbar.qml in Phase 2b.
+        // Header — Phase 2a placeholder. Replaced by PlotToolbar in Task 5.
         Text {
             Layout.fillWidth: true
             text: viewer.scanSource
                 ? "● Live · " + (viewer.scanSource.live ? "LiveScanSource" : "PastScanSource")
+                  + "   ·   metric=" + viewer.metric.toUpperCase()
+                  + "   window=" + viewer.windowSeconds + "s"
                 : "○ No active scan source"
             color: theme.textSecondary
             font.pixelSize: 12
             font.family: "Roboto Mono"
         }
 
-        PlotCell {
-            id: cell
+        GridLayout {
+            id: grid
             Layout.fillWidth: true
             Layout.fillHeight: true
-            source: viewer.scanSource
-            side: viewer._firstActive.side
-            camId: viewer._firstActive.cam
-            // Phase 2a default: BVI. Healthy mid-range values around 5
-            // fit well in the [0, 10] axis. BFI tends to ride near zero
-            // in many scans and would clamp invisibly to the bottom of
-            // a fixed [0, 10] range. Phase 2b adds a metric switcher
-            // and autoscale so BFI / mean / contrast all render usefully.
-            metric: "bvi"
-            windowSeconds: 15
-            yMin: 0.0
-            yMax: 10.0
-            traceColor: theme.statusBlue
+            columns: 4
+            rowSpacing: 6
+            columnSpacing: 6
+
+            Repeater {
+                model: viewer._cellModel
+                delegate: PlotCell {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    source: viewer.scanSource
+                    side: modelData.side
+                    camId: modelData.camId
+                    metric: viewer.metric
+                    windowSeconds: viewer.windowSeconds
+                    yMin: viewer.yMin
+                    yMax: viewer.yMax
+                    traceColor: viewer._traceColorForMetric(viewer.metric)
+                }
+            }
         }
     }
 }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -1,4 +1,5 @@
 import QtQuick 6.0
+import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
 import OpenMotion 1.0
 
@@ -24,6 +25,7 @@ Rectangle {
     property real windowSeconds: 15
     property real yMin: 0.0
     property real yMax: 10.0
+    property bool autoScale: true
 
     // ── Source subscription ────────────────────────────────────────────
     readonly property var scanSource: MOTIONInterface.currentScanSource
@@ -54,22 +56,39 @@ Rectangle {
         return theme.statusBlue
     }
 
+    // Autoscale tick — 1 Hz. Calls into the source's compute_bounds_for_metric
+    // (Phase 2b-i Task 1) and pushes the result into the viewer's yMin/yMax,
+    // which propagates to every cell via property binding.
+    Timer {
+        interval: 1000
+        running: viewer.autoScale && viewer.scanSource !== null
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: {
+            if (!viewer.scanSource) return
+            var b = viewer.scanSource.compute_bounds_for_metric(viewer.metric)
+            if (b && typeof b.yMin === "number" && typeof b.yMax === "number") {
+                viewer.yMin = b.yMin
+                viewer.yMax = b.yMax
+            }
+        }
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 12
         spacing: 8
 
-        // Header — Phase 2a placeholder. Replaced by PlotToolbar in Task 5.
-        Text {
+        PlotToolbar {
             Layout.fillWidth: true
-            text: viewer.scanSource
-                ? "● Live · " + (viewer.scanSource.live ? "LiveScanSource" : "PastScanSource")
-                  + "   ·   metric=" + viewer.metric.toUpperCase()
-                  + "   window=" + viewer.windowSeconds + "s"
-                : "○ No active scan source"
-            color: theme.textSecondary
-            font.pixelSize: 12
-            font.family: "Roboto Mono"
+            scanSource: viewer.scanSource
+            metric: viewer.metric
+            windowSeconds: viewer.windowSeconds
+            autoScale: viewer.autoScale
+
+            onMetricRequested: function(m) { viewer.metric = m }
+            onWindowSecondsRequested: function(s) { viewer.windowSeconds = s }
+            onAutoScaleToggled: function(enabled) { viewer.autoScale = enabled }
         }
 
         GridLayout {

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -62,11 +62,16 @@ Rectangle {
             source: viewer.scanSource
             side: viewer._firstActive.side
             camId: viewer._firstActive.cam
-            metric: "bfi"
+            // Phase 2a default: BVI. Healthy mid-range values around 5
+            // fit well in the [0, 10] axis. BFI tends to ride near zero
+            // in many scans and would clamp invisibly to the bottom of
+            // a fixed [0, 10] range. Phase 2b adds a metric switcher
+            // and autoscale so BFI / mean / contrast all render usefully.
+            metric: "bvi"
             windowSeconds: 15
             yMin: 0.0
             yMax: 10.0
-            traceColor: "#E74C3C"
+            traceColor: "#3498DB"
         }
     }
 }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -84,6 +84,22 @@ Rectangle {
         return entries
     }
 
+    // ── Autoscale recompute (shared by Timer + displayMode change) ────
+    function _recomputeAutoscale() {
+        if (!viewer.scanSource) return
+        var bp = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.primary)
+        if (bp && typeof bp.yMin === "number" && typeof bp.yMax === "number") {
+            viewer.primaryYMin = bp.yMin
+            viewer.primaryYMax = bp.yMax
+        }
+        var bs = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.secondary)
+        if (bs && typeof bs.yMin === "number" && typeof bs.yMax === "number") {
+            viewer.secondaryYMin = bs.yMin
+            viewer.secondaryYMax = bs.yMax
+        }
+        viewer._dirty = true
+    }
+
     // ── DVR controls (called from PlotCell MouseArea) ─────────────────
     // Window-bounds: hard floor at 0.5 s so wheel-zoom can't collapse
     // the visible window to nothing; ceiling at 600 s to keep the
@@ -206,21 +222,10 @@ Rectangle {
         repeat: true
         triggeredOnStart: true
         onTriggered: {
-            if (!viewer.scanSource) return
             // [LAG-DIAG] Time the full autoscale tick (two metrics' worth
             // of compute_bounds_for_metric + property writes).
             var _t0 = Date.now()
-            var bp = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.primary)
-            if (bp && typeof bp.yMin === "number" && typeof bp.yMax === "number") {
-                viewer.primaryYMin = bp.yMin
-                viewer.primaryYMax = bp.yMax
-            }
-            var bs = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.secondary)
-            if (bs && typeof bs.yMin === "number" && typeof bs.yMax === "number") {
-                viewer.secondaryYMin = bs.yMin
-                viewer.secondaryYMax = bs.yMax
-            }
-            viewer._dirty = true
+            viewer._recomputeAutoscale()
             var _ms = Date.now() - _t0
             if (_ms > 15) {
                 console.warn("[LAG-DIAG] autoscale tick took " + _ms + " ms")
@@ -241,10 +246,29 @@ Rectangle {
             autoScale: viewer.autoScale
             followLive: viewer.followLive
 
-            onDisplayModeRequested: function(mode) { viewer.displayMode = mode }
-            onWindowSecondsRequested: function(s) { viewer.windowSeconds = s; viewer._dirty = true }
-            onAutoScaleToggled: function(enabled) { viewer.autoScale = enabled }
-            onBackToLiveRequested: viewer.backToLive()
+            onDisplayModeRequested: function(mode) {
+                viewer.displayMode = mode
+                console.info("[Plot] displayMode → " + mode)
+                // Force an immediate autoscale recompute so the new pair
+                // of metrics renders into a sensible y-axis right away
+                // — without this the old (BFI/BVI-fit) bounds make
+                // mean (~100) and contrast (~0.3) draw entirely
+                // off-screen until the next autoscale tick.
+                viewer._recomputeAutoscale()
+            }
+            onWindowSecondsRequested: function(s) {
+                viewer.windowSeconds = s
+                viewer._dirty = true
+                console.info("[Plot] windowSeconds → " + s + " s")
+            }
+            onAutoScaleToggled: function(enabled) {
+                viewer.autoScale = enabled
+                console.info("[Plot] autoScale → " + enabled)
+            }
+            onBackToLiveRequested: {
+                viewer.backToLive()
+                console.info("[Plot] back-to-live (followLive → true)")
+            }
         }
 
         GridLayout {

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -24,6 +24,21 @@ Rectangle {
     // again when Phase 2b's loadPastScan installs a PastScanSource.
     readonly property var scanSource: MOTIONInterface.currentScanSource
 
+    // Phase 2a: show the first active camera from the user's mask config
+    // so the single cell renders SOMETHING regardless of mask choice.
+    // Phase 2b expands to a full per-camera grid driven by both masks.
+    readonly property var _firstActive: {
+        var lm = (MOTIONInterface.appConfig.leftMask  || 0) & 0xFF
+        var rm = (MOTIONInterface.appConfig.rightMask || 0) & 0xFF
+        for (var i = 0; i < 8; i++) {
+            if (lm & (1 << i)) return { side: "left",  cam: i }
+        }
+        for (var j = 0; j < 8; j++) {
+            if (rm & (1 << j)) return { side: "right", cam: j }
+        }
+        return { side: "left", cam: 0 }
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 12
@@ -45,8 +60,8 @@ Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: true
             source: viewer.scanSource
-            side: "left"
-            camId: 0
+            side: viewer._firstActive.side
+            camId: viewer._firstActive.cam
             metric: "bfi"
             windowSeconds: 15
             yMin: 0.0

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -92,9 +92,44 @@ Rectangle {
         return { primary: "bfi", secondary: "bvi" }
     }
 
+    // ── Viewer-driven paint throttle ───────────────────────────────────
+    // Single dirty flag set by ANY samplesAppended emission. A 33 ms
+    // Timer ticks paintTick (consumed by every PlotCell) whenever dirty.
+    // Caps total cell-paint rate to ~30 Hz regardless of how many
+    // samplesAppended signals fire in between, and renders all cells
+    // in one pass so they stay visually in lockstep.
+    property int paintTick: 0
+    property bool _dirty: true   // start true so cells paint at least once
+
+    Connections {
+        target: viewer.scanSource
+        ignoreUnknownSignals: true
+        function onSamplesAppended(s, c, m, n) {
+            viewer._dirty = true
+        }
+    }
+
+    Timer {
+        id: paintThrottle
+        interval: 33
+        running: viewer.scanSource !== null
+        repeat: true
+        onTriggered: {
+            if (viewer._dirty) {
+                viewer._dirty = false
+                viewer.paintTick++
+            }
+        }
+    }
+
+    // Source change forces an immediate paint without waiting for the
+    // first samplesAppended.
+    onScanSourceChanged: viewer._dirty = true
+
     // Autoscale tick — 1 Hz. Computes bounds for both metrics in the
     // current display pair and pushes them into the viewer's per-metric
-    // ranges, which propagate to every cell via property bindings.
+    // ranges. Setting _dirty afterward ensures cells repaint promptly
+    // with the new range.
     Timer {
         interval: 1000
         running: viewer.autoScale && viewer.scanSource !== null
@@ -112,6 +147,7 @@ Rectangle {
                 viewer.secondaryYMin = bs.yMin
                 viewer.secondaryYMax = bs.yMax
             }
+            viewer._dirty = true
         }
     }
 
@@ -159,6 +195,7 @@ Rectangle {
                     secondaryYMin: viewer.secondaryYMin
                     secondaryYMax: viewer.secondaryYMax
                     secondaryColor: viewer._traceColorForMetric(viewer._displayPair.secondary)
+                    paintTick: viewer.paintTick
                 }
             }
         }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -31,18 +31,36 @@ Rectangle {
     readonly property var scanSource: MOTIONInterface.currentScanSource
 
     // ── Grid model ─────────────────────────────────────────────────────
-    // 16 entries in row-major order matching the layout grid:
-    //   row 0: L1 L2 L3 L4
-    //   row 1: L5 L6 L7 L8
-    //   row 2: R1 R2 R3 R4
-    //   row 3: R5 R6 R7 R8
-    readonly property var _cellModel: {
+    // Only renders cells for active cameras (bits set in leftMask /
+    // rightMask). Layout: 4 columns max, left-side cams fill the top
+    // rows, right-side cams fill the rows below. No empty trailing
+    // cells unless a side's active count isn't a multiple of 4.
+    readonly property var _activeCellModel: {
+        var lm = (MOTIONInterface.appConfig.leftMask  || 0) & 0xFF
+        var rm = (MOTIONInterface.appConfig.rightMask || 0) & 0xFF
+        var leftCams = []
+        var rightCams = []
+        for (var i = 0; i < 8; i++) {
+            if (lm & (1 << i)) leftCams.push(i)
+            if (rm & (1 << i)) rightCams.push(i)
+        }
         var entries = []
-        var sides = ["left", "right"]
-        for (var s = 0; s < sides.length; s++) {
-            for (var c = 0; c < 8; c++) {
-                entries.push({ side: sides[s], camId: c })
-            }
+        var leftRows = Math.ceil(leftCams.length / 4)
+        for (var li = 0; li < leftCams.length; li++) {
+            entries.push({
+                side: "left",
+                camId: leftCams[li],
+                row: Math.floor(li / 4),
+                col: li % 4
+            })
+        }
+        for (var ri = 0; ri < rightCams.length; ri++) {
+            entries.push({
+                side: "right",
+                camId: rightCams[ri],
+                row: leftRows + Math.floor(ri / 4),
+                col: ri % 4
+            })
         }
         return entries
     }
@@ -100,8 +118,10 @@ Rectangle {
             columnSpacing: 6
 
             Repeater {
-                model: viewer._cellModel
+                model: viewer._activeCellModel
                 delegate: PlotCell {
+                    Layout.row: modelData.row
+                    Layout.column: modelData.col
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     source: viewer.scanSource
@@ -113,6 +133,22 @@ Rectangle {
                     yMax: viewer.yMax
                     traceColor: viewer._traceColorForMetric(viewer.metric)
                 }
+            }
+        }
+
+        // Placeholder when no cameras are active (both masks 0). Lets the
+        // viewer still show its toolbar + scan-source state without an
+        // empty grid below it.
+        Item {
+            visible: viewer._activeCellModel.length === 0
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Text {
+                anchors.centerIn: parent
+                text: "No active cameras selected"
+                color: theme.textTertiary
+                font.pixelSize: 14
+                font.family: "Roboto Mono"
             }
         }
     }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -95,8 +95,11 @@ Rectangle {
         // Capture the currently-visible window start so pan/zoom from
         // followLive transitions smoothly (no visual jump). After this
         // the caller mutates windowStartT/windowSeconds freely.
-        if (viewer.followLive && viewer.scanSource) {
-            viewer.windowStartT = Math.max(0, viewer.scanSource.liveEdge - viewer.windowSeconds)
+        if (viewer.followLive) {
+            // Use the snapshot (matches what's actually drawn) rather
+            // than re-reading source.liveEdge — avoids a one-frame jump
+            // at the moment of pan/zoom on a fast source.
+            viewer.windowStartT = Math.max(0, viewer.liveEdgeSnapshot - viewer.windowSeconds)
         }
         viewer.followLive = false
     }
@@ -140,6 +143,12 @@ Rectangle {
     property int paintTick: 0
     property bool _dirty: true   // start true so cells paint at least once
 
+    // Snapshot of source.liveEdge captured once per paintTick. All cells
+    // read this (not source.liveEdge directly) so their windows stay
+    // perfectly synced even when individual cell paints land at slightly
+    // different wall-clock times under load.
+    property real liveEdgeSnapshot: 0.0
+
     Connections {
         target: viewer.scanSource
         ignoreUnknownSignals: true
@@ -156,6 +165,7 @@ Rectangle {
         onTriggered: {
             if (viewer._dirty) {
                 viewer._dirty = false
+                viewer.liveEdgeSnapshot = viewer.scanSource ? viewer.scanSource.liveEdge : 0
                 viewer.paintTick++
             }
         }
@@ -163,7 +173,10 @@ Rectangle {
 
     // Source change forces an immediate paint without waiting for the
     // first samplesAppended.
-    onScanSourceChanged: viewer._dirty = true
+    onScanSourceChanged: {
+        viewer.liveEdgeSnapshot = viewer.scanSource ? viewer.scanSource.liveEdge : 0
+        viewer._dirty = true
+    }
 
     // Autoscale tick — 1 Hz. Computes bounds for both metrics in the
     // current display pair and pushes them into the viewer's per-metric
@@ -239,6 +252,7 @@ Rectangle {
                     secondaryYMax: viewer.secondaryYMax
                     secondaryColor: viewer._traceColorForMetric(viewer._displayPair.secondary)
                     paintTick: viewer.paintTick
+                    liveEdgeSnapshot: viewer.liveEdgeSnapshot
                     panZoomTarget: viewer
                 }
             }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -159,7 +159,11 @@ Rectangle {
 
     Timer {
         id: paintThrottle
-        interval: 33
+        // 50 ms = 20 Hz — gives Qt's scene graph headroom under load.
+        // Visually smooth: each pan/scroll frame still moves the trace
+        // by ~2 px in a 200 px cell. Lower than 20 Hz starts to look
+        // jerky; higher overloads under 8-cell × 2-metric paint cost.
+        interval: 50
         running: viewer.scanSource !== null
         repeat: true
         onTriggered: {

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -50,11 +50,10 @@ Rectangle {
     readonly property var scanSource: MOTIONInterface.currentScanSource
 
     // ── Grid model ─────────────────────────────────────────────────────
-    // Only renders cells for active cameras (bits set in leftMask /
-    // rightMask). Layout: 4 columns max, left-side cams fill the top
-    // rows, right-side cams fill the rows below. No empty trailing
-    // cells unless a side's active count isn't a multiple of 4.
-    readonly property var _activeCellModel: {
+    // Dev mode (default) — one cell per active camera (bits set in
+    // leftMask / rightMask). 4 columns max; left-side cams fill the
+    // top rows, right-side cams fill the rows below.
+    readonly property var _devCellModel: {
         var lm = (MOTIONInterface.appConfig.leftMask  || 0) & 0xFF
         var rm = (MOTIONInterface.appConfig.rightMask || 0) & 0xFF
         var leftCams = []
@@ -83,6 +82,18 @@ Rectangle {
         }
         return entries
     }
+
+    // Reduced mode — 2 cells, one per side, each rendering the
+    // side-averaged stream (cam_id=-1, fed by SDK's SideAveragingStage
+    // via _LivePlotSink.consume). Stacked vertically in a single column.
+    readonly property var _reducedCellModel: [
+        { side: "left",  camId: -1, row: 0, col: 0 },
+        { side: "right", camId: -1, row: 1, col: 0 }
+    ]
+
+    readonly property var _activeCellModel: viewer.reducedMode
+        ? _reducedCellModel
+        : _devCellModel
 
     // ── Autoscale recompute (shared by Timer + displayMode change) ────
     function _recomputeAutoscale() {
@@ -264,7 +275,9 @@ Rectangle {
             id: grid
             Layout.fillWidth: true
             Layout.fillHeight: true
-            columns: 4
+            // Reduced mode: single column, 2 stacked cells. Dev mode:
+            // 4 columns, rows determined by active-cam count.
+            columns: viewer.reducedMode ? 1 : 4
             rowSpacing: 6
             columnSpacing: 6
 

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -15,6 +15,50 @@ Rectangle {
     border.color: theme.borderSoft
     border.width: 1
 
+    // Keyboard focus — viewer starts focused so spec keys (← → +/- 0
+    // Home End Esc) work without a prior click. Click on a cell or
+    // the scrubber re-focuses; Esc clears focus so text inputs (notes
+    // editor, subject ID) take precedence afterward.
+    focus: true
+    activeFocusOnTab: true
+
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Left) {
+            var dt = (event.modifiers & Qt.ShiftModifier)
+                ? -viewer.windowSeconds : -1
+            viewer._kbPan(dt)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Right) {
+            var dt2 = (event.modifiers & Qt.ShiftModifier)
+                ? viewer.windowSeconds : 1
+            viewer._kbPan(dt2)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Plus || event.key === Qt.Key_Equal
+                   || event.key === Qt.Key_Up) {
+            // Equal key shares the physical key with Plus on US layouts
+            // — accept it so the user doesn't need to hold Shift. ↑/↓
+            // mirror mouse-wheel direction: wheel-up zooms in.
+            viewer._kbZoom(0.8)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Minus || event.key === Qt.Key_Underscore
+                   || event.key === Qt.Key_Down) {
+            viewer._kbZoom(1.25)
+            event.accepted = true
+        } else if (event.key === Qt.Key_0) {
+            viewer._kbReset()
+            event.accepted = true
+        } else if (event.key === Qt.Key_Home) {
+            viewer.setWindow(0, viewer.windowSeconds)
+            event.accepted = true
+        } else if (event.key === Qt.Key_End) {
+            viewer._kbEnd()
+            event.accepted = true
+        } else if (event.key === Qt.Key_Escape) {
+            viewer.focus = false
+            event.accepted = true
+        }
+    }
+
     AppTheme { id: theme }
 
     // ── Inputs ─────────────────────────────────────────────────────────
@@ -147,6 +191,44 @@ Rectangle {
     function backToLive() {
         viewer.followLive = true
         viewer._dirty = true
+    }
+
+    // ── Keyboard shortcut helpers ──────────────────────────────────────
+    // Default windowSeconds matches PlotToolbar's "15 s" combo entry —
+    // the `0` shortcut resets to this canonical value.
+    readonly property real _defaultWindowSeconds: 15
+
+    function _kbPan(seconds) {
+        _ensureFrozen()
+        setWindow(viewer.windowStartT + seconds, viewer.windowSeconds)
+    }
+
+    function _kbZoom(factor) {
+        _ensureFrozen()
+        // Zoom around the center of the currently-visible window so the
+        // operator's mental anchor stays put on the screen.
+        var center = viewer.windowStartT + viewer.windowSeconds / 2
+        var newSec = viewer.windowSeconds * factor
+        setWindow(center - newSec / 2, newSec)
+    }
+
+    function _kbEnd() {
+        // Past mode: pin window so the rightmost data sits at the right
+        // edge. Live mode: resume followLive (snaps to liveEdge AND
+        // keeps tracking new samples as they arrive).
+        if (viewer.scanSource && viewer.scanSource.live) {
+            backToLive()
+        } else {
+            setWindow(
+                Math.max(0, viewer.liveEdgeSnapshot - viewer.windowSeconds),
+                viewer.windowSeconds
+            )
+        }
+    }
+
+    function _kbReset() {
+        viewer.windowSeconds = _defaultWindowSeconds
+        backToLive()
     }
 
     // ── Hover crosshair ────────────────────────────────────────────────
@@ -361,6 +443,7 @@ Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: 28
             visible: viewer.scanSource !== null
+            focusTarget: viewer
             fullScanDuration: viewer.liveEdgeSnapshot
             // When followLive, project the visible window onto the live
             // edge so the inset stays glued to the right; when paused

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -182,12 +182,13 @@ Rectangle {
         viewer._dirty = true
     }
 
-    // Autoscale tick — 1 Hz. Computes bounds for both metrics in the
-    // current display pair and pushes them into the viewer's per-metric
-    // ranges. Setting _dirty afterward ensures cells repaint promptly
-    // with the new range.
+    // Autoscale tick — every 3 s. compute_bounds_for_metric walks every
+    // sample across all buffers, so the per-call cost scales with scan
+    // duration; 3 s amortizes that work without making the y-axis feel
+    // unresponsive (a 3-second delay between bound adjustments is hard
+    // to notice during live monitoring).
     Timer {
-        interval: 1000
+        interval: 3000
         running: viewer.autoScale && viewer.scanSource !== null
         repeat: true
         triggeredOnStart: true

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -415,8 +415,14 @@ Rectangle {
                 var c = viewer._activeCellModel[i]
                 var pv = viewer.scanSource.value_at(c.side, c.camId, primMetric, t)
                 var sv = viewer.scanSource.value_at(c.side, c.camId, secMetric, t)
+                // Reduced mode uses camId=-1 for the side-averaged stream;
+                // (c.camId + 1) would render "L0"/"R0" instead of the
+                // cell's own "LEFT AVG" / "RIGHT AVG" label.
+                var label = c.camId === -1
+                    ? c.side.charAt(0).toUpperCase() + " AVG"
+                    : c.side.charAt(0).toUpperCase() + (c.camId + 1)
                 rows.push({
-                    label: c.side.charAt(0).toUpperCase() + (c.camId + 1),
+                    label: label,
                     pVal: pv, pColor: primColor,
                     sVal: sv, sColor: secColor,
                 })

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -159,11 +159,11 @@ Rectangle {
 
     Timer {
         id: paintThrottle
-        // 50 ms = 20 Hz — gives Qt's scene graph headroom under load.
-        // Visually smooth: each pan/scroll frame still moves the trace
-        // by ~2 px in a 200 px cell. Lower than 20 Hz starts to look
-        // jerky; higher overloads under 8-cell × 2-metric paint cost.
-        interval: 50
+        // 33 ms = 30 Hz — restored from the 50 ms throttle once the
+        // mean-binning fix dropped per-paint data volume back to width × 1
+        // samples. Each tick moves the trace ~1 sample at the data rate
+        // (40 Hz), so the scroll feels continuous instead of stepwise.
+        interval: 33
         running: viewer.scanSource !== null
         repeat: true
         onTriggered: {

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -214,10 +214,16 @@ Rectangle {
     }
 
     // Source change forces an immediate paint without waiting for the
-    // first samplesAppended.
+    // first samplesAppended; also resets followLive so each new source
+    // (live or past) opens at its own latest window.
     onScanSourceChanged: {
         viewer.liveEdgeSnapshot = viewer.scanSource ? viewer.scanSource.liveEdge : 0
+        viewer.followLive = true
         viewer._dirty = true
+        // Re-fit y-axis to the new source's data immediately, otherwise
+        // a past scan loaded with very different value ranges would draw
+        // off-axis until the next autoscale tick.
+        viewer._recomputeAutoscale()
     }
 
     // Autoscale tick — every 3 s. compute_bounds_for_metric walks every
@@ -245,6 +251,7 @@ Rectangle {
             windowSeconds: viewer.windowSeconds
             autoScale: viewer.autoScale
             followLive: viewer.followLive
+            liveSourceAvailable: MOTIONInterface.liveSourceAvailable
 
             onDisplayModeRequested: function(mode) {
                 viewer.displayMode = mode
@@ -266,8 +273,17 @@ Rectangle {
                 console.info("[Plot] autoScale → " + enabled)
             }
             onBackToLiveRequested: {
-                viewer.backToLive()
-                console.info("[Plot] back-to-live (followLive → true)")
+                // When the viewer is on a past source, "Back to live"
+                // means switch back to the held LiveScanSource. When
+                // already live (just paused), it means resume follow.
+                if (viewer.scanSource && viewer.scanSource.live === false
+                        && MOTIONInterface.liveSourceAvailable) {
+                    MOTIONInterface.showLiveSource()
+                    console.info("[Plot] back-to-live (past → live source)")
+                } else {
+                    viewer.backToLive()
+                    console.info("[Plot] back-to-live (followLive → true)")
+                }
             }
         }
 

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -63,15 +63,28 @@ Rectangle {
 
     // ── Inputs ─────────────────────────────────────────────────────────
     property bool reducedMode: false   // honored in Phase 2b-ii
+    // displayMode pair selector — driven externally (BloodFlow.qml binds
+    // it from settingsModal.showBfiBvi). "bfi_bvi" overlays BFI+BVI on
+    // each cell; "mean_contrast" overlays Mean+Contrast.
+    property string displayMode: "bfi_bvi"
+    // autoScale — driven externally from Settings; when true, the 3 s
+    // _recomputeAutoscale timer below repins primary/secondary YMin/YMax
+    // to per-metric percentile bounds across the buffer.
+    property bool autoScale: true
 
     // ── State (owned here; pushed to every cell) ───────────────────────
-    // displayMode: "bfi_bvi" overlays BFI+BVI on each cell;
-    // "mean_contrast" overlays Mean+Contrast. Each metric has its own
-    // y-axis mapping (primary*/secondary*) so the two traces don't
-    // squash each other when their ranges differ wildly.
-    property string displayMode: "bfi_bvi"
+    // windowSeconds is internal — the bottom-right pill overlay edits it
+    // via _windowSecondsRequested. Each metric has its own y-axis mapping
+    // (primary*/secondary*) so the two traces don't squash each other
+    // when their ranges differ wildly.
     property real windowSeconds: 15
-    property bool autoScale: true
+
+    // When displayMode changes (e.g. from the Settings modal flipping
+    // BFI/BVI ↔ Mean/Contrast), the previously-fit y-bounds will be
+    // for the wrong pair — mean ~100 + contrast ~0.3 would render
+    // entirely off-axis until the next 3 s autoscale tick. Force an
+    // immediate recompute so the switch lands cleanly.
+    onDisplayModeChanged: viewer._recomputeAutoscale()
 
     // ── Time-axis state ────────────────────────────────────────────────
     // followLive = true: cells render the last `windowSeconds` of data
@@ -83,12 +96,47 @@ Rectangle {
     property bool followLive: true
     property real windowStartT: 0.0
 
-    // Independent y-axis bounds per metric — kept here so every cell
-    // shares the same scale.
-    property real primaryYMin: 0.0
-    property real primaryYMax: 10.0
-    property real secondaryYMin: 0.0
-    property real secondaryYMax: 10.0
+    // Y-axis bounds — when autoScale is true, _autoPrimaryYMin/Max are
+    // written by _recomputeAutoscale (every 3 s + on displayMode change)
+    // and primaryYMin/Max read them through the derived bindings below.
+    // When autoScale is false, primaryYMin/Max instead read the per-
+    // metric clamps from settingsModal (settingBfiMin/Max etc.) so the
+    // operator's preferred fixed scale applies.
+    property real _autoPrimaryYMin: 0.0
+    property real _autoPrimaryYMax: 10.0
+    property real _autoSecondaryYMin: 0.0
+    property real _autoSecondaryYMax: 10.0
+
+    // Manual-bound inputs — BloodFlow.qml binds these from settingsModal.
+    property real settingBfiMin: 0.0
+    property real settingBfiMax: 10.0
+    property real settingBviMin: 0.0
+    property real settingBviMax: 10.0
+    property real settingMeanMin: 0.0
+    property real settingMeanMax: 500.0
+    property real settingContrastMin: 0.0
+    property real settingContrastMax: 1.0
+
+    function _settingBound(metric, which) {
+        if (metric === "bfi")      return which === "min" ? settingBfiMin      : settingBfiMax
+        if (metric === "bvi")      return which === "min" ? settingBviMin      : settingBviMax
+        if (metric === "mean")     return which === "min" ? settingMeanMin     : settingMeanMax
+        if (metric === "contrast") return which === "min" ? settingContrastMin : settingContrastMax
+        return which === "min" ? 0.0 : 10.0
+    }
+
+    readonly property real primaryYMin: autoScale
+        ? _autoPrimaryYMin
+        : _settingBound(_displayPair.primary, "min")
+    readonly property real primaryYMax: autoScale
+        ? _autoPrimaryYMax
+        : _settingBound(_displayPair.primary, "max")
+    readonly property real secondaryYMin: autoScale
+        ? _autoSecondaryYMin
+        : _settingBound(_displayPair.secondary, "min")
+    readonly property real secondaryYMax: autoScale
+        ? _autoSecondaryYMax
+        : _settingBound(_displayPair.secondary, "max")
 
     // ── Source subscription ────────────────────────────────────────────
     readonly property var scanSource: MOTIONInterface.currentScanSource
@@ -140,17 +188,19 @@ Rectangle {
         : _devCellModel
 
     // ── Autoscale recompute (shared by Timer + displayMode change) ────
+    // Writes to _auto* — the derived primaryYMin/Max bindings above
+    // pick the _auto vs setting-bound value based on autoScale.
     function _recomputeAutoscale() {
         if (!viewer.scanSource) return
         var bp = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.primary)
         if (bp && typeof bp.yMin === "number" && typeof bp.yMax === "number") {
-            viewer.primaryYMin = bp.yMin
-            viewer.primaryYMax = bp.yMax
+            viewer._autoPrimaryYMin = bp.yMin
+            viewer._autoPrimaryYMax = bp.yMax
         }
         var bs = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.secondary)
         if (bs && typeof bs.yMin === "number" && typeof bs.yMax === "number") {
-            viewer.secondaryYMin = bs.yMin
-            viewer.secondaryYMax = bs.yMax
+            viewer._autoSecondaryYMin = bs.yMin
+            viewer._autoSecondaryYMax = bs.yMax
         }
         viewer._dirty = true
     }
@@ -244,12 +294,15 @@ Rectangle {
     }
 
     // ── Trace color per metric ─────────────────────────────────────────
+    // Hex values match the legacy EmbeddedRealtimePlot defaults so the
+    // visual identity carries across the viewer swap — clinicians don't
+    // suddenly see a different palette for the same metric.
     function _traceColorForMetric(m) {
-        if (m === "bfi")      return theme.accentRed
-        if (m === "bvi")      return theme.statusBlue
-        if (m === "mean")     return theme.accentOrange
-        if (m === "contrast") return theme.accentYellow
-        return theme.statusBlue
+        if (m === "bfi")      return "#E74C3C"  // red
+        if (m === "bvi")      return "#3498DB"  // blue
+        if (m === "mean")     return "#2ECC71"  // green
+        if (m === "contrast") return "#9B59B6"  // purple
+        return "#3498DB"
     }
 
     // ── Display-mode pair resolution ───────────────────────────────────
@@ -405,68 +458,54 @@ Rectangle {
         onTriggered: viewer._recomputeAutoscale()
     }
 
+    // Window-seconds options — duplicated here from the old PlotToolbar
+    // so the new bottom-right overlay can use the same list. Keeping
+    // the labels formatter symmetric (15 → "15 s", 300 → "5 min").
+    readonly property var _windowOptions: [
+        { value: 5,   label: "5 s" },
+        { value: 15,  label: "15 s" },
+        { value: 30,  label: "30 s" },
+        { value: 60,  label: "1 min" },
+        { value: 300, label: "5 min" }
+    ]
+
+    function _labelForWindowSeconds(s) {
+        for (var i = 0; i < viewer._windowOptions.length; i++) {
+            if (viewer._windowOptions[i].value === s)
+                return viewer._windowOptions[i].label
+        }
+        // Custom (wheel-zoomed) value — show as "<n>s" or "<m>m" tersely.
+        if (s >= 60) return Math.round(s / 60 * 10) / 10 + " min"
+        return Math.round(s * 10) / 10 + " s"
+    }
+
+    // Triggered by the bottom-right back-to-live overlay button.
+    function _backToLiveRequested() {
+        if (viewer.scanSource && viewer.scanSource.live === false
+                && MOTIONInterface.liveSourceAvailable) {
+            MOTIONInterface.showLiveSource()
+            console.info("[Plot] back-to-live (past → live source)")
+        } else {
+            viewer.backToLive()
+            console.info("[Plot] back-to-live (followLive → true)")
+        }
+    }
+
+    // Triggered by the bottom-right window-seconds menu.
+    function _windowSecondsRequested(s) {
+        if (viewer.followLive) {
+            viewer.windowSeconds = s
+        } else {
+            viewer.setWindow(viewer.windowStartT, s)
+        }
+        viewer._dirty = true
+        console.info("[Plot] windowSeconds → " + s + " s")
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 12
         spacing: 8
-
-        PlotToolbar {
-            Layout.fillWidth: true
-            scanSource: viewer.scanSource
-            displayMode: viewer.displayMode
-            windowSeconds: viewer.windowSeconds
-            autoScale: viewer.autoScale
-            followLive: viewer.followLive
-            liveSourceAvailable: MOTIONInterface.liveSourceAvailable
-            developerMode: MOTIONInterface.appConfig.developerMode === true
-            showProfiling: viewer.showProfiling
-
-            onDisplayModeRequested: function(mode) {
-                viewer.displayMode = mode
-                console.info("[Plot] displayMode → " + mode)
-                // Force an immediate autoscale recompute so the new pair
-                // of metrics renders into a sensible y-axis right away
-                // — without this the old (BFI/BVI-fit) bounds make
-                // mean (~100) and contrast (~0.3) draw entirely
-                // off-screen until the next autoscale tick.
-                viewer._recomputeAutoscale()
-            }
-            onWindowSecondsRequested: function(s) {
-                // Route through setWindow so the off-edge cap re-applies
-                // — expanding from 5 s to 60 s while paused near liveEdge
-                // would otherwise push the right edge past liveEdge.
-                // When followLive, setWindow's _ensureFrozen snapshots
-                // the current view first, preserving the visual position.
-                if (viewer.followLive) {
-                    viewer.windowSeconds = s
-                } else {
-                    viewer.setWindow(viewer.windowStartT, s)
-                }
-                viewer._dirty = true
-                console.info("[Plot] windowSeconds → " + s + " s")
-            }
-            onAutoScaleToggled: function(enabled) {
-                viewer.autoScale = enabled
-                console.info("[Plot] autoScale → " + enabled)
-            }
-            onShowProfilingToggled: function(enabled) {
-                viewer.showProfiling = enabled
-                console.info("[Plot] showProfiling → " + enabled)
-            }
-            onBackToLiveRequested: {
-                // When the viewer is on a past source, "Back to live"
-                // means switch back to the held LiveScanSource. When
-                // already live (just paused), it means resume follow.
-                if (viewer.scanSource && viewer.scanSource.live === false
-                        && MOTIONInterface.liveSourceAvailable) {
-                    MOTIONInterface.showLiveSource()
-                    console.info("[Plot] back-to-live (past → live source)")
-                } else {
-                    viewer.backToLive()
-                    console.info("[Plot] back-to-live (followLive → true)")
-                }
-            }
-        }
 
         GridLayout {
             id: grid
@@ -524,6 +563,7 @@ Rectangle {
         }
 
         PlotScrubber {
+            id: scrubber
             Layout.fillWidth: true
             Layout.preferredHeight: 28
             visible: viewer.scanSource !== null
@@ -557,8 +597,15 @@ Rectangle {
                   && viewer._activeCellModel.length > 0
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.topMargin: 56  // clear the toolbar
-        anchors.rightMargin: 16
+        // When the back-to-live pill is showing in the top-right corner,
+        // push the tooltip down past it (BTL height + same rim margin
+        // we use between the BTL pill and the plot rim) so the two
+        // don't overlap. Otherwise sit at the standard edge margin.
+        anchors.topMargin: viewer._overlayEdgeMarginPx
+                           + (viewer._showBackToLive
+                              ? backToLiveOverlay.height + viewer._overlayMarginPx
+                              : 0)
+        anchors.rightMargin: viewer._overlayEdgeMarginPx
         color: theme.bgElevated
         border.color: theme.borderSubtle
         border.width: 1
@@ -649,26 +696,279 @@ Rectangle {
         }
     }
 
-    // ── Profile HUD overlay ────────────────────────────────────────────
-    // Top-left of the plot grid; ports the legacy EmbeddedRealtimePlot
-    // counters forward per spec §248. Visible only when both
-    // developerMode AND showProfiling are true so clinical users never
-    // see it. The values are refreshed by the 1 Hz profHudTimer above
-    // (which also gates `running` on this overlay's visibility so the
-    // EWMA + division work doesn't run in production builds).
+    // ── Overlay margins ───────────────────────────────────────────────
+    // Plot grid lives inside a ColumnLayout that's anchored fill to the
+    // viewer with a 12 px outer margin. Visual rim margin we want
+    // between an overlay and the plot cell edge is another 12 px. So
+    // for the LEFT/RIGHT/TOP edges (anchored to viewer's edges) the
+    // total margin is outer-layout-margin + rim-margin. The BOTTOM
+    // edge is further inset by the scrubber area (scrubber height +
+    // ColumnLayout.spacing).
+    readonly property real _overlayMarginPx: 12      // rim margin (inside grid)
+    readonly property real _outerLayoutMarginPx: 12  // ColumnLayout.anchors.margins
+    readonly property real _scrubberAreaPx: 28 + 8   // scrubber height + Layout.spacing
+    // Convenience: full edge margin from viewer.{right,top,left}.
+    readonly property real _overlayEdgeMarginPx: _outerLayoutMarginPx + _overlayMarginPx
+    // Convenience: full bottom margin from viewer.bottom.
+    readonly property real _overlayBottomMarginPx: _outerLayoutMarginPx + _scrubberAreaPx + _overlayMarginPx
+
+    // Signals back to the host (BloodFlow.qml) for state that's owned by
+    // settingsModal — Autoscale and BFI/BVI ↔ Mean/Contrast persist in
+    // app config and are also reachable from the Settings modal, so the
+    // bottom-right popup switches just request changes; BloodFlow.qml
+    // applies them to settingsModal which then flows back into the
+    // viewer's `autoScale` / `displayMode` bindings.
+    signal autoScaleToggleRequested(bool enabled)
+    signal displayModeToggleRequested(bool bfiBviMode)
+
+    // ── Top-right overlay: back-to-live ───────────────────────────────
+    // Same spacing guidelines as bottom-right overlay group.
+    readonly property bool _showBackToLive:
+        viewer.scanSource !== null
+        && (
+            (viewer.scanSource.live === false && MOTIONInterface.liveSourceAvailable)
+            || (viewer.scanSource.live === true && !viewer.followLive)
+        )
+
+    Rectangle {
+        id: backToLiveOverlay
+        visible: viewer._showBackToLive
+        width: backToLiveText.implicitWidth + 28
+        height: 36
+        radius: 18
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: viewer._overlayEdgeMarginPx
+        anchors.rightMargin: viewer._overlayEdgeMarginPx
+        z: 6
+        color: Qt.rgba(0.10, 0.10, 0.12, 0.82)
+        border.color: theme.accentRed
+        border.width: 1
+
+        Text {
+            id: backToLiveText
+            anchors.centerIn: parent
+            text: (viewer.scanSource !== null
+                   && viewer.scanSource.live === false
+                   && MOTIONInterface.liveSourceAvailable)
+                  ? "← Back to live scan"
+                  : "● Back to live"
+            color: theme.accentRed
+            font.pixelSize: 13
+            font.family: "Roboto Mono"
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: viewer._backToLiveRequested()
+        }
+    }
+
+    // ── Bottom-right overlay: window-seconds pill + three-dot menu ────
+    // Window-seconds pill shows the current zoom and opens a dropdown
+    // menu of the canonical zoom options when clicked. The three-dot
+    // button to its right opens a popup with switches for display mode,
+    // autoscale, and (dev-only) profiler.
+    Row {
+        id: bottomRightOverlay
+        visible: viewer.scanSource !== null
+        spacing: 8
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.rightMargin: viewer._overlayEdgeMarginPx
+        anchors.bottomMargin: viewer._overlayBottomMarginPx
+        z: 6
+
+        Rectangle {
+            id: windowSecondsPill
+            width: windowSecondsText.implicitWidth + 38
+            height: 36
+            radius: 18
+            color: Qt.rgba(0.10, 0.10, 0.12, 0.82)
+            border.color: theme.borderSubtle
+            border.width: 1
+
+            Text {
+                id: windowSecondsText
+                anchors.left: parent.left
+                anchors.leftMargin: 14
+                anchors.verticalCenter: parent.verticalCenter
+                text: viewer._labelForWindowSeconds(viewer.windowSeconds)
+                color: theme.textPrimary
+                font.pixelSize: 13
+                font.family: "Roboto Mono"
+            }
+            Text {
+                anchors.right: parent.right
+                anchors.rightMargin: 12
+                anchors.verticalCenter: parent.verticalCenter
+                text: "▾"
+                color: theme.textTertiary
+                font.pixelSize: 12
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: windowSecondsMenu.popup(windowSecondsPill, 0, windowSecondsPill.height + 4)
+            }
+
+            Menu {
+                id: windowSecondsMenu
+                // Match the bottom-right settings popup's visual style
+                // — same translucent dark card, subtle border, rounded
+                // corners — so the two corner overlays read as parts
+                // of the same control system. Keeping the default
+                // MenuItem contentItem (instead of overriding it) so
+                // implicitWidth resolves correctly; a custom Text
+                // contentItem leaves the menu zero-width and the items
+                // un-clickable.
+                padding: 6
+                implicitWidth: 120
+                background: Rectangle {
+                    color: Qt.rgba(0.12, 0.12, 0.14, 0.96)
+                    border.color: theme.borderSubtle
+                    border.width: 1
+                    radius: 8
+                }
+                Repeater {
+                    model: viewer._windowOptions
+                    MenuItem {
+                        text: modelData.label
+                        font.family: "Roboto Mono"
+                        font.pixelSize: 13
+                        onTriggered: viewer._windowSecondsRequested(modelData.value)
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            id: settingsMenuButton
+            width: 36
+            height: 36
+            radius: 18
+            color: settingsPopup.opened
+                   ? Qt.rgba(0.29, 0.56, 0.89, 0.85)
+                   : Qt.rgba(0.10, 0.10, 0.12, 0.82)
+            border.color: settingsPopup.opened ? "#4A90E2" : theme.borderSubtle
+            border.width: 1
+
+            Text {
+                anchors.centerIn: parent
+                text: "⋯"
+                color: settingsPopup.opened ? "white" : theme.textPrimary
+                font.pixelSize: 20
+                font.bold: true
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: settingsPopup.opened ? settingsPopup.close() : settingsPopup.open()
+            }
+
+            // Popup opens UPWARD from the button so it doesn't cover
+            // the scrubber. Width tracks the longest switch row.
+            Popup {
+                id: settingsPopup
+                parent: settingsMenuButton
+                x: settingsMenuButton.width - width
+                y: -height - 6
+                padding: 0
+                width: popupColumn.implicitWidth + 24
+                height: popupColumn.implicitHeight + 16
+                modal: false
+                focus: true
+                closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+                background: Rectangle {
+                    color: Qt.rgba(0.12, 0.12, 0.14, 0.95)
+                    border.color: theme.borderSubtle
+                    border.width: 1
+                    radius: 8
+                }
+
+                contentItem: Column {
+                    id: popupColumn
+                    spacing: 6
+                    padding: 12
+
+                    Row {
+                        spacing: 8
+                        Switch {
+                            id: bfiBviSwitch
+                            checked: viewer.displayMode === "bfi_bvi"
+                            // Switch's `text` lives inside its indicator —
+                            // use a sibling Text for free placement.
+                            onToggled: viewer.displayModeToggleRequested(checked)
+                        }
+                        Text {
+                            anchors.verticalCenter: bfiBviSwitch.verticalCenter
+                            text: bfiBviSwitch.checked ? "BFI / BVI" : "Mean / Contrast"
+                            color: theme.textPrimary
+                            font.pixelSize: 12
+                            font.family: "Roboto Mono"
+                        }
+                    }
+                    Row {
+                        spacing: 8
+                        Switch {
+                            id: autoScaleSwitch
+                            checked: viewer.autoScale
+                            onToggled: viewer.autoScaleToggleRequested(checked)
+                        }
+                        Text {
+                            anchors.verticalCenter: autoScaleSwitch.verticalCenter
+                            text: "Autoscale"
+                            color: theme.textPrimary
+                            font.pixelSize: 12
+                            font.family: "Roboto Mono"
+                        }
+                    }
+                    Row {
+                        visible: MOTIONInterface.appConfig.developerMode === true
+                        spacing: 8
+                        Switch {
+                            id: profilerSwitch
+                            checked: viewer.showProfiling
+                            onToggled: viewer.showProfiling = checked
+                        }
+                        Text {
+                            anchors.verticalCenter: profilerSwitch.verticalCenter
+                            text: "Profiler"
+                            color: "#4A90E2"
+                            font.pixelSize: 12
+                            font.family: "Roboto Mono"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Bottom-left overlay: profiler HUD ─────────────────────────────
+    // Developer-only HUD; toggled from the bottom-right settings menu's
+    // Profiler switch. Renders as a static overlay anchored at the
+    // bottom-left corner of the plot grid, with the same rim margin as
+    // the other overlays.
     Rectangle {
         id: profileHud
-        visible: viewer._hudVisible
-        anchors.top: parent.top
+        visible: MOTIONInterface.appConfig.developerMode === true
+                 && viewer.showProfiling
+                 && viewer.scanSource !== null
         anchors.left: parent.left
-        anchors.topMargin: 56
-        anchors.leftMargin: 16
-        color: theme.bgElevated
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: viewer._overlayEdgeMarginPx
+        anchors.bottomMargin: viewer._overlayBottomMarginPx
+        z: 5
+        width: hudColumn.implicitWidth + 16
+        height: hudColumn.implicitHeight + 12
+        color: Qt.rgba(0.10, 0.10, 0.12, 0.85)
         border.color: "#4A90E2"
         border.width: 1
         radius: 4
-        width: hudColumn.implicitWidth + 16
-        height: hudColumn.implicitHeight + 12
 
         Column {
             id: hudColumn

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -26,8 +26,18 @@ Rectangle {
     // y-axis mapping (primary*/secondary*) so the two traces don't
     // squash each other when their ranges differ wildly.
     property string displayMode: "bfi_bvi"
-    property int windowSeconds: 15
+    property real windowSeconds: 15
     property bool autoScale: true
+
+    // ── Time-axis state ────────────────────────────────────────────────
+    // followLive = true: cells render the last `windowSeconds` of data
+    // up to source.liveEdge (DVR "live" mode). False: the visible window
+    // is pinned at [windowStartT, windowStartT + windowSeconds] and any
+    // new samples scroll on without moving the view (DVR "paused" mode).
+    // Any pan/wheel-zoom interaction sets followLive=false; only the
+    // "Back to live" button restores it.
+    property bool followLive: true
+    property real windowStartT: 0.0
 
     // Independent y-axis bounds per metric — kept here so every cell
     // shares the same scale.
@@ -187,6 +197,8 @@ Rectangle {
                     side: modelData.side
                     camId: modelData.camId
                     windowSeconds: viewer.windowSeconds
+                    followLive: viewer.followLive
+                    windowStartT: viewer.windowStartT
                     metric: viewer._displayPair.primary
                     yMin: viewer.primaryYMin
                     yMax: viewer.primaryYMax

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -132,6 +132,18 @@ Rectangle {
         viewer._dirty = true
     }
 
+    // ── Hover crosshair ────────────────────────────────────────────────
+    // Cells broadcast cursor time here via cursorAt(); cells read
+    // viewer.cursorT to draw the synced vertical line. NaN means hide.
+    property real cursorT: NaN
+
+    function cursorAt(t) {
+        viewer.cursorT = t
+        // Mark dirty so the next paintThrottle tick (≤ 33 ms) repaints
+        // every cell with the new crosshair x — no per-mousemove paints.
+        viewer._dirty = true
+    }
+
     // ── Trace color per metric ─────────────────────────────────────────
     function _traceColorForMetric(m) {
         if (m === "bfi")      return theme.accentRed
@@ -280,6 +292,7 @@ Rectangle {
                     paintTick: viewer.paintTick
                     liveEdgeSnapshot: viewer.liveEdgeSnapshot
                     panZoomTarget: viewer
+                    cursorT: viewer.cursorT
                 }
             }
         }
@@ -297,6 +310,104 @@ Rectangle {
                 color: theme.textTertiary
                 font.pixelSize: 14
                 font.family: "Roboto Mono"
+            }
+        }
+    }
+
+    // ── Hover tooltip ──────────────────────────────────────────────────
+    // Top-right floating panel: appears when cursorT is finite (hover
+    // active over any cell), lists the time + per-cell primary/secondary
+    // values at that time. Per-cell values are queried from the source
+    // via value_at() each tick — bound to paintTick so the tooltip
+    // refreshes in lockstep with the cells.
+    Rectangle {
+        id: hoverTooltip
+        visible: isFinite(viewer.cursorT) && viewer.scanSource !== null
+                  && viewer._activeCellModel.length > 0
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 56  // clear the toolbar
+        anchors.rightMargin: 16
+        color: theme.bgElevated
+        border.color: theme.borderSubtle
+        border.width: 1
+        radius: 4
+        width: tooltipColumn.implicitWidth + 16
+        height: tooltipColumn.implicitHeight + 12
+
+        // Force a recompute of the rows when paintTick advances. We bind
+        // to paintTick rather than cursorT so the tooltip only refreshes
+        // at the throttled tick rate, not on every mousemove.
+        property var _rows: {
+            void viewer.paintTick  // dependency
+            if (!isFinite(viewer.cursorT) || !viewer.scanSource) return []
+            var t = viewer.cursorT
+            var primMetric = viewer._displayPair.primary
+            var secMetric = viewer._displayPair.secondary
+            var primColor = viewer._traceColorForMetric(primMetric)
+            var secColor = viewer._traceColorForMetric(secMetric)
+            var rows = []
+            for (var i = 0; i < viewer._activeCellModel.length; i++) {
+                var c = viewer._activeCellModel[i]
+                var pv = viewer.scanSource.value_at(c.side, c.camId, primMetric, t)
+                var sv = viewer.scanSource.value_at(c.side, c.camId, secMetric, t)
+                rows.push({
+                    label: c.side.charAt(0).toUpperCase() + (c.camId + 1),
+                    pVal: pv, pColor: primColor,
+                    sVal: sv, sColor: secColor,
+                })
+            }
+            return rows
+        }
+
+        Column {
+            id: tooltipColumn
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.margins: 8
+            spacing: 1
+
+            Text {
+                text: {
+                    var t = viewer.cursorT
+                    if (!isFinite(t)) return ""
+                    var mins = Math.floor(t / 60)
+                    var secs = (t - mins * 60).toFixed(3)
+                    return "t = " + mins + ":" + (secs < 10 ? "0" + secs : secs) + " s"
+                }
+                color: theme.textSecondary
+                font.pixelSize: 11
+                font.family: "Roboto Mono"
+                font.bold: true
+            }
+            Repeater {
+                model: hoverTooltip._rows
+                delegate: Row {
+                    spacing: 6
+                    Text {
+                        text: modelData.label
+                        width: 30
+                        color: theme.textSecondary
+                        font.pixelSize: 10
+                        font.family: "Roboto Mono"
+                    }
+                    Text {
+                        text: isFinite(modelData.pVal) ? modelData.pVal.toFixed(2) : "—"
+                        width: 50
+                        horizontalAlignment: Text.AlignRight
+                        color: modelData.pColor
+                        font.pixelSize: 10
+                        font.family: "Roboto Mono"
+                    }
+                    Text {
+                        text: isFinite(modelData.sVal) ? modelData.sVal.toFixed(2) : "—"
+                        width: 50
+                        horizontalAlignment: Text.AlignRight
+                        color: modelData.sColor
+                        font.pixelSize: 10
+                        font.family: "Roboto Mono"
+                    }
+                }
             }
         }
     }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -920,6 +920,10 @@ Rectangle {
                     padding: 12
 
                     Row {
+                        // Hidden in reduced (clinical) mode — that view only
+                        // ever shows the BFI/BVI side averages, so the
+                        // Mean/Contrast alternative isn't offered there.
+                        visible: !viewer.reducedMode
                         spacing: 8
                         PopupPillSwitch {
                             id: bfiBviSwitch

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -7,6 +7,7 @@ import OpenMotion 1.0
 // GridLayout with per-camera cells + toolbar + scrubber.
 Rectangle {
     id: viewer
+    anchors.fill: parent
     color: "#0E0E0E"
     radius: 8
     border.color: "#2A2A2A"

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -890,6 +890,30 @@ Rectangle {
                     radius: 8
                 }
 
+                // Mini Switch styled to match SettingsModal's PillSwitch —
+                // blue-background pill with white thumb when on, dark
+                // background when off. Animated thumb glide on toggle.
+                component PopupPillSwitch: Switch {
+                    id: psCtrl
+                    scale: 0.9
+                    indicator: Rectangle {
+                        x:      psCtrl.leftPadding
+                        y:      (psCtrl.height - height) / 2
+                        width:  44; height: 24; radius: 12
+                        color:  psCtrl.checked ? theme.accentBlue : theme.bgInput
+                        border.color: psCtrl.checked ? theme.accentBlue : theme.borderSoft
+                        border.width: 1
+                        Behavior on color { ColorAnimation { duration: 120 } }
+
+                        Rectangle {
+                            x:      psCtrl.checked ? parent.width - width - 3 : 3
+                            y:      3; width: 18; height: 18; radius: 9
+                            color:  "#FFFFFF"
+                            Behavior on x { NumberAnimation { duration: 120 } }
+                        }
+                    }
+                }
+
                 contentItem: Column {
                     id: popupColumn
                     spacing: 6
@@ -897,11 +921,9 @@ Rectangle {
 
                     Row {
                         spacing: 8
-                        Switch {
+                        PopupPillSwitch {
                             id: bfiBviSwitch
                             checked: viewer.displayMode === "bfi_bvi"
-                            // Switch's `text` lives inside its indicator —
-                            // use a sibling Text for free placement.
                             onToggled: viewer.displayModeToggleRequested(checked)
                         }
                         Text {
@@ -914,7 +936,7 @@ Rectangle {
                     }
                     Row {
                         spacing: 8
-                        Switch {
+                        PopupPillSwitch {
                             id: autoScaleSwitch
                             checked: viewer.autoScale
                             onToggled: viewer.autoScaleToggleRequested(checked)
@@ -930,7 +952,7 @@ Rectangle {
                     Row {
                         visible: MOTIONInterface.appConfig.developerMode === true
                         spacing: 8
-                        Switch {
+                        PopupPillSwitch {
                             id: profilerSwitch
                             checked: viewer.showProfiling
                             onToggled: viewer.showProfiling = checked

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -166,7 +166,20 @@ Rectangle {
         interval: 33
         running: viewer.scanSource !== null
         repeat: true
+        // [LAG-DIAG] Capture inter-tick gap; if the main event loop is
+        // blocked by anything (paint, slot, GC), the next Timer fire
+        // arrives late and we'll see a >50 ms gap printed.
+        property real _lastTickMs: 0
         onTriggered: {
+            var nowMs = Date.now()
+            if (paintThrottle._lastTickMs > 0) {
+                var gap = nowMs - paintThrottle._lastTickMs
+                if (gap > 50) {
+                    console.warn("[LAG-DIAG] paintThrottle gap=" + gap +
+                                 " ms (expected ~33 ms)")
+                }
+            }
+            paintThrottle._lastTickMs = nowMs
             if (viewer._dirty) {
                 viewer._dirty = false
                 viewer.liveEdgeSnapshot = viewer.scanSource ? viewer.scanSource.liveEdge : 0
@@ -194,6 +207,9 @@ Rectangle {
         triggeredOnStart: true
         onTriggered: {
             if (!viewer.scanSource) return
+            // [LAG-DIAG] Time the full autoscale tick (two metrics' worth
+            // of compute_bounds_for_metric + property writes).
+            var _t0 = Date.now()
             var bp = viewer.scanSource.compute_bounds_for_metric(viewer._displayPair.primary)
             if (bp && typeof bp.yMin === "number" && typeof bp.yMax === "number") {
                 viewer.primaryYMin = bp.yMin
@@ -205,6 +221,10 @@ Rectangle {
                 viewer.secondaryYMax = bs.yMax
             }
             viewer._dirty = true
+            var _ms = Date.now() - _t0
+            if (_ms > 15) {
+                console.warn("[LAG-DIAG] autoscale tick took " + _ms + " ms")
+            }
         }
     }
 

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -201,10 +201,12 @@ Rectangle {
             displayMode: viewer.displayMode
             windowSeconds: viewer.windowSeconds
             autoScale: viewer.autoScale
+            followLive: viewer.followLive
 
             onDisplayModeRequested: function(mode) { viewer.displayMode = mode }
-            onWindowSecondsRequested: function(s) { viewer.windowSeconds = s }
+            onWindowSecondsRequested: function(s) { viewer.windowSeconds = s; viewer._dirty = true }
             onAutoScaleToggled: function(enabled) { viewer.autoScale = enabled }
+            onBackToLiveRequested: viewer.backToLive()
         }
 
         GridLayout {

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -325,6 +325,26 @@ Rectangle {
                 font.family: "Roboto Mono"
             }
         }
+
+        PlotScrubber {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 28
+            visible: viewer.scanSource !== null
+            fullScanDuration: viewer.liveEdgeSnapshot
+            // When followLive, project the visible window onto the live
+            // edge so the inset stays glued to the right; when paused
+            // (panned/zoomed), reflect the user-set windowStartT.
+            windowStartT: viewer.followLive
+                ? Math.max(0, viewer.liveEdgeSnapshot - viewer.windowSeconds)
+                : viewer.windowStartT
+            windowSeconds: viewer.windowSeconds
+            followLive: viewer.followLive
+
+            onPanRequested: function(startT) {
+                viewer.setWindow(startT, viewer.windowSeconds)
+                console.info("[Plot] scrubber pan → " + startT.toFixed(2) + " s")
+            }
+        }
     }
 
     // ── Hover tooltip ──────────────────────────────────────────────────

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -8,10 +8,12 @@ import OpenMotion 1.0
 Rectangle {
     id: viewer
     anchors.fill: parent
-    color: "#0E0E0E"
+    color: theme.bgPlot
     radius: 8
-    border.color: "#2A2A2A"
+    border.color: theme.borderSoft
     border.width: 1
+
+    AppTheme { id: theme }
 
     // ── Inputs ─────────────────────────────────────────────────────────
     // Reduced mode is consumed by Phase 2b for layout selection. Stored
@@ -50,7 +52,7 @@ Rectangle {
             text: viewer.scanSource
                 ? "● Live · " + (viewer.scanSource.live ? "LiveScanSource" : "PastScanSource")
                 : "○ No active scan source"
-            color: "#CCCCCC"
+            color: theme.textSecondary
             font.pixelSize: 12
             font.family: "Roboto Mono"
         }
@@ -71,7 +73,7 @@ Rectangle {
             windowSeconds: 15
             yMin: 0.0
             yMax: 10.0
-            traceColor: "#3498DB"
+            traceColor: theme.statusBlue
         }
     }
 }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -84,6 +84,35 @@ Rectangle {
         return entries
     }
 
+    // ── DVR controls (called from PlotCell MouseArea) ─────────────────
+    // Window-bounds: hard floor at 0.5 s so wheel-zoom can't collapse
+    // the visible window to nothing; ceiling at 600 s to keep the
+    // decimation point count sane for very-long scans.
+    readonly property real _minWindowSeconds: 0.5
+    readonly property real _maxWindowSeconds: 600.0
+
+    function _ensureFrozen() {
+        // Capture the currently-visible window start so pan/zoom from
+        // followLive transitions smoothly (no visual jump). After this
+        // the caller mutates windowStartT/windowSeconds freely.
+        if (viewer.followLive && viewer.scanSource) {
+            viewer.windowStartT = Math.max(0, viewer.scanSource.liveEdge - viewer.windowSeconds)
+        }
+        viewer.followLive = false
+    }
+
+    function setWindow(startT, seconds) {
+        _ensureFrozen()
+        viewer.windowSeconds = Math.max(_minWindowSeconds, Math.min(_maxWindowSeconds, seconds))
+        viewer.windowStartT = Math.max(0, startT)
+        viewer._dirty = true
+    }
+
+    function backToLive() {
+        viewer.followLive = true
+        viewer._dirty = true
+    }
+
     // ── Trace color per metric ─────────────────────────────────────────
     function _traceColorForMetric(m) {
         if (m === "bfi")      return theme.accentRed
@@ -208,6 +237,7 @@ Rectangle {
                     secondaryYMax: viewer.secondaryYMax
                     secondaryColor: viewer._traceColorForMetric(viewer._displayPair.secondary)
                     paintTick: viewer.paintTick
+                    panZoomTarget: viewer
                 }
             }
         }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -281,8 +281,79 @@ Rectangle {
         ignoreUnknownSignals: true
         function onSamplesAppended(s, c, m, n) {
             viewer._dirty = true
+            viewer._profSamplesAccum += n
         }
     }
+
+    // ── Profile HUD state ──────────────────────────────────────────────
+    // Hidden behind developerMode && showProfiling — clinical users
+    // never see this overlay. Counters accumulate per tick; the 1 Hz
+    // _profHudTimer below converts them to display values.
+    property int _profSamplesAccum: 0        // samples since last 1Hz roll-up
+    property real _profPaintTickMs: 0.0      // last tick's dispatch duration
+    property real _profCanvasMsSum: 0.0      // current-tick canvas-ms accumulator
+    property int _profCanvasCount: 0         // # cells that reported this tick
+    property int _profPointsAccum: 0         // points painted this tick
+    // Display values — read by the HUD overlay, refreshed at 1 Hz.
+    property real profSampleRateHz: 0.0
+    property real profPaintTickMsAvg: 0.0
+    property real profCanvasMsAvg: 0.0
+    property real profCanvasMsMax: 0.0
+    property int profPointsLastTick: 0
+    property real _profHudLastWall: 0
+
+    // PlotCell calls this from its onPaint with the wall-time it took
+    // and the points-painted count. We accumulate, the 1 Hz HUD timer
+    // computes the rolling average / max.
+    function recordCellPaint(ms, points) {
+        viewer._profCanvasMsSum += ms
+        viewer._profCanvasCount += 1
+        viewer._profPointsAccum += points
+        if (ms > viewer.profCanvasMsMax) viewer.profCanvasMsMax = ms
+    }
+
+    Timer {
+        id: profHudTimer
+        interval: 1000
+        repeat: true
+        // No need to run when the HUD isn't visible — saves the per-tick
+        // EWMA + division on every clinical-user session.
+        running: viewer._hudVisible
+        triggeredOnStart: true
+        onTriggered: {
+            var now = Date.now()
+            if (viewer._profHudLastWall > 0) {
+                var dtSec = (now - viewer._profHudLastWall) * 0.001
+                if (dtSec > 0) {
+                    var instantHz = viewer._profSamplesAccum / dtSec
+                    // EWMA α=0.15 matches the legacy plot's rate display.
+                    viewer.profSampleRateHz = (viewer.profSampleRateHz === 0)
+                        ? instantHz
+                        : 0.85 * viewer.profSampleRateHz + 0.15 * instantHz
+                }
+            }
+            viewer._profSamplesAccum = 0
+            viewer._profHudLastWall = now
+            // Snapshot per-tick canvas stats then reset for the next sec.
+            if (viewer._profCanvasCount > 0) {
+                viewer.profCanvasMsAvg = viewer._profCanvasMsSum / viewer._profCanvasCount
+            }
+            viewer.profPointsLastTick = viewer._profPointsAccum
+            viewer._profCanvasMsSum = 0
+            viewer._profCanvasCount = 0
+            viewer._profPointsAccum = 0
+            viewer.profCanvasMsMax = 0
+        }
+    }
+
+    // Runtime toggle — initialized from app_config.showProfiling but
+    // flippable from the PlotToolbar's Profiler checkbox at runtime.
+    // The toolbar checkbox itself is hidden outside developer mode,
+    // and _hudVisible further gates on developerMode so the HUD can't
+    // appear in clinical builds even if showProfiling is flipped.
+    property bool showProfiling: MOTIONInterface.appConfig.showProfiling === true
+    readonly property bool _hudVisible: MOTIONInterface.appConfig.developerMode === true
+                                        && viewer.showProfiling
 
     Timer {
         id: paintThrottle
@@ -294,9 +365,16 @@ Rectangle {
         repeat: true
         onTriggered: {
             if (viewer._dirty) {
+                var t0 = viewer._hudVisible ? Date.now() : 0
                 viewer._dirty = false
                 viewer.liveEdgeSnapshot = viewer.scanSource ? viewer.scanSource.liveEdge : 0
                 viewer.paintTick++
+                if (viewer._hudVisible) {
+                    var dt = Date.now() - t0
+                    viewer.profPaintTickMsAvg = (viewer.profPaintTickMsAvg === 0)
+                        ? dt
+                        : 0.85 * viewer.profPaintTickMsAvg + 0.15 * dt
+                }
             }
         }
     }
@@ -340,6 +418,8 @@ Rectangle {
             autoScale: viewer.autoScale
             followLive: viewer.followLive
             liveSourceAvailable: MOTIONInterface.liveSourceAvailable
+            developerMode: MOTIONInterface.appConfig.developerMode === true
+            showProfiling: viewer.showProfiling
 
             onDisplayModeRequested: function(mode) {
                 viewer.displayMode = mode
@@ -368,6 +448,10 @@ Rectangle {
             onAutoScaleToggled: function(enabled) {
                 viewer.autoScale = enabled
                 console.info("[Plot] autoScale → " + enabled)
+            }
+            onShowProfilingToggled: function(enabled) {
+                viewer.showProfiling = enabled
+                console.info("[Plot] showProfiling → " + enabled)
             }
             onBackToLiveRequested: {
                 // When the viewer is on a past source, "Back to live"
@@ -561,6 +645,68 @@ Rectangle {
                         font.family: "Roboto Mono"
                     }
                 }
+            }
+        }
+    }
+
+    // ── Profile HUD overlay ────────────────────────────────────────────
+    // Top-left of the plot grid; ports the legacy EmbeddedRealtimePlot
+    // counters forward per spec §248. Visible only when both
+    // developerMode AND showProfiling are true so clinical users never
+    // see it. The values are refreshed by the 1 Hz profHudTimer above
+    // (which also gates `running` on this overlay's visibility so the
+    // EWMA + division work doesn't run in production builds).
+    Rectangle {
+        id: profileHud
+        visible: viewer._hudVisible
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: 56
+        anchors.leftMargin: 16
+        color: theme.bgElevated
+        border.color: "#4A90E2"
+        border.width: 1
+        radius: 4
+        width: hudColumn.implicitWidth + 16
+        height: hudColumn.implicitHeight + 12
+
+        Column {
+            id: hudColumn
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.margins: 8
+            spacing: 1
+
+            Text {
+                text: "PROFILE"
+                color: "#4A90E2"
+                font.pixelSize: 11
+                font.family: "Roboto Mono"
+                font.bold: true
+            }
+            Text {
+                text: "rate    " + viewer.profSampleRateHz.toFixed(1) + " Hz"
+                color: theme.textSecondary
+                font.pixelSize: 10
+                font.family: "Roboto Mono"
+            }
+            Text {
+                text: "tick    " + viewer.profPaintTickMsAvg.toFixed(2) + " ms"
+                color: theme.textSecondary
+                font.pixelSize: 10
+                font.family: "Roboto Mono"
+            }
+            Text {
+                text: "canvas  " + viewer.profCanvasMsAvg.toFixed(2) + " ms avg"
+                color: theme.textSecondary
+                font.pixelSize: 10
+                font.family: "Roboto Mono"
+            }
+            Text {
+                text: "points  " + viewer.profPointsLastTick
+                color: theme.textSecondary
+                font.pixelSize: 10
+                font.family: "Roboto Mono"
             }
         }
     }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -175,27 +175,13 @@ Rectangle {
 
     Timer {
         id: paintThrottle
-        // 33 ms = 30 Hz — restored from the 50 ms throttle once the
-        // mean-binning fix dropped per-paint data volume back to width × 1
-        // samples. Each tick moves the trace ~1 sample at the data rate
-        // (40 Hz), so the scroll feels continuous instead of stepwise.
+        // 33 ms = 30 Hz. Each tick moves the trace ~1 sample at the
+        // data rate (40 Hz), so the scroll feels continuous instead
+        // of stepwise.
         interval: 33
         running: viewer.scanSource !== null
         repeat: true
-        // [LAG-DIAG] Capture inter-tick gap; if the main event loop is
-        // blocked by anything (paint, slot, GC), the next Timer fire
-        // arrives late and we'll see a >50 ms gap printed.
-        property real _lastTickMs: 0
         onTriggered: {
-            var nowMs = Date.now()
-            if (paintThrottle._lastTickMs > 0) {
-                var gap = nowMs - paintThrottle._lastTickMs
-                if (gap > 50) {
-                    console.warn("[LAG-DIAG] paintThrottle gap=" + gap +
-                                 " ms (expected ~33 ms)")
-                }
-            }
-            paintThrottle._lastTickMs = nowMs
             if (viewer._dirty) {
                 viewer._dirty = false
                 viewer.liveEdgeSnapshot = viewer.scanSource ? viewer.scanSource.liveEdge : 0
@@ -221,16 +207,7 @@ Rectangle {
         running: viewer.autoScale && viewer.scanSource !== null
         repeat: true
         triggeredOnStart: true
-        onTriggered: {
-            // [LAG-DIAG] Time the full autoscale tick (two metrics' worth
-            // of compute_bounds_for_metric + property writes).
-            var _t0 = Date.now()
-            viewer._recomputeAutoscale()
-            var _ms = Date.now() - _t0
-            if (_ms > 15) {
-                console.warn("[LAG-DIAG] autoscale tick took " + _ms + " ms")
-            }
-        }
+        onTriggered: viewer._recomputeAutoscale()
     }
 
     ColumnLayout {

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -1,4 +1,5 @@
 {
+  "useNewPlotViewer": false,
   "forceLaserFail": false,
   "cameraTempAlertThresholdC": 110,
   "sensorDebugLogging": false,

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -1,5 +1,4 @@
 {
-  "useNewPlotViewer": false,
   "forceLaserFail": false,
   "cameraTempAlertThresholdC": 110,
   "sensorDebugLogging": false,

--- a/data_sources.py
+++ b/data_sources.py
@@ -321,6 +321,36 @@ class ScanDataSource(QObject):
         t_arr, v_arr = buf.window_decimated(t_lo, t_hi, int(max_points))
         return [[float(t), float(v)] for t, v in zip(t_arr, v_arr)]
 
+    @pyqtSlot(str, int, str, float, result=float)
+    def value_at(self, side: str, cam_id: int, metric: str, t: float) -> float:
+        """Return the buffer's value for the sample nearest to time `t`.
+        NaN if the buffer doesn't exist, is empty, or the nearest sample
+        is itself non-finite. Used by the viewer's hover tooltip."""
+        buf = self.buffers.get((side, int(cam_id), metric))
+        if buf is None or buf.n == 0:
+            return float("nan")
+        t_slice = buf.t[: buf.n]
+        idx = int(np.searchsorted(t_slice, t, side="left"))
+        if idx >= buf.n:
+            idx = buf.n - 1
+        elif idx > 0 and abs(t_slice[idx - 1] - t) < abs(t_slice[idx] - t):
+            idx -= 1
+        v = float(buf.v[idx])
+        return v if np.isfinite(v) else float("nan")
+
+    @pyqtSlot(str, int, result=float)
+    def dropped_at_for(self, side: str, cam_id: int) -> float:
+        """Return the dropout timestamp for (side, cam_id), or NaN if the
+        camera hasn't been flagged as dropped this scan. PlotCell uses
+        this to draw a vertical bar at the dropout time. The bar is
+        per-(side, cam) so any one of its metric buffers' dropped_at
+        suffices."""
+        for metric in ("bfi", "bvi", "mean", "contrast"):
+            buf = self.buffers.get((side, int(cam_id), metric))
+            if buf is not None and buf.dropped_at is not None:
+                return float(buf.dropped_at)
+        return float("nan")
+
     @pyqtSlot(str, result="QVariantMap")
     @pyqtSlot(str, float, float, float, result="QVariantMap")
     def compute_bounds_for_metric(

--- a/data_sources.py
+++ b/data_sources.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from PyQt6.QtCore import QObject, QTimer, pyqtSignal
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot
 
 
 _INITIAL_CAPACITY = 4096  # ≈ 100 s @ 40 Hz; doubles on overflow.
@@ -173,6 +173,30 @@ class ScanDataSource(QObject):
             buf = _CameraBuffer()
             self.buffers[key] = buf
         return buf
+
+    @pyqtSlot(str, int, str, float, float, int, result="QVariantList")
+    def points_for_window(
+        self,
+        side: str,
+        cam_id: int,
+        metric: str,
+        t_lo: float,
+        t_hi: float,
+        max_points: int,
+    ) -> list:
+        """QML-facing: return a list of [t, v] pairs for the requested
+        (side, cam_id, metric) buffer in the window [t_lo, t_hi], strided
+        to at most max_points. Returns [] when the buffer doesn't exist
+        or the window is empty.
+
+        Each pair is [float, float]. The list is a fresh allocation per
+        call — Phase 2b can optimize with typed-array passthrough if paint
+        cost becomes a bottleneck."""
+        buf = self.buffers.get((side, int(cam_id), metric))
+        if buf is None:
+            return []
+        t_arr, v_arr = buf.window_decimated(t_lo, t_hi, int(max_points))
+        return [[float(t), float(v)] for t, v in zip(t_arr, v_arr)]
 
     def note_dirty(self, side: str, cam_id: int, metric: str, added: int) -> None:
         """Record that `added` new samples landed in (side, cam, metric).

--- a/data_sources.py
+++ b/data_sources.py
@@ -558,12 +558,22 @@ class LiveScanSource(ScanDataSource):
         """Materialize session_data rows for [t_lo, t_hi] (padded) into
         the transient DB-window buffers, if not already covered. Padding
         by one window each side means small pans reuse the cached load
-        instead of re-querying every paint."""
+        instead of re-querying every paint.
+
+        want_hi is capped at the newest available sample (liveEdge) so the
+        cached window never claims to cover future/nonexistent rows — that
+        false coverage used to make the staleness check short-circuit and
+        serve a stale window while live data piled up unshown. Callers only
+        pass t_hi up to the in-memory boundary anyway (the recent portion is
+        served from memory), so this cap is a belt-and-suspenders guard."""
         if t_lo >= self._db_window_lo and t_hi <= self._db_window_hi:
             return
         span = max(1.0, t_hi - t_lo)
         want_lo = max(0.0, t_lo - span)
+        edge = self.liveEdge
         want_hi = t_hi + span
+        if edge > 0.0:
+            want_hi = min(want_hi, edge)
         try:
             self._db_window_buffers, _ = _bucketize_session_rows(
                 self._db, self._db_session_id, t_lo=want_lo, t_hi=want_hi
@@ -595,16 +605,44 @@ class LiveScanSource(ScanDataSource):
         # Only reach for the DB once data has actually been ring-trimmed.
         if not self._needs_db_tail(side, int(cam_id), metric, t_lo) or not self._db_ready():
             return super().points_for_window(side, cam_id, metric, t_lo, t_hi, int(max_points))
-        # Pan-into-past beyond the in-memory window: serve from the DB
-        # tail. The DB has the full history, so a DB-only read of
-        # [t_lo, t_hi] is correct — only the un-flushed live edge
-        # (~100 ms) is absent, never inside a panned-back window.
-        self._ensure_db_window(t_lo, t_hi)
-        buf = self._db_window_buffers.get((side, int(cam_id), metric))
-        if buf is None:
-            return []
-        t_arr, v_arr = buf.window_decimated(t_lo, t_hi, int(max_points))
-        return [[float(t), float(v)] for t, v in zip(t_arr, v_arr)]
+
+        # Straddling window: t_lo is below the oldest in-memory sample but
+        # t_hi may reach into (or past) the live edge. Split at the in-memory
+        # boundary and stitch: serve the OLD portion [t_lo, split] from the
+        # DB tail (static history) and the RECENT portion [split, t_hi] from
+        # the in-memory buffer (fresh every paint). Serving the recent portion
+        # from the DB instead would freeze the live trace — the DB window is
+        # cached and only reloads when `split` advances, so new live samples
+        # wouldn't appear until the next reload. The DB is queried only up to
+        # `split`, never into the live/future region.
+        buf = self.buffers.get((side, int(cam_id), metric))
+        split = float(buf.t[0])  # _needs_db_tail guarantees buf valid & n>0
+        db_hi = min(split, float(t_hi))
+        mem_lo = max(split, float(t_lo))
+
+        # Proportional point budget so trace density (stride) is consistent
+        # across the seam rather than each portion getting the full budget.
+        total_span = max(1e-9, float(t_hi) - float(t_lo))
+        db_span = max(0.0, db_hi - float(t_lo))
+        mem_span = max(0.0, float(t_hi) - mem_lo)
+        mp = int(max_points)
+        db_max = max(1, int(round(mp * db_span / total_span)))
+        mem_max = max(1, int(round(mp * mem_span / total_span)))
+
+        db_pts: list = []
+        if db_span > 0.0:
+            self._ensure_db_window(float(t_lo), db_hi)
+            dbuf = self._db_window_buffers.get((side, int(cam_id), metric))
+            if dbuf is not None:
+                t_arr, v_arr = dbuf.window_decimated(float(t_lo), db_hi, db_max)
+                db_pts = [[float(t), float(v)] for t, v in zip(t_arr, v_arr)]
+
+        mem_pts: list = []
+        if mem_span > 0.0:
+            mem_pts = super().points_for_window(
+                side, cam_id, metric, mem_lo, float(t_hi), mem_max
+            )
+        return db_pts + mem_pts
 
     @pyqtSlot(str, int, str, float, result=float)
     def value_at(self, side, cam_id, metric, t):

--- a/data_sources.py
+++ b/data_sources.py
@@ -22,8 +22,15 @@ import numpy as np
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot, pyqtProperty
 
 
-_INITIAL_CAPACITY = 4096    # ≈ 100 s @ 40 Hz; doubles on overflow.
 _MAX_CAPACITY = 72000       # ≈ 30 min @ 40 Hz; ring-trim above this.
+_INITIAL_CAPACITY = _MAX_CAPACITY
+# Pre-allocate at the cap. Mid-scan grow events (np.resize → alloc +
+# copy) at the 7-min and 14-min doublings stressed Python's allocator
+# hard enough to stall the SDK parser thread — the data_queue would
+# overflow, USB chunks got dropped, and the parser never recovered
+# (eventually surfaced as CRC mismatches on misaligned reads). At
+# ~1.44 MB per buffer × ~32 active buffers ≈ 46 MB the static
+# allocation cost is fine and consistent across the scan.
 
 
 class _CameraBuffer:

--- a/data_sources.py
+++ b/data_sources.py
@@ -513,46 +513,87 @@ class LiveScanSource(ScanDataSource):
         self._scan_db_path = scan_db_path
         self._db = None                       # omotion.ScanDatabase read handle
         self._db_session_id: Optional[int] = None
-        self._db_unavailable = False          # set True after a failed resolve
+        self._db_unavailable = False          # set True only on HARD failure
+        # Exact session label for THIS scan (f"{scan_id}_{subject_id}"), set
+        # by the connector right after start_scan via set_scan_label. Lets
+        # the DB tail bind to this scan's session row by label instead of
+        # guessing the newest session (which could be another scan's).
+        self._scan_label: Optional[str] = None
         self._db_window_buffers: dict = {}     # transient (side,cam,metric)->buffer
         self._db_window_lo = float("inf")     # loaded range, exclusive sentinel
         self._db_window_hi = float("-inf")
 
+    def set_scan_label(self, label: Optional[str]) -> None:
+        """Bind this live source to a specific scan-DB session by label
+        (``f"{scan_id}_{subject_id}"``). Called once, right after the scan
+        starts; the DB tail resolves the session_id from it on first use."""
+        if label:
+            self._scan_label = str(label)
+
     # ── DB tail (lazy) ──────────────────────────────────────────────────────
 
     def _db_ready(self) -> bool:
-        """Resolve the read-only DB handle + this live scan's session_id
-        on first use. The live scan is always the newest session row, so
-        we resolve by MAX(id). Only ever called after the in-memory
-        buffer has ring-trimmed (>30 min in), by which point the session
-        row exists. Returns False (permanently, after one failure) if the
-        DB is unavailable — the source then behaves as in-memory-only."""
+        """Resolve the read-only DB handle + this live scan's session_id on
+        first use. Only ever called after the in-memory buffer has ring-
+        trimmed, by which point the session row exists.
+
+        Binds to THIS scan's session by its exact label (set via
+        set_scan_label) so a concurrent/older scan's session is never picked;
+        falls back to the newest session only when no label was provided
+        (older callers). Permanent disable (_db_unavailable) is reserved for
+        HARD failures — no DB path, or an exception opening it. A merely
+        not-yet-visible session row is a SOFT miss: returns False without
+        disabling so a later paint retries (the row is created at scan start,
+        so this should essentially never persist)."""
         if self._db_unavailable:
             return False
         if self._db is not None and self._db_session_id is not None:
             return True
         if not self._scan_db_path:
-            self._db_unavailable = True
+            self._db_unavailable = True  # hard: no path → never works
             return False
         try:
-            from omotion.ScanDatabase import ScanDatabase
-            self._db = ScanDatabase(db_path=self._scan_db_path)
-            row = next(
-                self._db._connection().execute(
-                    "SELECT id FROM sessions ORDER BY id DESC LIMIT 1"
-                ),
-                None,
-            )
-            if row is None:
-                self._db_unavailable = True
+            if self._db is None:
+                from omotion.ScanDatabase import ScanDatabase
+                self._db = ScanDatabase(db_path=self._scan_db_path)
+            sid = self._resolve_session_id()
+            if sid is None:
+                # Soft miss — keep _db open and retry on a later paint.
                 return False
-            self._db_session_id = int(row[0])
-            logger.info("LiveScanSource: DB tail engaged (session_id=%d)", self._db_session_id)
+            self._db_session_id = sid
+            logger.info(
+                "LiveScanSource: DB tail engaged (session_id=%d, label=%r)",
+                sid, self._scan_label,
+            )
             return True
         except Exception:
             logger.exception("LiveScanSource: DB tail unavailable")
-            self._db_unavailable = True
+            self._db_unavailable = True  # hard failure
             return False
+
+    def _resolve_session_id(self) -> Optional[int]:
+        """Return this scan's session_id, or None if not yet resolvable.
+
+        Prefers an exact label match (this scan's session row); falls back to
+        the newest session when no label was bound. Raises only on a real DB
+        error (handled by _db_ready)."""
+        conn = self._db._connection()
+        if self._scan_label:
+            row = next(
+                conn.execute(
+                    "SELECT id FROM sessions WHERE session_label = ? "
+                    "ORDER BY session_start DESC, id DESC LIMIT 1",
+                    (self._scan_label,),
+                ),
+                None,
+            )
+            return int(row[0]) if row is not None else None
+        # No label bound (older callers): newest session is this live scan.
+        row = next(
+            conn.execute("SELECT id FROM sessions ORDER BY id DESC LIMIT 1"),
+            None,
+        )
+        return int(row[0]) if row is not None else None
 
     def _ensure_db_window(self, t_lo: float, t_hi: float) -> None:
         """Materialize session_data rows for [t_lo, t_hi] (padded) into

--- a/data_sources.py
+++ b/data_sources.py
@@ -786,15 +786,18 @@ def _bucketize_session_rows(
 ) -> tuple[dict, bool]:
     """Query session_data rows for a session (optionally a time slice)
     and bucket them into a fresh {(side, cam_id, metric): _CameraBuffer}
-    dict. Returns (buffers, has_per_cam_bfi). Shared by PastScanSource's
-    full load and LiveScanSource's lazy DB-tail window.
+    dict. Returns (buffers, has_bfi). Shared by PastScanSource's full load
+    and LiveScanSource's lazy DB-tail window.
 
-    cam_id >= 0 rows are per-cam (from the SDK "live" channel sink);
-    cam_id == -1 rows are the side-aggregated corrected-frame
-    placeholders. has_per_cam_bfi reflects whether any real per-cam
-    BFI/BVI landed — the caller uses it to decide on CSV fallback."""
+    Rows are bucketed by their stored cam_id verbatim:
+      - cam_id 0..7 — per-camera BFI/BVI/mean/contrast (normal-mode scans).
+      - cam_id == -1 — the reduced-mode dark-corrected per-side average
+        (bfi/bvi/mean/contrast), written by ScanDBSink's "final_side" path.
+    has_bfi reflects whether ANY finite BFI/BVI landed (either layout) — the
+    caller uses it to decide whether to fall back to the corrected CSV (only
+    pre-pipeline scans, which carry no BFI/BVI in the DB)."""
     buffers: dict = {}
-    has_per_cam_bfi = False
+    has_bfi = False
     for row in scan_db.iter_session_data(session_id, t_lo=t_lo, t_hi=t_hi):
         side = _SIDE_INT_TO_STR.get(int(row["side"]))
         if side is None:
@@ -806,8 +809,8 @@ def _bucketize_session_rows(
             value = row.get(metric)
             if value is None:
                 continue
-            if cam_id >= 0 and metric in ("bfi", "bvi"):
-                has_per_cam_bfi = True
+            if metric in ("bfi", "bvi"):
+                has_bfi = True
             key = (side, cam_id, metric)
             buf = buffers.get(key)
             if buf is None:
@@ -817,7 +820,7 @@ def _bucketize_session_rows(
                 buf = _CameraBuffer(max_capacity=None)
                 buffers[key] = buf
             buf.append(t=t, v=float(value), frame_id=frame_id)
-    return buffers, has_per_cam_bfi
+    return buffers, has_bfi
 
 
 class PastScanSource(ScanDataSource):
@@ -840,69 +843,19 @@ class PastScanSource(ScanDataSource):
         self._live = False
         self.session_id = int(session_id)
 
-        # session_data carries either:
-        #   - Per-cam BFI/BVI rows from the SDK's "live" channel sink
-        #     (cam_id 0..7, side 0/1, bfi+bvi+mean+contrast) — Phase 1
-        #     and newer scans. The loop below buckets these directly
-        #     into the per-cam (side, cam_id, metric) buffers.
-        #   - Side-aggregated corrected-frame placeholder rows
-        #     (cam_id=-1, side=0, mean+contrast only) — bucketed into
-        #     (left, -1, mean) and (left, -1, contrast).
-        # Older scans recorded before the live-channel write landed
-        # have ONLY the placeholder rows; CSV fallback below picks
-        # those up for per-cam display.
-        self.buffers, has_per_cam_bfi = _bucketize_session_rows(scan_db, self.session_id)
+        # session_data carries, by cam_id:
+        #   - cam_id 0..7  — per-camera BFI/BVI/mean/contrast (normal-mode scans).
+        #   - cam_id == -1 — the reduced-mode dark-corrected per-side average
+        #     (written by ScanDBSink's "final_side" path). Reduced cells query
+        #     cam_id=-1, so replay reads it straight from the DB — no derivation.
+        # Pre-pipeline scans carry no BFI/BVI in the DB; the CSV fallback covers
+        # those.
+        self.buffers, has_bfi = _bucketize_session_rows(scan_db, self.session_id)
 
-        # CSV fallback — load only when the DB didn't already carry per-cam
-        # BFI/BVI. Pre-Phase-1 scans land here. CsvSink writes this CSV
-        # unconditionally for every scan (not gated by writeRawCsv).
-        if not has_per_cam_bfi and corrected_csv_path:
+        # CSV fallback — only when the DB carried no BFI/BVI at all (old scans).
+        # CsvSink writes the corrected CSV for those.
+        if not has_bfi and corrected_csv_path:
             self._load_corrected_csv(corrected_csv_path)
-
-        # Reduced-mode side averages (cam_id=-1) aren't persisted per-cam in
-        # the DB or the normal per-cam CSV, so derive them from the per-cam
-        # buffers — otherwise reduced-mode replay is empty (the reduced cells
-        # query cam_id=-1). No-op when a reduced CSV already supplied them.
-        self._derive_side_averages()
-
-    def _derive_side_averages(self) -> None:
-        """Build the reduced-mode side-average buffers (cam_id=-1) from the
-        per-cam buffers, reproducing what the live viewer showed.
-
-        The scan DB (and the normal per-cam corrected CSV) carry per-camera
-        BFI/BVI at cam_id 0..7 but never the side average at cam_id=-1 — the
-        SDK's ScanDBSink "live" channel only writes per-cam rows. Live, the
-        cam_id=-1 buffer was fed one sample per frame equal to that frame's
-        single active-camera value: each histogram frame carries exactly one
-        camera (raw_hist[i, side, cam]), so SideAveragingStage's nanmean over
-        the all-but-one-NaN row reduces to that camera's value. The faithful
-        reconstruction is therefore the per-cam samples for a side merged into
-        one time-ordered stream; the renderer's mean-binning then averages
-        across cameras within each display bin, exactly as it did live.
-
-        Only bfi/bvi (the reduced-mode metrics) are derived, and only when no
-        cam_id=-1 buffer already exists (a reduced-mode CSV provides one)."""
-        for side in ("left", "right"):
-            for metric in ("bfi", "bvi"):
-                if (side, -1, metric) in self.buffers:
-                    continue  # reduced CSV already supplied it — don't clobber
-                parts = [
-                    buf for (s, c, m), buf in self.buffers.items()
-                    if s == side and m == metric and c >= 0 and buf.n > 0
-                ]
-                if not parts:
-                    continue
-                t_all = np.concatenate([b.t[: b.n] for b in parts])
-                v_all = np.concatenate([b.v[: b.n] for b in parts])
-                f_all = np.concatenate([b.frame_id[: b.n] for b in parts])
-                order = np.argsort(t_all, kind="stable")
-                size = int(t_all.size)
-                merged = _CameraBuffer(initial_capacity=max(4, size), max_capacity=None)
-                merged.t[:size] = t_all[order]
-                merged.v[:size] = v_all[order]
-                merged.frame_id[:size] = f_all[order]
-                merged.n = size
-                self.buffers[(side, -1, metric)] = merged
 
     def _load_corrected_csv(self, csv_path: str) -> None:
         """Load per-(side, cam, metric) samples from the corrected CSV

--- a/data_sources.py
+++ b/data_sources.py
@@ -170,3 +170,80 @@ class ScanDataSource(QObject):
         self._pending = {}
         for (side, cam_id, metric), count in pending.items():
             self.samplesAppended.emit(side, cam_id, metric, count)
+
+
+class LiveScanSource(ScanDataSource):
+    """ScanDataSource fed by the in-flight pipeline. Constructed at scan
+    start; lives as long as the connector holds a reference."""
+
+    def __init__(self, plot_t0: float, parent: Optional[QObject] = None) -> None:
+        super().__init__(plot_t0=plot_t0, parent=parent)
+        self.live = True
+
+    def append_uncorrected(
+        self,
+        side: str,
+        cam_id: int,
+        frame_id: int,
+        t: float,
+        bfi: float,
+        bvi: float,
+        mean: Optional[float] = None,
+        contrast: Optional[float] = None,
+    ) -> None:
+        """Append one frame's worth of uncorrected metrics.
+
+        bfi and bvi are always appended (NaN included — the source stores
+        what arrives). mean/contrast are appended only when non-None;
+        the existing _LivePlotSink passes None for samples where the
+        SDK reported a non-finite mean_dc_rt / contrast_sn_rt."""
+        self._append_one(side, cam_id, "bfi", frame_id, t, bfi)
+        self._append_one(side, cam_id, "bvi", frame_id, t, bvi)
+        if mean is not None:
+            self._append_one(side, cam_id, "mean", frame_id, t, mean)
+        if contrast is not None:
+            self._append_one(side, cam_id, "contrast", frame_id, t, contrast)
+
+    def apply_corrected_batch(self, batch: list) -> None:
+        """Overwrite in place at matching frame_ids across all 4 metrics.
+
+        Payload shape matches scanCorrectedBatch.emit: list[dict] with
+        keys side, camId, frameId, bfi, bvi, mean, contrast (ts is
+        ignored — t is set at live-append time, not at correction time)."""
+        for sample in batch:
+            side = str(sample["side"])
+            cam_id = int(sample["camId"])
+            frame_id = int(sample["frameId"])
+            for metric_key, payload_key in (
+                ("bfi", "bfi"),
+                ("bvi", "bvi"),
+                ("mean", "mean"),
+                ("contrast", "contrast"),
+            ):
+                buf = self.buffers.get((side, cam_id, metric_key))
+                if buf is None:
+                    continue
+                buf.apply_corrected(frame_id=frame_id, value=float(sample[payload_key]))
+
+    def mark_dropped(self, side: str, cam_id: int, t: float) -> None:
+        """Record a dropout timestamp on every existing metric buffer for
+        this (side, cam). Idempotent per _CameraBuffer.mark_dropped."""
+        for metric in ("bfi", "bvi", "mean", "contrast"):
+            buf = self.buffers.get((side, int(cam_id), metric))
+            if buf is not None:
+                buf.mark_dropped(t)
+
+    # ── internal ──────────────────────────────────────────────────────────
+
+    def _append_one(
+        self,
+        side: str,
+        cam_id: int,
+        metric: str,
+        frame_id: int,
+        t: float,
+        v: float,
+    ) -> None:
+        buf = self.get_or_create_buffer(side, cam_id, metric)
+        buf.append(t=t, v=v, frame_id=frame_id)
+        self.note_dirty(side, cam_id, metric, added=1)

--- a/data_sources.py
+++ b/data_sources.py
@@ -94,6 +94,28 @@ class _CameraBuffer:
         i_hi = int(np.searchsorted(t_slice, t_hi, side="right"))
         return i_lo, i_hi
 
+    def window_decimated(
+        self,
+        t_lo: float,
+        t_hi: float,
+        max_points: int,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return (t, v) arrays covering [t_lo, t_hi], strided to at most
+        max_points samples. Caller must not mutate the returned arrays —
+        they are views into the underlying buffer.
+
+        Empty arrays returned when the window contains no samples or the
+        buffer is empty."""
+        i_lo, i_hi = self.window_indices(t_lo, t_hi)
+        n_window = i_hi - i_lo
+        if n_window <= 0:
+            return self.t[0:0], self.v[0:0]
+        if n_window <= max_points:
+            return self.t[i_lo:i_hi], self.v[i_lo:i_hi]
+        # Stride down to at most max_points by taking every Nth sample.
+        stride = -(-n_window // max_points)  # ceil division
+        return self.t[i_lo:i_hi:stride], self.v[i_lo:i_hi:stride]
+
     def mark_dropped(self, t: float) -> None:
         """Record the first dropout timestamp for this stream. Idempotent —
         later calls don't overwrite the earlier dropout."""

--- a/data_sources.py
+++ b/data_sources.py
@@ -49,7 +49,8 @@ class _CameraBuffer:
     multi-hour scans at the cost of pan-back history beyond ~30 min.
     """
 
-    __slots__ = ("t", "v", "frame_id", "n", "_frame_id_to_index", "dropped_at")
+    __slots__ = ("t", "v", "frame_id", "n", "_frame_id_to_index", "dropped_at",
+                 "ring_trimmed")
 
     def __init__(
         self,
@@ -64,6 +65,11 @@ class _CameraBuffer:
             {} if track_frame_ids else None
         )
         self.dropped_at: Optional[float] = None
+        # True once _ring_trim has dropped older samples — i.e. data
+        # below t[0] now lives only in the DB, not memory. LiveScanSource
+        # uses this to decide whether a pan below t[0] needs the DB tail
+        # vs is simply before the scan start (no data, serve from memory).
+        self.ring_trimmed: bool = False
 
     def _grow(self) -> None:
         """Double the capacity of all three parallel arrays atomically.
@@ -83,6 +89,7 @@ class _CameraBuffer:
         self.v[:half] = self.v[half:]
         self.frame_id[:half] = self.frame_id[half:]
         self.n = half
+        self.ring_trimmed = True
         # Frame-id lookup positions shift after the trim; safest to
         # drop the mapping and rebuild lazily on subsequent appends.
         if self._frame_id_to_index is not None:
@@ -533,25 +540,31 @@ class LiveScanSource(ScanDataSource):
             logger.exception("LiveScanSource: DB window load failed")
             # Leave the previous window in place; a later paint retries.
 
-    def _in_memory_start(self, side: str, cam_id: int, metric: str) -> float:
-        """Oldest in-memory timestamp for one buffer, or +inf if empty.
-        Below this, data has been ring-trimmed and lives only in the DB."""
+    def _needs_db_tail(self, side: str, cam_id: int, metric: str, t_lo: float) -> bool:
+        """True iff the requested t_lo is below the oldest IN-MEMORY
+        sample AND that buffer has actually ring-trimmed (so the older
+        data exists only in the DB). Crucially, when the buffer has NOT
+        trimmed, t_lo below t[0] just means the window extends before the
+        scan started — there's no older data, so serve from memory. This
+        is the hot-path guard: during normal live scanning (pre-trim) it
+        short-circuits to False WITHOUT touching the DB, so we never open
+        a connection or query per-paint until a scan actually exceeds the
+        ~30 min in-memory window."""
         buf = self.buffers.get((side, int(cam_id), metric))
-        if buf is None or buf.n == 0:
-            return float("inf")
-        return float(buf.t[0])
+        if buf is None or buf.n == 0 or not buf.ring_trimmed:
+            return False
+        return t_lo < float(buf.t[0])
 
     @pyqtSlot(str, int, str, float, float, int, result="QVariantList")
     def points_for_window(self, side, cam_id, metric, t_lo, t_hi, max_points):
-        # Fast path: the whole requested window is still in memory (or no
-        # DB tail configured) — defer to the base implementation.
-        mem_start = self._in_memory_start(side, int(cam_id), metric)
-        if t_lo >= mem_start or not self._db_ready():
+        # Fast path: whole window in memory, or buffer not yet trimmed.
+        # Only reach for the DB once data has actually been ring-trimmed.
+        if not self._needs_db_tail(side, int(cam_id), metric, t_lo) or not self._db_ready():
             return super().points_for_window(side, cam_id, metric, t_lo, t_hi, int(max_points))
-        # Pan-into-past: serve from the DB tail. The DB has the full
-        # history (including the in-memory overlap), so a DB-only read of
-        # [t_lo, t_hi] is correct — only the un-flushed live edge (~100 ms)
-        # is absent, and that's never inside a panned-back window.
+        # Pan-into-past beyond the in-memory window: serve from the DB
+        # tail. The DB has the full history, so a DB-only read of
+        # [t_lo, t_hi] is correct — only the un-flushed live edge
+        # (~100 ms) is absent, never inside a panned-back window.
         self._ensure_db_window(t_lo, t_hi)
         buf = self._db_window_buffers.get((side, int(cam_id), metric))
         if buf is None:
@@ -561,8 +574,7 @@ class LiveScanSource(ScanDataSource):
 
     @pyqtSlot(str, int, str, float, result=float)
     def value_at(self, side, cam_id, metric, t):
-        mem_start = self._in_memory_start(side, int(cam_id), metric)
-        if t >= mem_start or not self._db_ready():
+        if not self._needs_db_tail(side, int(cam_id), metric, t) or not self._db_ready():
             return super().value_at(side, cam_id, metric, t)
         self._ensure_db_window(t, t)
         buf = self._db_window_buffers.get((side, int(cam_id), metric))

--- a/data_sources.py
+++ b/data_sources.py
@@ -224,21 +224,26 @@ class ScanDataSource(QObject):
         samples are available (too noisy to autoscale meaningfully).
 
         Matches legacy EmbeddedRealtimePlot._boundsFromArray semantics."""
-        values: list[float] = []
+        # Stay in numpy throughout — building a Python list from
+        # `.tolist()` was the dominant cost of this slot at 1 Hz over
+        # 8 cams × 2 metrics × growing buffers.
+        chunks: list[np.ndarray] = []
         for (_side, _cam_id, m), buf in self.buffers.items():
             if m != metric or buf.n == 0:
                 continue
             slice_v = buf.v[: buf.n]
             finite_mask = np.isfinite(slice_v)
             if finite_mask.any():
-                values.extend(slice_v[finite_mask].tolist())
+                chunks.append(slice_v[finite_mask])
 
-        if len(values) < 4:
+        if not chunks:
+            return {"yMin": 0.0, "yMax": 1.0}
+        combined = np.concatenate(chunks)
+        if combined.size < 4:
             return {"yMin": 0.0, "yMax": 1.0}
 
-        arr = np.asarray(values, dtype=np.float64)
-        lo = float(np.percentile(arr, percentile_lo))
-        hi = float(np.percentile(arr, percentile_hi))
+        lo = float(np.percentile(combined, percentile_lo))
+        hi = float(np.percentile(combined, percentile_hi))
 
         if lo == hi:
             lo -= 0.5

--- a/data_sources.py
+++ b/data_sources.py
@@ -208,6 +208,45 @@ class ScanDataSource(QObject):
         t_arr, v_arr = buf.window_decimated(t_lo, t_hi, int(max_points))
         return [[float(t), float(v)] for t, v in zip(t_arr, v_arr)]
 
+    @pyqtSlot(str, result="QVariantMap")
+    @pyqtSlot(str, float, float, float, result="QVariantMap")
+    def compute_bounds_for_metric(
+        self,
+        metric: str,
+        percentile_lo: float = 2.0,
+        percentile_hi: float = 98.0,
+        pad_frac: float = 0.25,
+    ) -> dict:
+        """Aggregate finite values across every (side, cam_id) buffer for
+        `metric`, return padded percentile bounds as {"yMin": ..., "yMax": ...}.
+
+        Neutral fallback {"yMin": 0.0, "yMax": 1.0} when fewer than 4 valid
+        samples are available (too noisy to autoscale meaningfully).
+
+        Matches legacy EmbeddedRealtimePlot._boundsFromArray semantics."""
+        values: list[float] = []
+        for (_side, _cam_id, m), buf in self.buffers.items():
+            if m != metric or buf.n == 0:
+                continue
+            slice_v = buf.v[: buf.n]
+            finite_mask = np.isfinite(slice_v)
+            if finite_mask.any():
+                values.extend(slice_v[finite_mask].tolist())
+
+        if len(values) < 4:
+            return {"yMin": 0.0, "yMax": 1.0}
+
+        arr = np.asarray(values, dtype=np.float64)
+        lo = float(np.percentile(arr, percentile_lo))
+        hi = float(np.percentile(arr, percentile_hi))
+
+        if lo == hi:
+            lo -= 0.5
+            hi += 0.5
+
+        pad = (hi - lo) * pad_frac
+        return {"yMin": lo - pad, "yMax": hi + pad}
+
     def note_dirty(self, side: str, cam_id: int, metric: str, added: int) -> None:
         """Record that `added` new samples landed in (side, cam, metric).
         Coalesces with any previous note since the last flush."""

--- a/data_sources.py
+++ b/data_sources.py
@@ -247,3 +247,41 @@ class LiveScanSource(ScanDataSource):
         buf = self.get_or_create_buffer(side, cam_id, metric)
         buf.append(t=t, v=v, frame_id=frame_id)
         self.note_dirty(side, cam_id, metric, added=1)
+
+
+# session_data.side is stored as INTEGER (0 = left, 1 = right) but the
+# rest of the app uses string side names. Normalize on the way in.
+_SIDE_INT_TO_STR = {0: "left", 1: "right"}
+
+
+class PastScanSource(ScanDataSource):
+    """ScanDataSource constructed from an SDK ScanDatabase session_id.
+    Bucketizes session_data rows into per-(side, cam, metric) buffers
+    using the same layout as LiveScanSource."""
+
+    def __init__(
+        self,
+        scan_db,                # omotion.ScanDatabase — duck-typed for tests
+        session_id: int,
+        parent: Optional[QObject] = None,
+    ) -> None:
+        super().__init__(plot_t0=0.0, parent=parent)
+        self.live = False
+        self.session_id = int(session_id)
+
+        for row in scan_db.iter_session_data(self.session_id):
+            side_int = int(row["side"])
+            side = _SIDE_INT_TO_STR.get(side_int)
+            if side is None:
+                # Unknown side encoding — silently skip rather than crash on
+                # legacy / corrupted data; the load is best-effort.
+                continue
+            cam_id = int(row["cam_id"])
+            frame_id = int(row["frame_id"])
+            t = float(row["timestamp_s"])
+            for metric in ("bfi", "bvi", "mean", "contrast"):
+                value = row.get(metric)
+                if value is None:
+                    continue
+                buf = self.get_or_create_buffer(side, cam_id, metric)
+                buf.append(t=t, v=float(value), frame_id=frame_id)

--- a/data_sources.py
+++ b/data_sources.py
@@ -325,14 +325,23 @@ class ScanDataSource(QObject):
     def value_at(self, side: str, cam_id: int, metric: str, t: float) -> float:
         """Return the buffer's value for the sample nearest to time `t`.
         NaN if the buffer doesn't exist, is empty, or the nearest sample
-        is itself non-finite. Used by the viewer's hover tooltip."""
+        is itself non-finite. Used by the viewer's hover tooltip.
+
+        Concurrency: snapshots buf.n locally because the SDK pipeline
+        thread may call _CameraBuffer.append (incrementing n) between
+        our reads. Without the snapshot, a torn read of n caused
+        IndexErrors when the searchsorted-returned idx happened to
+        equal the captured slice size but failed the (stale-n) clamp."""
         buf = self.buffers.get((side, int(cam_id), metric))
-        if buf is None or buf.n == 0:
+        if buf is None:
             return float("nan")
-        t_slice = buf.t[: buf.n]
+        n = buf.n
+        if n == 0:
+            return float("nan")
+        t_slice = buf.t[:n]
         idx = int(np.searchsorted(t_slice, t, side="left"))
-        if idx >= buf.n:
-            idx = buf.n - 1
+        if idx >= n:
+            idx = n - 1
         elif idx > 0 and abs(t_slice[idx - 1] - t) < abs(t_slice[idx] - t):
             idx -= 1
         v = float(buf.v[idx])

--- a/data_sources.py
+++ b/data_sources.py
@@ -168,16 +168,42 @@ class _CameraBuffer:
         if n_window <= max_points:
             return self.t[i_lo:i_hi], self.v[i_lo:i_hi]
 
+        # Smooth-then-decimate. A moving-average kernel of width
+        # `stride * 3` is applied across the visible samples, then we
+        # pick `max_points` evenly-spaced points from the smoothed
+        # signal. The overlap (each output averages 3 strides' worth)
+        # means consecutive paints differ in each output by ~1/(3*stride)
+        # of the underlying noise — no visible per-paint flicker even
+        # when the window scrolls one sample at a time. Cost is
+        # O(n_window) cumsum + O(max_points) sample, fully vectorised.
         stride = -(-n_window // max_points)  # ceil division
-        n_full = (n_window // stride) * stride  # truncate to clean reshape
-        end = i_lo + n_full
-        t_block = self.t[i_lo:end].reshape(-1, stride)
-        v_block = self.v[i_lo:end].reshape(-1, stride)
-        # nanmean: bins with all-NaN values produce NaN (renderer skips).
-        # Suppress the warning np raises on all-NaN slices — the NaN
-        # output is the documented contract.
-        with np.errstate(invalid="ignore"):
-            return t_block.mean(axis=1), np.nanmean(v_block, axis=1)
+        smooth_w = max(3, stride * 3)
+        half = smooth_w // 2
+
+        v_slice = self.v[i_lo:i_hi]
+        finite = np.isfinite(v_slice)
+        v_clean = np.where(finite, v_slice, 0.0).astype(np.float64)
+        # Cumulative sums with a leading 0 so window means are
+        # (cum[hi+1] - cum[lo]) / (n[hi+1] - n[lo]) for any [lo, hi].
+        v_cum = np.empty(n_window + 1, dtype=np.float64)
+        v_cum[0] = 0.0
+        np.cumsum(v_clean, out=v_cum[1:])
+        n_cum = np.empty(n_window + 1, dtype=np.int64)
+        n_cum[0] = 0
+        np.cumsum(finite, out=n_cum[1:], dtype=np.int64)
+
+        # Evenly-spaced output centres across the visible window.
+        idxs = np.linspace(0, n_window - 1, max_points).astype(np.int64)
+        lo_i = np.clip(idxs - half, 0, n_window)
+        hi_i = np.clip(idxs + half + 1, 0, n_window)
+        counts = n_cum[hi_i] - n_cum[lo_i]
+        sums = v_cum[hi_i] - v_cum[lo_i]
+        with np.errstate(invalid="ignore", divide="ignore"):
+            v_out = np.where(counts > 0, sums / np.maximum(counts, 1), np.nan)
+        # Output t is the actual sample t at the centre index — keeps
+        # the time axis exact even with the smoothing kernel offset.
+        t_out = self.t[i_lo:i_hi][idxs]
+        return t_out, v_out.astype(np.float32)
 
     def mark_dropped(self, t: float) -> None:
         """Record the first dropout timestamp for this stream. Idempotent —

--- a/data_sources.py
+++ b/data_sources.py
@@ -59,16 +59,17 @@ class _CameraBuffer:
         self,
         initial_capacity: Optional[int] = None,
         track_frame_ids: bool = False,
-        max_capacity: int = _MAX_CAPACITY,
+        max_capacity: Optional[int] = _MAX_CAPACITY,
     ) -> None:
         # Ring-trim threshold: when the buffer fills to max_capacity, the
-        # oldest half is dropped. Default ~30 min @ 40 Hz; the live source
-        # can pass a smaller value (e.g. for testing the DB lazy-load
-        # without waiting 30 min). PastScanSource / the DB window keep the
-        # large default so they never trim during a bulk load.
-        self._max_capacity = max(2, int(max_capacity))
+        # oldest half is dropped. The LIVE source passes a finite value
+        # (liveCacheMaxSeconds × 40 Hz) to bound memory. PastScanSource
+        # and the DB-tail window pass max_capacity=None (UNBOUNDED) — they
+        # bulk-load a finite, already-known result set and must never drop
+        # their own rows, so they grow-only from a small initial size.
+        self._max_capacity = None if max_capacity is None else max(2, int(max_capacity))
         if initial_capacity is None:
-            initial_capacity = self._max_capacity
+            initial_capacity = self._max_capacity if self._max_capacity is not None else 4096
         self.t = np.empty(initial_capacity, dtype=np.float64)
         self.v = np.empty(initial_capacity, dtype=np.float32)
         self.frame_id = np.empty(initial_capacity, dtype=np.int64)
@@ -85,9 +86,12 @@ class _CameraBuffer:
 
     def _grow(self) -> None:
         """Double the capacity of all three parallel arrays atomically,
-        capped at max_capacity. All three must always stay the same
-        length — this method is the single chokepoint for that invariant."""
-        new_cap = min(self.t.shape[0] * 2, self._max_capacity)
+        capped at max_capacity (uncapped when max_capacity is None — the
+        unbounded historical/DB-window buffers). All three must always stay
+        the same length — this method is the single chokepoint for that
+        invariant."""
+        doubled = self.t.shape[0] * 2
+        new_cap = doubled if self._max_capacity is None else min(doubled, self._max_capacity)
         self.t = np.resize(self.t, new_cap)
         self.v = np.resize(self.v, new_cap)
         self.frame_id = np.resize(self.frame_id, new_cap)
@@ -114,7 +118,10 @@ class _CameraBuffer:
         """Append one sample. Grows capacity (doubling) on overflow up
         to max_capacity; at the cap, ring-trims the oldest half."""
         if self.n >= self.t.shape[0]:
-            if self.t.shape[0] >= self._max_capacity:
+            # Unbounded (max_capacity=None): always grow, never trim — these
+            # buffers bulk-load a finite, already-known result set (a past scan
+            # or a DB-tail window) and must never drop their own loaded rows.
+            if self._max_capacity is not None and self.t.shape[0] >= self._max_capacity:
                 self._ring_trim()
             else:
                 self._grow()
@@ -280,7 +287,7 @@ class ScanDataSource(QObject):
 
     def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
                  track_frame_ids: bool = False,
-                 buffer_max_capacity: int = _MAX_CAPACITY) -> None:
+                 buffer_max_capacity: Optional[int] = _MAX_CAPACITY) -> None:
         super().__init__(parent)
         self.plot_t0 = float(plot_t0)
         # Subclasses set _live in __init__ — backing store for the
@@ -293,10 +300,13 @@ class ScanDataSource(QObject):
         # overwrites; saves a per-buffer frame_id dict that scales with
         # scan duration. Tests opt in via the constructor flag.
         self._track_frame_ids = track_frame_ids
-        # Ring-trim threshold for buffers this source creates. Live
-        # sources can shrink it (config) to exercise the DB tail without
-        # a 30 min scan. Past/DB-window sources keep the large default.
-        self._buffer_max_capacity = int(buffer_max_capacity)
+        # Ring-trim threshold for buffers this source creates. Live sources
+        # pass a finite value (config) to bound memory; past sources pass None
+        # (UNBOUNDED) so a bulk load of a long scan never ring-trims away its
+        # own oldest rows mid-load.
+        self._buffer_max_capacity = (
+            None if buffer_max_capacity is None else int(buffer_max_capacity)
+        )
 
         # Pending dirty bookkeeping: (side, cam, metric) -> accumulated count.
         self._pending: dict[tuple[str, int, str], int] = {}
@@ -722,7 +732,10 @@ def _bucketize_session_rows(
             key = (side, cam_id, metric)
             buf = buffers.get(key)
             if buf is None:
-                buf = _CameraBuffer()
+                # Unbounded: this is a bulk load of a finite query result
+                # (a full past scan or a DB-tail window). A finite ring-trim
+                # cap would drop the oldest loaded rows mid-load.
+                buf = _CameraBuffer(max_capacity=None)
                 buffers[key] = buf
             buf.append(t=t, v=float(value), frame_id=frame_id)
     return buffers, has_per_cam_bfi
@@ -740,7 +753,11 @@ class PastScanSource(ScanDataSource):
         corrected_csv_path: Optional[str] = None,
         parent: Optional[QObject] = None,
     ) -> None:
-        super().__init__(plot_t0=0.0, parent=parent)
+        # Unbounded buffers: a past scan is a finite, already-known result set
+        # loaded in bulk (DB rows and/or the corrected CSV). With a finite
+        # ring-trim cap, loading a long scan would drop its own oldest rows
+        # as it filled — corrupting the very history the viewer pans back to.
+        super().__init__(plot_t0=0.0, parent=parent, buffer_max_capacity=None)
         self._live = False
         self.session_id = int(session_id)
 
@@ -762,6 +779,51 @@ class PastScanSource(ScanDataSource):
         # unconditionally for every scan (not gated by writeRawCsv).
         if not has_per_cam_bfi and corrected_csv_path:
             self._load_corrected_csv(corrected_csv_path)
+
+        # Reduced-mode side averages (cam_id=-1) aren't persisted per-cam in
+        # the DB or the normal per-cam CSV, so derive them from the per-cam
+        # buffers — otherwise reduced-mode replay is empty (the reduced cells
+        # query cam_id=-1). No-op when a reduced CSV already supplied them.
+        self._derive_side_averages()
+
+    def _derive_side_averages(self) -> None:
+        """Build the reduced-mode side-average buffers (cam_id=-1) from the
+        per-cam buffers, reproducing what the live viewer showed.
+
+        The scan DB (and the normal per-cam corrected CSV) carry per-camera
+        BFI/BVI at cam_id 0..7 but never the side average at cam_id=-1 — the
+        SDK's ScanDBSink "live" channel only writes per-cam rows. Live, the
+        cam_id=-1 buffer was fed one sample per frame equal to that frame's
+        single active-camera value: each histogram frame carries exactly one
+        camera (raw_hist[i, side, cam]), so SideAveragingStage's nanmean over
+        the all-but-one-NaN row reduces to that camera's value. The faithful
+        reconstruction is therefore the per-cam samples for a side merged into
+        one time-ordered stream; the renderer's mean-binning then averages
+        across cameras within each display bin, exactly as it did live.
+
+        Only bfi/bvi (the reduced-mode metrics) are derived, and only when no
+        cam_id=-1 buffer already exists (a reduced-mode CSV provides one)."""
+        for side in ("left", "right"):
+            for metric in ("bfi", "bvi"):
+                if (side, -1, metric) in self.buffers:
+                    continue  # reduced CSV already supplied it — don't clobber
+                parts = [
+                    buf for (s, c, m), buf in self.buffers.items()
+                    if s == side and m == metric and c >= 0 and buf.n > 0
+                ]
+                if not parts:
+                    continue
+                t_all = np.concatenate([b.t[: b.n] for b in parts])
+                v_all = np.concatenate([b.v[: b.n] for b in parts])
+                f_all = np.concatenate([b.frame_id[: b.n] for b in parts])
+                order = np.argsort(t_all, kind="stable")
+                size = int(t_all.size)
+                merged = _CameraBuffer(initial_capacity=max(4, size), max_capacity=None)
+                merged.t[:size] = t_all[order]
+                merged.v[:size] = v_all[order]
+                merged.frame_id[:size] = f_all[order]
+                merged.n = size
+                self.buffers[(side, -1, metric)] = merged
 
     def _load_corrected_csv(self, csv_path: str) -> None:
         """Load per-(side, cam, metric) samples from the corrected CSV

--- a/data_sources.py
+++ b/data_sources.py
@@ -42,13 +42,19 @@ class _CameraBuffer:
         self._frame_id_to_index: dict[int, int] = {}
         self.dropped_at: Optional[float] = None
 
+    def _grow(self) -> None:
+        """Double the capacity of all three parallel arrays atomically.
+        All three must always stay the same length — this method is the
+        single chokepoint that enforces that invariant."""
+        new_cap = self.t.shape[0] * 2
+        self.t = np.resize(self.t, new_cap)
+        self.v = np.resize(self.v, new_cap)
+        self.frame_id = np.resize(self.frame_id, new_cap)
+
     def append(self, t: float, v: float, frame_id: int) -> None:
         """Append one sample. Grows capacity (doubling) on overflow."""
         if self.n >= self.t.shape[0]:
-            new_cap = self.t.shape[0] * 2
-            self.t = np.resize(self.t, new_cap)
-            self.v = np.resize(self.v, new_cap)
-            self.frame_id = np.resize(self.frame_id, new_cap)
+            self._grow()
         idx = self.n
         self.t[idx] = t
         self.v[idx] = v
@@ -62,7 +68,9 @@ class _CameraBuffer:
 
     def apply_corrected(self, frame_id: int, value: float) -> None:
         """Overwrite v at the row whose frame_id matches. Silent no-op if
-        no such frame_id was appended (race: final arrived before live)."""
+        no such frame_id was appended (race: final arrived before live).
+
+        Value is stored as float32; sub-float32 precision is lost on write."""
         if frame_id == -1:
             return
         idx = self._frame_id_to_index.get(int(frame_id))
@@ -72,7 +80,12 @@ class _CameraBuffer:
 
     def window_indices(self, t_lo: float, t_hi: float) -> tuple[int, int]:
         """Return (i_lo, i_hi) such that t[i_lo:i_hi] covers [t_lo, t_hi].
-        i_hi is right-exclusive. Binary search; O(log n)."""
+        i_hi is right-exclusive. Binary search; O(log n).
+
+        Precondition: t[0:n] is monotonically non-decreasing. The live pipeline
+        appends in timestamp order at 40 Hz; PastScanSource reads rows ordered
+        by timestamp_s ASC from the SDK query. Out-of-order append silently
+        returns wrong indices — np.searchsorted does not validate."""
         if self.n == 0:
             return 0, 0
         t_slice = self.t[: self.n]

--- a/data_sources.py
+++ b/data_sources.py
@@ -548,19 +548,22 @@ class PastScanSource(ScanDataSource):
         self._live = False
         self.session_id = int(session_id)
 
-        # The SDK currently writes only side-aggregated CORRECTED-FRAME
-        # placeholders into session_data: cam_id=-1, side=0 (left
-        # sentinel), bfi/bvi=NULL, mean/contrast=values. So this loop
-        # populates (left, -1, mean) and (left, -1, contrast). Per-cam
-        # data isn't recoverable here (the spec's "PR 3 will carry per-
-        # cam data" hasn't landed). BFI/BVI come from corrected_csv_path
-        # below.
+        # session_data carries either:
+        #   - Per-cam BFI/BVI rows from the SDK's "live" channel sink
+        #     (cam_id 0..7, side 0/1, bfi+bvi+mean+contrast) — Phase 1
+        #     and newer scans. The loop below buckets these directly
+        #     into the per-cam (side, cam_id, metric) buffers.
+        #   - Side-aggregated corrected-frame placeholder rows
+        #     (cam_id=-1, side=0, mean+contrast only) — bucketed into
+        #     (left, -1, mean) and (left, -1, contrast).
+        # Older scans recorded before the live-channel write landed
+        # have ONLY the placeholder rows; CSV fallback below picks
+        # those up for per-cam display.
+        has_per_cam_bfi = False
         for row in scan_db.iter_session_data(self.session_id):
             side_int = int(row["side"])
             side = _SIDE_INT_TO_STR.get(side_int)
             if side is None:
-                # Unknown side encoding — silently skip rather than crash on
-                # legacy / corrupted data; the load is best-effort.
                 continue
             cam_id = int(row["cam_id"])
             frame_id = int(row["frame_id"])
@@ -569,16 +572,15 @@ class PastScanSource(ScanDataSource):
                 value = row.get(metric)
                 if value is None:
                     continue
+                if cam_id >= 0 and metric in ("bfi", "bvi"):
+                    has_per_cam_bfi = True
                 buf = self.get_or_create_buffer(side, cam_id, metric)
                 buf.append(t=t, v=float(value), frame_id=frame_id)
 
-        # Corrected CSV: columns frame_id, timestamp_s, bfi_left, bfi_right,
-        # bvi_left, bvi_right — side-averaged BFI/BVI per row. Populates
-        # (left, -1, bfi/bvi) and (right, -1, bfi/bvi) so reduced-mode
-        # replay (which uses cam_id=-1 cells) can render the recorded
-        # blood-flow traces. Empty cells (missing values written as ',,')
-        # are skipped per side.
-        if corrected_csv_path:
+        # CSV fallback — load only when the DB didn't already carry per-cam
+        # BFI/BVI. Pre-Phase-1 scans land here. CsvSink writes this CSV
+        # unconditionally for every scan (not gated by writeRawCsv).
+        if not has_per_cam_bfi and corrected_csv_path:
             self._load_corrected_csv(corrected_csv_path)
 
     def _load_corrected_csv(self, csv_path: str) -> None:

--- a/data_sources.py
+++ b/data_sources.py
@@ -100,21 +100,41 @@ class _CameraBuffer:
         t_hi: float,
         max_points: int,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """Return (t, v) arrays covering [t_lo, t_hi], strided to at most
-        max_points samples. Caller must not mutate the returned arrays —
-        they are views into the underlying buffer.
+        """Return (t, v) arrays covering [t_lo, t_hi] at no more than
+        max_points samples. When decimation is required, samples are
+        mean-binned (each output value = mean of `stride` consecutive
+        input samples) rather than stride-subsampled.
 
-        Empty arrays returned when the window contains no samples or the
-        buffer is empty."""
+        Mean-binning matters: simple stride subsampling at e.g.
+        stride=2 causes the rendered trace to alternate between odd-
+        and even-indexed samples as the window scrolls one sample at a
+        time, producing a visible "jumping between two datasets"
+        aliasing. Mean-binning averages each pair/triple so the
+        per-bin value changes only fractionally as the window slides.
+
+        NaN samples within a bin are skipped via np.nanmean; a bin
+        whose samples are all non-finite returns NaN (the renderer's
+        existing isFinite guard skips it).
+
+        Empty arrays returned when the window contains no samples or
+        the buffer is empty."""
         i_lo, i_hi = self.window_indices(t_lo, t_hi)
         n_window = i_hi - i_lo
         if n_window <= 0:
             return self.t[0:0], self.v[0:0]
         if n_window <= max_points:
             return self.t[i_lo:i_hi], self.v[i_lo:i_hi]
-        # Stride down to at most max_points by taking every Nth sample.
+
         stride = -(-n_window // max_points)  # ceil division
-        return self.t[i_lo:i_hi:stride], self.v[i_lo:i_hi:stride]
+        n_full = (n_window // stride) * stride  # truncate to clean reshape
+        end = i_lo + n_full
+        t_block = self.t[i_lo:end].reshape(-1, stride)
+        v_block = self.v[i_lo:end].reshape(-1, stride)
+        # nanmean: bins with all-NaN values produce NaN (renderer skips).
+        # Suppress the warning np raises on all-NaN slices — the NaN
+        # output is the documented contract.
+        with np.errstate(invalid="ignore"):
+            return t_block.mean(axis=1), np.nanmean(v_block, axis=1)
 
     def mark_dropped(self, t: float) -> None:
         """Record the first dropout timestamp for this stream. Idempotent —

--- a/data_sources.py
+++ b/data_sources.py
@@ -337,11 +337,6 @@ class ScanDataSource(QObject):
         samples are available (too noisy to autoscale meaningfully).
 
         Matches legacy EmbeddedRealtimePlot._boundsFromArray semantics."""
-        # [LAG-DIAG] Time the autoscale walk — scales with total samples
-        # across all buffers for this metric, so suspect when long scans
-        # start to lag.
-        import time as _time
-        _lag_t0 = _time.perf_counter()
         # Stay in numpy throughout — building a Python list from
         # `.tolist()` was the dominant cost of this slot at 1 Hz over
         # 8 cams × 2 metrics × growing buffers.
@@ -368,17 +363,6 @@ class ScanDataSource(QObject):
             hi += 0.5
 
         pad = (hi - lo) * pad_frac
-        # [LAG-DIAG] Log when this exceeds 20 ms — at 3 Hz a long autoscale
-        # call directly blocks the QML event loop and would manifest as
-        # a paint hiccup.
-        _lag_ms = (_time.perf_counter() - _lag_t0) * 1000.0
-        if _lag_ms > 20.0:
-            import logging as _logging
-            _logging.getLogger("openmotion.bloodflow-app.connector").warning(
-                "[LAG-DIAG] compute_bounds_for_metric(%s) took %.1f ms "
-                "(samples=%d, buffers=%d)",
-                metric, _lag_ms, combined.size, len(chunks),
-            )
         return {"yMin": lo - pad, "yMax": hi + pad}
 
     def note_dirty(self, side: str, cam_id: int, metric: str, added: int) -> None:

--- a/data_sources.py
+++ b/data_sources.py
@@ -166,20 +166,13 @@ class _CameraBuffer:
         if n_window <= 0:
             return self.t[0:0], self.v[0:0]
 
-        # Stride-aligned causal smoothing — always applied, even when
-        # n_window <= max_points. Previously we returned raw samples in
-        # that case and only switched to smoothing once the window
-        # filled, which produced a visible "downsampled" appearance
-        # flip + a perf ramp during the first ~5 s of the scan. With a
-        # minimum stride of 2 the kernel is always wide enough to
-        # suppress aliasing without much loss of detail.
-        #
-        # Each output sits at an ABSOLUTE sample index that is a multiple
-        # of `stride` — so the same absolute sample always maps to the
-        # same output regardless of which paint we're on. And the
-        # smoothing is CAUSAL (window covers [N-w+1, N], only samples
-        # at or before N) — so once a sample is appended, the output at
-        # that absolute index has its final value and never changes.
+        # Stride-aligned causal smoothing. Each output sits at an
+        # ABSOLUTE sample index that is a multiple of `stride` — so the
+        # same absolute sample always maps to the same output regardless
+        # of which paint we're on. And the smoothing is CAUSAL (window
+        # covers [N-w+1, N], only samples at or before N) — so once a
+        # sample is appended, the output at that absolute index has its
+        # final value and never changes.
         #
         # Stride is derived from the TIME WINDOW (× nominal 40 Hz), not
         # from n_window. Keying on n_window meant stride crept up as
@@ -189,10 +182,25 @@ class _CameraBuffer:
         # with a new causal window — producing a visible "morph" of
         # the trace shape each time it ticked. Time-keyed stride is
         # invariant under data growth, so the trace stays put.
+        #
+        # window = stride (not stride*3) keeps the low-pass at the
+        # Nyquist-minimum — just enough to suppress aliasing across the
+        # stride-subsampled output, without smearing real detail.
+        # Earlier 3× kernel hid features even at the tightest 5 s zoom.
         nominal_hz = 40.0  # SDK histogram cadence
         expected_samples = max(1.0, (t_hi - t_lo) * nominal_hz)
-        stride = max(2, int(-(-expected_samples // max_points)))
-        window = stride * 3
+        stride = max(1, int(-(-expected_samples // max_points)))
+
+        # Zoomed-in tight enough that every sample fits — no decimation
+        # needed, return raw samples. (The earlier `max(2, ...)` floor
+        # always forced a 2-sample average even when not needed, which
+        # was the source of "looks filtered" at 5 s zoom.)
+        if stride == 1:
+            t_out = self.t[i_lo:i_hi]
+            v_out = self.v[i_lo:i_hi]
+            return t_out, v_out
+
+        window = stride
 
         # Stride-aligned absolute indices that fall within [i_lo, i_hi).
         first_k = (i_lo + stride - 1) // stride

--- a/data_sources.py
+++ b/data_sources.py
@@ -16,10 +16,13 @@ Nothing in QML consumes these yet — Phase 1 is purely additive.
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 import numpy as np
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot, pyqtProperty
+
+logger = logging.getLogger("openmotion.bloodflow-app.data_sources")
 
 
 _MAX_CAPACITY = 72000       # ≈ 30 min @ 40 Hz; ring-trim above this.
@@ -534,6 +537,7 @@ class LiveScanSource(ScanDataSource):
                 self._db_unavailable = True
                 return False
             self._db_session_id = int(row[0])
+            logger.info("LiveScanSource: DB tail engaged (session_id=%d)", self._db_session_id)
             return True
         except Exception:
             logger.exception("LiveScanSource: DB tail unavailable")

--- a/data_sources.py
+++ b/data_sources.py
@@ -50,13 +50,22 @@ class _CameraBuffer:
     """
 
     __slots__ = ("t", "v", "frame_id", "n", "_frame_id_to_index", "dropped_at",
-                 "ring_trimmed")
+                 "ring_trimmed", "_max_capacity")
 
     def __init__(
         self,
-        initial_capacity: int = _INITIAL_CAPACITY,
+        initial_capacity: Optional[int] = None,
         track_frame_ids: bool = False,
+        max_capacity: int = _MAX_CAPACITY,
     ) -> None:
+        # Ring-trim threshold: when the buffer fills to max_capacity, the
+        # oldest half is dropped. Default ~30 min @ 40 Hz; the live source
+        # can pass a smaller value (e.g. for testing the DB lazy-load
+        # without waiting 30 min). PastScanSource / the DB window keep the
+        # large default so they never trim during a bulk load.
+        self._max_capacity = max(2, int(max_capacity))
+        if initial_capacity is None:
+            initial_capacity = self._max_capacity
         self.t = np.empty(initial_capacity, dtype=np.float64)
         self.v = np.empty(initial_capacity, dtype=np.float32)
         self.frame_id = np.empty(initial_capacity, dtype=np.int64)
@@ -72,10 +81,10 @@ class _CameraBuffer:
         self.ring_trimmed: bool = False
 
     def _grow(self) -> None:
-        """Double the capacity of all three parallel arrays atomically.
-        All three must always stay the same length — this method is the
-        single chokepoint that enforces that invariant."""
-        new_cap = self.t.shape[0] * 2
+        """Double the capacity of all three parallel arrays atomically,
+        capped at max_capacity. All three must always stay the same
+        length — this method is the single chokepoint for that invariant."""
+        new_cap = min(self.t.shape[0] * 2, self._max_capacity)
         self.t = np.resize(self.t, new_cap)
         self.v = np.resize(self.v, new_cap)
         self.frame_id = np.resize(self.frame_id, new_cap)
@@ -83,11 +92,14 @@ class _CameraBuffer:
     def _ring_trim(self) -> None:
         """At-cap: drop the oldest half of the buffer in-place so new
         appends keep landing at index n without unbounded growth.
-        Called when capacity has already reached _MAX_CAPACITY."""
-        half = _MAX_CAPACITY // 2
-        self.t[:half] = self.t[half:]
-        self.v[:half] = self.v[half:]
-        self.frame_id[:half] = self.frame_id[half:]
+        Called when capacity has already reached max_capacity."""
+        half = self._max_capacity // 2
+        # Keep the most recent `half` samples (parity-safe — works for
+        # odd max_capacity too, e.g. a test-configured small cache).
+        keep_from = self.n - half
+        self.t[:half] = self.t[keep_from:self.n]
+        self.v[:half] = self.v[keep_from:self.n]
+        self.frame_id[:half] = self.frame_id[keep_from:self.n]
         self.n = half
         self.ring_trimmed = True
         # Frame-id lookup positions shift after the trim; safest to
@@ -97,9 +109,9 @@ class _CameraBuffer:
 
     def append(self, t: float, v: float, frame_id: int) -> None:
         """Append one sample. Grows capacity (doubling) on overflow up
-        to _MAX_CAPACITY; above that, ring-trims the oldest half."""
+        to max_capacity; at the cap, ring-trims the oldest half."""
         if self.n >= self.t.shape[0]:
-            if self.t.shape[0] >= _MAX_CAPACITY:
+            if self.t.shape[0] >= self._max_capacity:
                 self._ring_trim()
             else:
                 self._grow()
@@ -264,7 +276,8 @@ class ScanDataSource(QObject):
     samplesAppended = pyqtSignal(str, int, str, int)
 
     def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
-                 track_frame_ids: bool = False) -> None:
+                 track_frame_ids: bool = False,
+                 buffer_max_capacity: int = _MAX_CAPACITY) -> None:
         super().__init__(parent)
         self.plot_t0 = float(plot_t0)
         # Subclasses set _live in __init__ — backing store for the
@@ -277,6 +290,10 @@ class ScanDataSource(QObject):
         # overwrites; saves a per-buffer frame_id dict that scales with
         # scan duration. Tests opt in via the constructor flag.
         self._track_frame_ids = track_frame_ids
+        # Ring-trim threshold for buffers this source creates. Live
+        # sources can shrink it (config) to exercise the DB tail without
+        # a 30 min scan. Past/DB-window sources keep the large default.
+        self._buffer_max_capacity = int(buffer_max_capacity)
 
         # Pending dirty bookkeeping: (side, cam, metric) -> accumulated count.
         self._pending: dict[tuple[str, int, str], int] = {}
@@ -324,7 +341,8 @@ class ScanDataSource(QObject):
         key = (side, int(cam_id), metric)
         buf = self.buffers.get(key)
         if buf is None:
-            buf = _CameraBuffer(track_frame_ids=self._track_frame_ids)
+            buf = _CameraBuffer(track_frame_ids=self._track_frame_ids,
+                                max_capacity=self._buffer_max_capacity)
             self.buffers[key] = buf
         return buf
 
@@ -472,9 +490,11 @@ class LiveScanSource(ScanDataSource):
 
     def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
                  track_frame_ids: bool = False,
-                 scan_db_path: Optional[str] = None) -> None:
+                 scan_db_path: Optional[str] = None,
+                 cache_max_samples: int = _MAX_CAPACITY) -> None:
         super().__init__(plot_t0=plot_t0, parent=parent,
-                         track_frame_ids=track_frame_ids)
+                         track_frame_ids=track_frame_ids,
+                         buffer_max_capacity=cache_max_samples)
         self._live = True
         # DB tail state — all lazily initialized on first pan-into-past.
         self._scan_db_path = scan_db_path

--- a/data_sources.py
+++ b/data_sources.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
 
 _INITIAL_CAPACITY = 4096  # ≈ 100 s @ 40 Hz; doubles on overflow.
@@ -98,3 +99,74 @@ class _CameraBuffer:
         later calls don't overwrite the earlier dropout."""
         if self.dropped_at is None:
             self.dropped_at = float(t)
+
+
+_FLUSH_INTERVAL_MS = 100  # spec §"Throttled UI notify"
+
+
+class ScanDataSource(QObject):
+    """Base for live and past scan sources. Owns per-(side, cam, metric)
+    _CameraBuffer instances and a throttled samplesAppended signal.
+
+    Subclasses populate buffers; the base handles bookkeeping (liveEdge
+    cache, flush timer, signal coalescing).
+    """
+
+    # (side, cam_id, metric, added_count) — coalesced across the flush window.
+    samplesAppended = pyqtSignal(str, int, str, int)
+
+    def __init__(self, plot_t0: float, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self.plot_t0 = float(plot_t0)
+        self.live: bool = False  # LiveScanSource overrides to True
+        self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
+
+        # Pending dirty bookkeeping: (side, cam, metric) -> accumulated count.
+        self._pending: dict[tuple[str, int, str], int] = {}
+
+        # Throttle timer — fires every 100 ms while the source is alive.
+        # Tests can call _flush() directly and ignore the timer entirely.
+        self._flush_timer = QTimer(self)
+        self._flush_timer.setInterval(_FLUSH_INTERVAL_MS)
+        self._flush_timer.timeout.connect(self._flush)
+        self._flush_timer.start()
+
+    # ── public ────────────────────────────────────────────────────────────
+
+    @property
+    def liveEdge(self) -> float:
+        """The maximum timestamp across all buffers, or 0.0 if empty."""
+        edge = 0.0
+        for b in self.buffers.values():
+            if b.n > 0:
+                last_t = float(b.t[b.n - 1])
+                if last_t > edge:
+                    edge = last_t
+        return edge
+
+    def get_or_create_buffer(self, side: str, cam_id: int, metric: str) -> _CameraBuffer:
+        key = (side, int(cam_id), metric)
+        buf = self.buffers.get(key)
+        if buf is None:
+            buf = _CameraBuffer()
+            self.buffers[key] = buf
+        return buf
+
+    def note_dirty(self, side: str, cam_id: int, metric: str, added: int) -> None:
+        """Record that `added` new samples landed in (side, cam, metric).
+        Coalesces with any previous note since the last flush."""
+        if added <= 0:
+            return
+        key = (side, int(cam_id), metric)
+        self._pending[key] = self._pending.get(key, 0) + added
+
+    # ── internal ──────────────────────────────────────────────────────────
+
+    def _flush(self) -> None:
+        """Emit one samplesAppended per dirty buffer and clear pending."""
+        if not self._pending:
+            return
+        pending = self._pending
+        self._pending = {}
+        for (side, cam_id, metric), count in pending.items():
+            self.samplesAppended.emit(side, cam_id, metric, count)

--- a/data_sources.py
+++ b/data_sources.py
@@ -22,25 +22,40 @@ import numpy as np
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot, pyqtProperty
 
 
-_INITIAL_CAPACITY = 4096  # ≈ 100 s @ 40 Hz; doubles on overflow.
+_INITIAL_CAPACITY = 4096    # ≈ 100 s @ 40 Hz; doubles on overflow.
+_MAX_CAPACITY = 72000       # ≈ 30 min @ 40 Hz; ring-trim above this.
 
 
 class _CameraBuffer:
     """Append-only growable buffer for one (side, cam_id, metric) stream.
 
-    Holds three parallel arrays (t, v, frame_id) plus a frame_id → index
-    lookup so corrected-batch overwrites can rewrite in place. NaN values
-    are stored; the renderer is responsible for skipping them on draw.
+    Holds three parallel arrays (t, v, frame_id). NaN values are stored;
+    the renderer is responsible for skipping them on draw.
+
+    Optional `track_frame_ids=True` enables a frame_id → array-index
+    lookup for in-place corrected-batch overwrites. Off by default
+    (the new viewer no longer applies corrections, and tracking the
+    dict added meaningful memory + GC pressure over long scans).
+
+    Above _MAX_CAPACITY samples, the oldest half is dropped on the
+    next overflow (drop-oldest ring behavior). Bounds memory for
+    multi-hour scans at the cost of pan-back history beyond ~30 min.
     """
 
     __slots__ = ("t", "v", "frame_id", "n", "_frame_id_to_index", "dropped_at")
 
-    def __init__(self, initial_capacity: int = _INITIAL_CAPACITY) -> None:
+    def __init__(
+        self,
+        initial_capacity: int = _INITIAL_CAPACITY,
+        track_frame_ids: bool = False,
+    ) -> None:
         self.t = np.empty(initial_capacity, dtype=np.float64)
         self.v = np.empty(initial_capacity, dtype=np.float32)
         self.frame_id = np.empty(initial_capacity, dtype=np.int64)
         self.n = 0
-        self._frame_id_to_index: dict[int, int] = {}
+        self._frame_id_to_index: Optional[dict[int, int]] = (
+            {} if track_frame_ids else None
+        )
         self.dropped_at: Optional[float] = None
 
     def _grow(self) -> None:
@@ -52,10 +67,28 @@ class _CameraBuffer:
         self.v = np.resize(self.v, new_cap)
         self.frame_id = np.resize(self.frame_id, new_cap)
 
+    def _ring_trim(self) -> None:
+        """At-cap: drop the oldest half of the buffer in-place so new
+        appends keep landing at index n without unbounded growth.
+        Called when capacity has already reached _MAX_CAPACITY."""
+        half = _MAX_CAPACITY // 2
+        self.t[:half] = self.t[half:]
+        self.v[:half] = self.v[half:]
+        self.frame_id[:half] = self.frame_id[half:]
+        self.n = half
+        # Frame-id lookup positions shift after the trim; safest to
+        # drop the mapping and rebuild lazily on subsequent appends.
+        if self._frame_id_to_index is not None:
+            self._frame_id_to_index.clear()
+
     def append(self, t: float, v: float, frame_id: int) -> None:
-        """Append one sample. Grows capacity (doubling) on overflow."""
+        """Append one sample. Grows capacity (doubling) on overflow up
+        to _MAX_CAPACITY; above that, ring-trims the oldest half."""
         if self.n >= self.t.shape[0]:
-            self._grow()
+            if self.t.shape[0] >= _MAX_CAPACITY:
+                self._ring_trim()
+            else:
+                self._grow()
         idx = self.n
         self.t[idx] = t
         self.v[idx] = v
@@ -63,16 +96,19 @@ class _CameraBuffer:
         # frame_id == -1 is the SDK's "unknown" sentinel; don't index it —
         # apply_corrected with frame_id=-1 must NOT silently rewrite the
         # most-recent unknown sample.
-        if frame_id != -1:
+        if self._frame_id_to_index is not None and frame_id != -1:
             self._frame_id_to_index[int(frame_id)] = idx
         self.n += 1
 
     def apply_corrected(self, frame_id: int, value: float) -> None:
-        """Overwrite v at the row whose frame_id matches. Silent no-op if
-        no such frame_id was appended (race: final arrived before live).
+        """Overwrite v at the row whose frame_id matches. Silent no-op
+        when frame-id tracking is disabled (the default), when
+        frame_id is the -1 sentinel, or when no matching frame_id was
+        appended (race: final arrived before live, or the row was
+        dropped by a ring-trim).
 
         Value is stored as float32; sub-float32 precision is lost on write."""
-        if frame_id == -1:
+        if self._frame_id_to_index is None or frame_id == -1:
             return
         idx = self._frame_id_to_index.get(int(frame_id))
         if idx is None:
@@ -157,11 +193,16 @@ class ScanDataSource(QObject):
     # (side, cam_id, metric, added_count) — coalesced across the flush window.
     samplesAppended = pyqtSignal(str, int, str, int)
 
-    def __init__(self, plot_t0: float, parent: Optional[QObject] = None) -> None:
+    def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
+                 track_frame_ids: bool = False) -> None:
         super().__init__(parent)
         self.plot_t0 = float(plot_t0)
         self.live: bool = False  # LiveScanSource overrides to True
         self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
+        # Default False — production no longer uses corrected-batch
+        # overwrites; saves a per-buffer frame_id dict that scales with
+        # scan duration. Tests opt in via the constructor flag.
+        self._track_frame_ids = track_frame_ids
 
         # Pending dirty bookkeeping: (side, cam, metric) -> accumulated count.
         self._pending: dict[tuple[str, int, str], int] = {}
@@ -200,7 +241,7 @@ class ScanDataSource(QObject):
         key = (side, int(cam_id), metric)
         buf = self.buffers.get(key)
         if buf is None:
-            buf = _CameraBuffer()
+            buf = _CameraBuffer(track_frame_ids=self._track_frame_ids)
             self.buffers[key] = buf
         return buf
 
@@ -296,8 +337,10 @@ class LiveScanSource(ScanDataSource):
     """ScanDataSource fed by the in-flight pipeline. Constructed at scan
     start; lives as long as the connector holds a reference."""
 
-    def __init__(self, plot_t0: float, parent: Optional[QObject] = None) -> None:
-        super().__init__(plot_t0=plot_t0, parent=parent)
+    def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
+                 track_frame_ids: bool = False) -> None:
+        super().__init__(plot_t0=plot_t0, parent=parent,
+                         track_frame_ids=track_frame_ids)
         self.live = True
 
     def append_uncorrected(

--- a/data_sources.py
+++ b/data_sources.py
@@ -285,6 +285,11 @@ class ScanDataSource(QObject):
         samples are available (too noisy to autoscale meaningfully).
 
         Matches legacy EmbeddedRealtimePlot._boundsFromArray semantics."""
+        # [LAG-DIAG] Time the autoscale walk — scales with total samples
+        # across all buffers for this metric, so suspect when long scans
+        # start to lag.
+        import time as _time
+        _lag_t0 = _time.perf_counter()
         # Stay in numpy throughout — building a Python list from
         # `.tolist()` was the dominant cost of this slot at 1 Hz over
         # 8 cams × 2 metrics × growing buffers.
@@ -311,6 +316,17 @@ class ScanDataSource(QObject):
             hi += 0.5
 
         pad = (hi - lo) * pad_frac
+        # [LAG-DIAG] Log when this exceeds 20 ms — at 3 Hz a long autoscale
+        # call directly blocks the QML event loop and would manifest as
+        # a paint hiccup.
+        _lag_ms = (_time.perf_counter() - _lag_t0) * 1000.0
+        if _lag_ms > 20.0:
+            import logging as _logging
+            _logging.getLogger("openmotion.bloodflow-app.connector").warning(
+                "[LAG-DIAG] compute_bounds_for_metric(%s) took %.1f ms "
+                "(samples=%d, buffers=%d)",
+                metric, _lag_ms, combined.size, len(chunks),
+            )
         return {"yMin": lo - pad, "yMax": hi + pad}
 
     def note_dirty(self, side: str, cam_id: int, metric: str, added: int) -> None:

--- a/data_sources.py
+++ b/data_sources.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot, pyqtProperty
 
 
 _INITIAL_CAPACITY = 4096  # ≈ 100 s @ 40 Hz; doubles on overflow.
@@ -155,9 +155,19 @@ class ScanDataSource(QObject):
 
     # ── public ────────────────────────────────────────────────────────────
 
-    @property
+    @pyqtProperty(float)
     def liveEdge(self) -> float:
-        """The maximum timestamp across all buffers, or 0.0 if empty."""
+        """The maximum timestamp across all buffers, or 0.0 if empty.
+
+        Exposed as ``pyqtProperty`` (not plain ``@property``) so QML can
+        read it from JavaScript inside ``PlotCell.onPaint``. Plain Python
+        properties don't appear in PyQt6's meta-object and resolve to
+        ``undefined`` in QML, which would NaN-poison the paint math.
+
+        No notify signal: PlotCell repaints on ``samplesAppended`` (which
+        carries the dirty-buffer signal) and reads liveEdge fresh inside
+        onPaint.
+        """
         edge = 0.0
         for b in self.buffers.values():
             if b.n > 0:

--- a/data_sources.py
+++ b/data_sources.py
@@ -168,41 +168,56 @@ class _CameraBuffer:
         if n_window <= max_points:
             return self.t[i_lo:i_hi], self.v[i_lo:i_hi]
 
-        # Smooth-then-decimate. A moving-average kernel of width
-        # `stride * 3` is applied across the visible samples, then we
-        # pick `max_points` evenly-spaced points from the smoothed
-        # signal. The overlap (each output averages 3 strides' worth)
-        # means consecutive paints differ in each output by ~1/(3*stride)
-        # of the underlying noise — no visible per-paint flicker even
-        # when the window scrolls one sample at a time. Cost is
-        # O(n_window) cumsum + O(max_points) sample, fully vectorised.
-        stride = -(-n_window // max_points)  # ceil division
-        smooth_w = max(3, stride * 3)
-        half = smooth_w // 2
+        # Stride-aligned causal smoothing.
+        #
+        # Each output sits at an ABSOLUTE sample index that is a multiple
+        # of `stride` — so the same absolute sample always maps to the
+        # same output regardless of which paint we're on. And the
+        # smoothing is CAUSAL (window covers [N-w+1, N], only samples
+        # at or before N) — so once a sample is appended, the output at
+        # that absolute index has its final value and never changes.
+        #
+        # The previous linspace-relative-to-i_lo + symmetric smoothing
+        # made every output's underlying absolute sample drift one slot
+        # left per paint AND made edge values keep re-smoothing as more
+        # post-edge samples arrived. Combined this showed as peaks
+        # morphing / sharpening as they scrolled left. With the new
+        # design the visible trace simply translates — output values
+        # are time-invariant once computed.
+        stride = max(1, -(-n_window // max_points))
+        window = max(3, stride * 3)
 
-        v_slice = self.v[i_lo:i_hi]
-        finite = np.isfinite(v_slice)
-        v_clean = np.where(finite, v_slice, 0.0).astype(np.float64)
-        # Cumulative sums with a leading 0 so window means are
-        # (cum[hi+1] - cum[lo]) / (n[hi+1] - n[lo]) for any [lo, hi].
-        v_cum = np.empty(n_window + 1, dtype=np.float64)
+        # Stride-aligned absolute indices that fall within [i_lo, i_hi).
+        first_k = (i_lo + stride - 1) // stride
+        last_k = (i_hi - 1) // stride
+        if last_k < first_k:
+            return self.t[0:0], self.v[0:0]
+        abs_idxs = np.arange(first_k, last_k + 1) * stride
+
+        # Cumsum range covers the causal lookback for the leftmost output
+        # all the way through the rightmost output (inclusive).
+        cum_lo = max(0, int(abs_idxs[0]) - window + 1)
+        cum_hi = int(abs_idxs[-1]) + 1
+        v_block = self.v[cum_lo:cum_hi]
+        f_block = np.isfinite(v_block)
+        v_clean = np.where(f_block, v_block, 0.0).astype(np.float64)
+        v_cum = np.empty(v_block.size + 1, dtype=np.float64)
         v_cum[0] = 0.0
         np.cumsum(v_clean, out=v_cum[1:])
-        n_cum = np.empty(n_window + 1, dtype=np.int64)
+        n_cum = np.empty(v_block.size + 1, dtype=np.int64)
         n_cum[0] = 0
-        np.cumsum(finite, out=n_cum[1:], dtype=np.int64)
+        np.cumsum(f_block, out=n_cum[1:], dtype=np.int64)
 
-        # Evenly-spaced output centres across the visible window.
-        idxs = np.linspace(0, n_window - 1, max_points).astype(np.int64)
-        lo_i = np.clip(idxs - half, 0, n_window)
-        hi_i = np.clip(idxs + half + 1, 0, n_window)
-        counts = n_cum[hi_i] - n_cum[lo_i]
-        sums = v_cum[hi_i] - v_cum[lo_i]
+        # Per-output causal window = [abs_idx - window + 1, abs_idx],
+        # translated into v_block-local indices.
+        local = abs_idxs - cum_lo
+        lo_b = np.maximum(0, local - window + 1)
+        hi_b = local + 1
+        counts = n_cum[hi_b] - n_cum[lo_b]
+        sums = v_cum[hi_b] - v_cum[lo_b]
         with np.errstate(invalid="ignore", divide="ignore"):
             v_out = np.where(counts > 0, sums / np.maximum(counts, 1), np.nan)
-        # Output t is the actual sample t at the centre index — keeps
-        # the time axis exact even with the smoothing kernel offset.
-        t_out = self.t[i_lo:i_hi][idxs]
+        t_out = self.t[abs_idxs]
         return t_out, v_out.astype(np.float32)
 
     def mark_dropped(self, t: float) -> None:

--- a/data_sources.py
+++ b/data_sources.py
@@ -165,10 +165,14 @@ class _CameraBuffer:
         n_window = i_hi - i_lo
         if n_window <= 0:
             return self.t[0:0], self.v[0:0]
-        if n_window <= max_points:
-            return self.t[i_lo:i_hi], self.v[i_lo:i_hi]
 
-        # Stride-aligned causal smoothing.
+        # Stride-aligned causal smoothing — always applied, even when
+        # n_window <= max_points. Previously we returned raw samples in
+        # that case and only switched to smoothing once the window
+        # filled, which produced a visible "downsampled" appearance
+        # flip + a perf ramp during the first ~5 s of the scan. With a
+        # minimum stride of 2 the kernel is always wide enough to
+        # suppress aliasing without much loss of detail.
         #
         # Each output sits at an ABSOLUTE sample index that is a multiple
         # of `stride` — so the same absolute sample always maps to the
@@ -184,8 +188,8 @@ class _CameraBuffer:
         # morphing / sharpening as they scrolled left. With the new
         # design the visible trace simply translates — output values
         # are time-invariant once computed.
-        stride = max(1, -(-n_window // max_points))
-        window = max(3, stride * 3)
+        stride = max(2, -(-n_window // max_points))
+        window = stride * 3
 
         # Stride-aligned absolute indices that fall within [i_lo, i_hi).
         first_k = (i_lo + stride - 1) // stride

--- a/data_sources.py
+++ b/data_sources.py
@@ -1,0 +1,87 @@
+"""Per-scan data sources for the bloodflow real-time plot viewer.
+
+See docs/superpowers/specs/2026-05-22-realtime-plot-viewer-design.md for
+the full design. Phase 1 introduces:
+
+  - _CameraBuffer   : per-(side, cam, metric) growable numpy buffer.
+  - ScanDataSource  : QObject base. Owns per-key buffers + the throttled
+                      samplesAppended signal.
+  - LiveScanSource  : appends from the in-flight pipeline; supports
+                      corrected-batch in-place overwrites.
+  - PastScanSource  : constructed from an SDK ScanDatabase session_id;
+                      bucketizes session_data rows into the same layout.
+
+Nothing in QML consumes these yet — Phase 1 is purely additive.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+_INITIAL_CAPACITY = 4096  # ≈ 100 s @ 40 Hz; doubles on overflow.
+
+
+class _CameraBuffer:
+    """Append-only growable buffer for one (side, cam_id, metric) stream.
+
+    Holds three parallel arrays (t, v, frame_id) plus a frame_id → index
+    lookup so corrected-batch overwrites can rewrite in place. NaN values
+    are stored; the renderer is responsible for skipping them on draw.
+    """
+
+    __slots__ = ("t", "v", "frame_id", "n", "_frame_id_to_index", "dropped_at")
+
+    def __init__(self, initial_capacity: int = _INITIAL_CAPACITY) -> None:
+        self.t = np.empty(initial_capacity, dtype=np.float64)
+        self.v = np.empty(initial_capacity, dtype=np.float32)
+        self.frame_id = np.empty(initial_capacity, dtype=np.int64)
+        self.n = 0
+        self._frame_id_to_index: dict[int, int] = {}
+        self.dropped_at: Optional[float] = None
+
+    def append(self, t: float, v: float, frame_id: int) -> None:
+        """Append one sample. Grows capacity (doubling) on overflow."""
+        if self.n >= self.t.shape[0]:
+            new_cap = self.t.shape[0] * 2
+            self.t = np.resize(self.t, new_cap)
+            self.v = np.resize(self.v, new_cap)
+            self.frame_id = np.resize(self.frame_id, new_cap)
+        idx = self.n
+        self.t[idx] = t
+        self.v[idx] = v
+        self.frame_id[idx] = frame_id
+        # frame_id == -1 is the SDK's "unknown" sentinel; don't index it —
+        # apply_corrected with frame_id=-1 must NOT silently rewrite the
+        # most-recent unknown sample.
+        if frame_id != -1:
+            self._frame_id_to_index[int(frame_id)] = idx
+        self.n += 1
+
+    def apply_corrected(self, frame_id: int, value: float) -> None:
+        """Overwrite v at the row whose frame_id matches. Silent no-op if
+        no such frame_id was appended (race: final arrived before live)."""
+        if frame_id == -1:
+            return
+        idx = self._frame_id_to_index.get(int(frame_id))
+        if idx is None:
+            return
+        self.v[idx] = value
+
+    def window_indices(self, t_lo: float, t_hi: float) -> tuple[int, int]:
+        """Return (i_lo, i_hi) such that t[i_lo:i_hi] covers [t_lo, t_hi].
+        i_hi is right-exclusive. Binary search; O(log n)."""
+        if self.n == 0:
+            return 0, 0
+        t_slice = self.t[: self.n]
+        i_lo = int(np.searchsorted(t_slice, t_lo, side="left"))
+        i_hi = int(np.searchsorted(t_slice, t_hi, side="right"))
+        return i_lo, i_hi
+
+    def mark_dropped(self, t: float) -> None:
+        """Record the first dropout timestamp for this stream. Idempotent —
+        later calls don't overwrite the earlier dropout."""
+        if self.dropped_at is None:
+            self.dropped_at = float(t)

--- a/data_sources.py
+++ b/data_sources.py
@@ -450,13 +450,134 @@ class ScanDataSource(QObject):
 
 class LiveScanSource(ScanDataSource):
     """ScanDataSource fed by the in-flight pipeline. Constructed at scan
-    start; lives as long as the connector holds a reference."""
+    start; lives as long as the connector holds a reference.
+
+    Bounded-memory + DB tail: the in-memory _CameraBuffers ring-trim at
+    _MAX_CAPACITY (~30 min @ 40 Hz), dropping the oldest half. Older
+    samples remain in the scan DB (the SDK's ScanDBSink "live" channel
+    writes per-cam BFI/BVI as the scan runs). When the viewer pans
+    BEFORE the in-memory window, points_for_window / value_at lazily
+    load the requested range from the DB into a transient window so the
+    full scan history stays navigable without unbounded memory growth.
+
+    Pass scan_db_path to enable the DB tail; None (the default, e.g. in
+    unit tests) keeps the legacy in-memory-only behavior."""
 
     def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
-                 track_frame_ids: bool = False) -> None:
+                 track_frame_ids: bool = False,
+                 scan_db_path: Optional[str] = None) -> None:
         super().__init__(plot_t0=plot_t0, parent=parent,
                          track_frame_ids=track_frame_ids)
         self._live = True
+        # DB tail state — all lazily initialized on first pan-into-past.
+        self._scan_db_path = scan_db_path
+        self._db = None                       # omotion.ScanDatabase read handle
+        self._db_session_id: Optional[int] = None
+        self._db_unavailable = False          # set True after a failed resolve
+        self._db_window_buffers: dict = {}     # transient (side,cam,metric)->buffer
+        self._db_window_lo = float("inf")     # loaded range, exclusive sentinel
+        self._db_window_hi = float("-inf")
+
+    # ── DB tail (lazy) ──────────────────────────────────────────────────────
+
+    def _db_ready(self) -> bool:
+        """Resolve the read-only DB handle + this live scan's session_id
+        on first use. The live scan is always the newest session row, so
+        we resolve by MAX(id). Only ever called after the in-memory
+        buffer has ring-trimmed (>30 min in), by which point the session
+        row exists. Returns False (permanently, after one failure) if the
+        DB is unavailable — the source then behaves as in-memory-only."""
+        if self._db_unavailable:
+            return False
+        if self._db is not None and self._db_session_id is not None:
+            return True
+        if not self._scan_db_path:
+            self._db_unavailable = True
+            return False
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            self._db = ScanDatabase(db_path=self._scan_db_path)
+            row = next(
+                self._db._connection().execute(
+                    "SELECT id FROM sessions ORDER BY id DESC LIMIT 1"
+                ),
+                None,
+            )
+            if row is None:
+                self._db_unavailable = True
+                return False
+            self._db_session_id = int(row[0])
+            return True
+        except Exception:
+            logger.exception("LiveScanSource: DB tail unavailable")
+            self._db_unavailable = True
+            return False
+
+    def _ensure_db_window(self, t_lo: float, t_hi: float) -> None:
+        """Materialize session_data rows for [t_lo, t_hi] (padded) into
+        the transient DB-window buffers, if not already covered. Padding
+        by one window each side means small pans reuse the cached load
+        instead of re-querying every paint."""
+        if t_lo >= self._db_window_lo and t_hi <= self._db_window_hi:
+            return
+        span = max(1.0, t_hi - t_lo)
+        want_lo = max(0.0, t_lo - span)
+        want_hi = t_hi + span
+        try:
+            self._db_window_buffers, _ = _bucketize_session_rows(
+                self._db, self._db_session_id, t_lo=want_lo, t_hi=want_hi
+            )
+            self._db_window_lo = want_lo
+            self._db_window_hi = want_hi
+        except Exception:
+            logger.exception("LiveScanSource: DB window load failed")
+            # Leave the previous window in place; a later paint retries.
+
+    def _in_memory_start(self, side: str, cam_id: int, metric: str) -> float:
+        """Oldest in-memory timestamp for one buffer, or +inf if empty.
+        Below this, data has been ring-trimmed and lives only in the DB."""
+        buf = self.buffers.get((side, int(cam_id), metric))
+        if buf is None or buf.n == 0:
+            return float("inf")
+        return float(buf.t[0])
+
+    @pyqtSlot(str, int, str, float, float, int, result="QVariantList")
+    def points_for_window(self, side, cam_id, metric, t_lo, t_hi, max_points):
+        # Fast path: the whole requested window is still in memory (or no
+        # DB tail configured) — defer to the base implementation.
+        mem_start = self._in_memory_start(side, int(cam_id), metric)
+        if t_lo >= mem_start or not self._db_ready():
+            return super().points_for_window(side, cam_id, metric, t_lo, t_hi, int(max_points))
+        # Pan-into-past: serve from the DB tail. The DB has the full
+        # history (including the in-memory overlap), so a DB-only read of
+        # [t_lo, t_hi] is correct — only the un-flushed live edge (~100 ms)
+        # is absent, and that's never inside a panned-back window.
+        self._ensure_db_window(t_lo, t_hi)
+        buf = self._db_window_buffers.get((side, int(cam_id), metric))
+        if buf is None:
+            return []
+        t_arr, v_arr = buf.window_decimated(t_lo, t_hi, int(max_points))
+        return [[float(t), float(v)] for t, v in zip(t_arr, v_arr)]
+
+    @pyqtSlot(str, int, str, float, result=float)
+    def value_at(self, side, cam_id, metric, t):
+        mem_start = self._in_memory_start(side, int(cam_id), metric)
+        if t >= mem_start or not self._db_ready():
+            return super().value_at(side, cam_id, metric, t)
+        self._ensure_db_window(t, t)
+        buf = self._db_window_buffers.get((side, int(cam_id), metric))
+        if buf is None or buf.n == 0:
+            return float("nan")
+        n = buf.n
+        t_slice = buf.t[:n]
+        import numpy as _np
+        idx = int(_np.searchsorted(t_slice, t, side="left"))
+        if idx >= n:
+            idx = n - 1
+        elif idx > 0 and abs(t_slice[idx - 1] - t) < abs(t_slice[idx] - t):
+            idx -= 1
+        v = float(buf.v[idx])
+        return v if _np.isfinite(v) else float("nan")
 
     def append_uncorrected(
         self,
@@ -532,6 +653,45 @@ class LiveScanSource(ScanDataSource):
 _SIDE_INT_TO_STR = {0: "left", 1: "right"}
 
 
+def _bucketize_session_rows(
+    scan_db,
+    session_id: int,
+    t_lo: Optional[float] = None,
+    t_hi: Optional[float] = None,
+) -> tuple[dict, bool]:
+    """Query session_data rows for a session (optionally a time slice)
+    and bucket them into a fresh {(side, cam_id, metric): _CameraBuffer}
+    dict. Returns (buffers, has_per_cam_bfi). Shared by PastScanSource's
+    full load and LiveScanSource's lazy DB-tail window.
+
+    cam_id >= 0 rows are per-cam (from the SDK "live" channel sink);
+    cam_id == -1 rows are the side-aggregated corrected-frame
+    placeholders. has_per_cam_bfi reflects whether any real per-cam
+    BFI/BVI landed — the caller uses it to decide on CSV fallback."""
+    buffers: dict = {}
+    has_per_cam_bfi = False
+    for row in scan_db.iter_session_data(session_id, t_lo=t_lo, t_hi=t_hi):
+        side = _SIDE_INT_TO_STR.get(int(row["side"]))
+        if side is None:
+            continue
+        cam_id = int(row["cam_id"])
+        frame_id = int(row["frame_id"])
+        t = float(row["timestamp_s"])
+        for metric in ("bfi", "bvi", "mean", "contrast"):
+            value = row.get(metric)
+            if value is None:
+                continue
+            if cam_id >= 0 and metric in ("bfi", "bvi"):
+                has_per_cam_bfi = True
+            key = (side, cam_id, metric)
+            buf = buffers.get(key)
+            if buf is None:
+                buf = _CameraBuffer()
+                buffers[key] = buf
+            buf.append(t=t, v=float(value), frame_id=frame_id)
+    return buffers, has_per_cam_bfi
+
+
 class PastScanSource(ScanDataSource):
     """ScanDataSource constructed from an SDK ScanDatabase session_id.
     Bucketizes session_data rows into per-(side, cam, metric) buffers
@@ -559,23 +719,7 @@ class PastScanSource(ScanDataSource):
         # Older scans recorded before the live-channel write landed
         # have ONLY the placeholder rows; CSV fallback below picks
         # those up for per-cam display.
-        has_per_cam_bfi = False
-        for row in scan_db.iter_session_data(self.session_id):
-            side_int = int(row["side"])
-            side = _SIDE_INT_TO_STR.get(side_int)
-            if side is None:
-                continue
-            cam_id = int(row["cam_id"])
-            frame_id = int(row["frame_id"])
-            t = float(row["timestamp_s"])
-            for metric in ("bfi", "bvi", "mean", "contrast"):
-                value = row.get(metric)
-                if value is None:
-                    continue
-                if cam_id >= 0 and metric in ("bfi", "bvi"):
-                    has_per_cam_bfi = True
-                buf = self.get_or_create_buffer(side, cam_id, metric)
-                buf.append(t=t, v=float(value), frame_id=frame_id)
+        self.buffers, has_per_cam_bfi = _bucketize_session_rows(scan_db, self.session_id)
 
         # CSV fallback — load only when the DB didn't already carry per-cam
         # BFI/BVI. Pre-Phase-1 scans land here. CsvSink writes this CSV

--- a/data_sources.py
+++ b/data_sources.py
@@ -181,14 +181,17 @@ class _CameraBuffer:
         # at or before N) — so once a sample is appended, the output at
         # that absolute index has its final value and never changes.
         #
-        # The previous linspace-relative-to-i_lo + symmetric smoothing
-        # made every output's underlying absolute sample drift one slot
-        # left per paint AND made edge values keep re-smoothing as more
-        # post-edge samples arrived. Combined this showed as peaks
-        # morphing / sharpening as they scrolled left. With the new
-        # design the visible trace simply translates — output values
-        # are time-invariant once computed.
-        stride = max(2, -(-n_window // max_points))
+        # Stride is derived from the TIME WINDOW (× nominal 40 Hz), not
+        # from n_window. Keying on n_window meant stride crept up as
+        # samples accumulated within a fixed zoom (e.g. 24 → 25 when
+        # n_window crossed 4800 at the same zoom level), and every
+        # stride change relocated every output to a new absolute index
+        # with a new causal window — producing a visible "morph" of
+        # the trace shape each time it ticked. Time-keyed stride is
+        # invariant under data growth, so the trace stays put.
+        nominal_hz = 40.0  # SDK histogram cadence
+        expected_samples = max(1.0, (t_hi - t_lo) * nominal_hz)
+        stride = max(2, int(-(-expected_samples // max_points)))
         window = stride * 3
 
         # Stride-aligned absolute indices that fall within [i_lo, i_hi).

--- a/data_sources.py
+++ b/data_sources.py
@@ -249,7 +249,11 @@ class ScanDataSource(QObject):
                  track_frame_ids: bool = False) -> None:
         super().__init__(parent)
         self.plot_t0 = float(plot_t0)
-        self.live: bool = False  # LiveScanSource overrides to True
+        # Subclasses set _live in __init__ — backing store for the
+        # `live` pyqtProperty below. Must be a pyqtProperty (not a
+        # plain attribute) for QML to read it; plain Python attributes
+        # are invisible to QML and read as `undefined`.
+        self._live: bool = False
         self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
         # Default False — production no longer uses corrected-batch
         # overwrites; saves a per-buffer frame_id dict that scales with
@@ -267,6 +271,15 @@ class ScanDataSource(QObject):
         self._flush_timer.start()
 
     # ── public ────────────────────────────────────────────────────────────
+
+    @pyqtProperty(bool, constant=True)
+    def live(self) -> bool:
+        """True for LiveScanSource, False for PastScanSource. Must be a
+        pyqtProperty (not a plain attribute) for QML to read it — plain
+        Python attributes resolve to ``undefined`` in QML, which silently
+        broke the toolbar's source-type label and the "Back to live"
+        button's variant selection (both branched on `scanSource.live`)."""
+        return self._live
 
     @pyqtProperty(float)
     def liveEdge(self) -> float:
@@ -432,7 +445,7 @@ class LiveScanSource(ScanDataSource):
                  track_frame_ids: bool = False) -> None:
         super().__init__(plot_t0=plot_t0, parent=parent,
                          track_frame_ids=track_frame_ids)
-        self.live = True
+        self._live = True
 
     def append_uncorrected(
         self,
@@ -520,7 +533,7 @@ class PastScanSource(ScanDataSource):
         parent: Optional[QObject] = None,
     ) -> None:
         super().__init__(plot_t0=0.0, parent=parent)
-        self.live = False
+        self._live = False
         self.session_id = int(session_id)
 
         for row in scan_db.iter_session_data(self.session_id):

--- a/data_sources.py
+++ b/data_sources.py
@@ -541,12 +541,20 @@ class PastScanSource(ScanDataSource):
         self,
         scan_db,                # omotion.ScanDatabase — duck-typed for tests
         session_id: int,
+        corrected_csv_path: Optional[str] = None,
         parent: Optional[QObject] = None,
     ) -> None:
         super().__init__(plot_t0=0.0, parent=parent)
         self._live = False
         self.session_id = int(session_id)
 
+        # The SDK currently writes only side-aggregated CORRECTED-FRAME
+        # placeholders into session_data: cam_id=-1, side=0 (left
+        # sentinel), bfi/bvi=NULL, mean/contrast=values. So this loop
+        # populates (left, -1, mean) and (left, -1, contrast). Per-cam
+        # data isn't recoverable here (the spec's "PR 3 will carry per-
+        # cam data" hasn't landed). BFI/BVI come from corrected_csv_path
+        # below.
         for row in scan_db.iter_session_data(self.session_id):
             side_int = int(row["side"])
             side = _SIDE_INT_TO_STR.get(side_int)
@@ -563,3 +571,79 @@ class PastScanSource(ScanDataSource):
                     continue
                 buf = self.get_or_create_buffer(side, cam_id, metric)
                 buf.append(t=t, v=float(value), frame_id=frame_id)
+
+        # Corrected CSV: columns frame_id, timestamp_s, bfi_left, bfi_right,
+        # bvi_left, bvi_right — side-averaged BFI/BVI per row. Populates
+        # (left, -1, bfi/bvi) and (right, -1, bfi/bvi) so reduced-mode
+        # replay (which uses cam_id=-1 cells) can render the recorded
+        # blood-flow traces. Empty cells (missing values written as ',,')
+        # are skipped per side.
+        if corrected_csv_path:
+            self._load_corrected_csv(corrected_csv_path)
+
+    def _load_corrected_csv(self, csv_path: str) -> None:
+        """Load per-(side, cam, metric) samples from the corrected CSV
+        written by SDK's CsvSink. Two formats:
+
+        - Normal (dev) mode — 82 cols: frame_id, timestamp_s,
+          bfi_l1..bfi_r8, bvi_l1..bvi_r8, mean_l1..mean_r8,
+          contrast_l1..contrast_r8, temp_l1..temp_r8. Each metric
+          column populates (side, cam_id=0..7, metric).
+        - Reduced mode — 6 cols: frame_id, timestamp_s, bfi_left,
+          bfi_right, bvi_left, bvi_right. Each side column populates
+          (side, cam_id=-1, metric).
+
+        This CSV is written unconditionally for every scan (SDK's
+        CsvSink isn't gated by writeRawCsv). Empty cells are skipped.
+        Best-effort load — a missing or malformed file just means the
+        viewer shows whatever else PastScanSource managed to read.
+        """
+        import csv as _csv
+
+        try:
+            with open(csv_path, "r", encoding="utf-8") as f:
+                reader = _csv.DictReader(f)
+                fieldnames = reader.fieldnames or []
+                # Detect format by presence of the per-cam column for
+                # cam 1 in either format.
+                is_per_cam = any(c == "bfi_l1" for c in fieldnames)
+                is_reduced = any(c == "bfi_left" for c in fieldnames)
+                if not (is_per_cam or is_reduced):
+                    return
+                for row in reader:
+                    try:
+                        frame_id = int(row.get("frame_id", -1))
+                        t = float(row["timestamp_s"])
+                    except (ValueError, KeyError, TypeError):
+                        continue
+                    if is_per_cam:
+                        for metric in ("bfi", "bvi", "mean", "contrast"):
+                            for side, side_prefix in (("left", "l"), ("right", "r")):
+                                for cam_idx in range(8):
+                                    # Columns are 1-indexed (l1..l8) so add 1
+                                    # for the column name but store 0-indexed.
+                                    col = f"{metric}_{side_prefix}{cam_idx + 1}"
+                                    raw = row.get(col, "")
+                                    if raw is None or raw == "":
+                                        continue
+                                    try:
+                                        v = float(raw)
+                                    except ValueError:
+                                        continue
+                                    buf = self.get_or_create_buffer(side, cam_idx, metric)
+                                    buf.append(t=t, v=v, frame_id=frame_id)
+                    elif is_reduced:
+                        for metric in ("bfi", "bvi"):
+                            for side in ("left", "right"):
+                                col = f"{metric}_{side}"
+                                raw = row.get(col, "")
+                                if raw is None or raw == "":
+                                    continue
+                                try:
+                                    v = float(raw)
+                                except ValueError:
+                                    continue
+                                buf = self.get_or_create_buffer(side, -1, metric)
+                                buf.append(t=t, v=v, frame_id=frame_id)
+        except OSError:
+            pass

--- a/docs/superpowers/plans/2026-05-28-reduced-mode-side-average.md
+++ b/docs/superpowers/plans/2026-05-28-reduced-mode-side-average.md
@@ -1,0 +1,224 @@
+# Reduced-Mode Side Average — Implementation Plan
+
+> **For agentic workers:** execute task-by-task. Each task is TDD (write the
+> failing test first), ends in one focused commit, and keeps its repo's suite
+> green. Steps use `- [ ]` checkboxes.
+
+**Goal:** Compute the reduced-mode per-side BFI/BVI average as one pure spatial
+operation, applied on two paths — the **live/realtime** path for display and the
+**corrected** path for the DB/replay record — and persist the corrected average
+so replay reads it back instead of re-deriving it.
+
+**Architecture:** A pure `spatial_side_average` helper is used by (A) a live
+stage that replaces `SideAveragingStage` (per-capture spatial mean of `bfi_live`
+→ display only) and (B) a new corrected final-path stage (per-capture spatial
+mean of the enriched corrected frames → emitted for the DB). `ScanDBSink`
+persists the corrected `cam_id=-1` rows in reduced mode and writes no per-camera
+rows; replay reads `cam_id=-1` straight from the DB (the derive-on-read code is
+deleted). Live (realtime) and DB (corrected) intentionally differ.
+
+**Spec:** [../specs/2026-05-28-reduced-mode-side-average-design.md](../specs/2026-05-28-reduced-mode-side-average-design.md) (rev 2)
+
+**Tech stack:** SDK `omotion.pipeline` (Python 3.12, numpy, pytest) on
+`feature/side-avg-nanmean`; app (PyQt6, pytest) on `feature/realtime-plot-viewer`.
+
+---
+
+## Cross-repo sequencing
+
+Land in this order; each repo's suite stays green at every commit. The two
+branches still merge together (the app's reduced-mode display depends on the
+SDK live-stage output shape).
+
+1. **SDK Phase 1** — shared helper + live stage (replaces `SideAveragingStage`).
+2. **SDK Phase 2** — corrected stage + DB persistence.
+3. **App Phase 3** — live sink consumes the new live-stage output; replay reads
+   the DB.
+4. **Integration** — round-trip test + final review.
+
+> The live stage's output-shape change (Task 2) and the app live-sink change
+> (Task 7) are a matched pair — verify them together before declaring the live
+> display fixed, even though they're separate commits in separate repos.
+
+---
+
+## File structure
+
+**SDK (`feature/side-avg-nanmean`):**
+- `omotion/pipeline/stages/side_avg.py` — rewrite: `LiveSideAverageStage`
+  (spatial per-capture). Houses the shared `spatial_side_average` helper.
+- `omotion/pipeline/stages/corrected_side_avg.py` — new: `CorrectedSideAverageStage`.
+- `omotion/pipeline/batch.py` — no new event type needed (Stage B reuses
+  `LiveEmit(channel="final_side", …)`); confirm during Task 4.
+- `omotion/pipeline/factory.py` — swap stage A, add stage B.
+- `omotion/pipeline/sinks.py` — `ScanDBSink`: consume `final_side`, reduced-mode
+  gate on `_consume_live`, fix stale `_consume_final`.
+- `tests/test_pipeline/…`
+
+**App (`feature/realtime-plot-viewer`):**
+- `motion_connector.py` — `_LivePlotSink`.
+- `data_sources.py` — remove `PastScanSource._derive_side_averages`.
+- `tests/test_live_plot_sink.py`, `tests/test_data_sources.py`.
+
+---
+
+## SDK Phase 1 — shared helper + live stage
+
+### Task 1: `spatial_side_average` pure helper
+
+**Files:** Modify `omotion/pipeline/stages/side_avg.py`; Test
+`tests/test_pipeline/test_side_avg_stage.py`.
+
+- [ ] **Write the failing test.** Given per-camera BFI for one side at one
+  instant (a 1-D array indexed by camera, NaN for absent), assert the nan-aware
+  mean over the *selected* cameras only; unselected cameras ignored; all-NaN → NaN.
+- [ ] **Run** `pytest tests/test_pipeline/test_side_avg_stage.py -k spatial -v` → FAIL.
+- [ ] **Implement** a module-level pure function, e.g.
+  `spatial_side_average(values_by_cam: np.ndarray, cam_indices: np.ndarray) -> float`
+  using `np.nanmean` with the "Mean of empty slice" warning suppressed.
+- [ ] **Run** → PASS.
+- [ ] **Commit** `refactor(pipeline): extract pure spatial_side_average helper`.
+
+### Task 2: `LiveSideAverageStage` (replaces `SideAveragingStage`)
+
+**Files:** Rewrite `omotion/pipeline/stages/side_avg.py`; Modify
+`omotion/pipeline/factory.py` and `tests/test_pipeline/test_factory.py`; Tests in
+`tests/test_pipeline/test_side_avg_stage.py` (+ retire the running-average tests
+in `test_side_avg_reduced_live.py`).
+
+- [ ] **Write the failing tests** (TDD), all on realistic one-camera-per-row input:
+  - per-capture spatial mean of *that capture's* cameras, emitted once per
+    `frame_id` at the capture's timestamp (finite at one representative row,
+    NaN elsewhere);
+  - **no temporal carry** — a camera absent from a later capture contributes no
+    stale value;
+  - capture straddling a batch boundary → emitted once, correct value/timestamp,
+    final capture flushed at `on_scan_stop`;
+  - dense input still reduces to the per-row mean (back-compat).
+- [ ] **Run** the stage tests → FAIL.
+- [ ] **Implement** `LiveSideAverageStage` (`name = "live_side_average"`):
+  per-side accumulator keyed by the in-progress `frame_id` (sum+count of finite
+  per-cam BFI/BVI), fold each row, emit via `bfi_live_side`/`bvi_live_side`
+  finite only at the representative row on capture change; `reset()` and
+  `on_scan_stop()` flush. No carry-forward of camera values.
+- [ ] Swap it into `default_pipeline` where `SideAveragingStage` was; update the
+  `test_factory` expected stage-name list (`side_averaging` → `live_side_average`).
+- [ ] **Run** `pytest tests/test_pipeline/ -q` (deselect the USB-hardware smoke) → PASS.
+- [ ] **Commit** `feat(pipeline): LiveSideAverageStage — pure per-capture spatial average`.
+
+---
+
+## SDK Phase 2 — corrected stage + persistence
+
+### Task 3: `CorrectedSideAverageStage` (final-path)
+
+**Files:** Create `omotion/pipeline/stages/corrected_side_avg.py`; Test
+`tests/test_pipeline/test_corrected_side_avg_stage.py`.
+
+- [ ] **Write the failing test.** Feed per-`(side,cam)` `EnrichedCorrectedInterval`
+  events (via `batch.events`) for one dark-bounded window across several cameras;
+  assert the stage emits, per side, the per-timestamp spatial mean across the
+  active cameras (using `spatial_side_average`), and flushes at `on_scan_stop`.
+- [ ] **Run** → FAIL.
+- [ ] **Implement** the stage: scan `batch.events` for `IntervalClosed` carrying an
+  `EnrichedCorrectedInterval`; gather enriched frames per side keyed by the
+  interval bounds `(left_abs, right_abs)`; once all active cameras for that window
+  are present (or at `on_scan_stop`), group frames by timestamp, average BFI/BVI
+  (and mean/contrast) across cameras, and append
+  `LiveEmit(channel="final_side", payload=<side-aggregated corrected series>)`.
+- [ ] **Run** → PASS.
+- [ ] **Commit** `feat(pipeline): CorrectedSideAverageStage — per-side corrected average`.
+
+### Task 4: Wire Stage B into the pipeline
+
+**Files:** Modify `omotion/pipeline/factory.py`, `tests/test_pipeline/test_factory.py`.
+
+- [ ] **Write/extend** `test_factory` to expect `corrected_side_average` in the
+  stage list (after `DarkCorrectionStage`, gated on `reduced_mode`).
+- [ ] **Run** → FAIL.
+- [ ] **Implement:** add `CorrectedSideAverageStage(enabled=metadata.reduced_mode, …)`
+  after the dark-correction stage so it sees the emitted `IntervalClosed` events.
+  Confirm `LiveEmit(channel="final_side")` routes with no runner change (the
+  runner already dispatches `LiveEmit` by channel).
+- [ ] **Run** `pytest tests/test_pipeline/ -q` → PASS.
+- [ ] **Commit** `feat(pipeline): wire CorrectedSideAverageStage into default_pipeline`.
+
+### Task 5: `ScanDBSink` — persist corrected average, reduced-mode gate
+
+**Files:** Modify `omotion/pipeline/sinks.py`; Test
+`tests/test_pipeline/test_sinks_db.py` (or the existing DB-sink test).
+
+- [ ] **Write the failing tests:**
+  - reduced mode: a `final_side` payload writes `cam_id=-1` rows (bfi/bvi/mean/
+    contrast, side 0/1); `_consume_live` writes **no** per-camera rows;
+  - normal mode: per-camera live rows still written; no side rows;
+  - the stale `_consume_final` no longer drops per-camera bfi/bvi to None
+    (either it's superseded by `final_side` or fixed — assert the corrected
+    side rows carry real bfi/bvi).
+- [ ] **Run** → FAIL.
+- [ ] **Implement:** add `"final_side"` to `ScanDBSink.channels`; `_consume_side`
+  writes `cam_id=-1` corrected rows. Gate `_consume_live` on `self._meta.reduced_mode`
+  to skip per-camera writes in reduced mode. Remove/replace the stale
+  `_consume_final` placeholder.
+- [ ] **Run** `pytest tests/test_pipeline/ -q` → PASS.
+- [ ] **Commit** `feat(sdk): ScanDBSink persists corrected side average; reduced mode = average only`.
+
+---
+
+## App Phase 3 — live display + replay
+
+### Task 6: `_LivePlotSink` consumes the live-stage output
+
+**Files:** Modify `motion_connector.py`; Modify `tests/test_live_plot_sink.py`.
+
+- [ ] **Update the tests:** `cam_id=-1` appended from the finite
+  `bfi_live_side`/`bvi_live_side` samples (one per capture); the per-`frame_id`
+  dedup added earlier is removed (the stage owns it); per-camera buffers + the
+  dropout-watchdog heartbeat are still updated in reduced mode.
+- [ ] **Run** `pytest tests/test_live_plot_sink.py -q` → FAIL.
+- [ ] **Implement:** append `cam_id=-1` wherever `bfi_live_side[i,side]` is finite;
+  drop `_last_side_avg_fid`; leave the per-camera append/heartbeat path intact.
+- [ ] **Run** → PASS.
+- [ ] **Commit** `fix: live sink reads per-capture side average from the stage`.
+
+### Task 7: Replay reads the DB; remove the derive
+
+**Files:** Modify `data_sources.py`; Modify `tests/test_data_sources.py`.
+
+- [ ] **Update the tests:** `PastScanSource` and the `LiveScanSource` DB-tail
+  return the stored `cam_id=-1` series directly (a fixture with `cam_id=-1` rows);
+  assert no derivation runs (the derive method is gone). Remove the old
+  merge-derive tests.
+- [ ] **Run** `pytest tests/test_data_sources.py -q` → FAIL (derive removed).
+- [ ] **Implement:** delete `PastScanSource._derive_side_averages` and its call;
+  `_bucketize_session_rows` already buckets `cam_id=-1` into `(side,-1,bfi/bvi)`.
+- [ ] **Run** → PASS.
+- [ ] **Commit** `fix: replay reads stored cam_id=-1 average; drop derive-on-read`.
+
+---
+
+## Integration
+
+### Task 8: Round-trip + final review
+
+**Files:** Test `openmotion-sdk/tests/test_pipeline/test_reduced_roundtrip.py`.
+
+- [ ] **Write the test:** run a synthetic reduced-mode scan through
+  `default_pipeline` + `ScanDBSink`; read the `cam_id=-1` series back from the DB;
+  assert it equals **Stage B's corrected output** sample-for-sample (NOT the live
+  display — those differ by design).
+- [ ] **Run** → PASS.
+- [ ] **Final review:** full SDK pipeline suite + app `test_data_sources.py` /
+  `test_live_plot_sink.py` green; grep for dead references to
+  `SideAveragingStage` / `_derive_side_averages`; confirm `default_pipeline`
+  stage order; update the realtime-plot-viewer status doc.
+- [ ] **Commit** `test(pipeline): reduced-mode round-trip — stored == corrected average`.
+
+---
+
+## Self-review checks (run before calling it done)
+
+- Old reduced scans (no stored `cam_id=-1`) replay empty — expected (BETA); not a regression to fix here.
+- Normal-mode per-camera rows still realtime (corrected-per-cam persistence is a separate follow-up — do not scope-creep into it).
+- No `app_config.json` commits; no scan-output artifacts staged.
+- SDK and app changes reviewed together before any merge (they're a matched pair).

--- a/docs/superpowers/specs/2026-05-22-realtime-plot-viewer-design.md
+++ b/docs/superpowers/specs/2026-05-22-realtime-plot-viewer-design.md
@@ -1,0 +1,330 @@
+# Real-time Plot Viewer Redesign — Design Spec
+
+**Date:** 2026-05-22
+**Issue:** _(none yet — file when this work is queued)_
+**Feature:** Replace the bloodflow app's two real-time plot widgets (`EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`) and the matplotlib-popout-based history visualization (`processing/visualize_bloodflow.py`) with one unified, Saleae-Logic-inspired in-app viewer. Adds DVR-style scrollback during live scans, mouse-driven pan/zoom, a synced crosshair tooltip across all camera cells, and on-demand replay of any past scan from the existing `ScanDatabase` — all without leaving the BloodFlow page.
+
+---
+
+## Background
+
+Today's bloodflow app has three separate paths for looking at BFI/BVI data:
+
+1. **Live, developer mode** — `components/EmbeddedRealtimePlot.qml` (825 LOC). A `Canvas`-based per-camera grid (4×2 or 4×4) of BFI/BVI traces over a hard 15-second sliding window. The window prunes old samples; nothing pre-15s is reachable without leaving the page. The plot is feature-rich (per-cell dropout markers, dev-mode profiling HUD, optional mean/contrast view, autoscale modes) but coupled tightly to the live signal stream.
+2. **Live, reduced (clinical) mode** — `components/ReducedPlotView.qml` (402 LOC). A second `Canvas`-based plot of per-side averages over a 15-second window. Different code, same scroll-prevention.
+3. **Past data** — `components/HistoryModal.qml` (418 LOC). A modal scan-picker whose action buttons call `MOTIONInterface.visualize_*()` slots in `motion_connector.py` (lines 3138-3251), which in turn launch external **matplotlib** windows via `processing/visualize_bloodflow.py`. The matplotlib window is non-interactive in the app's UX sense — separate window, separate styling, separate set of axes.
+
+The current 15-second wall hurts clinical and engineering use equally: an operator who notices something interesting cannot scroll back to it without stopping the scan; reviewing yesterday's recording means a matplotlib popout. The SDK-side data pipeline rearchitecture (see [openmotion-sdk @ feature/data-pipeline-tweaks](../../../../openmotion-sdk/docs/superpowers/specs/2026-05-22-data-pipeline-rearchitecture-design.md)) is paving the way to a `ScanDBSink` that already populates `session_data` rows on disk — i.e. every scan we run now has a queryable, fully-corrected record on disk. That backing store is what makes in-viewer past-scan replay feasible.
+
+---
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| R1  | One viewer component renders both the per-camera (developer-mode) grid and the per-side averaged (reduced-mode) layout. No second plot component. |
+| R2  | During an active scan the operator can pan and zoom in time without stopping the scan ("DVR scrollback"). New live data continues to accumulate; only the visible window pauses on the timestamp the operator has pinned. |
+| R3  | A persistent **"Back to live"** affordance restores the visible window to track the live edge. Default at scan start is `followLive = true`. |
+| R4  | Any pan, wheel-zoom, scrubber drag, or scrubber click during a live scan breaks `followLive`. There is no implicit auto-resume — only the explicit button restores it. |
+| R5  | Hover anywhere in the viewer renders a **synced vertical crosshair** at the same timestamp on every cell, plus a single tooltip listing each visible camera's BFI/BVI (or μ/C in mean/contrast mode) at that timestamp and frame ID. The tooltip auto-flips at the viewport edge. |
+| R6  | The time axis is shared across all cells (Saleae-style). Pan or zoom in any cell moves all cells. Y-axes remain independent. |
+| R7  | A scan picker (the existing HistoryModal, no popout) lets the operator load any past scan in the local `ScanDatabase` into the same viewer. Loading clears the previous past-scan source and reassigns the viewer; the live source, if any, keeps streaming in the background. |
+| R8  | The viewer supports a clean roundtrip past → live: the **"Back to live"** button reassigns to the in-progress live source when one exists, or is hidden when one does not. |
+| R9  | The viewer queries the SDK's `ScanDatabase` directly for past scans (via `iter_session_data(session_id)`). It does not invoke the SDK pipeline. No matplotlib. |
+| R10 | At least the following scan size is supported in memory without UI stutter: **30 minutes × 40 Hz × 16 cameras × 4 metrics** (~30 MB of `float32` samples). |
+| R11 | Live data is **append-only into a Python-side numpy buffer**. The QML side does not maintain a parallel growing JS array. JS-side per-frame allocation does not occur. |
+| R12 | The corrected-batch backfill semantics from today (`_on_corrected_batch` overwrites in-place at matching frame IDs) are preserved verbatim. The viewer sees both passes without any special handling. |
+| R13 | Per-camera dropout markers from today (`markDroppedOut(side, camId, timeStr)`) are preserved. The marker is rendered as a vertical bar at the timestamp the dropout was first detected. |
+| R14 | Rendering performance: pan/zoom is interactive (≤16 ms per gesture frame at 16 cells × 30 min of data). Achieved by binary-search index lookup + stride decimation to ≤ 2 × cell-pixel-width visible points. |
+| R15 | Aesthetics: the viewer stays within today's `AppTheme.qml` palette. No global theme change. Improvements are limited to grid lines, axis labels with proper tick spacing, antialiased strokes, hover highlights, consistent typography. |
+| R16 | The legacy popout matplotlib path (`processing/visualize_bloodflow.py`, `MOTIONInterface.visualize_bloodflow/visualize_corrected/visualize_corrected_signal`) is removed after the new viewer reaches stable in-tree status. |
+| R17 | The migration is reversible at any phase via a single `app_config.json` flag (`useNewPlotViewer`, default `false` while building, flipped to `true` at Phase 3). |
+
+---
+
+## Architecture
+
+### One viewer, one data abstraction, two data sources
+
+```
+                ┌──────────────────────┐
+                │   PlotViewer.qml     │   pan / zoom / crosshair
+                │                      │   tooltip / follow-live
+                │ ─ pure UI state ─    │   are all here
+                └──────────┬───────────┘
+                           │ subscribes
+                           ▼
+                ┌──────────────────────┐
+                │   ScanDataSource     │   numpy buffers, per-(side, cam, metric)
+                │   (Python QObject)   │   emits samplesAppended(side, cam, …)
+                └──────┬───────────┬───┘
+                       │           │
+            ┌──────────▼──┐    ┌───▼──────────────┐
+            │ LiveScan    │    │ PastScanSource   │
+            │ Source      │    │ — queries SDK    │
+            │ — adapts    │    │   ScanDatabase   │
+            │   today's   │    │   .iter_session_ │
+            │   connector │    │   data(sid)      │
+            │   callbacks │    │                  │
+            └─────────────┘    └──────────────────┘
+```
+
+- **The viewer is dumb.** It renders whatever the source gives it and owns view-state only: `windowStartT`, `windowSeconds`, `followLive`, `cursorT` (for hover). No data accumulation.
+- **The source owns the data.** Append-only `numpy.ndarray` buffers, one pair `(t, v)` per `(side, cam_id, metric)`. Resized in-place (`numpy.resize`) when the per-buffer capacity is exceeded. Throttled change signal at ~10 Hz so the viewer's paint cadence is bounded by paint cost, not by sample rate.
+- **`motion_connector` owns source lifecycle.** It exposes `currentScanSource` as a `pyqtProperty`. Scan-start constructs a fresh `LiveScanSource` and assigns it. Switching scans is one property assignment. The live source keeps streaming in the background while a past source is currentl displayed; "Back to live" is one assignment back.
+
+### The viewer is mostly decoupled from the SDK pipeline rework
+
+The SDK is mid-rearchitecture (see [`openmotion-sdk feature/data-pipeline-tweaks`](../../../../openmotion-sdk/docs/superpowers/specs/2026-05-22-data-pipeline-rearchitecture-design.md)). For this viewer:
+
+- **Past-scan replay** reads `ScanDatabase.iter_session_data(session_id)`. That API existed before the rearchitecture and isn't part of the rework — `session_data` rows are the corrected output already, no pipeline involvement at view time.
+- **Live data** hooks `motion_connector`'s existing `_on_uncorrected` / `_on_corrected_batch` / `_on_temp_sample` callbacks. When SDK PR 3 swaps `ScanWorkflow` to the channel/sink protocol, only the `LiveScanSource` adapter changes — the viewer doesn't.
+
+The viewer work ships independently of the pipeline PRs.
+
+---
+
+## Components and files
+
+### New (Python)
+
+- `data_sources.py` (new, top-level next to `motion_connector.py`)
+  - `class ScanDataSource(QObject)` — base. Owns the per-`(side, cam_id, metric)` numpy arrays, `metadata`, `liveEdge`, `live` flag, and the throttled `samplesAppended(side: str, cam_id: int, metric: str, addedCount: int)` signal.
+  - `class LiveScanSource(ScanDataSource)` — constructed at scan start. Methods: `append_uncorrected(side, cam_id, frame_id, t, bfi, bvi, mean, contrast)`, `append_temperature(side, cam_id, temp)`, `apply_corrected_batch(corrected_batch)` (overwrite-in-place at matching frame IDs), `mark_dropped(side, cam_id, t)`.
+  - `class PastScanSource(ScanDataSource)` — constructed from a `session_id`. Reads via `omotion.ScanDatabase.iter_session_data(session_id)`, bucketizes into the same numpy layout, sets `live = False` and `liveEdge = duration`.
+  - `class _CameraBuffer` — internal helper. Holds `t: np.ndarray`, `v: np.ndarray`, `n: int` (high-water mark), `dropped_at: Optional[float]`. Method `append(t, v)` doubles capacity on overflow. Method `window_indices(t_lo, t_hi)` returns `(i_lo, i_hi)` via `np.searchsorted` (binary search, O(log n)).
+
+### New (QML)
+
+- `components/PlotViewer.qml` — top-level. Subscribes to `MOTIONInterface.currentScanSource`. Owns view-state. Lays out cells in a `GridLayout`. Captures wheel / drag / hover at the viewport level. Holds the global crosshair overlay (`Item`, not part of any `Canvas`) and the tooltip popup.
+- `components/PlotCell.qml` — single trace `Canvas`. Pure render. Receives `windowStartT`, `windowSeconds`, `bounds`, `series` reference. Repaints only on data growth (signaled by viewer) and on view-state change.
+- `components/PlotToolbar.qml` — top bar: scan label, **"● Back to live"** button (visible per R8), `Window: 15s ▾` dropdown (values: `5s, 15s, 30s, 1m, 5m, Full scan`), auto-scale toggle (single global toggle; the existing per-plot autoscale variant is dropped — defer reintroducing if anyone misses it), metric switcher (BFI/BVI ↔ μ/C in dev mode), "Open scan…" button → opens HistoryModal.
+- `components/PlotScrubber.qml` — bottom timeline showing the full scan extent with the visible window as a draggable inset rectangle.
+
+### Modified
+
+- `motion_connector.py`
+  - Add `currentScanSource: ScanDataSource` as a `pyqtProperty` with a notify signal.
+  - At scan start, construct a fresh `LiveScanSource` and assign to `currentScanSource`. Wire the existing `_on_uncorrected` / `_on_corrected_batch` / `_on_temp_sample` / dropout callbacks into the new source's `append_*` methods *in addition to* today's QML signals during Phase 1. By Phase 3, the QML signals are unwired.
+  - Add `@pyqtSlot(int) def loadPastScan(self, session_id: int) -> None`. Runs the `ScanDatabase` query on a `QThread` (HistoryModal's existing "Processing…" overlay covers the wait). Assigns the resulting `PastScanSource` to `currentScanSource`.
+- `pages/BloodFlow.qml`
+  - Replace the `EmbeddedRealtimePlot` / `ReducedPlotView` conditional with a single `PlotViewer { reducedMode: MOTIONInterface.appConfig.reducedMode }`.
+- `components/HistoryModal.qml`
+  - Add one new primary action button: **"View in plot →"**. `onClicked`: `MOTIONInterface.loadPastScan(selected.sessionId); root.close()`.
+  - Hide the legacy "Visualize BFI/BVI (legacy)" / "Visualize Contrast/Mean (legacy)" / "Visualize BFI/BVI" / "Visualize Contrast/Mean" buttons behind `appConfig.developerMode && !appConfig.useNewPlotViewer` for the bridge releases; remove entirely in Phase 5.
+
+### Deprecated, removed in Phase 5
+
+- `components/EmbeddedRealtimePlot.qml` (825 LOC)
+- `components/ReducedPlotView.qml` (402 LOC)
+- `processing/visualize_bloodflow.py`
+- `MOTIONInterface.visualize_bloodflow`, `.visualize_corrected`, `.visualize_corrected_signal` slots and their matplotlib imports
+- Legacy QML signals on `MOTIONInterface` for per-sample BFI/BVI/mean/contrast emission (after Phase 3 confirms no other consumer)
+
+---
+
+## Data flow — live
+
+```
+SDK ScanWorkflow callbacks
+   _on_uncorrected(sample)  ─┐
+   _on_corrected_batch(...) ─┼─► motion_connector  ─►  LiveScanSource.append_*()
+   _on_temp_sample(...)     ─┘                          │
+                                                        │  numpy array
+                                                        ▼  append, batched
+                                          buffer[(side,cam,metric)]:
+                                              t  = np.empty(64k); n_t = 0
+                                              v  = np.empty(64k); n_v = 0
+                                                        │
+                                          every 100 ms  │  emits
+                                                        ▼
+                                          samplesAppended(side, camId, metric, added)
+                                                        │
+                                                        ▼
+                                          PlotViewer.requestRepaint()
+```
+
+- **Per-(side, cam, metric) buffer grows in place.** Initial capacity 64k slots (≈25 min @ 40 Hz). Double on overflow. No per-sample Python allocation.
+- **Corrected-batch overwrites in place.** `apply_corrected_batch(batch)` looks up each `(side, cam_id, frame_id)` in a small `dict[frame_id → index]` side-table (kept on the buffer) and rewrites the value. Preserves today's "live shows best-effort, corrected backfills" behavior verbatim. No new signal class — the viewer sees the rewritten values on the next repaint.
+- **Throttled UI notify.** The source coalesces appends into a single `samplesAppended` emission at most every 100 ms even if 40 frames arrived in that window. Repaint is paint-cost-bounded, not data-rate-bounded.
+- **Dropout marker is data, not a separate signal.** `LiveScanSource.mark_dropped(side, cam_id, t)` sets `buffer.dropped_at`. The viewer renders a vertical bar at that timestamp the next time the cell repaints. Replaces today's separate `markDroppedOut` JS call.
+
+## Data flow — past
+
+```
+HistoryModal              motion_connector             SDK ScanDatabase
+─────────                 ───────────────              ───────────────
+[View in plot]  ─click─► loadPastScan(scanId)
+                              │ (QThread)
+                              │
+                              │  iter_session_data(session_id)
+                              │
+                              ▼─────────────────────────►   indexed
+                                                            on
+                                                            (session_id,
+                              ◄─── rows ────────────────────ts)
+                              │
+                              │  build PastScanSource:
+                              │    arrays_per_(side,cam,metric)
+                              │
+                              │  currentScanSource = past
+                              ▼
+                          PlotViewer    (reactive — same code
+                          property      path as live; only
+                          change)       difference is `live=False`)
+```
+
+- **One SQL read per scan.** `iter_session_data` is an indexed range scan; a 30-min scan = ~1.15M rows × 7 cols. Bucketing into numpy should be sub-second on modern hardware. If measured timing exceeds 250 ms, the load runs on a `QThread` with HistoryModal's existing "Processing…" overlay.
+- **Past-source metadata fills the toolbar.** `scan_id`, subject label, start time, duration, masks. The bloodflow app already serializes the scan's `reducedMode` and side masks into the `sessions.session_meta` JSON blob (see `MOTIONInterface.get_scan_details`). `PastScanSource` reads those first; if absent for older DBs, it falls back to inferring the masks from which `(side, cam_id)` keys actually appear in `session_data`.
+- **Side encoding mismatch.** `session_data.side` is `INTEGER (0/1)` while `session_raw.side` is `TEXT ('left'/'right')`. `PastScanSource` normalizes to `'left'/'right'` internally so its buffer keys match `LiveScanSource`'s.
+- **Memory eviction is simple.** When `currentScanSource` is reassigned, the previous source loses its only reference. Python GC reclaims. No tile cache, no LRU — at ~30 MB ceiling there is no payoff and YAGNI applies.
+- **Switching back to live.** `currentScanSource = liveScanSource` if `liveScanSource is not None`. The live source kept streaming and accumulating in the background while past was shown.
+
+---
+
+## Interaction model
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Toolbar:  [● Live]  ⌚ Window: 15s ▾   📐 Auto-scale  μ/C ↔ BFI │
+├─────────────────────────────────────────────────────────────────┤
+│   L-1    │    L-2    │    R-1    │    R-2                       │
+│ ─╱╲──┼─  │ ──╲╱┼───  │ ─╱─╲┼──   │ ──╲╱┼──    ◄ synced crosshair│
+│      ┊   │       ┊   │       ┊   │       ┊                      │
+│ ──────────────── tooltip: t=02:14.325, frame 5373 ─────────────  │
+│ ──────────────── L-1 BFI 4.62 BVI 3.18 │ L-2 BFI 4.71 BVI 3.22 ─ │
+│   …                                                              │
+├─────────────────────────────────────────────────────────────────┤
+│ [██████████░░░░░░░░░] ◀──── full scan: 0:00 ──── 04:32 ────▶    │
+│                          ↑ visible window (draggable)            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Cursor + tooltip (always sync'd across all cells)
+
+- **Hover** → vertical crosshair at cursor x on every cell. One tooltip near the cursor lists each visible camera's BFI/BVI (or μ/C in dev-mode mean/contrast) at the cursor timestamp + the per-side frame ID. Tooltip auto-flips at the viewport edge.
+- **Cursor leaves the viewer** → crosshair + tooltip clear.
+
+### Pan + zoom (also sync'd)
+
+- **Mouse wheel** on any cell → zoom time-axis around cursor x. Y-axis fixed (or fit-visible per toolbar toggle).
+- **Click-drag horizontal** → pan time. Y-axis untouched.
+- **Double-click on a cell** → fit that cell's Y to the visible-time window.
+- **`Shift + double-click`** → fit Y on every cell.
+- **Scrubber drag** → moves the visible window across the full scan extent.
+- **Scrubber always reflects the full scan.** During a live scan the scrubber's full-extent indicator grows in real-time even when the visible window is pinned — so the operator can see how far behind the live edge they have wandered.
+
+### Follow-live
+
+- `followLive: bool` lives on the viewer. `true` at scan start.
+- While `true`, the visible window's right edge tracks `currentScanSource.liveEdge` at the existing 10 Hz repaint tick. Window length is `windowSeconds` (toolbar dropdown, default 15 s).
+- Any pan, wheel-zoom, scrubber drag, or scrubber click sets `followLive = false`. No implicit auto-resume.
+- **"● Back to live"** button (toolbar): clicked → sets `followLive = true` and snaps the window to `[liveEdge - windowSeconds, liveEdge]`. Visible when `followLive == false && currentScanSource is liveScanSource`.
+- When a *past* source is current, the button reads **"Back to live →"** and reassigns `currentScanSource = liveScanSource` (and sets `followLive = true`). Hidden when no live scan exists.
+
+### Keyboard (active when the viewer has focus)
+
+- `← / →` pan by 1 s. `Shift+←/→` pan by `windowSeconds`.
+- `+ / -` zoom in / out. `0` resets to default `windowSeconds`.
+- `Home` jump to scan start. `End` jump to scan end (past mode) or live edge (live mode, also sets `followLive = true`).
+- `Esc` clear viewer focus.
+
+### Explicitly NOT in v1
+
+- Box-select / range-zoom rectangle (Saleae has this; defer).
+- User annotations / markers (defer; needs a DB column).
+- Two scans overlaid for comparison (the chosen picker model is one at a time).
+
+---
+
+## Rendering + performance
+
+- **Stay with QML `Canvas`.** It is what the current plots use, it is already tuned (dev-mode profiler proves performance is workable), and "targeted polish on the existing theme" does not justify a renderer swap.
+- **Decimate at draw time.** Per cell, per paint: ask the source for `window_indices(side, cam, metric, t_lo, t_hi) → (i_lo, i_hi)` (binary search, O(log n) in Python). Then stride to ≤ 2 × cell-pixel-width samples. Worst case (30-min scan zoomed out, 200-px-wide cell): ~400 pts drawn instead of 72,000. Zoomed in (1 s window): all 40 pts drawn. Loss is below pixel resolution.
+- **Index lookup happens in Python** on the source, not in QML/JS. Keeps the JS side trivial — just receives an index range plus a typed-array view of values to draw.
+- **Crosshair + tooltip are separate QML `Item`s**, not part of the `Canvas` paint. Cursor movement repositions the overlay; no canvas repaint per hover frame. Cells repaint only on data growth and on view-state change.
+- **Paint cadence stays at the current 10 Hz tick** during live. On pan/zoom it fires once per gesture frame (the gesture's `onPositionChanged` debounced to one repaint per ~16 ms via `Qt.callLater`).
+- **Antialiased strokes** with `ctx.lineWidth = 1.5` plus integer-pixel snapping for grid lines. The visible polish win is mostly clean grid + crisp ticks + theme-aligned axis labels, not the trace itself.
+- **Profile HUD ports forward.** The dev-mode `_profSampleRateHz`, `_profRenderMs`, `_profCanvasMsAvg`, `_profTotalPoints` counters from `EmbeddedRealtimePlot.qml` move into `PlotViewer.qml`. Visible only with `developerMode && showProfiling`.
+
+---
+
+## Error handling
+
+| Failure | Where | Response |
+|---|---|---|
+| **DB read fails** (file gone, schema mismatch, corrupt row) | `PastScanSource.__init__` raises | `motion_connector.loadPastScan` catches, emits the existing `errorOccurred(msg)` signal. HistoryModal already binds it to a message dialog. `currentScanSource` is left untouched. |
+| **Empty scan / no `session_data` rows** | `PastScanSource.__init__` | Build an empty source with `metadata.duration = 0`. Viewer renders a centered "No corrected samples in this scan" placeholder instead of an empty grid. |
+| **Live signal arrives with NaN / non-finite value** | `LiveScanSource.append_*` | Store NaN. The renderer already skips non-finite (`isFinite()` guards in current code). Tooltip shows `--` for that camera at that timestamp. |
+| **Live numpy buffer overflows** (scan > 25 min) | `_CameraBuffer._grow` | Double the array. One `logging.WARNING`. No user-visible behavior. |
+| **Past-scan load takes > 250 ms** | `motion_connector.loadPastScan` | Run on a `QThread`. Reuse HistoryModal's "Processing…" overlay until the new `currentScanSource` is ready. Cancel button drops the load. |
+| **Camera dropout mid-scan** | `LiveScanSource.mark_dropped` | Sets `buffer.dropped_at`. Viewer draws a vertical bar at that x. Past sources never set it (replay shows the full recorded stream). |
+| **Window or zoom math goes out of bounds** (`t_lo > t_hi`, NaN propagation) | viewer | Clamp to source's `[0, duration]`. Don't crash. |
+| **Source assignment during paint** (race: scan stop swaps to past mid-frame) | viewer | All paint reads in a cell go through a `currentScanSource` snapshot captured at paint start. The next tick picks up the new source. |
+
+No new error categories the existing app does not already handle — this design routes them through the new source/viewer instead of through the matplotlib popout.
+
+---
+
+## Testing
+
+| Layer | What | How | Hardware? |
+|---|---|---|---|
+| `data_sources.py` unit | Append, grow, `window_indices`, corrected-batch overwrite-in-place, dropout marker | pytest, pure Python | No |
+| `PastScanSource` integration | Construct from a synthetic SQLite `session_data` (built in `tmp_path` via `sqlite3` stdlib); assert shapes, timestamps, mask inference | pytest + sqlite3 stdlib | No |
+| Live wiring | `motion_connector` calls `LiveScanSource.append_*` from each existing callback exactly once per sample | Inject a fake source; assert call counts | No |
+| QML smoke | `PlotViewer` constructs, switches sources, doesn't print QML warnings | Add a headless test to `tests/` that loads `BloodFlow.qml` with a stub source | No |
+| Manual / HIL | Pan-during-scan, jump-to-live, crosshair sync, load-past-from-history, dropout indicator, both modes (dev grid + reduced) | Manual checklist in this spec's PR description; runs once per release on hardware | Yes |
+
+No new hardware-only tests. The pure-software unit tests cover the bulk of the logic and run in CI without changes to the existing harness markers.
+
+---
+
+## Phased rollout
+
+Each phase is one PR against `next`, independently shippable, independently reversible.
+
+1. **Phase 1 — `ScanDataSource` Python.** Add `data_sources.py` with `ScanDataSource`, `LiveScanSource`, `PastScanSource`, `_CameraBuffer`. Wire `motion_connector` to construct & append into a `LiveScanSource` *in addition to* today's QML signals — nothing in QML consumes the source yet. Full unit + `PastScanSource` integration coverage. Apps still ship the legacy plots.
+2. **Phase 2 — `PlotViewer` component, feature-flagged.** Build `PlotViewer.qml` + `PlotCell.qml` + `PlotToolbar.qml` + `PlotScrubber.qml`. Add `MOTIONInterface.loadPastScan` slot. Gate the BloodFlow.qml swap behind `app_config.json` key `useNewPlotViewer: false`. Toggle locally to dev and iterate.
+3. **Phase 3 — Swap in `BloodFlow.qml`.** Replace `EmbeddedRealtimePlot` and `ReducedPlotView` with `PlotViewer { reducedMode: appConfig.reducedMode }`. Flip the flag default to `true`. Old components stay in tree as fallback.
+4. **Phase 4 — HistoryModal integration.** Add "View in plot →" button; existing matplotlib buttons stay under `developerMode && !useNewPlotViewer` for one release as fallback.
+5. **Phase 5 — Cleanup.** Delete `EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`, `processing/visualize_bloodflow.py`, the legacy `visualize_*` slots and matplotlib imports, the legacy QML per-sample signals (after Phase 3 confirms no other consumer), and the `useNewPlotViewer` flag. Happens after one full release where Phases 1–4 are stable.
+
+### Risk mitigation per step
+
+- **After Phase 1:** nothing in QML changed. Unit tests cover the new code. Legacy plots run unchanged.
+- **After Phase 2:** new code exists but is dark in production builds (flag default `false`).
+- **After Phase 3:** the new viewer is live by default. If clinical use surfaces a regression, flip the flag and the old plots come back. No source revert needed.
+- **After Phase 4:** matplotlib popout still reachable via developerMode fallback for one release. Clinical operators never see it.
+- **After Phase 5:** the legacy paths are gone. Any new bug is in the new code only.
+
+---
+
+## Non-goals
+
+- The SDK pipeline rearchitecture is **not** in scope. The viewer reads from `ScanDatabase.iter_session_data` (a stable, pre-rearchitecture API) and the existing `motion_connector` callbacks. The adapter layer is the only thing that changes when SDK PR 3 lands.
+- A new `AppTheme.qml` or any other change outside the viewer's own files. Aesthetic improvements are limited to grid lines, ticks, antialiased strokes, hover highlights, and consistent typography pulled from existing theme tokens.
+- Marker / annotation persistence. Defer until a `session_data_annotations` table exists.
+- Cross-scan overlays. Defer; the chosen picker model is single-source.
+- Replacement of `HistogramView.qml`. That is a separate widget for raw histogram inspection and is out of scope here.
+
+## Out-of-scope follow-ups
+
+These become easier after the viewer lands but are not part of this work:
+
+- Box-select / range-zoom rectangle (Saleae-style click-and-drag area zoom).
+- User-placed timeline markers with notes (needs a DB column).
+- Cross-scan overlays via tab/multi-source viewer.
+- Pre-aggregated/decimated DB views for very-long-scan support (>30 min); only needed if scan duration ceiling moves up.
+
+---
+
+## References
+
+- [`openmotion-bloodflow-app/components/EmbeddedRealtimePlot.qml`](../../../components/EmbeddedRealtimePlot.qml) — current developer-mode plot being replaced.
+- [`openmotion-bloodflow-app/components/ReducedPlotView.qml`](../../../components/ReducedPlotView.qml) — current reduced-mode plot being replaced.
+- [`openmotion-bloodflow-app/components/HistoryModal.qml`](../../../components/HistoryModal.qml) — scan picker being repurposed as the past-scan launcher.
+- [`openmotion-bloodflow-app/motion_connector.py`](../../../motion_connector.py) — adds `currentScanSource` and `loadPastScan` (lines 1647, 1716 are the relevant existing live-stream callbacks).
+- [`openmotion-sdk/omotion/ScanDatabase.py`](../../../../openmotion-sdk/omotion/ScanDatabase.py) — `iter_session_data(session_id)` is the past-source read path.
+- [`openmotion-sdk/docs/superpowers/specs/2026-05-22-data-pipeline-rearchitecture-design.md`](../../../../openmotion-sdk/docs/superpowers/specs/2026-05-22-data-pipeline-rearchitecture-design.md) — concurrent SDK rework. The viewer is decoupled from its timeline.
+- Saleae Logic 2 documentation, used as the interaction-model reference.

--- a/docs/superpowers/specs/2026-05-28-reduced-mode-side-average-design.md
+++ b/docs/superpowers/specs/2026-05-28-reduced-mode-side-average-design.md
@@ -1,0 +1,228 @@
+# Reduced-Mode Side Average — Design Spec
+
+**Date:** 2026-05-28
+**Status:** Proposed (review before implementation) — rev 2
+**Branches:** SDK `feature/side-avg-nanmean` · app `feature/realtime-plot-viewer` (must merge together)
+**Related:** [2026-05-22-realtime-plot-viewer-design.md](./2026-05-22-realtime-plot-viewer-design.md)
+
+---
+
+## Problem
+
+In reduced (clinical) mode the viewer shows one averaged BFI/BVI trace per side
+(`cam_id = -1`). Today that value is reconstructed in several places that have
+drifted apart, and the reconstruction conflates two different ideas of
+"average." Two clarifications drive this rev:
+
+### Two averaging axes — keep them separate
+
+- **Spatial** — average the *selected cameras* of one side at a **single
+  capture instant** → one left value, one right value. This is the only
+  averaging the reduced-mode side trace needs.
+- **Temporal (rolling / windowed)** — smooth one stream over *time*. There is
+  **no shared rolling-average endpoint or stage** in the sink pipeline (the
+  monolith's `on_rolling_avg_fn` / `rolling_avg_*` is gone). Temporal averaging
+  is **owned by each consumer**: `ContactQualityWorkflow` keeps its own
+  per-`(side,cam)` rolling window over light-frame means; `CalibrationWorkflow`
+  (calibration *and* test) does its own windowed average over the corrected
+  stream; the viewer does display-time mean-binning. None of these is touched by
+  this design — the reduced-mode **spatial** average is a separate concern.
+
+The `SideAveragingStage` patch made this session computes a *running* average —
+it holds each camera's latest value and averages those, which mixes cameras from
+**different instants** whenever they report at slightly different times. That is
+a temporal smear leaking into what must be a pure spatial average. The clean
+operation uses only the cameras of the **same** capture (same `frame_id` /
+timestamp), with no carry-forward.
+
+### Two data paths — live (realtime) vs corrected
+
+The pipeline produces BFI/BVI twice:
+
+- **Live / realtime** — `bfi_live` / `bvi_live`, computed from the realtime dark
+  estimator (`mean_dc_rt` / `contrast_sn_rt`) + calibration, per frame. Immediate,
+  best-effort. Drives the live display.
+- **Corrected** — when a dark interval closes, `DarkCorrectionStage._enrich_corrected_frame`
+  recomputes each camera's BFI/BVI from the **interpolated** dark baseline +
+  shot-noise + calibration, producing `EnrichedCorrectedFrame(side, cam_id, mean,
+  std, contrast, bfi, bvi)`. Accurate, retroactive. This is the "actual
+  dark-frame-corrected" data.
+
+The **live display should use the live/realtime average; the DB/CSV record
+should use the corrected average.** They are intentionally different — the
+stored record is the more-accurate one. Today neither is done cleanly:
+`ScanDBSink._consume_final` receives the enriched corrected frames but **throws
+the per-camera BFI/BVI away** (writes `cam_id=-1, side=0, bfi=None`, keeping only
+mean/contrast — there's a stale "PR 3 will carry per-cam data" comment). So the
+corrected BFI/BVI is computed and discarded at persistence, and the DB instead
+gets re-derived realtime values.
+
+## Root cause
+
+The side average is computed-on-read in multiple ways, the realtime/corrected
+paths are conflated at the sink, and the spatial average accidentally carries a
+temporal component. Fix: **define one pure spatial-average operation, apply it
+to each path explicitly, compute it once per path, and persist the corrected
+one.**
+
+## Decisions (locked with stakeholder)
+
+1. **Spatial side-average is one pure operation** — average the selected
+   cameras at a single capture instant. No carry-forward, no temporal element.
+   Drop the running-average behavior.
+2. **Live and DB differ by design** — live display = realtime side average; DB /
+   replay = corrected side average.
+3. **The corrected side-average is built in a dedicated final-path stage** (not
+   in the sink), since the corrected path emits per-`(side, cam)` intervals that
+   must be gathered across cameras.
+4. **Replace `SideAveragingStage`** with the live spatial-average stage.
+5. **Reduced mode persists the average only** — the corrected `cam_id=-1` rows;
+   no per-camera BFI/BVI rows.
+6. **Per-camera live values keep flowing to the live sink in memory** (NOT
+   NaN-ed) so the camera-dropout watchdog still sees each camera.
+
+---
+
+## Design
+
+### Shared operation: `spatial_side_average`
+
+A pure helper (no state, no time): given the per-camera BFI/BVI for the active
+cameras of one side at one capture instant, return the (nan-aware) mean. Used by
+both stages so there is exactly one definition of "side average."
+
+### Stage A — live spatial average (display) — replaces `SideAveragingStage`
+
+- Placement unchanged: after `BfiBviStage` + `DarkFrameHoldStage`, gated on
+  `metadata.reduced_mode`.
+- Input: `bfi_live` / `bvi_live` (`(n, 2, 8)`, one camera finite per row).
+- Groups the rows of each capture by `frame_id` (rows of one capture are
+  contiguous; a tiny accumulator carries the in-progress capture across a batch
+  boundary), applies `spatial_side_average`, and emits **one (left, right) per
+  capture** as `LiveEmit(channel="live_side", SideAverageSample)` — flushed at
+  `on_scan_stop`. No carry-forward of camera values across captures.
+  *(As built: a dedicated event, not the originally-specced finite-at-row
+  `bfi_live_side` array — the array can't flush the final capture through the
+  zero-row `on_scan_stop` batch, and the event is symmetric with Stage B. The
+  `bfi_live_side`/`bvi_live_side` FrameBatch fields were removed.)*
+- Consumed by the app `_LivePlotSink` → in-memory `cam_id=-1` buffer (realtime
+  display). **Not persisted.**
+
+> The accumulator here is *only* streaming plumbing to gather a capture's
+> cameras (they arrive as separate one-camera rows). It resets every capture —
+> it is not a temporal average.
+
+### Stage B — corrected spatial average (DB / replay) — NEW, final-path
+
+- Consumes the per-`(side, cam)` `EnrichedCorrectedInterval` events
+  (`IntervalClosed`) on the final path.
+- Gathers, per side, the enriched frames across the active cameras of the same
+  interval (all cameras of a side share the same dark-bounded `(left_abs,
+  right_abs)`), groups them by timestamp, and applies `spatial_side_average` →
+  a **side-aggregated corrected series** (one left/right value per capture
+  timestamp). Flushes the final interval at `on_scan_stop`.
+- Emits `LiveEmit(channel="final_side", SideAverageSample)` per capture that
+  `ScanDBSink` writes verbatim. Purely spatial (group-by-timestamp) — the
+  cross-camera/-event gathering is plumbing, like Stage A's accumulator.
+
+### Persistence — `ScanDBSink`
+
+- **Reduced mode:** the `"final_side"` channel writes Stage B's corrected output
+  as `cam_id=-1` rows (bfi, bvi, mean, contrast; side 0/1), buffered like the raw
+  rows. `_consume_live` writes **nothing** (the live side average is display-
+  only). Net: `session_data` holds corrected `cam_id=-1` rows only.
+- **Normal mode:** unchanged — `_consume_live` writes per-camera realtime rows.
+  (Persisting *corrected* per-camera in normal mode is a natural follow-up, out
+  of scope here.)
+- The stale `"final"`-channel `_consume_final` (NULL-bfi placeholders) was
+  removed; ScanDBSink no longer subscribes to `"final"`.
+
+### Live view — app `_LivePlotSink`
+
+- Subscribes to `{"live", "live_side"}`; appends `cam_id=-1` from the
+  `live_side` `SideAverageSample` (the stage owns the per-capture dedup).
+- **Keep** appending per-camera values to in-memory buffers and updating the
+  dropout-watchdog heartbeat. Reduced mode just doesn't render per-camera cells.
+
+### Replay — app `data_sources.py`
+
+- **Remove** `PastScanSource._derive_side_averages` and the merge logic.
+  `_bucketize_session_rows` already buckets `cam_id=-1` rows into
+  `(side, -1, bfi/bvi)`, so `PastScanSource` and the `LiveScanSource` DB-tail get
+  the **corrected** side average straight from the DB. The empty-pan-back bug
+  disappears with no extra code. Replay now shows the corrected trace (more
+  accurate than the live realtime trace was — expected, per decision #2).
+
+### Dropout watchdog (why per-camera live values stay alive)
+
+`_LivePlotSink` uses per-camera BFI arrival as the dropout heartbeat, and that
+update sits *after* the `isfinite(bfi)` guard. NaN-ing per-camera BFI would make
+every camera look dropped. Hence decision #6: leave per-camera `bfi_live` /
+`bvi_live` untouched; only the *new* `cam_id=-1` averages are the reduced-mode
+display/persist paths.
+
+### Disposition of the running-average commit
+
+The `SideAveragingStage` running-average (SDK `69d573e`) is superseded by Stage
+A and will be replaced, not separately reverted — leaving it in place until the
+replacement lands avoids re-introducing the live jumpiness in the interim.
+
+---
+
+## Data flow (reduced mode, after this change)
+
+| Source | Path | Spatial avg | Consumer |
+|---|---|---|---|
+| `bfi_live` (realtime) | live | **Stage A**, per capture | in-memory `cam_id=-1` → live display |
+| `EnrichedCorrectedFrame` (corrected) | final | **Stage B**, per capture | side-agg payload → `ScanDBSink` `cam_id=-1` → replay |
+| per-camera `bfi_live` | live | — | in-memory buffers (dropout watchdog only) |
+
+Two streams, two intentionally-different averages, each computed once.
+
+---
+
+## Test plan
+
+The dense-batch unit tests hid the original bug because they never fed the
+realistic one-camera-per-row layout. The plan closes that and pins the
+spatial-only and live-vs-corrected guarantees.
+
+1. **`spatial_side_average` unit test** — pure-function: correct nan-aware mean
+   over selected cameras; ignores unselected cameras; all-NaN → NaN.
+2. **Stage A, realistic one-camera-per-row** — feed a capture's cameras as
+   consecutive one-cam rows; assert the emitted side value is the spatial mean of
+   *that capture's* cameras, emitted **once per capture** (~40 Hz), at the
+   capture's timestamp. Explicitly assert **no temporal carry**: a camera missing
+   from a later capture does not contribute a stale value.
+3. **Stage A straddle** — split a capture across two batches; emitted once, right
+   value/timestamp; final capture flushed at `on_scan_stop`.
+4. **Stage B gather-across-cameras** — feed per-`(side, cam)` enriched intervals
+   for one window; assert the side-aggregated series is the per-timestamp spatial
+   mean across the active cameras, flushed at scan stop.
+5. **Round-trip: stored == corrected-path average** — run a synthetic reduced
+   scan through pipeline + `ScanDBSink`; read the `cam_id=-1` series back; assert
+   it equals **Stage B's corrected output** (NOT the live display — those differ
+   by design).
+6. **DB persistence** — reduced mode writes corrected `cam_id=-1` rows and **no**
+   per-camera rows; normal mode writes per-camera and no side rows.
+7. **Replay reads DB** — `PastScanSource` and the DB-tail return the stored
+   `cam_id=-1` series with no derivation (assert the derive code is gone).
+8. **Dropout watchdog intact** — reduced mode: per-camera heartbeats still fire
+   (no spurious dropouts) even though per-camera values aren't displayed/persisted.
+
+---
+
+## Open questions
+
+- **Old scans** (recorded before this change) have no stored corrected
+  `cam_id=-1` average → reduced-mode replay of them would be empty. Recommend
+  accepting it (BETA); a thin legacy fallback is possible but reintroduces a
+  derive path.
+- **Normal-mode per-camera: live vs corrected.** The corrected per-camera BFI/BVI
+  is now available (enriched frames) and currently discarded. Persisting
+  *corrected* per-camera rows in normal mode (instead of realtime) would make the
+  whole DB record corrected, consistent with the reduced-mode decision. Proposed
+  as a follow-up, not part of this change.
+- **Mean/Contrast in reduced mode** aren't displayed (switch hidden) and so
+  aren't separately surfaced; Stage B can still carry corrected mean/contrast on
+  the `cam_id=-1` rows for completeness.

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -1,0 +1,83 @@
+# Realtime Plot Viewer — Session Status
+
+**Branch:** `feature/realtime-plot-viewer` (bloodflow-app) + `feature/side-avg-nanmean` (openmotion-sdk)
+**PR:** #142 (bloodflow-app). Companion SDK PR not yet opened.
+**Last updated:** 2026-05-27
+
+## What's Shipped (Most Recent First)
+
+### openmotion-bloodflow-app
+- `fa51bda` — docs: note SDK-side junk-frame filter in cell label
+- `fdda357` — clearer loadPastScan diagnostic (source=db/csv/db-only-sentinel)
+- `6d5b0f6` — PastScanSource reads per-cam from session_data (skips CSV fallback when DB has per-cam BFI)
+- `1982eae` — past-scan replay from per-cam CSV + popup switch styling (PillSwitch from SettingsModal)
+- `81d1465` — plot UI restructure: corner overlays + decimation tuning (stride floor 2→1, window = stride not stride*3)
+- `54d3a2e` — profile HUD + decimation morph fix (time-keyed stride, not n_window-keyed)
+- `adf22e5` — pinch-zoom on PlotCell for touchscreen
+- `da8edae` — keyboard shortcuts (←→ pan, ↑↓ +/- zoom, Home/End, 0 reset, Esc)
+- `b1dd074` — viewer .live invisible to QML + tooltip label "L AVG"
+- `66f673f` — scrubber crash + off-edge pan
+- `56a6980` — reduced-mode traces missing — drop strict NaN filter
+- Earlier: Phase 1 data_sources + Phase 2a-c PlotViewer / toolbar / scrubber / crosshair / tooltip / dropout / past-scan replay
+
+### openmotion-sdk (`feature/side-avg-nanmean` branch)
+- `11f9cc7` — BfiBviStage sanity excludes exact upper extreme (BFI=10.0) — fixes task #50 last-frame junk
+- `8fccedc` — BfiBviStage NaN-filters values outside [-2, 12] sanity range
+- `c043782` — iter_session_data accepts optional t_lo/t_hi time range (Phase 3 prereq)
+- `ef6e46d` — ScanDBSink writes per-cam BFI/BVI to session_data on "live" channel
+- `2c1360b` — SideAveragingStage uses nanmean (fixes reduced-mode side-avg cells empty)
+
+## Architectural Decisions
+
+- **Phase 1+2+3 MVP done.** Per-cam BFI/BVI now lives in `session_data` during live scans; PastScanSource reads it directly from DB. Live source bounded at 30 min via existing `_MAX_CAPACITY` ring-trim.
+- **Corner overlays replace top toolbar.** Top-right: back-to-live pill. Bottom-right: window-seconds pill + `⋯` settings menu (display mode, autoscale, profiler [dev-only]). Bottom-left: profiler HUD when toggled on.
+- **Settings is source of truth for autoScale + displayMode.** Overlay popup writes back via signals; settingsModal owns persisted state. Bound from BloodFlow.qml.
+- **Time-keyed decimation stride** (not n_window-keyed) — eliminates "trace morphs every few seconds" artifact at wide zoom.
+- **Stride floor = 1 + window = stride** for the smoothing kernel. Earlier `max(2, …) × 3` over-filtered the 5 s zoom; now raw samples render at tight zoom, Nyquist-minimum smoothing kicks in once decimation is actually needed.
+- **CSV fallback for old scans.** Pre-Phase-1 scans don't have per-cam BFI rows in DB; PastScanSource falls through to the per-cam corrected CSV (`{scan_id}.csv`, 82 columns, always written by CsvSink regardless of `writeRawCsv`).
+
+## Open Items
+
+### Bugs / Polish
+- ~~**Task #50**: junk values in last frame at scan stop~~ **DONE** in SDK `11f9cc7`. BfiBviStage now NaN's BFI/BVI outside `[-2, 10)` (lower inclusive for legit BFI=0 occlusion readings, upper exclusive for the formula's degenerate extreme). Verified: scan 111 has 0 BFI=10.0 rows (was 7 in scan 110), cell labels show clean values like `BFI -0.18 BVI 4.79`.
+
+### Spec phases not yet done
+- **Phase 3 full lazy-load**: pan-into-past beyond the 30-min in-memory cache on a live scan. Currently the workaround is "stop the scan, reload via History" — PastScanSource reads the full session from DB. True lazy-on-pan would need LiveScanSource to fall through to DB query when `t_lo < buf.t[0]`.
+- **Phase 3 swap to default**: flip `useNewPlotViewer` default to `true` and remove the legacy `EmbeddedRealtimePlot` / `ReducedPlotView` loaders from `BloodFlow.qml`. Currently both paths exist behind the flag.
+- **Phase 4 cleanup**: HistoryModal still shows 4 matplotlib popout buttons alongside "View in plot →". Per spec they should gate on `developerMode && !useNewPlotViewer` so clinical users only see the new viewer.
+- **Phase 5 cleanup**: delete `EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`, `processing/visualize_bloodflow.py`, legacy QML per-sample signals. After Phase 3 is stable for one release.
+
+### Test coverage gaps
+- Headless QML smoke test (needs pytest-qt; deferred)
+- Lazy-load query path (when Phase 3 full lands)
+
+## Gotchas For Next Session
+
+- **`live` must be `@pyqtProperty(bool, constant=True)`** on ScanDataSource — plain `self.live = True` is invisible to QML and resolves to `undefined`. (Bug we already fixed; if anyone touches the class don't regress.)
+- **`scrubber.top` from outside the ColumnLayout reads as 0** — Layout children's positions don't project cleanly to external anchors. Bottom overlays use `parent.bottom` with explicit `_overlayBottomMarginPx = 60` (12 outer + 28 scrubber + 8 spacing + 12 rim).
+- **`writeRawCsv: false` only disables the multi-MB raw histogram CSV** (`_raw.csv`). The per-cam corrected CSV (`{scan_id}.csv`, 82 cols) is always written by `CsvSink` — that's how matplotlib popout works regardless of the setting.
+- **User reverts `config/app_config.json` frequently** — never include it in commits. Their local `useNewPlotViewer: true` toggle is for testing only.
+- **Reduced mode requires 2 Start clicks**: first click runs CQ, second click ("Start Scan") begins the actual capture. HIL automation must wait for `CQ Final Compare` log line between clicks. The button label changes but the panel cache keys on the literal label so `click_panel('Start Scan')` is the right call after CQ.
+- **Dev mode is single-click Start.**
+- **Once a scan is running, `click_panel('Start')` still works** to stop — the button position is cached under "Start" even though the label says "Stop". The panel cache positions are by label-at-calibration-time.
+- **Decimation tests bake in the formulas.** When tuning `window_decimated`, expect to update `test_camera_buffer_window_decimated_*` tests to match new stride/window math.
+- **The companion SDK PR has 3 commits** — must merge first (or together) before bloodflow-app PR #142 can land. User has said they're holding the PR merges until everything is finished.
+
+## Quick Reference — Where Things Live
+
+- **PlotViewer.qml** — root component. Corner overlays + ColumnLayout (grid + scrubber). 940+ lines.
+- **PlotCell.qml** — single trace canvas. PinchHandler for touch, MouseArea for mouse, keyboard focus on click.
+- **PlotScrubber.qml** — bottom timeline. Blue inset = followLive, orange = paused, green tick = liveEdge.
+- **PlotToolbar.qml** — **dead code now**, kept for one release as fallback. Can delete in Phase 5 cleanup.
+- **data_sources.py** — `_CameraBuffer`, `ScanDataSource`, `LiveScanSource`, `PastScanSource`. Past now CSV-aware (`_load_corrected_csv`) + DB-aware.
+- **motion_connector.py** — `MOTIONConnector` (4000+ lines). `loadPastScan` (1772), `showLiveSource` (1763), `_LivePlotSink.consume` (171).
+- **openmotion-sdk/omotion/pipeline/sinks.py** — `ScanDBSink._consume_live` (Phase 1)
+- **openmotion-sdk/omotion/ScanDatabase.py** — `iter_session_data` now accepts t_lo/t_hi
+
+## How To Resume
+
+1. Read this file first.
+2. `git log feature/realtime-plot-viewer --oneline -20` to refresh the commit list.
+3. `git log feature/side-avg-nanmean --oneline -10` in the SDK repo for companion changes.
+4. Check task list (TaskList) for outstanding items.
+5. If picking up Phase 3 full lazy-load: see `data_sources.py:_CameraBuffer._ring_trim` for the current memory cap; need to add DB-fallback path in `LiveScanSource.points_for_window` / `value_at`.

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -7,6 +7,9 @@
 ## What's Shipped (Most Recent First)
 
 ### openmotion-bloodflow-app
+- `5c1f23d` — **Phase 3 swap**: useNewPlotViewer default flipped to true. Legacy Loaders stay as 1-release fallback.
+- `258e0df` — **Phase 4**: hide matplotlib popouts in HistoryModal when new viewer is on
+- `ddf760a` — docs: session status log
 - `fa51bda` — docs: note SDK-side junk-frame filter in cell label
 - `fdda357` — clearer loadPastScan diagnostic (source=db/csv/db-only-sentinel)
 - `6d5b0f6` — PastScanSource reads per-cam from session_data (skips CSV fallback when DB has per-cam BFI)
@@ -43,9 +46,9 @@
 
 ### Spec phases not yet done
 - **Phase 3 full lazy-load**: pan-into-past beyond the 30-min in-memory cache on a live scan. Currently the workaround is "stop the scan, reload via History" — PastScanSource reads the full session from DB. True lazy-on-pan would need LiveScanSource to fall through to DB query when `t_lo < buf.t[0]`.
-- **Phase 3 swap to default**: flip `useNewPlotViewer` default to `true` and remove the legacy `EmbeddedRealtimePlot` / `ReducedPlotView` loaders from `BloodFlow.qml`. Currently both paths exist behind the flag.
-- **Phase 4 cleanup**: HistoryModal still shows 4 matplotlib popout buttons alongside "View in plot →". Per spec they should gate on `developerMode && !useNewPlotViewer` so clinical users only see the new viewer.
-- **Phase 5 cleanup**: delete `EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`, `processing/visualize_bloodflow.py`, legacy QML per-sample signals. After Phase 3 is stable for one release.
+- ~~**Phase 3 swap to default**~~ **DONE** in `5c1f23d`. Legacy Loaders stay as 1-release fallback per spec.
+- ~~**Phase 4 cleanup**~~ **DONE** in `258e0df`. All matplotlib popouts now gate on `useNewPlotViewer !== true`.
+- **Phase 5 cleanup**: delete `EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`, `PlotToolbar.qml` (dead), `processing/visualize_bloodflow.py`, legacy QML per-sample signals. After Phase 3 is stable for one release.
 
 ### Test coverage gaps
 - Headless QML smoke test (needs pytest-qt; deferred)

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -7,8 +7,12 @@
 ## What's Shipped (Most Recent First)
 
 ### openmotion-bloodflow-app
+- `4ed0db3` — fix: define logger in data_sources (DB-tail NameError crash on first lazy-load)
+- `ed6fa74` — log History modal button presses (console.warn diagnostics)
+- `2dad750` — configurable live cache size (liveCacheMaxSeconds, default 1800 s)
+- `0e43556` — fix: live plot 1 Hz regression from DB-tail guard (ring_trimmed flag)
 - `cd35103` — corrected CSV opt-in: writeCorrectedCsv config flag (default False); DB is the store
-- `28c759a` — **Phase 3 lazy-load**: LiveScanSource DB tail — pan past the 30-min in-memory window loads from DB
+- `28c759a` — **Phase 3 lazy-load**: LiveScanSource DB tail — pan past the in-memory window loads from DB
 - `5c1f23d` — **Phase 3 swap**: useNewPlotViewer default flipped to true. Legacy Loaders stay as 1-release fallback.
 - `258e0df` — **Phase 4**: hide matplotlib popouts in HistoryModal when new viewer is on
 - `ddf760a` — docs: session status log
@@ -25,7 +29,8 @@
 - `56a6980` — reduced-mode traces missing — drop strict NaN filter
 - Earlier: Phase 1 data_sources + Phase 2a-c PlotViewer / toolbar / scrubber / crosshair / tooltip / dropout / past-scan replay
 
-### openmotion-sdk (`feature/side-avg-nanmean` branch)
+### openmotion-sdk (`feature/side-avg-nanmean` branch) — PR openmotion-sdk#61
+- `d5ff501` — suppress "Mean of empty slice" warning in SideAveragingStage
 - `83a78bf` — gate corrected CSV behind write_corrected; forced on when no scan DB configured
 - `11f9cc7` — BfiBviStage sanity excludes exact upper extreme (BFI=10.0) — fixes task #50 last-frame junk
 - `8fccedc` — BfiBviStage NaN-filters values outside [-2, 12] sanity range
@@ -48,7 +53,7 @@
 - ~~**Task #50**: junk values in last frame at scan stop~~ **DONE** in SDK `11f9cc7`. BfiBviStage now NaN's BFI/BVI outside `[-2, 10)` (lower inclusive for legit BFI=0 occlusion readings, upper exclusive for the formula's degenerate extreme). Verified: scan 111 has 0 BFI=10.0 rows (was 7 in scan 110), cell labels show clean values like `BFI -0.18 BVI 4.79`.
 
 ### Spec phases not yet done
-- ~~**Phase 3 full lazy-load**~~ **DONE** in `28c759a`. LiveScanSource falls through to a transient DB window when `t_lo < buffer's oldest in-memory timestamp`. **CAVEAT: only triggers after the 30-min ring-trim — NOT hardware-verified (would need a 30+ min scan). Unit tests cover the logic (4 tests); app launches clean.** First real >30-min scan should confirm pan-into-deep-past renders.
+- ~~**Phase 3 full lazy-load**~~ **DONE + HARDWARE-VERIFIED** (`28c759a` + `4ed0db3`). LiveScanSource falls through to a transient DB window when `t_lo < buffer's oldest in-memory timestamp`. Verified 2026-05-28 via `liveCacheMaxSeconds: 60` test config: a 7-min scan ring-trimmed, pan-back logged `DB tail engaged (session_id=120)`, no crash. **Two bugs found+fixed during verification:** (1) `data_sources.py` had no `logger` defined → NameError on first DB-tail use (`4ed0db3`); (2) SDK `side_avg.py` "Mean of empty slice" warning spam (`d5ff501`). `liveCacheMaxSeconds` is a new config knob (default 1800 s) added to shrink the cache for this kind of testing.
 - ~~**Phase 3 swap to default**~~ **DONE** in `5c1f23d`. Legacy Loaders stay as 1-release fallback per spec.
 - ~~**Phase 4 cleanup**~~ **DONE** in `258e0df`. All matplotlib popouts now gate on `useNewPlotViewer !== true`.
 - **Phase 5 cleanup**: delete `EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`, `PlotToolbar.qml` (dead), `processing/visualize_bloodflow.py`, legacy QML per-sample signals. After Phase 3 is stable for one release.

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -7,6 +7,7 @@
 ## What's Shipped (Most Recent First)
 
 ### openmotion-bloodflow-app
+- `cd35103` — corrected CSV opt-in: writeCorrectedCsv config flag (default False); DB is the store
 - `28c759a` — **Phase 3 lazy-load**: LiveScanSource DB tail — pan past the 30-min in-memory window loads from DB
 - `5c1f23d` — **Phase 3 swap**: useNewPlotViewer default flipped to true. Legacy Loaders stay as 1-release fallback.
 - `258e0df` — **Phase 4**: hide matplotlib popouts in HistoryModal when new viewer is on
@@ -25,6 +26,7 @@
 - Earlier: Phase 1 data_sources + Phase 2a-c PlotViewer / toolbar / scrubber / crosshair / tooltip / dropout / past-scan replay
 
 ### openmotion-sdk (`feature/side-avg-nanmean` branch)
+- `83a78bf` — gate corrected CSV behind write_corrected; forced on when no scan DB configured
 - `11f9cc7` — BfiBviStage sanity excludes exact upper extreme (BFI=10.0) — fixes task #50 last-frame junk
 - `8fccedc` — BfiBviStage NaN-filters values outside [-2, 12] sanity range
 - `c043782` — iter_session_data accepts optional t_lo/t_hi time range (Phase 3 prereq)

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -2,7 +2,35 @@
 
 **Branch:** `feature/realtime-plot-viewer` (bloodflow-app) + `feature/side-avg-nanmean` (openmotion-sdk)
 **PR:** #142 (bloodflow-app). Companion SDK PR not yet opened.
-**Last updated:** 2026-05-27
+**Last updated:** 2026-05-28
+
+## Reduced-mode side-average rework (2026-05-28)
+
+Design + plan: `docs/superpowers/specs/2026-05-28-reduced-mode-side-average-design.md`
+(rev 2) and `docs/superpowers/plans/2026-05-28-reduced-mode-side-average.md`.
+
+**Why:** the reduced-mode per-side average was computed-on-read in three diverging
+places (live display, history replay, DB tail) and conflated spatial vs temporal
+averaging. Now it's one pure spatial op, computed once per path and persisted.
+
+**Key decisions:** spatial average = mean across the selected cameras at one
+capture instant (no temporal carry); **live (realtime) ≠ DB (corrected)** by
+design; reduced-mode DB persists the average only.
+
+**As built (SDK `feature/side-avg-nanmean`):**
+- `spatial_side_average` pure helper (single definition).
+- `LiveSideAverageStage` (replaces `SideAveragingStage`) → `LiveEmit("live_side")`,
+  realtime per-capture average for display.
+- `CorrectedSideAverageStage` (new, final-path) → `LiveEmit("final_side")`, the
+  dark-corrected average gathered from the enriched intervals.
+- `ScanDBSink`: `"final"`→`"final_side"`, persists corrected `cam_id=-1` rows;
+  skips per-cam rows in reduced mode.
+- Round-trip test: stored `cam_id=-1` == Stage B output.
+- The `bfi_live_side`/`bvi_live_side` FrameBatch arrays were removed (events
+  replace them); `SideAverageSample` payload added to `batch.py`.
+
+**As built (app):** `_LivePlotSink` reads the `live_side` event; the
+`PastScanSource` derive-on-read is deleted (replay reads `cam_id=-1` from the DB).
 
 ## What's Shipped (Most Recent First)
 

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -46,6 +46,8 @@
 - **Time-keyed decimation stride** (not n_window-keyed) — eliminates "trace morphs every few seconds" artifact at wide zoom.
 - **Stride floor = 1 + window = stride** for the smoothing kernel. Earlier `max(2, …) × 3` over-filtered the 5 s zoom; now raw samples render at tight zoom, Nyquist-minimum smoothing kicks in once decimation is actually needed.
 - **CSV fallback for old scans.** Pre-Phase-1 scans don't have per-cam BFI rows in DB; PastScanSource falls through to the per-cam corrected CSV (`{scan_id}.csv`, 82 columns, always written by CsvSink regardless of `writeRawCsv`).
+- **Live cache default = 60 s** (`1c4be27`). Since the DB tail is verified, hold only 60 s in memory (~1 MB/buffer vs ~37 MB at 30 min); deep history serves from the DB. Configurable via `liveCacheMaxSeconds`. Watch-item: DB query on deep pan-back is synchronous on the QML thread — raise the value if it ever stutters.
+- **loadPastScan diagnostic = KEEP** (decided 2026-05-28). The `[Plot] loaded past scan … source=db/csv` info line stays — it's a useful operational breadcrumb (which scan, from where, how many samples), not a debug hack.
 
 ## Open Items
 

--- a/docs/superpowers/status/realtime-plot-viewer-session.md
+++ b/docs/superpowers/status/realtime-plot-viewer-session.md
@@ -7,6 +7,7 @@
 ## What's Shipped (Most Recent First)
 
 ### openmotion-bloodflow-app
+- `28c759a` — **Phase 3 lazy-load**: LiveScanSource DB tail — pan past the 30-min in-memory window loads from DB
 - `5c1f23d` — **Phase 3 swap**: useNewPlotViewer default flipped to true. Legacy Loaders stay as 1-release fallback.
 - `258e0df` — **Phase 4**: hide matplotlib popouts in HistoryModal when new viewer is on
 - `ddf760a` — docs: session status log
@@ -45,7 +46,7 @@
 - ~~**Task #50**: junk values in last frame at scan stop~~ **DONE** in SDK `11f9cc7`. BfiBviStage now NaN's BFI/BVI outside `[-2, 10)` (lower inclusive for legit BFI=0 occlusion readings, upper exclusive for the formula's degenerate extreme). Verified: scan 111 has 0 BFI=10.0 rows (was 7 in scan 110), cell labels show clean values like `BFI -0.18 BVI 4.79`.
 
 ### Spec phases not yet done
-- **Phase 3 full lazy-load**: pan-into-past beyond the 30-min in-memory cache on a live scan. Currently the workaround is "stop the scan, reload via History" — PastScanSource reads the full session from DB. True lazy-on-pan would need LiveScanSource to fall through to DB query when `t_lo < buf.t[0]`.
+- ~~**Phase 3 full lazy-load**~~ **DONE** in `28c759a`. LiveScanSource falls through to a transient DB window when `t_lo < buffer's oldest in-memory timestamp`. **CAVEAT: only triggers after the 30-min ring-trim — NOT hardware-verified (would need a 30+ min scan). Unit tests cover the logic (4 tests); app launches clean.** First real >30-min scan should confirm pan-into-deep-past renders.
 - ~~**Phase 3 swap to default**~~ **DONE** in `5c1f23d`. Legacy Loaders stay as 1-release fallback per spec.
 - ~~**Phase 4 cleanup**~~ **DONE** in `258e0df`. All matplotlib popouts now gate on `useNewPlotViewer !== true`.
 - **Phase 5 cleanup**: delete `EmbeddedRealtimePlot.qml`, `ReducedPlotView.qml`, `PlotToolbar.qml` (dead), `processing/visualize_bloodflow.py`, legacy QML per-sample signals. After Phase 3 is stable for one release.

--- a/main.py
+++ b/main.py
@@ -127,6 +127,11 @@ def _load_app_config() -> dict:
         # legacy EmbeddedRealtimePlot / ReducedPlotView pair. Default false;
         # flip locally in app_config.json to try the new viewer.
         "useNewPlotViewer": False,
+        # Phase 2b: profile HUD overlay on the new PlotViewer — sample
+        # rate, paint-tick ms, avg canvas-paint ms, total points
+        # painted. Gated on `developerMode && showProfiling` so clinical
+        # users never see it.
+        "showProfiling": False,
     }
     config_path = resource_path("config", "app_config.json")
     if not config_path.exists():

--- a/main.py
+++ b/main.py
@@ -109,6 +109,11 @@ def _load_app_config() -> dict:
         # read from there). Default off; set true to keep exporting it
         # for external analysis tools.
         "writeCorrectedCsv": False,
+        # Seconds of live data held in memory per plot buffer before the
+        # oldest half is ring-trimmed (older data then lazy-loads from the
+        # scan DB on pan-into-past). Default 30 min. Lower it (e.g. 60) to
+        # test the DB lazy-load without a long scan.
+        "liveCacheMaxSeconds": 1800,
         "autoScale": False,
         "autoScalePerPlot": False,
         "reducedMode": False,

--- a/main.py
+++ b/main.py
@@ -123,6 +123,10 @@ def _load_app_config() -> dict:
         "cq_rolling_avg_window": 10,
         "cq_dark_threshold_per_camera": [3.0] * 8,
         "cq_light_threshold_per_camera": [15.0] * 8,
+        # Phase 2a: dev-only flag to mount the new PlotViewer instead of the
+        # legacy EmbeddedRealtimePlot / ReducedPlotView pair. Default false;
+        # flip locally in app_config.json to try the new viewer.
+        "useNewPlotViewer": False,
     }
     config_path = resource_path("config", "app_config.json")
     if not config_path.exists():

--- a/main.py
+++ b/main.py
@@ -123,10 +123,12 @@ def _load_app_config() -> dict:
         "cq_rolling_avg_window": 10,
         "cq_dark_threshold_per_camera": [3.0] * 8,
         "cq_light_threshold_per_camera": [15.0] * 8,
-        # Phase 2a: dev-only flag to mount the new PlotViewer instead of the
-        # legacy EmbeddedRealtimePlot / ReducedPlotView pair. Default false;
-        # flip locally in app_config.json to try the new viewer.
-        "useNewPlotViewer": False,
+        # Phase 3 (spec §289): new PlotViewer is now the default. The
+        # legacy EmbeddedRealtimePlot / ReducedPlotView Loaders are kept
+        # in BloodFlow.qml as a one-release fallback — set this flag to
+        # false in app_config.json if a regression surfaces and you need
+        # the old plots back. Will be removed entirely in Phase 5 cleanup.
+        "useNewPlotViewer": True,
         # Phase 2b: profile HUD overlay on the new PlotViewer — sample
         # rate, paint-tick ms, avg canvas-paint ms, total points
         # painted. Gated on `developerMode && showProfiling` so clinical

--- a/main.py
+++ b/main.py
@@ -110,10 +110,11 @@ def _load_app_config() -> dict:
         # for external analysis tools.
         "writeCorrectedCsv": False,
         # Seconds of live data held in memory per plot buffer before the
-        # oldest half is ring-trimmed (older data then lazy-loads from the
-        # scan DB on pan-into-past). Default 30 min. Lower it (e.g. 60) to
-        # test the DB lazy-load without a long scan.
-        "liveCacheMaxSeconds": 1800,
+        # oldest half is ring-trimmed; older data then lazy-loads from the
+        # scan DB on pan-into-past. 60 s keeps memory tiny (~1 MB vs ~37 MB
+        # at 30 min) and leans on the verified DB tail for deep history.
+        # Raise it if synchronous DB queries on deep pan-back ever stutter.
+        "liveCacheMaxSeconds": 60,
         "autoScale": False,
         "autoScalePerPlot": False,
         "reducedMode": False,

--- a/main.py
+++ b/main.py
@@ -104,6 +104,11 @@ def _load_app_config() -> dict:
         "dataDirectory": None,
         "writeRawCsv": True,
         "rawCsvDurationSec": None,
+        # Corrected per-cam CSV ({scan_id}.csv) is redundant now that
+        # per-cam BFI/BVI lands in scans.db (the new viewer + past replay
+        # read from there). Default off; set true to keep exporting it
+        # for external analysis tools.
+        "writeCorrectedCsv": False,
         "autoScale": False,
         "autoScalePerPlot": False,
         "reducedMode": False,

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -174,11 +174,6 @@ class _LivePlotSink:
         if batch.bfi_live is None:
             return
 
-        # [LAG-DIAG] Time the per-batch live processing. Log if it spikes
-        # past 10 ms — anything that high is delaying samples reaching
-        # the new viewer's source.
-        _lag_t0 = time.perf_counter()
-
         n = batch.bfi_live.shape[0]
         connector = self._connector
         threshold = connector._camera_temp_alert_threshold_c
@@ -299,15 +294,6 @@ class _LivePlotSink:
                     contrast=contrast_for_source,
                 )
 
-        # [LAG-DIAG] Per-batch live processing time. 10 ms threshold so
-        # normal batches stay quiet and only outliers print.
-        _lag_ms = (time.perf_counter() - _lag_t0) * 1000.0
-        if _lag_ms > 10.0:
-            logger.warning(
-                "[LAG-DIAG] _LivePlotSink.consume took %.1f ms (n_frames=%d)",
-                _lag_ms, n,
-            )
-
     def on_complete(self) -> None:
         pass
 
@@ -334,10 +320,6 @@ class _FinalBatchSink:
     def consume(self, channel: str, batch) -> None:
         if channel != "final":
             return
-        # [LAG-DIAG] Time the corrected-batch processing end-to-end —
-        # this fires once per dark-interval close and is the suspected
-        # source of the user-observed "dark-frame stutter".
-        _lag_t0 = time.perf_counter()
         # Current SDK final payloads are EnrichedCorrectedInterval objects with
         # .frames; keep .samples fallback for older corrected-batch shims.
         connector = self._connector
@@ -346,7 +328,6 @@ class _FinalBatchSink:
         samples = getattr(batch, "frames", None)
         if samples is None:
             samples = getattr(batch, "samples", ())
-        _lag_n_samples = len(samples) if hasattr(samples, "__len__") else -1
         for s in samples:
             side = str(getattr(s, "side", ""))
             cam_id = int(getattr(s, "cam_id", -1))
@@ -371,12 +352,7 @@ class _FinalBatchSink:
                 "contrast": float(getattr(s, "contrast", 0.0)),
             })
         if payload:
-            # [LAG-DIAG] Sub-time the legacy Qt emit (which fans out to
-            # EmbeddedRealtimePlot's slot — still connected even when the
-            # plot is hidden behind the new viewer flag).
-            _emit_t0 = time.perf_counter()
             connector.scanCorrectedBatch.emit(payload)
-            _emit_ms = (time.perf_counter() - _emit_t0) * 1000.0
             # New viewer intentionally NOT fed corrected values for now —
             # the in-place buffer rewrite at every dark-interval close
             # caused visible mid-scan disruption ("data jumping between
@@ -384,18 +360,6 @@ class _FinalBatchSink:
             # corrections via scanCorrectedBatch.emit above. Re-enable
             # `self._live_source.apply_corrected_batch(payload)` when we
             # have a smoother handoff (e.g. dual-buffer overlay).
-        else:
-            _emit_ms = 0.0
-
-        # [LAG-DIAG] Always log — dark-interval closes are rare events
-        # so the line volume is low and per-event timing is what we
-        # actually care about for the user-observed stutter.
-        _lag_total_ms = (time.perf_counter() - _lag_t0) * 1000.0
-        logger.warning(
-            "[LAG-DIAG] _FinalBatchSink.consume total=%.1f ms "
-            "(emit=%.1f ms, n_samples=%d, payload=%d)",
-            _lag_total_ms, _emit_ms, _lag_n_samples, len(payload),
-        )
 
     def on_complete(self) -> None:
         pass

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -174,6 +174,11 @@ class _LivePlotSink:
         if batch.bfi_live is None:
             return
 
+        # [LAG-DIAG] Time the per-batch live processing. Log if it spikes
+        # past 10 ms — anything that high is delaying samples reaching
+        # the new viewer's source.
+        _lag_t0 = time.perf_counter()
+
         n = batch.bfi_live.shape[0]
         connector = self._connector
         threshold = connector._camera_temp_alert_threshold_c
@@ -294,6 +299,15 @@ class _LivePlotSink:
                     contrast=contrast_for_source,
                 )
 
+        # [LAG-DIAG] Per-batch live processing time. 10 ms threshold so
+        # normal batches stay quiet and only outliers print.
+        _lag_ms = (time.perf_counter() - _lag_t0) * 1000.0
+        if _lag_ms > 10.0:
+            logger.warning(
+                "[LAG-DIAG] _LivePlotSink.consume took %.1f ms (n_frames=%d)",
+                _lag_ms, n,
+            )
+
     def on_complete(self) -> None:
         pass
 
@@ -320,6 +334,10 @@ class _FinalBatchSink:
     def consume(self, channel: str, batch) -> None:
         if channel != "final":
             return
+        # [LAG-DIAG] Time the corrected-batch processing end-to-end —
+        # this fires once per dark-interval close and is the suspected
+        # source of the user-observed "dark-frame stutter".
+        _lag_t0 = time.perf_counter()
         # Current SDK final payloads are EnrichedCorrectedInterval objects with
         # .frames; keep .samples fallback for older corrected-batch shims.
         connector = self._connector
@@ -328,6 +346,7 @@ class _FinalBatchSink:
         samples = getattr(batch, "frames", None)
         if samples is None:
             samples = getattr(batch, "samples", ())
+        _lag_n_samples = len(samples) if hasattr(samples, "__len__") else -1
         for s in samples:
             side = str(getattr(s, "side", ""))
             cam_id = int(getattr(s, "cam_id", -1))
@@ -352,7 +371,12 @@ class _FinalBatchSink:
                 "contrast": float(getattr(s, "contrast", 0.0)),
             })
         if payload:
+            # [LAG-DIAG] Sub-time the legacy Qt emit (which fans out to
+            # EmbeddedRealtimePlot's slot — still connected even when the
+            # plot is hidden behind the new viewer flag).
+            _emit_t0 = time.perf_counter()
             connector.scanCorrectedBatch.emit(payload)
+            _emit_ms = (time.perf_counter() - _emit_t0) * 1000.0
             # New viewer intentionally NOT fed corrected values for now —
             # the in-place buffer rewrite at every dark-interval close
             # caused visible mid-scan disruption ("data jumping between
@@ -360,6 +384,18 @@ class _FinalBatchSink:
             # corrections via scanCorrectedBatch.emit above. Re-enable
             # `self._live_source.apply_corrected_batch(payload)` when we
             # have a smoother handoff (e.g. dual-buffer overlay).
+        else:
+            _emit_ms = 0.0
+
+        # [LAG-DIAG] Always log — dark-interval closes are rare events
+        # so the line volume is low and per-event timing is what we
+        # actually care about for the user-observed stutter.
+        _lag_total_ms = (time.perf_counter() - _lag_t0) * 1000.0
+        logger.warning(
+            "[LAG-DIAG] _FinalBatchSink.consume total=%.1f ms "
+            "(emit=%.1f ms, n_samples=%d, payload=%d)",
+            _lag_total_ms, _emit_ms, _lag_n_samples, len(payload),
+        )
 
     def on_complete(self) -> None:
         pass

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -602,6 +602,7 @@ class MOTIONConnector(QObject):
         self._dropout_timer = QTimer(self)
         self._dropout_timer.setInterval(1000)
         self._dropout_timer.timeout.connect(self._on_dropout_check)
+        self._plot_t0: float = 0.0  # set at scan start; consumed by _on_dropout_check
 
         # Trigger-ON elapsed mirrors — populated from start_capture locals so
         # _on_dropout_check / _scan_elapsed_str can read them off the instance.
@@ -1857,6 +1858,7 @@ class MOTIONConnector(QObject):
         # after a mid-scan unplug/replug, the two sides' clocks diverge and the
         # QML plot's shared `latestTimestamp` prunes the lagging side to empty.
         plot_t0 = time.monotonic()
+        self._plot_t0 = plot_t0  # used by _on_dropout_check to compute dropout-marker t
         # Real-time plot viewer: construct a fresh LiveScanSource for this scan
         # and install it on the connector. Phase 1 has no QML consumer yet —
         # the sinks (added in subsequent tasks) accumulate samples here in
@@ -2705,6 +2707,13 @@ class MOTIONConnector(QObject):
                 )
                 self._camera_dropped.add(key)
                 self.cameraDropoutDetected.emit(side, cam_id, elapsed_str)
+                # Also feed the new LiveScanSource so Phase 2+'s PlotViewer can
+                # render a dropout bar. Time is relative to plot_t0 to match the
+                # per-sample t axis (sample timestamps from the SDK use the same
+                # plot_t0-anchored monotonic origin).
+                src = self._current_scan_source
+                if src is not None and getattr(src, "live", False):
+                    src.mark_dropped(side=side, cam_id=cam_id, t=now - self._plot_t0)
 
     def _scan_elapsed_str(self) -> str:
         """Return current scan elapsed trigger-ON time as HH:MM:SS."""

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -249,6 +249,8 @@ class _LivePlotSink:
                     run_logger.warning(msg)
                     logger.warning(msg)
 
+                mean_for_source: Optional[float] = None
+                contrast_for_source: Optional[float] = None
                 if not is_dark:
                     # Two-pass refinement matches the BFI/BVI pattern: emit
                     # the realtime dark-corrected mean (mean_dc_rt) and
@@ -261,12 +263,14 @@ class _LivePlotSink:
                     if batch.mean_dc_rt is not None:
                         mean_val = float(batch.mean_dc_rt[i, side_idx, cam_id])
                         if math.isfinite(mean_val):
+                            mean_for_source = mean_val
                             connector.scanMeanSampled.emit(
                                 side, cam_id, abs_frame_id, plot_ts, mean_val
                             )
                     if batch.contrast_sn_rt is not None:
                         contrast_val = float(batch.contrast_sn_rt[i, side_idx, cam_id])
                         if math.isfinite(contrast_val):
+                            contrast_for_source = contrast_val
                             connector.scanContrastSampled.emit(
                                 side, cam_id, abs_frame_id, plot_ts, contrast_val
                             )
@@ -276,20 +280,9 @@ class _LivePlotSink:
                 connector.scanCameraTemperature.emit(side, cam_id, temp_c)
 
                 # Also feed the LiveScanSource so the new PlotViewer (Phase 2+)
-                # has a parallel record. mean/contrast are None when the SDK
-                # reported a non-finite value (existing emit-time NaN guards
-                # above set the optional payload to None for that metric).
-                mean_for_source: Optional[float] = None
-                contrast_for_source: Optional[float] = None
-                if not is_dark:
-                    if batch.mean_dc_rt is not None:
-                        mv = float(batch.mean_dc_rt[i, side_idx, cam_id])
-                        if math.isfinite(mv):
-                            mean_for_source = mv
-                    if batch.contrast_sn_rt is not None:
-                        cv = float(batch.contrast_sn_rt[i, side_idx, cam_id])
-                        if math.isfinite(cv):
-                            contrast_for_source = cv
+                # has a parallel record. mean/contrast already filtered for
+                # is_dark / non-finite above; None here means "metric not
+                # available for this sample".
                 self._live_source.append_uncorrected(
                     side=side,
                     cam_id=cam_id,
@@ -1962,6 +1955,7 @@ class MOTIONConnector(QObject):
         if not started:
             self._capture_running = False
             self._stop_runlog()
+            self._set_current_scan_source(None)  # release the orphaned LiveScanSource — scan never started
             # Log at WARNING so this is visible in the run log file —
             # captureLog signal goes through QML console.log which is
             # filtered out by default.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -43,7 +43,7 @@ from motion_config import (
     load_tec_params,
 )
 from utils.resource_path import resource_path
-from data_sources import LiveScanSource, ScanDataSource
+from data_sources import LiveScanSource, PastScanSource, ScanDataSource
 import numpy as np
 import pandas as pd
 
@@ -498,6 +498,7 @@ class MOTIONConnector(QObject):
 
     # Real-time plot viewer source — see data_sources.py.
     currentScanSourceChanged = pyqtSignal()
+    liveSourceAvailableChanged = pyqtSignal()
 
     configProgress = pyqtSignal(int)
     configLog = pyqtSignal(str)
@@ -670,6 +671,10 @@ class MOTIONConnector(QObject):
         self._console_connected_at: float | None = None
         # Real-time plot viewer source — assigned at scan start by startCapture.
         self._current_scan_source: ScanDataSource | None = None
+        # The most-recent LiveScanSource is kept alive even after the user
+        # navigates to a past scan, so "Back to live" can reassign without
+        # reconstructing. None when no scan has run this session.
+        self._live_scan_source: LiveScanSource | None = None
 
         self.laser_params = load_laser_params(config_dir, force_fault=self._force_laser_fail)
         self._tec_voltage_default = load_tec_params(config_dir)
@@ -1730,9 +1735,17 @@ class MOTIONConnector(QObject):
 
     @pyqtProperty(QObject, notify=currentScanSourceChanged)
     def currentScanSource(self) -> ScanDataSource | None:
-        """Current ScanDataSource — fresh LiveScanSource at each scan start.
-        Phase 1 has no QML consumer; Phase 2's PlotViewer will bind to this."""
+        """Current ScanDataSource bound to the PlotViewer. Usually the
+        live source during a scan; can be a PastScanSource while the
+        user is reviewing history via loadPastScan."""
         return self._current_scan_source
+
+    @pyqtProperty(bool, notify=liveSourceAvailableChanged)
+    def liveSourceAvailable(self) -> bool:
+        """True when a LiveScanSource is held (i.e. at least one scan
+        has run this session). PlotToolbar uses this to decide whether
+        the "Back to live" button should switch sources back to live."""
+        return self._live_scan_source is not None
 
     def _set_current_scan_source(self, source: ScanDataSource | None) -> None:
         """Replace the active source. Dedupes identical-instance assignments
@@ -1741,6 +1754,49 @@ class MOTIONConnector(QObject):
             return
         self._current_scan_source = source
         self.currentScanSourceChanged.emit()
+
+    @pyqtSlot()
+    def showLiveSource(self) -> None:
+        """Switch the viewer back to the held live source, if any.
+        No-op when no LiveScanSource has been created this session."""
+        if self._live_scan_source is None:
+            return
+        self._set_current_scan_source(self._live_scan_source)
+        logger.info("[Plot] viewer switched back to live source")
+
+    @pyqtSlot(str)
+    def loadPastScan(self, session_label: str) -> None:
+        """Open the saved scan with the given session_label (the
+        YYYYMMDD_HHMMSS_userLabel string used elsewhere in the UI) and
+        display it in the PlotViewer. The held live source is left
+        intact so a subsequent showLiveSource() can return to it.
+
+        Synchronous load — for a typical 30-min scan the SQLite walk
+        completes in well under a second, but if this becomes too slow
+        on long scans we can move it onto a QThread."""
+        if not session_label:
+            logger.warning("loadPastScan: empty session_label")
+            return
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db_path = getattr(self._interface, "scan_db_path", None)
+            if not db_path:
+                logger.warning("loadPastScan: scan_db_path unavailable on interface")
+                return
+            db = ScanDatabase(db_path)
+            session = db.get_session_by_label(session_label)
+            if not session:
+                logger.warning("loadPastScan: no session found for label %r", session_label)
+                return
+            session_id = int(session["id"])
+            past = PastScanSource(scan_db=db, session_id=session_id, parent=self)
+            self._set_current_scan_source(past)
+            logger.info(
+                "[Plot] loaded past scan %r (session_id=%d) into viewer",
+                session_label, session_id,
+            )
+        except Exception:
+            logger.exception("loadPastScan failed for label %r", session_label)
 
     @pyqtSlot(str, result=int)
     @pyqtSlot(str, str, result=int)
@@ -1883,6 +1939,13 @@ class MOTIONConnector(QObject):
         # the sinks (added in subsequent tasks) accumulate samples here in
         # parallel with the legacy Qt signal emissions.
         live_source = LiveScanSource(plot_t0=plot_t0, parent=self)
+        # Track the live source separately so the user can navigate
+        # to a past scan and return; emit so QML rebinds the
+        # PlotToolbar's "Back to live" visibility.
+        first_live = self._live_scan_source is None
+        self._live_scan_source = live_source
+        if first_live:
+            self.liveSourceAvailableChanged.emit()
         self._set_current_scan_source(live_source)
         self._capture_left_path = ""
         self._capture_right_path = ""

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1813,10 +1813,17 @@ class MOTIONConnector(QObject):
             n_buffers = len(past.buffers)
             n_samples = sum(b.n for b in past.buffers.values())
             sample_keys = sorted(past.buffers.keys())[:8]
+            # Detect which source actually populated per-cam BFI: if
+            # any (side, cam_id != -1, bfi) buffer exists, the DB was
+            # sufficient and the CSV fallback was skipped.
+            db_had_per_cam = any(
+                k[1] >= 0 and k[2] == "bfi" for k in past.buffers
+            )
             logger.info(
-                "[Plot] loaded past scan %r (session_id=%d) csv=%s: "
+                "[Plot] loaded past scan %r (session_id=%d) source=%s: "
                 "buffers=%d samples=%d liveEdge=%.3f sample_keys=%s",
-                session_label, session_id, bool(corrected_csv),
+                session_label, session_id,
+                "db" if db_had_per_cam else ("csv" if corrected_csv else "db-only-sentinel"),
                 n_buffers, n_samples, past.liveEdge, sample_keys,
             )
         except Exception:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -9,6 +9,7 @@ from PyQt6.QtCore import (
     QRecursiveMutex,
 )
 from pathlib import Path
+from typing import Optional
 import logging
 import math
 import base58
@@ -157,9 +158,11 @@ class _LivePlotSink:
 
     channels = {"live"}
 
-    def __init__(self, connector: "MOTIONConnector", plot_t0: float):
+    def __init__(self, connector: "MOTIONConnector", plot_t0: float,
+                 live_source: "LiveScanSource"):
         self._connector = connector
         self._plot_t0 = plot_t0
+        self._live_source = live_source
         self._temp_alerted: dict[tuple[str, int], bool] = {}
 
     def on_scan_start(self, meta) -> None:
@@ -271,6 +274,32 @@ class _LivePlotSink:
                 connector.scanBfiSampled.emit(side, cam_id, abs_frame_id, plot_ts, bfi)
                 connector.scanBviSampled.emit(side, cam_id, abs_frame_id, plot_ts, bvi)
                 connector.scanCameraTemperature.emit(side, cam_id, temp_c)
+
+                # Also feed the LiveScanSource so the new PlotViewer (Phase 2+)
+                # has a parallel record. mean/contrast are None when the SDK
+                # reported a non-finite value (existing emit-time NaN guards
+                # above set the optional payload to None for that metric).
+                mean_for_source: Optional[float] = None
+                contrast_for_source: Optional[float] = None
+                if not is_dark:
+                    if batch.mean_dc_rt is not None:
+                        mv = float(batch.mean_dc_rt[i, side_idx, cam_id])
+                        if math.isfinite(mv):
+                            mean_for_source = mv
+                    if batch.contrast_sn_rt is not None:
+                        cv = float(batch.contrast_sn_rt[i, side_idx, cam_id])
+                        if math.isfinite(cv):
+                            contrast_for_source = cv
+                self._live_source.append_uncorrected(
+                    side=side,
+                    cam_id=cam_id,
+                    frame_id=abs_frame_id,
+                    t=plot_ts,
+                    bfi=bfi,
+                    bvi=bvi,
+                    mean=mean_for_source,
+                    contrast=contrast_for_source,
+                )
 
     def on_complete(self) -> None:
         pass

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1969,7 +1969,15 @@ class MOTIONConnector(QObject):
         # and install it on the connector. Phase 1 has no QML consumer yet —
         # the sinks (added in subsequent tasks) accumulate samples here in
         # parallel with the legacy Qt signal emissions.
-        live_source = LiveScanSource(plot_t0=plot_t0, parent=self)
+        # Pass the scan DB path so the live source can lazily load older
+        # samples from the DB tail when the user pans before the in-memory
+        # ring-trim window (>30 min into a long scan). None-safe: if the
+        # interface has no scan_db_path the source stays in-memory-only.
+        live_source = LiveScanSource(
+            plot_t0=plot_t0,
+            parent=self,
+            scan_db_path=getattr(self._interface, "scan_db_path", None),
+        )
         # Track the live source separately so the user can navigate
         # to a past scan and return; emit so QML rebinds the
         # PlotToolbar's "Back to live" visibility.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2065,6 +2065,12 @@ class MOTIONConnector(QObject):
             right_camera_mask=right_camera_mask,
             disable_laser=disable_laser,
             reduced_mode=self._app_config.get("reducedMode", False),
+            # Corrected CSV is opt-in now that per-cam BFI/BVI lands in
+            # the scan DB (the new viewer + past replay read from there).
+            # Default False to skip the redundant {scan_id}.csv; flip
+            # writeCorrectedCsv:true in app_config to keep exporting it.
+            # The SDK still forces it on if no DB is configured.
+            write_corrected_csv=self._app_config.get("writeCorrectedCsv", False),
             # Raw CSV duration forwarded to the pipeline's Tee("raw") gate
             # via raw_save_max_duration_s. None means unbounded (write entire
             # scan); 0 omits raw tee entirely.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2096,16 +2096,25 @@ class MOTIONConnector(QObject):
             self._capture_running = False
             self._stop_runlog()
             self._set_current_scan_source(None)  # release the orphaned LiveScanSource — scan never started
+            # start_scan refuses for two reasons: a prior worker still alive,
+            # or a pre-flight failure (e.g. the scan DB couldn't be opened, in
+            # which case the scan is aborted before the laser fires so its data
+            # isn't silently lost). last_scan_error carries the specific reason
+            # when it's the latter.
+            reason = getattr(self._scan_workflow, "last_scan_error", None)
             # Log at WARNING so this is visible in the run log file —
             # captureLog signal goes through QML console.log which is
             # filtered out by default.
-            logger.warning(
-                "startCapture aborted: SDK refused to spawn a new scan "
-                "(see ScanWorkflow.start_scan log for the underlying "
-                "reason — usually a previous worker thread that didn't "
-                "exit cleanly)."
-            )
-            self.captureLog.emit("Capture already running.")
+            if reason:
+                logger.warning("startCapture aborted: %s", reason)
+                self.captureLog.emit(f"Scan aborted: {reason}")
+                self.errorOccurred.emit(reason)
+            else:
+                logger.warning(
+                    "startCapture aborted: SDK refused to spawn a new scan "
+                    "(usually a previous worker thread that didn't exit cleanly)."
+                )
+                self.captureLog.emit("Capture already running.")
         return bool(started)
 
     def _log_scan_image_stats(self, left_csv: str, right_csv: str) -> None:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1973,10 +1973,16 @@ class MOTIONConnector(QObject):
         # samples from the DB tail when the user pans before the in-memory
         # ring-trim window (>30 min into a long scan). None-safe: if the
         # interface has no scan_db_path the source stays in-memory-only.
+        # In-memory cache size before ring-trim → DB tail. Default 30 min
+        # (1800 s × 40 Hz). Shrink liveCacheMaxSeconds in app_config to
+        # exercise the DB lazy-load quickly (e.g. 60 → eviction after 1 min).
+        _live_cache_sec = self._app_config.get("liveCacheMaxSeconds", 1800)
+        _live_cache_samples = max(2, int(float(_live_cache_sec) * 40))
         live_source = LiveScanSource(
             plot_t0=plot_t0,
             parent=self,
             scan_db_path=getattr(self._interface, "scan_db_path", None),
+            cache_max_samples=_live_cache_samples,
         )
         # Track the live source separately so the user can navigate
         # to a past scan and return; emit so QML rebinds the

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -298,21 +298,25 @@ class _LivePlotSink:
             # SDK's SideAveragingStage is enabled. Append under
             # cam_id=-1 so the new viewer's reduced-mode layout can
             # pick them up without colliding with the per-cam buffers.
+            # Append even when bfi/bvi are NaN: the renderer's
+            # `_drawTrace` skips non-finite points per-segment, and
+            # filtering here drops legitimate timestamps that would
+            # otherwise leave the buffer empty if a single cam's
+            # per-frame value is NaN (np.mean propagates NaN).
             bfi_side_arr = getattr(batch, "bfi_live_side", None)
             bvi_side_arr = getattr(batch, "bvi_live_side", None)
             if bfi_side_arr is not None and bvi_side_arr is not None and not is_dark:
                 for sa_side_idx, sa_side in enumerate(_SIDE_NAMES):
                     bfi_s = float(bfi_side_arr[i, sa_side_idx])
                     bvi_s = float(bvi_side_arr[i, sa_side_idx])
-                    if math.isfinite(bfi_s) and math.isfinite(bvi_s):
-                        self._live_source.append_uncorrected(
-                            side=sa_side,
-                            cam_id=-1,
-                            frame_id=abs_frame_id,
-                            t=plot_ts,
-                            bfi=bfi_s,
-                            bvi=bvi_s,
-                        )
+                    self._live_source.append_uncorrected(
+                        side=sa_side,
+                        cam_id=-1,
+                        frame_id=abs_frame_id,
+                        t=plot_ts,
+                        bfi=bfi_s,
+                        bvi=bvi_s,
+                    )
 
     def on_complete(self) -> None:
         pass

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1513,38 +1513,62 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot(result=list)
     def get_scan_list(self):
-        """Return sorted list of scan IDs.
+        """Return sorted list of scan IDs from BOTH the corrected CSVs on disk
+        and the scan database's sessions.
 
-        Supports three filename formats for the canonical scan CSV:
+        The scan DB is the system of record: reduced-mode scans (and any scan
+        with writeCorrectedCsv off) write no corrected CSV, so they exist only
+        as DB sessions. A session_label has the same shape as the CSV-derived
+        scan id (``YYYYMMDD_HHMMSS_userLabel``), so the two sources merge by id.
+
+        CSV filename formats supported (legacy / corrected-CSV scans):
           New (post-#44): {YYYYMMDD_HHMMSS}_{sessionId}.csv
           Mid:            {YYYYMMDD_HHMMSS}_{sessionId}_corrected.csv
           Legacy:         scan_{sessionId}_{YYYYMMDD_HHMMSS}_corrected.csv
         """
-        base_path = Path(self._directory)
-        if not base_path.exists():
-            return []
-
         seen: set[str] = set()
         ids: list[str] = []
-        for f in base_path.glob("*.csv"):
-            if not f.is_file():
-                continue
-            stem = f.stem
-            # Skip per-scan auxiliary files (raw histo, telemetry).
-            if self._AUX_CSV_RE.search(stem):
-                continue
-            # Mid format: strip the ``_corrected`` suffix to get the
-            # canonical scan id.
-            if stem.endswith("_corrected"):
-                stem = stem[:-10]
-            # Legacy format: ``scan_{sessionId}_{ts}`` — strip the
-            # ``scan_`` prefix.
-            if stem.startswith("scan_"):
-                stem = stem[5:]
-            if stem in seen:
-                continue
-            seen.add(stem)
-            ids.append(stem)
+
+        base_path = Path(self._directory)
+        if base_path.exists():
+            for f in base_path.glob("*.csv"):
+                if not f.is_file():
+                    continue
+                stem = f.stem
+                # Skip per-scan auxiliary files (raw histo, telemetry).
+                if self._AUX_CSV_RE.search(stem):
+                    continue
+                # Mid format: strip the ``_corrected`` suffix to get the
+                # canonical scan id.
+                if stem.endswith("_corrected"):
+                    stem = stem[:-10]
+                # Legacy format: ``scan_{sessionId}_{ts}`` — strip the
+                # ``scan_`` prefix.
+                if stem.startswith("scan_"):
+                    stem = stem[5:]
+                if stem in seen:
+                    continue
+                seen.add(stem)
+                ids.append(stem)
+
+        # DB-backed scans (no corrected CSV on disk). Best-effort: a missing or
+        # unreadable DB just leaves the CSV-derived list.
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if db_path:
+            try:
+                from omotion.ScanDatabase import ScanDatabase
+                db = ScanDatabase(db_path)
+                try:
+                    for session in db.iter_sessions():
+                        label = (session.get("session_label") or "").strip()
+                        if label and label not in seen:
+                            seen.add(label)
+                            ids.append(label)
+                finally:
+                    db.close()
+            except Exception:
+                logger.warning("get_scan_list: could not read scan DB sessions",
+                               exc_info=True)
 
         def ts_key(s):
             # New / mid format starts with YYYYMMDD (8 digits)

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -42,6 +42,7 @@ from motion_config import (
     load_tec_params,
 )
 from utils.resource_path import resource_path
+from data_sources import LiveScanSource, ScanDataSource
 import numpy as np
 import pandas as pd
 
@@ -444,6 +445,9 @@ class MOTIONConnector(QObject):
     vizFinished = pyqtSignal()
     visualizingChanged = pyqtSignal(bool)
 
+    # Real-time plot viewer source — see data_sources.py.
+    currentScanSourceChanged = pyqtSignal()
+
     configProgress = pyqtSignal(int)
     configLog = pyqtSignal(str)
     configFinished = pyqtSignal(bool, str)
@@ -612,6 +616,8 @@ class MOTIONConnector(QObject):
         self._last_fan_status: dict[str, bool | None] = {"left": None, "right": None}
         # Track console connection time for safety grace period (issue #107 follow-up)
         self._console_connected_at: float | None = None
+        # Real-time plot viewer source — assigned at scan start by startCapture.
+        self._current_scan_source: ScanDataSource | None = None
 
         self.laser_params = load_laser_params(config_dir, force_fault=self._force_laser_fail)
         self._tec_voltage_default = load_tec_params(config_dir)
@@ -1670,6 +1676,20 @@ class MOTIONConnector(QObject):
             except Exception as e:
                 logger.error(f"Failed to update scan notes on disk: {e}")
 
+    @pyqtProperty(QObject, notify=currentScanSourceChanged)
+    def currentScanSource(self) -> ScanDataSource | None:
+        """Current ScanDataSource — fresh LiveScanSource at each scan start.
+        Phase 1 has no QML consumer; Phase 2's PlotViewer will bind to this."""
+        return self._current_scan_source
+
+    def _set_current_scan_source(self, source: ScanDataSource | None) -> None:
+        """Replace the active source. Dedupes identical-instance assignments
+        so the notify signal only fires on real transitions."""
+        if source is self._current_scan_source:
+            return
+        self._current_scan_source = source
+        self.currentScanSourceChanged.emit()
+
     @pyqtSlot(str, result=int)
     @pyqtSlot(str, str, result=int)
     @pyqtSlot(str, str, int, result=int)
@@ -1805,6 +1825,12 @@ class MOTIONConnector(QObject):
         # after a mid-scan unplug/replug, the two sides' clocks diverge and the
         # QML plot's shared `latestTimestamp` prunes the lagging side to empty.
         plot_t0 = time.monotonic()
+        # Real-time plot viewer: construct a fresh LiveScanSource for this scan
+        # and install it on the connector. Phase 1 has no QML consumer yet —
+        # the sinks (added in subsequent tasks) accumulate samples here in
+        # parallel with the legacy Qt signal emissions.
+        live_source = LiveScanSource(plot_t0=plot_t0, parent=self)
+        self._set_current_scan_source(live_source)
         self._capture_left_path = ""
         self._capture_right_path = ""
         self._start_runlog(subject_id=subject_id)

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -164,9 +164,16 @@ class _LivePlotSink:
         self._plot_t0 = plot_t0
         self._live_source = live_source
         self._temp_alerted: dict[tuple[str, int], bool] = {}
+        # Last abs_frame_id for which a side-average sample was appended, per
+        # side index. The reduced-mode side average is one value per capture
+        # instant (frame_id), but each capture arrives as one frame row PER
+        # camera, so without this dedup the cam_id=-1 buffer would fill at
+        # N_cams×40 Hz and overflow the in-memory cache in seconds.
+        self._last_side_avg_fid: dict[int, int] = {}
 
     def on_scan_start(self, meta) -> None:
         self._temp_alerted.clear()
+        self._last_side_avg_fid.clear()
 
     def consume(self, channel: str, batch) -> None:
         if channel != "live":
@@ -294,28 +301,33 @@ class _LivePlotSink:
                     contrast=contrast_for_source,
                 )
 
-            # Side-averaged samples (reduced-mode) — present iff the
-            # SDK's SideAveragingStage is enabled. Append under
-            # cam_id=-1 so the new viewer's reduced-mode layout can
-            # pick them up without colliding with the per-cam buffers.
-            # Append even when bfi/bvi are NaN: the renderer's
-            # `_drawTrace` skips non-finite points per-segment, and
-            # filtering here drops legitimate timestamps that would
-            # otherwise leave the buffer empty if a single cam's
-            # per-frame value is NaN (np.mean propagates NaN).
+            # Side-averaged sample (reduced-mode) — present iff the SDK's
+            # SideAveragingStage is enabled. SideAveragingStage emits a running
+            # per-side average across the active cameras' latest values; append
+            # it under cam_id=-1 ONCE PER frame_id for THIS frame's side.
+            #
+            # Each capture instant (frame_id) arrives as one frame row per
+            # camera (all synced cameras share a frame_id), so appending per
+            # row drove the cam_id=-1 buffer at N_cams×40 Hz and overflowed the
+            # in-memory cache in seconds. Deduping by frame_id keeps it at the
+            # ~40 Hz capture cadence. Only the frame's own side is appended —
+            # the opposite side's value for this row is a stale/NaN carry that
+            # belongs to that side's own frames.
             bfi_side_arr = getattr(batch, "bfi_live_side", None)
             bvi_side_arr = getattr(batch, "bvi_live_side", None)
-            if bfi_side_arr is not None and bvi_side_arr is not None and not is_dark:
-                for sa_side_idx, sa_side in enumerate(_SIDE_NAMES):
-                    bfi_s = float(bfi_side_arr[i, sa_side_idx])
-                    bvi_s = float(bvi_side_arr[i, sa_side_idx])
+            if (bfi_side_arr is not None and bvi_side_arr is not None
+                    and not is_dark and side_ids is not None):
+                sa_side_idx = int(side_ids[i])
+                if (0 <= sa_side_idx < len(_SIDE_NAMES)
+                        and self._last_side_avg_fid.get(sa_side_idx) != abs_frame_id):
+                    self._last_side_avg_fid[sa_side_idx] = abs_frame_id
                     self._live_source.append_uncorrected(
-                        side=sa_side,
+                        side=_SIDE_NAMES[sa_side_idx],
                         cam_id=-1,
                         frame_id=abs_frame_id,
                         t=plot_ts,
-                        bfi=bfi_s,
-                        bvi=bvi_s,
+                        bfi=float(bfi_side_arr[i, sa_side_idx]),
+                        bvi=float(bvi_side_arr[i, sa_side_idx]),
                     )
 
     def on_complete(self) -> None:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -315,9 +315,11 @@ class _FinalBatchSink:
 
     channels = {"final"}
 
-    def __init__(self, connector: "MOTIONConnector", plot_t0: float):
+    def __init__(self, connector: "MOTIONConnector", plot_t0: float,
+                 live_source: "LiveScanSource"):
         self._connector = connector
         self._plot_t0 = plot_t0
+        self._live_source = live_source
 
     def on_scan_start(self, meta) -> None:
         pass
@@ -358,6 +360,7 @@ class _FinalBatchSink:
             })
         if payload:
             connector.scanCorrectedBatch.emit(payload)
+            self._live_source.apply_corrected_batch(payload)
 
     def on_complete(self) -> None:
         pass
@@ -1946,8 +1949,8 @@ class MOTIONConnector(QObject):
                 self._raw_csv_duration_sec if self._write_raw_csv else 0
             ),
             sinks=[
-                _LivePlotSink(connector=self, plot_t0=plot_t0),
-                _FinalBatchSink(connector=self, plot_t0=plot_t0),
+                _LivePlotSink(connector=self, plot_t0=plot_t0, live_source=live_source),
+                _FinalBatchSink(connector=self, plot_t0=plot_t0, live_source=live_source),
                 _TriggerStateSink(connector=self),
                 _CompletionSink(connector=self, on_complete_cb=_on_pipeline_complete),
             ],

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -149,14 +149,17 @@ class _LivePlotSink:
     """Subscribes to the 'live' pipeline channel and emits per-frame Qt
     signals into the QML realtime plot for each active camera.
 
-    The 'live' channel carries a FrameBatch after BfiBvi (and optionally
-    SideAveraging in reduced mode). Each batch may contain multiple frames
-    and both sides; we iterate frame × side × cam_id and call back into
-    the connector's _emit_frame_to_qml helper, which gates on the camera-
-    dropout watchdog and fires the Qt signals.
+    The 'live' channel carries a FrameBatch after BfiBvi. Each batch may
+    contain multiple frames and both sides; we iterate frame × side × cam_id
+    and call back into the connector's helpers, which gate on the camera-
+    dropout watchdog and fire the Qt signals.
+
+    The 'live_side' channel carries one SideAverageSample per capture per side
+    (from the SDK's LiveSideAverageStage, reduced mode) — the realtime per-side
+    average, appended under cam_id=-1 for the reduced-mode display.
     """
 
-    channels = {"live"}
+    channels = {"live", "live_side"}
 
     def __init__(self, connector: "MOTIONConnector", plot_t0: float,
                  live_source: "LiveScanSource"):
@@ -164,20 +167,17 @@ class _LivePlotSink:
         self._plot_t0 = plot_t0
         self._live_source = live_source
         self._temp_alerted: dict[tuple[str, int], bool] = {}
-        # Last abs_frame_id for which a side-average sample was appended, per
-        # side index. The reduced-mode side average is one value per capture
-        # instant (frame_id), but each capture arrives as one frame row PER
-        # camera, so without this dedup the cam_id=-1 buffer would fill at
-        # N_cams×40 Hz and overflow the in-memory cache in seconds.
-        self._last_side_avg_fid: dict[int, int] = {}
 
     def on_scan_start(self, meta) -> None:
         self._temp_alerted.clear()
-        self._last_side_avg_fid.clear()
 
-    def consume(self, channel: str, batch) -> None:
+    def consume(self, channel: str, payload) -> None:
+        if channel == "live_side":
+            self._consume_side_avg(payload)
+            return
         if channel != "live":
             return
+        batch = payload
         if batch.bfi_live is None:
             return
 
@@ -301,34 +301,22 @@ class _LivePlotSink:
                     contrast=contrast_for_source,
                 )
 
-            # Side-averaged sample (reduced-mode) — present iff the SDK's
-            # SideAveragingStage is enabled. SideAveragingStage emits a running
-            # per-side average across the active cameras' latest values; append
-            # it under cam_id=-1 ONCE PER frame_id for THIS frame's side.
-            #
-            # Each capture instant (frame_id) arrives as one frame row per
-            # camera (all synced cameras share a frame_id), so appending per
-            # row drove the cam_id=-1 buffer at N_cams×40 Hz and overflowed the
-            # in-memory cache in seconds. Deduping by frame_id keeps it at the
-            # ~40 Hz capture cadence. Only the frame's own side is appended —
-            # the opposite side's value for this row is a stale/NaN carry that
-            # belongs to that side's own frames.
-            bfi_side_arr = getattr(batch, "bfi_live_side", None)
-            bvi_side_arr = getattr(batch, "bvi_live_side", None)
-            if (bfi_side_arr is not None and bvi_side_arr is not None
-                    and not is_dark and side_ids is not None):
-                sa_side_idx = int(side_ids[i])
-                if (0 <= sa_side_idx < len(_SIDE_NAMES)
-                        and self._last_side_avg_fid.get(sa_side_idx) != abs_frame_id):
-                    self._last_side_avg_fid[sa_side_idx] = abs_frame_id
-                    self._live_source.append_uncorrected(
-                        side=_SIDE_NAMES[sa_side_idx],
-                        cam_id=-1,
-                        frame_id=abs_frame_id,
-                        t=plot_ts,
-                        bfi=float(bfi_side_arr[i, sa_side_idx]),
-                        bvi=float(bvi_side_arr[i, sa_side_idx]),
-                    )
+    def _consume_side_avg(self, sample) -> None:
+        """Append one reduced-mode per-side average (SideAverageSample from the
+        SDK's LiveSideAverageStage) under cam_id=-1. The stage already emits one
+        true spatial average per capture per side at ~40 Hz, so there's no dedup
+        or skipping here — we just store what it emits."""
+        side_idx = int(getattr(sample, "side", -1))
+        if not (0 <= side_idx < len(_SIDE_NAMES)):
+            return
+        self._live_source.append_uncorrected(
+            side=_SIDE_NAMES[side_idx],
+            cam_id=-1,
+            frame_id=int(getattr(sample, "frame_id", -1)),
+            t=float(getattr(sample, "t", 0.0)),
+            bfi=float(getattr(sample, "bfi", float("nan"))),
+            bvi=float(getattr(sample, "bvi", float("nan"))),
+        )
 
     def on_complete(self) -> None:
         pass

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2092,6 +2092,14 @@ class MOTIONConnector(QObject):
         )
 
         started = self._interface.start_scan(req)
+        if started:
+            # Bind the live source's DB tail to THIS scan's session row by its
+            # exact label (set synchronously inside start_scan), so a later
+            # pan-into-past resolves the right session instead of guessing the
+            # newest one.
+            label = getattr(self._scan_workflow, "current_scan_label", None)
+            if label:
+                live_source.set_scan_label(label)
         if not started:
             self._capture_running = False
             self._stop_runlog()

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -353,7 +353,13 @@ class _FinalBatchSink:
             })
         if payload:
             connector.scanCorrectedBatch.emit(payload)
-            self._live_source.apply_corrected_batch(payload)
+            # New viewer intentionally NOT fed corrected values for now —
+            # the in-place buffer rewrite at every dark-interval close
+            # caused visible mid-scan disruption ("data jumping between
+            # two datasets"). Legacy EmbeddedRealtimePlot still receives
+            # corrections via scanCorrectedBatch.emit above. Re-enable
+            # `self._live_source.apply_corrected_batch(payload)` when we
+            # have a smoother handoff (e.g. dual-buffer overlay).
 
     def on_complete(self) -> None:
         pass

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1793,11 +1793,31 @@ class MOTIONConnector(QObject):
                 logger.warning("loadPastScan: no session found for label %r", session_label)
                 return
             session_id = int(session["id"])
-            past = PastScanSource(scan_db=db, session_id=session_id, parent=self)
+            # Per-cam corrected CSV ({scan_id}.csv, 82-col wide format)
+            # is the only source of per-cam BFI/BVI/mean/contrast for
+            # past replay — the DB's session_data only holds side-
+            # aggregated corrected-frame placeholders. CsvSink writes
+            # this CSV unconditionally for every scan, so it's reliably
+            # available.
+            details = self.get_scan_details(session_label) or {}
+            corrected_csv = details.get("correctedPath") or None
+            past = PastScanSource(
+                scan_db=db,
+                session_id=session_id,
+                corrected_csv_path=corrected_csv,
+                parent=self,
+            )
             self._set_current_scan_source(past)
+            # Diagnostic — left in for now so we can spot regressions
+            # in past-scan loading. Cheap (one log line per click).
+            n_buffers = len(past.buffers)
+            n_samples = sum(b.n for b in past.buffers.values())
+            sample_keys = sorted(past.buffers.keys())[:8]
             logger.info(
-                "[Plot] loaded past scan %r (session_id=%d) into viewer",
-                session_label, session_id,
+                "[Plot] loaded past scan %r (session_id=%d) csv=%s: "
+                "buffers=%d samples=%d liveEdge=%.3f sample_keys=%s",
+                session_label, session_id, bool(corrected_csv),
+                n_buffers, n_samples, past.liveEdge, sample_keys,
             )
         except Exception:
             logger.exception("loadPastScan failed for label %r", session_label)

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -294,6 +294,26 @@ class _LivePlotSink:
                     contrast=contrast_for_source,
                 )
 
+            # Side-averaged samples (reduced-mode) — present iff the
+            # SDK's SideAveragingStage is enabled. Append under
+            # cam_id=-1 so the new viewer's reduced-mode layout can
+            # pick them up without colliding with the per-cam buffers.
+            bfi_side_arr = getattr(batch, "bfi_live_side", None)
+            bvi_side_arr = getattr(batch, "bvi_live_side", None)
+            if bfi_side_arr is not None and bvi_side_arr is not None and not is_dark:
+                for sa_side_idx, sa_side in enumerate(_SIDE_NAMES):
+                    bfi_s = float(bfi_side_arr[i, sa_side_idx])
+                    bvi_s = float(bvi_side_arr[i, sa_side_idx])
+                    if math.isfinite(bfi_s) and math.isfinite(bvi_s):
+                        self._live_source.append_uncorrected(
+                            side=sa_side,
+                            cam_id=-1,
+                            frame_id=abs_frame_id,
+                            t=plot_ts,
+                            bfi=bfi_s,
+                            bvi=bvi_s,
+                        )
+
     def on_complete(self) -> None:
         pass
 

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -240,6 +240,28 @@ Rectangle {
         id: plotViewerComponent
         PlotViewer {
             reducedMode: bloodFlow.reducedMode
+            autoScale: settingsModal.autoScale
+            displayMode: settingsModal.showBfiBvi ? "bfi_bvi" : "mean_contrast"
+            // Manual y-axis bounds — applied when autoScale is off.
+            settingBfiMin:      settingsModal.bfiMin
+            settingBfiMax:      settingsModal.bfiMax
+            settingBviMin:      settingsModal.bviMin
+            settingBviMax:      settingsModal.bviMax
+            settingMeanMin:     settingsModal.meanMin
+            settingMeanMax:     settingsModal.meanMax
+            settingContrastMin: settingsModal.contrastMin
+            settingContrastMax: settingsModal.contrastMax
+            // Bottom-right settings popup writes back through these
+            // signals → settingsModal owns the persisted state and
+            // the Settings modal stays in sync with the viewer's quick
+            // toggles.
+            onAutoScaleToggleRequested: function(enabled) {
+                settingsModal.autoScale = enabled
+                settingsModal.autoScalePerPlot = enabled
+            }
+            onDisplayModeToggleRequested: function(bfiBviMode) {
+                settingsModal.showBfiBvi = bfiBviMode
+            }
         }
     }
 

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -151,8 +151,8 @@ Rectangle {
         scanDialog.message = "Scanning..."
         scanDialog.stageText = "Preparing..."
         scanDialog.progress = 1
-        if (bloodFlow.reducedMode) reducedPlot.startScan()
-        else                        embeddedPlot.startScan(bloodFlow.leftMask, bloodFlow.rightMask)
+        if (bloodFlow.reducedMode) reducedPlotLoader.item?.startScan()
+        else                        embeddedPlotLoader.item?.startScan(bloodFlow.leftMask, bloodFlow.rightMask)
         scanRunner.start()
     }
 
@@ -181,8 +181,8 @@ Rectangle {
             if (bloodFlow.scanning) {
                 scanRunner.cancel()
                 scanDialog.close()
-                if (bloodFlow.reducedMode) reducedPlot.stopScan()
-                else                   embeddedPlot.stopScan()
+                if (bloodFlow.reducedMode) reducedPlotLoader.item?.stopScan()
+                else                   embeddedPlotLoader.item?.stopScan()
                 // Notes modal opens via MOTIONInterface.scanNotesReady
                 // after the SDK actually unwinds and the duration line
                 // has been appended to scanNotes. Opening it here would
@@ -256,64 +256,84 @@ Rectangle {
         sourceComponent: plotViewerComponent
     }
 
-    EmbeddedRealtimePlot {
-        id: embeddedPlot
-        visible: !bloodFlow._useNewViewer && !bloodFlow.reducedMode
+    // Legacy plots — wrapped in Loaders so they're FULLY UNMOUNTED when
+    // the new viewer is active. Previously `visible: false` left their
+    // QML Connections blocks alive, so every scanBfiSampled / scanBviSampled
+    // / scanMeanSampled / scanContrastSampled / scanCameraTemperature /
+    // scanCorrectedBatch emit still fired their slots — ~1600 cross-thread
+    // signal events/sec keeping the QML main thread pinned at 3-5 Hz
+    // paint, plus burst spikes (500-850 ms) at dark-frame closes when
+    // 8 corrected-batches arrive in ~100 ms each fanning out to the
+    // legacy plot's heavy in-place rewrite handler.
+    Loader {
+        id: embeddedPlotLoader
+        active: !bloodFlow._useNewViewer && !bloodFlow.reducedMode
+        visible: active
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: buttonPanel.right
         anchors.right: parent.right
         anchors.margins: 8
         anchors.leftMargin: 16
-
-        showBfiBvi:  settingsModal.showBfiBvi
-        windowSeconds: settingsModal.plotWindowSec
-        bfiColor: settingsModal.bfiColor
-        bviColor: settingsModal.bviColor
-        bviLowPassEnabled:  settingsModal.bviLowPassEnabled
-        bviLowPassCutoffHz: settingsModal.bviLowPassCutoffHz
-        bfiClampLow:  MOTIONInterface.appConfig.bfiClampLow  !== undefined ? MOTIONInterface.appConfig.bfiClampLow  : 0.0
-        bfiClampHigh: MOTIONInterface.appConfig.bfiClampHigh !== undefined ? MOTIONInterface.appConfig.bfiClampHigh : 10.0
-        bviClampLow:  MOTIONInterface.appConfig.bviClampLow  !== undefined ? MOTIONInterface.appConfig.bviClampLow  : 0.0
-        bviClampHigh: MOTIONInterface.appConfig.bviClampHigh !== undefined ? MOTIONInterface.appConfig.bviClampHigh : 10.0
-        autoScale:        settingsModal.autoScale
-        autoScalePerPlot: settingsModal.autoScalePerPlot
-        bfiMin:      settingsModal.bfiMin
-        bfiMax:      settingsModal.bfiMax
-        bviMin:      settingsModal.bviMin
-        bviMax:      settingsModal.bviMax
-        meanMin:     settingsModal.meanMin
-        meanMax:     settingsModal.meanMax
-        contrastMin: settingsModal.contrastMin
-        contrastMax: settingsModal.contrastMax
-        previewLeftMask:  bloodFlow.leftMask
-        previewRightMask: bloodFlow.rightMask
+        sourceComponent: Component {
+            EmbeddedRealtimePlot {
+                anchors.fill: parent
+                showBfiBvi:  settingsModal.showBfiBvi
+                windowSeconds: settingsModal.plotWindowSec
+                bfiColor: settingsModal.bfiColor
+                bviColor: settingsModal.bviColor
+                bviLowPassEnabled:  settingsModal.bviLowPassEnabled
+                bviLowPassCutoffHz: settingsModal.bviLowPassCutoffHz
+                bfiClampLow:  MOTIONInterface.appConfig.bfiClampLow  !== undefined ? MOTIONInterface.appConfig.bfiClampLow  : 0.0
+                bfiClampHigh: MOTIONInterface.appConfig.bfiClampHigh !== undefined ? MOTIONInterface.appConfig.bfiClampHigh : 10.0
+                bviClampLow:  MOTIONInterface.appConfig.bviClampLow  !== undefined ? MOTIONInterface.appConfig.bviClampLow  : 0.0
+                bviClampHigh: MOTIONInterface.appConfig.bviClampHigh !== undefined ? MOTIONInterface.appConfig.bviClampHigh : 10.0
+                autoScale:        settingsModal.autoScale
+                autoScalePerPlot: settingsModal.autoScalePerPlot
+                bfiMin:      settingsModal.bfiMin
+                bfiMax:      settingsModal.bfiMax
+                bviMin:      settingsModal.bviMin
+                bviMax:      settingsModal.bviMax
+                meanMin:     settingsModal.meanMin
+                meanMax:     settingsModal.meanMax
+                contrastMin: settingsModal.contrastMin
+                contrastMax: settingsModal.contrastMax
+                previewLeftMask:  bloodFlow.leftMask
+                previewRightMask: bloodFlow.rightMask
+            }
+        }
     }
 
     // FDA-mode data viewer — two big aggregated plots
-    ReducedPlotView {
-        id: reducedPlot
-        visible: !bloodFlow._useNewViewer && bloodFlow.reducedMode
-        windowSeconds: settingsModal.plotWindowSec
-        bfiColor: settingsModal.bfiColor
-        bviColor: settingsModal.bviColor
-        bviLowPassEnabled:  settingsModal.bviLowPassEnabled
-        bviLowPassCutoffHz: settingsModal.bviLowPassCutoffHz
-        bfiClampLow:  MOTIONInterface.appConfig.bfiClampLow  !== undefined ? MOTIONInterface.appConfig.bfiClampLow  : 0.0
-        bfiClampHigh: MOTIONInterface.appConfig.bfiClampHigh !== undefined ? MOTIONInterface.appConfig.bfiClampHigh : 10.0
-        bviClampLow:  MOTIONInterface.appConfig.bviClampLow  !== undefined ? MOTIONInterface.appConfig.bviClampLow  : 0.0
-        bviClampHigh: MOTIONInterface.appConfig.bviClampHigh !== undefined ? MOTIONInterface.appConfig.bviClampHigh : 10.0
-        autoScale: settingsModal.autoScale
-        bfiMin: settingsModal.bfiMin
-        bfiMax: settingsModal.bfiMax
-        bviMin: settingsModal.bviMin
-        bviMax: settingsModal.bviMax
+    Loader {
+        id: reducedPlotLoader
+        active: !bloodFlow._useNewViewer && bloodFlow.reducedMode
+        visible: active
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: buttonPanel.right
         anchors.right: parent.right
         anchors.margins: 8
         anchors.leftMargin: 16
+        sourceComponent: Component {
+            ReducedPlotView {
+                anchors.fill: parent
+                windowSeconds: settingsModal.plotWindowSec
+                bfiColor: settingsModal.bfiColor
+                bviColor: settingsModal.bviColor
+                bviLowPassEnabled:  settingsModal.bviLowPassEnabled
+                bviLowPassCutoffHz: settingsModal.bviLowPassCutoffHz
+                bfiClampLow:  MOTIONInterface.appConfig.bfiClampLow  !== undefined ? MOTIONInterface.appConfig.bfiClampLow  : 0.0
+                bfiClampHigh: MOTIONInterface.appConfig.bfiClampHigh !== undefined ? MOTIONInterface.appConfig.bfiClampHigh : 10.0
+                bviClampLow:  MOTIONInterface.appConfig.bviClampLow  !== undefined ? MOTIONInterface.appConfig.bviClampLow  : 0.0
+                bviClampHigh: MOTIONInterface.appConfig.bviClampHigh !== undefined ? MOTIONInterface.appConfig.bviClampHigh : 10.0
+                autoScale: settingsModal.autoScale
+                bfiMin: settingsModal.bfiMin
+                bfiMax: settingsModal.bfiMax
+                bviMin: settingsModal.bviMin
+                bviMax: settingsModal.bviMax
+            }
+        }
     }
 
     // ===== MODALS =====
@@ -448,7 +468,7 @@ Rectangle {
 
             if (err === "Canceled") {
                 scanDialog.close()
-                if (bloodFlow.reducedMode) reducedPlot.stopScan(); else embeddedPlot.stopScan()
+                if (bloodFlow.reducedMode) reducedPlotLoader.item?.stopScan(); else embeddedPlotLoader.item?.stopScan()
                 // Notes modal opens via MOTIONInterface.scanNotesReady.
                 return
             }
@@ -457,14 +477,14 @@ Rectangle {
                 scanDialog.appendLog("ERROR: " + err)
                 scanDialog.stageText = "Error during capture"
                 scanDialog.done = true
-                if (bloodFlow.reducedMode) reducedPlot.stopScan(); else embeddedPlot.stopScan()
+                if (bloodFlow.reducedMode) reducedPlotLoader.item?.stopScan(); else embeddedPlotLoader.item?.stopScan()
                 return
             }
 
             scanDialog.stageText = "Capture complete"
             scanDialog.progress = 100
             scanDialog.done = true
-            if (bloodFlow.reducedMode) reducedPlot.stopScan(); else embeddedPlot.stopScan()
+            if (bloodFlow.reducedMode) reducedPlotLoader.item?.stopScan(); else embeddedPlotLoader.item?.stopScan()
             // Notes modal opens via MOTIONInterface.scanNotesReady.
         }
     }

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -236,6 +236,13 @@ Rectangle {
     // Data viewer — fills remaining space to the right of ButtonPanel.
     // Phase 2a: useNewPlotViewer mounts the new PlotViewer via Loader when
     // true; otherwise the legacy plots below render unchanged.
+    Component {
+        id: plotViewerComponent
+        PlotViewer {
+            reducedMode: bloodFlow.reducedMode
+        }
+    }
+
     Loader {
         id: newPlotLoader
         active: bloodFlow._useNewViewer
@@ -246,9 +253,7 @@ Rectangle {
         anchors.right: parent.right
         anchors.margins: 8
         anchors.leftMargin: 16
-        sourceComponent: PlotViewer {
-            reducedMode: bloodFlow.reducedMode
-        }
+        sourceComponent: plotViewerComponent
     }
 
     EmbeddedRealtimePlot {

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -33,6 +33,11 @@ Rectangle {
     // FDA mode (read from app config). Forces Far camera pattern + free run,
     // hides scan-settings button, and swaps in the FDA plot view.
     property bool reducedMode: MOTIONInterface.appConfig.reducedMode === true
+    // Phase 2a: useNewPlotViewer flag selects between the new (foundation-only)
+    // PlotViewer and the legacy EmbeddedRealtimePlot / ReducedPlotView pair.
+    // Flag default is false (legacy renders). Flip locally via app_config.json
+    // to dev-test the new viewer.
+    readonly property bool _useNewViewer: MOTIONInterface.appConfig.useNewPlotViewer === true
     // In reduced mode, Start first runs a contact-quality preflight check.
     property bool reducedStartPending: false
     // Prevent late CQ callbacks from re-opening the modal while a stop/cancel
@@ -228,10 +233,27 @@ Rectangle {
                  settingsModal, contactQualityModal, scanDialog]
     }
 
-    // Data viewer — fills remaining space to the right of ButtonPanel
+    // Data viewer — fills remaining space to the right of ButtonPanel.
+    // Phase 2a: useNewPlotViewer mounts the new PlotViewer via Loader when
+    // true; otherwise the legacy plots below render unchanged.
+    Loader {
+        id: newPlotLoader
+        active: bloodFlow._useNewViewer
+        visible: bloodFlow._useNewViewer
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: buttonPanel.right
+        anchors.right: parent.right
+        anchors.margins: 8
+        anchors.leftMargin: 16
+        sourceComponent: PlotViewer {
+            reducedMode: bloodFlow.reducedMode
+        }
+    }
+
     EmbeddedRealtimePlot {
         id: embeddedPlot
-        visible: !bloodFlow.reducedMode
+        visible: !bloodFlow._useNewViewer && !bloodFlow.reducedMode
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: buttonPanel.right
@@ -266,7 +288,7 @@ Rectangle {
     // FDA-mode data viewer — two big aggregated plots
     ReducedPlotView {
         id: reducedPlot
-        visible: bloodFlow.reducedMode
+        visible: !bloodFlow._useNewViewer && bloodFlow.reducedMode
         windowSeconds: settingsModal.plotWindowSec
         bfiColor: settingsModal.bfiColor
         bviColor: settingsModal.bviColor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,25 @@ import psutil
 import pygetwindow as gw
 from pywinauto import Desktop as UiaDesktop
 
+
+# ─────────────────────────────────────────────
+# QCoreApplication for unit tests
+# ─────────────────────────────────────────────
+# Unit tests that exercise pyqtSignal / QObject (e.g. ScanDataSource)
+# need a QCoreApplication to exist before instantiating QObjects. HIL
+# tests get a full QApplication via the bloodflow app launch; unit
+# tests don't, so create a bare QCoreApplication once per session.
+@pytest.fixture(scope="session", autouse=True)
+def _qcoreapplication():
+    from PyQt6.QtCore import QCoreApplication
+    import sys
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QCoreApplication(sys.argv)
+    yield app
+    # Don't quit() — pytest-collected tests share this session-wide.
+
+
 # ─────────────────────────────────────────────
 # pyautogui defaults
 # ─────────────────────────────────────────────

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -345,7 +345,8 @@ class _FakeScanDatabase:
         self._conn = conn
         self._conn.row_factory = sqlite3.Row
 
-    def iter_session_data(self, session_id: int, side=None, cam_id=None):
+    def iter_session_data(self, session_id: int, side=None, cam_id=None,
+                          t_lo=None, t_hi=None):
         sql = "SELECT * FROM session_data WHERE session_id = ?"
         bindings = [session_id]
         if side is not None:
@@ -354,6 +355,12 @@ class _FakeScanDatabase:
         if cam_id is not None:
             sql += " AND cam_id = ?"
             bindings.append(cam_id)
+        if t_lo is not None:
+            sql += " AND timestamp_s >= ?"
+            bindings.append(float(t_lo))
+        if t_hi is not None:
+            sql += " AND timestamp_s <= ?"
+            bindings.append(float(t_hi))
         sql += " ORDER BY timestamp_s ASC"
         for row in self._conn.execute(sql, bindings):
             yield dict(row)
@@ -929,3 +936,79 @@ def test_dropped_at_for_finds_dropout_under_any_metric_key():
                            bfi=4.0, bvi=2.0)  # mean/contrast omitted
     src.mark_dropped(side="left", cam_id=3, t=8.0)
     assert src.dropped_at_for("left", 3) == pytest.approx(8.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LiveScanSource DB tail (Phase 3 lazy-load)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_live_scan_source_serves_in_memory_window_without_db(session_data_db):
+    """Fast path: when the requested window is within the in-memory
+    buffer, the DB tail is never consulted (even when a DB is wired)."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(10):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=i,
+                               t=10.0 + i * 0.025, bfi=5.0, bvi=6.0)
+    src._db = db            # wired but should not be hit
+    src._db_session_id = sid
+    pts = src.points_for_window("left", 0, "bfi", 10.0, 10.25, max_points=100)
+    assert len(pts) > 0
+    # All values are the in-memory 5.0, not the DB's ~1.x values.
+    assert all(abs(p[1] - 5.0) < 0.01 for p in pts)
+
+
+def test_live_scan_source_pans_into_db_tail(session_data_db):
+    """Pan-into-past: when t_lo is before the in-memory start (data
+    ring-trimmed), points_for_window serves the older range from the
+    DB tail. session_data_db has (left, 0) bfi samples at t≈0..0.1;
+    the in-memory buffer starts at t=10, so a request for [0, 0.1]
+    must come from the DB."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    # In-memory buffer simulates post-ring-trim state: starts at t=10.
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    src._db = db
+    src._db_session_id = sid
+
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
+    assert len(pts) > 0
+    # DB bfi values for (left, 0) are 1.0 + cam(0) + i*0.1 ≈ 1.0..1.4 —
+    # definitely not the in-memory 99.0.
+    assert all(p[1] < 50 for p in pts)
+
+
+def test_live_scan_source_value_at_uses_db_tail(session_data_db):
+    """value_at also falls through to the DB tail for times before the
+    in-memory window."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    src._db = db
+    src._db_session_id = sid
+
+    v = src.value_at("left", 0, "bfi", 0.0)
+    assert isfinite_or_nan(v)
+    assert v < 50  # DB value, not in-memory 99.0
+
+
+def test_live_scan_source_db_tail_disabled_without_path():
+    """No scan_db_path → DB tail permanently unavailable; pan-into-past
+    returns empty rather than erroring."""
+    src = LiveScanSource(plot_t0=0.0)  # no scan_db_path
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=5.0, bvi=6.0)
+    # Request before in-memory start — no DB, so base class returns
+    # whatever the in-memory buffer has for that window (empty).
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
+    assert pts == []
+
+
+def isfinite_or_nan(v):
+    return math.isfinite(v) or math.isnan(v)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -54,7 +54,7 @@ def test_camera_buffer_window_indices_binary_search():
     buf = _CameraBuffer(initial_capacity=64)
     for i in range(40):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
-    # Window covering t in [0.250, 0.500] should give indices [10, 20] (right-exclusive)
+    # Window covering t in [0.250, 0.500] should give indices [10, 21) (right-exclusive)
     i_lo, i_hi = buf.window_indices(0.250, 0.500)
     assert i_lo == 10
     assert i_hi == 21  # searchsorted right-side gives one past the last match

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -661,3 +661,86 @@ def test_scan_data_source_points_for_window_decimates_when_over_max():
     assert pts[0] == pytest.approx([0.0, 0.0])
     # Subsequent pairs at stride=4
     assert pts[1] == pytest.approx([0.1, 4.0])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource.compute_bounds_for_metric (Phase 2b-i autoscale)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_compute_bounds_neutral_fallback_when_no_buffers():
+    src = ScanDataSource(plot_t0=0.0)
+    b = src.compute_bounds_for_metric("bfi")
+    assert b == {"yMin": 0.0, "yMax": 1.0}
+
+
+def test_compute_bounds_neutral_fallback_when_under_4_samples():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    for i in range(3):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    b = src.compute_bounds_for_metric("bfi")
+    assert b == {"yMin": 0.0, "yMax": 1.0}
+
+
+def test_compute_bounds_pads_by_25_percent_each_side():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    # Values 0..99 — percentile 2 = ~2, percentile 98 = ~97. Pad = 0.25 * (97 - 2) = 23.75
+    for i in range(100):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    b = src.compute_bounds_for_metric("bfi", percentile_lo=2.0, percentile_hi=98.0, pad_frac=0.25)
+    # Approx: yMin ≈ 2 - 23.75 = -21.75; yMax ≈ 97 + 23.75 = 120.75
+    assert b["yMin"] == pytest.approx(-21.75, abs=1.0)
+    assert b["yMax"] == pytest.approx(120.75, abs=1.0)
+
+
+def test_compute_bounds_aggregates_across_cameras():
+    src = ScanDataSource(plot_t0=0.0)
+    # cam 0 covers 0..49, cam 1 covers 50..99
+    buf0 = src.get_or_create_buffer("left", 0, "bvi")
+    buf1 = src.get_or_create_buffer("left", 1, "bvi")
+    for i in range(50):
+        buf0.append(t=i * 0.025, v=float(i), frame_id=i)
+    for i in range(50):
+        buf1.append(t=i * 0.025, v=50.0 + i, frame_id=100 + i)
+    b = src.compute_bounds_for_metric("bvi")
+    # Aggregated range is 0..99 ; percentile bounds + padding
+    assert b["yMin"] < 0
+    assert b["yMax"] > 100
+
+
+def test_compute_bounds_ignores_other_metrics():
+    src = ScanDataSource(plot_t0=0.0)
+    bfi_buf = src.get_or_create_buffer("left", 0, "bfi")
+    bvi_buf = src.get_or_create_buffer("left", 0, "bvi")
+    for i in range(10):
+        bfi_buf.append(t=i * 0.025, v=float(i), frame_id=i)
+        bvi_buf.append(t=i * 0.025, v=float(i) * 100.0, frame_id=i)
+    b = src.compute_bounds_for_metric("bfi")
+    # Should only consider bfi samples (0..9), not bvi (0..900)
+    assert b["yMax"] < 50  # bvi would give yMax > 1000
+
+
+def test_compute_bounds_skips_non_finite():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    for i in range(10):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    buf.append(t=0.25, v=float("nan"), frame_id=10)
+    buf.append(t=0.275, v=float("inf"), frame_id=11)
+    # Should not crash and should produce finite bounds
+    b = src.compute_bounds_for_metric("bfi")
+    assert math.isfinite(b["yMin"])
+    assert math.isfinite(b["yMax"])
+
+
+def test_compute_bounds_expands_when_lo_equals_hi():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    for i in range(10):
+        buf.append(t=i * 0.025, v=5.0, frame_id=i)  # all the same value
+    b = src.compute_bounds_for_metric("bfi", pad_frac=0.0)
+    # When lo == hi, expand by ±0.5; with pad_frac=0 the result is [4.5, 5.5]
+    assert b["yMin"] == pytest.approx(4.5)
+    assert b["yMax"] == pytest.approx(5.5)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -621,3 +621,43 @@ def test_camera_buffer_window_decimated_partial_window():
     t_dec, v_dec = buf.window_decimated(t_lo=0.250, t_hi=0.500, max_points=100)
     assert len(t_dec) == 11  # indices 10..20 inclusive
     assert list(v_dec) == [np.float32(i) for i in range(10, 21)]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource.points_for_window (Phase 2a)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scan_data_source_points_for_window_returns_pairs():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    for i in range(10):
+        buf.append(t=i * 0.025, v=4.0 + i * 0.1, frame_id=i)
+
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 0.25, max_points=100)
+
+    # Window covers indices 0..10 (right-exclusive), so 10 pairs
+    assert len(pts) == 10
+    assert pts[0] == pytest.approx([0.0, 4.0])
+    assert pts[-1] == pytest.approx([0.225, 4.9])
+
+
+def test_scan_data_source_points_for_window_missing_buffer_returns_empty():
+    src = ScanDataSource(plot_t0=0.0)
+    pts = src.points_for_window("left", 7, "bvi", 0.0, 1.0, max_points=100)
+    assert pts == []
+
+
+def test_scan_data_source_points_for_window_decimates_when_over_max():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("right", 3, "mean")
+    for i in range(200):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+
+    pts = src.points_for_window("right", 3, "mean", 0.0, 5.0, max_points=50)
+    # 200 samples, max=50 → stride=4 → 50 pairs
+    assert len(pts) == 50
+    # First pair is the first sample
+    assert pts[0] == pytest.approx([0.0, 0.0])
+    # Subsequent pairs at stride=4
+    assert pts[1] == pytest.approx([0.1, 4.0])

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -56,6 +56,23 @@ def test_camera_buffer_small_max_capacity_ring_trims():
     assert float(buf.t[buf.n - 1]) == 10.0
 
 
+def test_camera_buffer_unbounded_never_ring_trims():
+    """max_capacity=None (past / DB-window buffers) grows without bound and
+    never ring-trims — it must keep every row it bulk-loads. Append well past
+    what would be the default cap had it been finite, and assert nothing is
+    dropped."""
+    buf = _CameraBuffer(initial_capacity=4, max_capacity=None)
+    n = 5000
+    for i in range(n):
+        buf.append(t=float(i), v=float(i), frame_id=i)
+    assert buf.n == n
+    assert not buf.ring_trimmed
+    # First and last rows both survive — no oldest-half drop occurred.
+    assert float(buf.t[0]) == 0.0
+    assert float(buf.t[buf.n - 1]) == float(n - 1)
+    assert buf.t.shape[0] >= n
+
+
 def test_camera_buffer_doubles_capacity_on_overflow():
     buf = _CameraBuffer(initial_capacity=2)
     for i in range(5):
@@ -430,18 +447,25 @@ def test_past_scan_source_bucketizes_rows_into_per_metric_buffers(session_data_d
     db, sid = session_data_db
     src = PastScanSource(scan_db=db, session_id=sid)
 
-    # 4 (side, cam) combos × 4 metrics = 16 buffers expected
+    # 4 (side, cam) combos × 4 metrics = 16 per-cam buffers, plus the
+    # derived reduced-mode side averages (cam_id=-1) for bfi/bvi on each side.
     expected_keys = {
         (side, cam, metric)
         for side in ("left", "right")
         for cam in (0, 3)
         for metric in ("bfi", "bvi", "mean", "contrast")
     }
+    expected_keys |= {
+        (side, -1, metric)
+        for side in ("left", "right")
+        for metric in ("bfi", "bvi")
+    }
     assert set(src.buffers.keys()) == expected_keys
 
-    # Each buffer holds the 5 rows for its (side, cam)
+    # Per-cam buffers hold their 5 rows; the merged side averages hold
+    # both cams' rows (2 cams × 5 = 10).
     for key, buf in src.buffers.items():
-        assert buf.n == 5
+        assert buf.n == (10 if key[1] == -1 else 5)
 
 
 def test_past_scan_source_normalizes_side_integer_to_string(session_data_db):
@@ -476,6 +500,68 @@ def test_past_scan_source_empty_session_yields_empty_source(tmp_path):
     src = PastScanSource(scan_db=db, session_id=42)
     assert src.buffers == {}
     assert src.liveEdge == 0.0
+
+
+def test_past_scan_source_derives_reduced_side_averages(session_data_db):
+    """DB-backed scans store per-cam BFI/BVI but no cam_id=-1 side average.
+    PastScanSource must derive cam_id=-1 by merging the per-cam buffers for
+    a side, time-ordered, so reduced-mode replay isn't empty."""
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+
+    for side in ("left", "right"):
+        for metric in ("bfi", "bvi"):
+            buf = src.buffers.get((side, -1, metric))
+            assert buf is not None, f"missing derived ({side}, -1, {metric})"
+            assert buf.n == 10  # cam 0 + cam 3, 5 samples each
+            ts = buf.t[: buf.n]
+            assert np.all(np.diff(ts) >= 0), "merged side buffer must be time-sorted"
+
+    # The merged left/bfi buffer carries BOTH cameras' values. At t=0:
+    # cam0 bfi = 1.0, cam3 bfi = 4.0 (1.0 + cam_id).
+    left_bfi = src.buffers[("left", -1, "bfi")]
+    n = left_bfi.n
+    at_t0 = left_bfi.v[:n][np.isclose(left_bfi.t[:n], 0.0)]
+    assert set(round(float(v), 3) for v in at_t0) == {1.0, 4.0}
+
+    # mean/contrast are NOT derived as side averages — only the reduced
+    # metrics (bfi/bvi) the reduced cells plot.
+    assert ("left", -1, "mean") not in src.buffers
+    assert ("left", -1, "contrast") not in src.buffers
+
+
+def test_past_scan_source_buffers_are_unbounded(session_data_db):
+    """Buffers a past scan creates (DB per-cam, derived side averages, and
+    CSV-loaded) must be unbounded so a long bulk load never ring-trims away
+    its own oldest rows."""
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+    for buf in src.buffers.values():
+        assert buf._max_capacity is None
+
+
+def test_past_scan_source_does_not_clobber_reduced_csv_side_average(tmp_path):
+    """If a reduced-mode CSV already populated cam_id=-1 buffers, the
+    derivation must leave them untouched (don't overwrite real recorded
+    side data with a merge of nonexistent per-cam buffers)."""
+    db_path = tmp_path / "scan.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SESSION_DATA_DDL)
+    conn.commit()
+    db = _FakeScanDatabase(conn)  # empty DB → triggers CSV fallback
+
+    csv_path = tmp_path / "reduced.csv"
+    csv_path.write_text(
+        "frame_id,timestamp_s,bfi_left,bfi_right,bvi_left,bvi_right\n"
+        "0,0.0,2.5,3.5,12.0,13.0\n"
+        "1,0.025,2.6,3.6,12.1,13.1\n",
+        encoding="utf-8",
+    )
+    src = PastScanSource(scan_db=db, session_id=1, corrected_csv_path=str(csv_path))
+
+    left_bfi = src.buffers[("left", -1, "bfi")]
+    assert left_bfi.n == 2  # the 2 CSV rows, not a merge
+    assert float(left_bfi.v[0]) == pytest.approx(2.5)
 
 
 def test_past_scan_source_skips_null_metric_values(tmp_path):

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -602,41 +602,38 @@ def test_camera_buffer_window_decimated_strides_when_over_max():
     buf = _CameraBuffer(initial_capacity=1024)
     for i in range(400):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
-    # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4.
-    # Overlap-smoothing with kernel width stride*3 = 12 → half = 6 → each
-    # output is the mean of 2*half+1 = 13 samples centred on the index.
-    # Linspace puts outputs at indices [0, 4, 8, 12, 16, ...]. Edge bins
-    # at low indices average fewer samples (clipped at 0).
+    # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4,
+    # window = stride*3 = 12. Stride-aligned abs idxs [0, 4, 8, 12, 16, ...].
+    # Causal window per output: [abs_idx - window + 1, abs_idx], clipped at 0.
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=100)
     assert len(t_dec) == 100
-    # idx=0:  samples [0..6]    → mean 21/7   = 3.0
-    # idx=4:  samples [0..10]   → mean 55/11  = 5.0
-    # idx=8:  samples [2..14]   → mean 104/13 = 8.0
-    # idx=12: samples [6..18]   → mean 156/13 = 12.0
-    # idx=16: samples [10..22]  → mean 208/13 = 16.0
+    # abs=0:  window [0..0]   → mean 0/1   = 0.0
+    # abs=4:  window [0..4]   → mean 10/5  = 2.0
+    # abs=8:  window [0..8]   → mean 36/9  = 4.0
+    # abs=12: window [1..12]  → mean 78/12 = 6.5
+    # abs=16: window [5..16]  → mean 126/12 = 10.5
     assert list(v_dec[:5]) == [
-        np.float32(3.0), np.float32(5.0), np.float32(8.0),
-        np.float32(12.0), np.float32(16.0),
+        np.float32(0.0), np.float32(2.0), np.float32(4.0),
+        np.float32(6.5), np.float32(10.5),
     ]
 
 
 def test_camera_buffer_window_decimated_smoothing_kills_alternation():
     """At stride=2 a plain subsample alternates between odd-index and
     even-index samples as the window scrolls, producing per-paint
-    flicker on noisy data. Overlap-smoothing (kernel wider than stride)
-    pulls each output toward the local mean so alternation can't
-    surface."""
+    flicker on noisy data. Causal smoothing pulls each output toward
+    the local mean so alternation can't surface."""
     buf = _CameraBuffer(initial_capacity=1024)
     # Strong noise pattern: alternating 0 and 10.
     for i in range(400):
         buf.append(t=i * 0.025, v=10.0 if (i % 2) else 0.0, frame_id=i)
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=200)
     assert len(t_dec) == 200
-    # Each output averages a 7-sample window (stride=2 → kernel=6 → 13
-    # samples centred). On alternating 0/10 the per-output mean is
-    # always within (4.0, 6.0) — pulled tight around the true mean 5.
-    for v in v_dec:
-        assert 4.0 < float(v) < 6.0
+    # Stride=2 → kernel=6. Once the causal window has fully filled
+    # (abs_idx >= 5 → 3 outputs in) each 6-sample window over alternating
+    # 0/10 contains exactly 3 zeros + 3 tens → mean = 5.0 EXACTLY.
+    for v in v_dec[3:]:
+        assert v == np.float32(5.0)
 
 
 def test_camera_buffer_window_decimated_empty_window_returns_empty_arrays():
@@ -698,14 +695,13 @@ def test_scan_data_source_points_for_window_decimates_when_over_max():
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
 
     pts = src.points_for_window("right", 3, "mean", 0.0, 5.0, max_points=50)
-    # 200 samples, max=50 → stride=4. Overlap-smoothed: each output's v
-    # is the mean of a 13-sample window centred on a linspace index; t
-    # is the actual sample t at the centre.
+    # 200 samples, max=50 → stride=4, window=12. Stride-aligned abs
+    # idxs [0, 4, 8, ...]. Causal window per output (clipped at 0).
     assert len(pts) == 50
-    # idx=0: window [0..6] (edge-clipped), mean = 21/7 = 3.0, t = 0.0
-    assert pts[0] == pytest.approx([0.0, 3.0])
-    # idx=4: window [0..10], mean = 55/11 = 5.0, t = 0.1
-    assert pts[1] == pytest.approx([0.1, 5.0])
+    # abs=0: window [0..0], mean = 0/1 = 0.0, t = 0.0
+    assert pts[0] == pytest.approx([0.0, 0.0])
+    # abs=4: window [0..4], mean = 10/5 = 2.0, t = 0.1
+    assert pts[1] == pytest.approx([0.1, 2.0])
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1198,6 +1198,54 @@ def test_live_scan_source_db_ready_resolve_path_no_nameerror(tmp_path):
     assert src._db_session_id == sid
 
 
+def test_live_scan_source_resolves_session_by_label_not_newest(tmp_path):
+    """With a scan label bound, the DB tail resolves THIS scan's session row
+    by exact label — even when a NEWER (other) session exists. MAX(id) alone
+    would wrongly pick the newer one."""
+    from omotion.ScanDatabase import ScanDatabase
+    import time as _t
+    db_path = str(tmp_path / "scan.db")
+    db = ScanDatabase(db_path=db_path)
+    mine = db.create_session(session_label="20260101_000000_subjA",
+                             session_start=_t.time(), session_notes=None,
+                             session_meta={})
+    # A newer, unrelated session (higher id, later start).
+    db.create_session(session_label="20260101_000500_subjB",
+                      session_start=_t.time() + 5, session_notes=None,
+                      session_meta={})
+    db.close()
+
+    src = LiveScanSource(plot_t0=0.0, scan_db_path=db_path)
+    src.set_scan_label("20260101_000000_subjA")
+    assert src._db_ready() is True
+    assert src._db_session_id == mine  # the labelled one, not the newest
+
+
+def test_live_scan_source_soft_retry_when_session_not_yet_present(tmp_path):
+    """A not-yet-visible session row is a SOFT miss: _db_ready returns False
+    without permanently disabling the tail, and a later call (once the row
+    exists) succeeds. Guards against the old one-failure permanent disable."""
+    from omotion.ScanDatabase import ScanDatabase
+    import time as _t
+    db_path = str(tmp_path / "scan.db")
+    ScanDatabase(db_path=db_path).close()  # create schema, no sessions yet
+
+    src = LiveScanSource(plot_t0=0.0, scan_db_path=db_path)
+    src.set_scan_label("20260101_000000_subjA")
+    assert src._db_ready() is False          # session row not there yet
+    assert src._db_unavailable is False      # NOT permanently disabled
+
+    # The session appears (as it would at scan start).
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label="20260101_000000_subjA",
+                            session_start=_t.time(), session_notes=None,
+                            session_meta={})
+    db.close()
+
+    assert src._db_ready() is True           # retry now resolves it
+    assert src._db_session_id == sid
+
+
 def test_live_scan_source_db_tail_disabled_without_path():
     """No scan_db_path → DB tail permanently unavailable; pan-into-past
     returns empty rather than erroring."""

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -68,7 +68,8 @@ def test_camera_buffer_window_indices_empty_buffer():
 
 
 def test_camera_buffer_apply_corrected_overwrites_in_place():
-    buf = _CameraBuffer(initial_capacity=8)
+    # apply_corrected requires the frame-id index, which is opt-in.
+    buf = _CameraBuffer(initial_capacity=8, track_frame_ids=True)
     buf.append(t=0.0, v=1.0, frame_id=100)
     buf.append(t=0.025, v=2.0, frame_id=101)
     buf.append(t=0.050, v=3.0, frame_id=102)
@@ -81,7 +82,7 @@ def test_camera_buffer_apply_corrected_overwrites_in_place():
 
 
 def test_camera_buffer_apply_corrected_unknown_frame_is_noop():
-    buf = _CameraBuffer(initial_capacity=8)
+    buf = _CameraBuffer(initial_capacity=8, track_frame_ids=True)
     buf.append(t=0.0, v=1.0, frame_id=100)
     # frame_id 999 was never appended — must not raise, must not corrupt state
     buf.apply_corrected(frame_id=999, value=42.0)
@@ -92,12 +93,21 @@ def test_camera_buffer_apply_corrected_unknown_frame_is_noop():
 def test_camera_buffer_apply_corrected_skips_sentinel_frame_id():
     """frame_id=-1 means 'unknown'; we don't index it, so apply_corrected(-1, ...)
     must not silently overwrite the most-recent -1 sample."""
-    buf = _CameraBuffer(initial_capacity=8)
+    buf = _CameraBuffer(initial_capacity=8, track_frame_ids=True)
     buf.append(t=0.0, v=1.0, frame_id=-1)
     buf.append(t=0.025, v=2.0, frame_id=-1)
     buf.apply_corrected(frame_id=-1, value=99.9)
     assert buf.v[0] == np.float32(1.0)
     assert buf.v[1] == np.float32(2.0)
+
+
+def test_camera_buffer_apply_corrected_noop_without_tracking():
+    """Default is track_frame_ids=False — apply_corrected is a silent
+    no-op even for valid frame_ids."""
+    buf = _CameraBuffer(initial_capacity=8)  # default: no tracking
+    buf.append(t=0.0, v=1.0, frame_id=100)
+    buf.apply_corrected(frame_id=100, value=99.9)
+    assert buf.v[0] == np.float32(1.0)  # unchanged
 
 
 def test_camera_buffer_mark_dropped_sets_timestamp_once():
@@ -243,7 +253,9 @@ def test_live_scan_source_append_uncorrected_notes_dirty():
 
 
 def test_live_scan_source_apply_corrected_batch_overwrites_in_place():
-    src = LiveScanSource(plot_t0=0.0)
+    # apply_corrected_batch is currently no-op in production; opt-in via
+    # the constructor flag exercises the original overwrite semantics.
+    src = LiveScanSource(plot_t0=0.0, track_frame_ids=True)
     # Seed live samples for frame_ids 100, 101, 102.
     for i, fid in enumerate((100, 101, 102)):
         src.append_uncorrected(

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -569,3 +569,55 @@ def test_live_scan_source_mark_dropped_multiple_metric_buffers():
     for metric in ("bfi", "bvi", "contrast"):
         assert src.buffers[("left", 2, metric)].dropped_at == 2.7
     assert ("left", 2, "mean") not in src.buffers
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _CameraBuffer.window_decimated (Phase 2a)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_camera_buffer_window_decimated_returns_unstrided_when_under_max():
+    buf = _CameraBuffer(initial_capacity=64)
+    for i in range(20):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=0.5, max_points=100)
+    # 20 samples in window, max_points=100 → no decimation
+    assert len(t_dec) == 20
+    assert list(v_dec) == [np.float32(i) for i in range(20)]
+
+
+def test_camera_buffer_window_decimated_strides_when_over_max():
+    buf = _CameraBuffer(initial_capacity=1024)
+    for i in range(400):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4
+    t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=100)
+    assert len(t_dec) == 100
+    assert list(v_dec[:5]) == [np.float32(0), np.float32(4), np.float32(8), np.float32(12), np.float32(16)]
+
+
+def test_camera_buffer_window_decimated_empty_window_returns_empty_arrays():
+    buf = _CameraBuffer(initial_capacity=64)
+    for i in range(10):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    # Window after the last sample
+    t_dec, v_dec = buf.window_decimated(t_lo=10.0, t_hi=11.0, max_points=100)
+    assert len(t_dec) == 0
+    assert len(v_dec) == 0
+
+
+def test_camera_buffer_window_decimated_empty_buffer_returns_empty_arrays():
+    buf = _CameraBuffer(initial_capacity=8)
+    t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=1.0, max_points=50)
+    assert len(t_dec) == 0
+    assert len(v_dec) == 0
+
+
+def test_camera_buffer_window_decimated_partial_window():
+    buf = _CameraBuffer(initial_capacity=64)
+    for i in range(40):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    # Window covers indices [10, 21) per the existing window_indices test.
+    t_dec, v_dec = buf.window_decimated(t_lo=0.250, t_hi=0.500, max_points=100)
+    assert len(t_dec) == 11  # indices 10..20 inclusive
+    assert list(v_dec) == [np.float32(i) for i in range(10, 21)]

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1049,6 +1049,27 @@ def test_live_scan_source_value_at_uses_db_tail(session_data_db):
     assert v < 50  # DB value, not in-memory 99.0
 
 
+def test_live_scan_source_db_ready_resolve_path_no_nameerror(tmp_path):
+    """Regression: _db_ready's resolve path called a module-level
+    `logger` that wasn't defined → NameError crash the first time the
+    DB tail actually engaged (only after ring-trim, so it slipped past
+    the tests that injected _db/_db_session_id directly). Exercise the
+    REAL resolve path against a temp DB with a session row."""
+    from omotion.ScanDatabase import ScanDatabase
+    import time as _t
+    db_path = str(tmp_path / "scan.db")
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label="regress", session_start=_t.time(),
+                            session_notes=None, session_meta={})
+    db.close()
+
+    src = LiveScanSource(plot_t0=0.0, scan_db_path=db_path)
+    # Opens the DB, resolves session via MAX(id), hits the logger.info
+    # line that used to NameError. Must return True without raising.
+    assert src._db_ready() is True
+    assert src._db_session_id == sid
+
+
 def test_live_scan_source_db_tail_disabled_without_path():
     """No scan_db_path → DB tail permanently unavailable; pan-into-past
     returns empty rather than erroring."""

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -464,3 +464,73 @@ def test_past_scan_source_skips_null_metric_values(tmp_path):
     assert ("left", 0, "bvi") not in src.buffers
     assert ("left", 0, "mean") not in src.buffers
     assert ("left", 0, "contrast") not in src.buffers
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# currentScanSource holder pattern — verified via a parallel mini-class
+# (MOTIONConnector uses the same pattern; see motion_connector.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+from PyQt6.QtCore import QObject, pyqtSignal
+from data_sources import LiveScanSource, ScanDataSource
+
+
+def _make_holder():
+    """Returns a fresh QObject with the same currentScanSource surface as
+    MOTIONConnector. Kept in-test rather than exported so production code
+    doesn't grow a separate abstraction layer just for testability."""
+
+    class _ScanSourceHolder(QObject):
+        currentScanSourceChanged = pyqtSignal()
+
+        def __init__(self):
+            super().__init__()
+            self._current_scan_source: ScanDataSource | None = None
+
+        @property
+        def currentScanSource(self):
+            return self._current_scan_source
+
+        def _set_current_scan_source(self, source):
+            if source is self._current_scan_source:
+                return
+            self._current_scan_source = source
+            self.currentScanSourceChanged.emit()
+
+    return _ScanSourceHolder()
+
+
+def test_current_scan_source_default_is_none():
+    holder = _make_holder()
+    assert holder.currentScanSource is None
+
+
+def test_set_current_scan_source_emits_notify():
+    holder = _make_holder()
+    received: list = []
+    holder.currentScanSourceChanged.connect(
+        lambda: received.append(holder.currentScanSource)
+    )
+
+    src1 = LiveScanSource(plot_t0=0.0)
+    holder._set_current_scan_source(src1)
+    assert holder.currentScanSource is src1
+    assert received == [src1]
+
+    src2 = LiveScanSource(plot_t0=10.0)
+    holder._set_current_scan_source(src2)
+    assert holder.currentScanSource is src2
+    assert received == [src1, src2]
+
+
+def test_set_current_scan_source_dedupes_same_instance():
+    holder = _make_holder()
+    src = LiveScanSource(plot_t0=0.0)
+    received: list = []
+    holder.currentScanSourceChanged.connect(
+        lambda: received.append(holder.currentScanSource)
+    )
+
+    holder._set_current_scan_source(src)
+    holder._set_current_scan_source(src)  # no-op — same instance
+    assert received == [src]

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -904,6 +904,36 @@ def test_dropped_at_for_returns_nan_when_buffer_missing():
     assert math.isnan(src.dropped_at_for("left", 7))
 
 
+def test_window_decimated_stride_stable_as_buffer_grows():
+    """Regression: when zoomed out, the visible window's time extent
+    is constant but n_window grows by 1 each new sample. The old
+    n_window-keyed stride crept up (e.g. ceil(800/200)=4 → ceil(801/200)=5
+    on the 801st sample), relocating every output to a new absolute
+    index with a new causal window — visible as the trace shape
+    'morphing' every few frames. The fix keys stride on (t_hi - t_lo)
+    so it's invariant under sample growth at fixed zoom."""
+    buf = _CameraBuffer(initial_capacity=2048)
+    for i in range(800):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)  # 20 s of data
+
+    # Decimate a window that fully contains the data. Use a wide
+    # window (60 s) so the visible time range exceeds the data extent
+    # — matches the user-reported "zoom all the way out" scenario.
+    t_a, v_a = buf.window_decimated(-40.0, 20.0, max_points=200)
+
+    # Add one more sample (followLive advancing by one frame).
+    buf.append(t=20.0, v=800.0, frame_id=800)
+
+    # Re-decimate with the SAME window. The outputs that were already
+    # painted should not change — adding a sample at the right edge
+    # must not alter the decimation of the earlier samples.
+    t_b, v_b = buf.window_decimated(-40.0, 20.0, max_points=200)
+    n_shared = min(len(t_a), len(t_b))
+    assert n_shared > 0
+    np.testing.assert_array_equal(t_a[:n_shared], t_b[:n_shared])
+    np.testing.assert_array_equal(v_a[:n_shared], v_b[:n_shared])
+
+
 def test_dropped_at_for_finds_dropout_under_any_metric_key():
     """dropped_at_for walks all 4 metric buffers for (side, cam) and
     returns the first dropout it finds — so the marker still surfaces

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -107,3 +107,59 @@ def test_camera_buffer_mark_dropped_sets_timestamp_once():
     # Idempotent — second call doesn't overwrite the first dropout time
     buf.mark_dropped(t=2.7)
     assert buf.dropped_at == 1.5
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource (base)
+# ─────────────────────────────────────────────────────────────────────────────
+
+from data_sources import ScanDataSource
+
+
+def test_scan_data_source_starts_with_no_buffers():
+    src = ScanDataSource(plot_t0=100.0)
+    assert src.live is False  # base class default; LiveScanSource overrides
+    assert src.liveEdge == 0.0
+    assert src.plot_t0 == 100.0
+    assert src.buffers == {}
+
+
+def test_scan_data_source_get_or_create_buffer_returns_same_instance():
+    src = ScanDataSource(plot_t0=0.0)
+    b1 = src.get_or_create_buffer("left", 0, "bfi")
+    b2 = src.get_or_create_buffer("left", 0, "bfi")
+    assert b1 is b2
+
+
+def test_scan_data_source_live_edge_tracks_max_timestamp():
+    src = ScanDataSource(plot_t0=0.0)
+    b = src.get_or_create_buffer("left", 0, "bfi")
+    b.append(t=0.5, v=1.0, frame_id=1)
+    b.append(t=1.25, v=2.0, frame_id=2)
+    b2 = src.get_or_create_buffer("right", 3, "bvi")
+    b2.append(t=0.75, v=3.0, frame_id=3)
+    assert src.liveEdge == 1.25
+
+
+def test_scan_data_source_samples_appended_emits_after_flush():
+    src = ScanDataSource(plot_t0=0.0)
+    received: list = []
+    src.samplesAppended.connect(lambda s, c, m, n: received.append((s, c, m, n)))
+
+    src.note_dirty("left", 0, "bfi", added=3)
+    src.note_dirty("left", 0, "bfi", added=2)  # coalesces
+    src.note_dirty("right", 4, "bvi", added=1)
+    assert received == []  # not yet flushed
+
+    src._flush()
+    assert sorted(received) == [("left", 0, "bfi", 5), ("right", 4, "bvi", 1)]
+
+
+def test_scan_data_source_flush_clears_pending():
+    src = ScanDataSource(plot_t0=0.0)
+    received: list = []
+    src.samplesAppended.connect(lambda s, c, m, n: received.append((s, c, m, n)))
+    src.note_dirty("left", 0, "bfi", added=1)
+    src._flush()
+    src._flush()  # nothing pending now
+    assert received == [("left", 0, "bfi", 1)]

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -447,25 +447,18 @@ def test_past_scan_source_bucketizes_rows_into_per_metric_buffers(session_data_d
     db, sid = session_data_db
     src = PastScanSource(scan_db=db, session_id=sid)
 
-    # 4 (side, cam) combos × 4 metrics = 16 per-cam buffers, plus the
-    # derived reduced-mode side averages (cam_id=-1) for bfi/bvi on each side.
+    # This fixture is a normal-mode scan: 4 (side, cam) combos × 4 metrics =
+    # 16 per-cam buffers, each holding its 5 rows. No cam_id=-1 (that's the
+    # reduced-mode side average, read straight from the DB when present).
     expected_keys = {
         (side, cam, metric)
         for side in ("left", "right")
         for cam in (0, 3)
         for metric in ("bfi", "bvi", "mean", "contrast")
     }
-    expected_keys |= {
-        (side, -1, metric)
-        for side in ("left", "right")
-        for metric in ("bfi", "bvi")
-    }
     assert set(src.buffers.keys()) == expected_keys
-
-    # Per-cam buffers hold their 5 rows; the merged side averages hold
-    # both cams' rows (2 cams × 5 = 10).
-    for key, buf in src.buffers.items():
-        assert buf.n == (10 if key[1] == -1 else 5)
+    for buf in src.buffers.values():
+        assert buf.n == 5
 
 
 def test_past_scan_source_normalizes_side_integer_to_string(session_data_db):
@@ -502,53 +495,56 @@ def test_past_scan_source_empty_session_yields_empty_source(tmp_path):
     assert src.liveEdge == 0.0
 
 
-def test_past_scan_source_derives_reduced_side_averages(session_data_db):
-    """DB-backed scans store per-cam BFI/BVI but no cam_id=-1 side average.
-    PastScanSource must derive cam_id=-1 by merging the per-cam buffers for
-    a side, time-ordered, so reduced-mode replay isn't empty."""
-    db, sid = session_data_db
-    src = PastScanSource(scan_db=db, session_id=sid)
+def test_past_scan_source_reads_cam_id_minus_1_from_db(tmp_path):
+    """A reduced-mode scan stores the corrected per-side average at cam_id=-1
+    (ScanDBSink's 'final_side' path). PastScanSource exposes those directly —
+    no derivation — so reduced-mode replay reads the corrected trace verbatim."""
+    db_path = tmp_path / "scan.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SESSION_DATA_DDL)
+    rows = []
+    for i in range(3):
+        for side in (0, 1):
+            rows.append((9, None, -1, side, 1000 + i, i * 0.025,
+                         2.0 + side + i * 0.1,    # bfi
+                         5.0 + side + i * 0.1,    # bvi
+                         0.3, 100.0))
+    conn.executemany(
+        "INSERT INTO session_data "
+        "(session_id, session_raw_id, cam_id, side, frame_id, timestamp_s, "
+        " bfi, bvi, contrast, mean) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    db = _FakeScanDatabase(conn)
 
-    for side in ("left", "right"):
-        for metric in ("bfi", "bvi"):
-            buf = src.buffers.get((side, -1, metric))
-            assert buf is not None, f"missing derived ({side}, -1, {metric})"
-            assert buf.n == 10  # cam 0 + cam 3, 5 samples each
-            ts = buf.t[: buf.n]
-            assert np.all(np.diff(ts) >= 0), "merged side buffer must be time-sorted"
-
-    # The merged left/bfi buffer carries BOTH cameras' values. At t=0:
-    # cam0 bfi = 1.0, cam3 bfi = 4.0 (1.0 + cam_id).
+    src = PastScanSource(scan_db=db, session_id=9)
+    # Only cam_id=-1 buffers (reduced-mode scan persists average only).
+    assert all(cam == -1 for (_s, cam, _m) in src.buffers.keys())
     left_bfi = src.buffers[("left", -1, "bfi")]
-    n = left_bfi.n
-    at_t0 = left_bfi.v[:n][np.isclose(left_bfi.t[:n], 0.0)]
-    assert set(round(float(v), 3) for v in at_t0) == {1.0, 4.0}
-
-    # mean/contrast are NOT derived as side averages — only the reduced
-    # metrics (bfi/bvi) the reduced cells plot.
-    assert ("left", -1, "mean") not in src.buffers
-    assert ("left", -1, "contrast") not in src.buffers
+    assert left_bfi.n == 3
+    assert float(left_bfi.v[0]) == pytest.approx(2.0)   # side 0, i 0
+    right_bvi = src.buffers[("right", -1, "bvi")]
+    assert float(right_bvi.v[0]) == pytest.approx(6.0)  # side 1, i 0
 
 
 def test_past_scan_source_buffers_are_unbounded(session_data_db):
-    """Buffers a past scan creates (DB per-cam, derived side averages, and
-    CSV-loaded) must be unbounded so a long bulk load never ring-trims away
-    its own oldest rows."""
+    """Buffers a past scan creates must be unbounded so a long bulk load never
+    ring-trims away its own oldest rows."""
     db, sid = session_data_db
     src = PastScanSource(scan_db=db, session_id=sid)
     for buf in src.buffers.values():
         assert buf._max_capacity is None
 
 
-def test_past_scan_source_does_not_clobber_reduced_csv_side_average(tmp_path):
-    """If a reduced-mode CSV already populated cam_id=-1 buffers, the
-    derivation must leave them untouched (don't overwrite real recorded
-    side data with a merge of nonexistent per-cam buffers)."""
+def test_past_scan_source_csv_fallback_when_db_has_no_bfi(tmp_path):
+    """A pre-pipeline scan with no BFI/BVI in the DB falls back to the reduced
+    corrected CSV, which populates the cam_id=-1 side buffers."""
     db_path = tmp_path / "scan.db"
     conn = sqlite3.connect(str(db_path))
     conn.executescript(_SESSION_DATA_DDL)
     conn.commit()
-    db = _FakeScanDatabase(conn)  # empty DB → triggers CSV fallback
+    db = _FakeScanDatabase(conn)  # empty DB → no BFI → CSV fallback
 
     csv_path = tmp_path / "reduced.csv"
     csv_path.write_text(
@@ -560,7 +556,7 @@ def test_past_scan_source_does_not_clobber_reduced_csv_side_average(tmp_path):
     src = PastScanSource(scan_db=db, session_id=1, corrected_csv_path=str(csv_path))
 
     left_bfi = src.buffers[("left", -1, "bfi")]
-    assert left_bfi.n == 2  # the 2 CSV rows, not a merge
+    assert left_bfi.n == 2
     assert float(left_bfi.v[0]) == pytest.approx(2.5)
 
 

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -590,10 +590,31 @@ def test_camera_buffer_window_decimated_strides_when_over_max():
     buf = _CameraBuffer(initial_capacity=1024)
     for i in range(400):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
-    # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4
+    # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4.
+    # Mean-binned: each output value = mean of `stride` adjacent samples.
+    # Bin 0 averages [0,1,2,3] → 1.5; bin 1 averages [4,5,6,7] → 5.5; etc.
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=100)
     assert len(t_dec) == 100
-    assert list(v_dec[:5]) == [np.float32(0), np.float32(4), np.float32(8), np.float32(12), np.float32(16)]
+    assert list(v_dec[:5]) == [
+        np.float32(1.5), np.float32(5.5), np.float32(9.5),
+        np.float32(13.5), np.float32(17.5),
+    ]
+
+
+def test_camera_buffer_window_decimated_mean_binning_smooths_alternation():
+    """The whole reason we mean-bin instead of stride-subsample: at
+    stride=2 a plain subsample shows odd-or-even samples depending on
+    which paint catches the window-scroll boundary, producing visible
+    flicker. With mean-binning the per-bin value is the mean of both
+    samples — no alternating-phase aliasing."""
+    buf = _CameraBuffer(initial_capacity=1024)
+    # Strong noise pattern: alternating 0 and 10.
+    for i in range(400):
+        buf.append(t=i * 0.025, v=10.0 if (i % 2) else 0.0, frame_id=i)
+    t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=200)
+    # stride = 2 → each bin averages one 0 and one 10 → 5.0
+    assert len(t_dec) == 200
+    assert all(v == np.float32(5.0) for v in v_dec)
 
 
 def test_camera_buffer_window_decimated_empty_window_returns_empty_arrays():
@@ -655,12 +676,13 @@ def test_scan_data_source_points_for_window_decimates_when_over_max():
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
 
     pts = src.points_for_window("right", 3, "mean", 0.0, 5.0, max_points=50)
-    # 200 samples, max=50 → stride=4 → 50 pairs
+    # 200 samples, max=50 → stride=4. Mean-binned: each output's v is the
+    # mean of 4 consecutive samples, t is the mean of their t values.
     assert len(pts) == 50
-    # First pair is the first sample
-    assert pts[0] == pytest.approx([0.0, 0.0])
-    # Subsequent pairs at stride=4
-    assert pts[1] == pytest.approx([0.1, 4.0])
+    # Bin 0: mean of indices 0,1,2,3 → t=0.0375, v=1.5
+    assert pts[0] == pytest.approx([0.0375, 1.5])
+    # Bin 1: mean of indices 4,5,6,7 → t=0.1375, v=5.5
+    assert pts[1] == pytest.approx([0.1375, 5.5])
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -971,6 +971,10 @@ def test_live_scan_source_pans_into_db_tail(session_data_db):
     for i in range(5):
         src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
                                t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    # Mark trimmed so the guard treats t<10 as "older data in DB" rather
+    # than "before scan start" (the pre-trim no-DB fast path).
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
 
@@ -981,6 +985,34 @@ def test_live_scan_source_pans_into_db_tail(session_data_db):
     assert all(p[1] < 50 for p in pts)
 
 
+def test_live_scan_source_pretrim_window_before_start_skips_db(session_data_db):
+    """Regression: early in a scan, followLive sets t_lo = liveEdge -
+    windowSeconds which can be BELOW the first sample (window extends
+    before scan start). The buffer hasn't ring-trimmed, so there's no
+    older data — must serve from memory and NEVER touch the DB (the
+    bug made this query the DB every paint → ~1 Hz UI updates)."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    # Scan just started: first sample at t=0.25, only ~0.3 s of data.
+    for i in range(12):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=i,
+                               t=0.25 + i * 0.025, bfi=5.0, bvi=6.0)
+    # Sentinel DB that explodes if queried — proves the fast path never
+    # reaches the DB pre-trim.
+    class _Boom:
+        def iter_session_data(self, *a, **k):
+            raise AssertionError("DB must not be queried before ring-trim")
+        def _connection(self):
+            raise AssertionError("DB must not be opened before ring-trim")
+    src._db = _Boom()
+    src._db_session_id = sid
+    # followLive window [-14.5, 0.5]: t_lo well before the first sample.
+    pts = src.points_for_window("left", 0, "bfi", -14.5, 0.5, max_points=100)
+    # Served from memory (the in-scan samples), no exception raised.
+    assert len(pts) > 0
+    assert all(abs(p[1] - 5.0) < 0.01 for p in pts)
+
+
 def test_live_scan_source_value_at_uses_db_tail(session_data_db):
     """value_at also falls through to the DB tail for times before the
     in-memory window."""
@@ -989,6 +1021,8 @@ def test_live_scan_source_value_at_uses_db_tail(session_data_db):
     for i in range(5):
         src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
                                t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
 
@@ -1004,8 +1038,11 @@ def test_live_scan_source_db_tail_disabled_without_path():
     for i in range(5):
         src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
                                t=10.0 + i * 0.025, bfi=5.0, bvi=6.0)
-    # Request before in-memory start — no DB, so base class returns
-    # whatever the in-memory buffer has for that window (empty).
+    # Trimmed + pan before start, but no DB path configured → falls
+    # through to the in-memory base impl, which has nothing for that
+    # window (buffer starts at t=10) → empty.
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
     pts = src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
     assert pts == []
 

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -297,3 +297,170 @@ def test_live_scan_source_mark_dropped_sets_buffer_dropped_at():
     # not per-metric, so we set it on every existing metric buffer.
     for metric in ("bfi", "bvi", "mean", "contrast"):
         assert src.buffers[("right", 5, metric)].dropped_at == 2.5
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PastScanSource
+# ─────────────────────────────────────────────────────────────────────────────
+
+from data_sources import PastScanSource
+
+
+# Schema mirrors openmotion-sdk/omotion/ScanDatabase.py:115-129.
+_SESSION_DATA_DDL = """
+    CREATE TABLE session_data (
+        id               INTEGER PRIMARY KEY,
+        session_id       INTEGER NOT NULL,
+        session_raw_id   INTEGER,
+        cam_id           INTEGER NOT NULL,
+        side             INTEGER NOT NULL CHECK(side IN (0, 1)),
+        frame_id         INTEGER NOT NULL DEFAULT -1,
+        timestamp_s      REAL    NOT NULL,
+        bfi              REAL,
+        bvi              REAL,
+        contrast         REAL,
+        mean             REAL
+    );
+"""
+
+
+class _FakeScanDatabase:
+    """Tiny stand-in for omotion.ScanDatabase that just yields session_data
+    rows for a given session_id from a synthetic sqlite DB. Matches the
+    real iter_session_data signature."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+        self._conn.row_factory = sqlite3.Row
+
+    def iter_session_data(self, session_id: int, side=None, cam_id=None):
+        sql = "SELECT * FROM session_data WHERE session_id = ?"
+        bindings = [session_id]
+        if side is not None:
+            sql += " AND side = ?"
+            bindings.append(side)
+        if cam_id is not None:
+            sql += " AND cam_id = ?"
+            bindings.append(cam_id)
+        sql += " ORDER BY timestamp_s ASC"
+        for row in self._conn.execute(sql, bindings):
+            yield dict(row)
+
+
+@pytest.fixture
+def session_data_db(tmp_path):
+    """Returns a (db, session_id) pair pre-populated with synthetic rows
+    spanning two sides × two cameras × 5 timestamps each."""
+    db_path = tmp_path / "scan.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SESSION_DATA_DDL)
+    session_id = 7
+
+    rows = []
+    for side_int, side_offset in ((0, 0), (1, 100)):  # left = 0, right = 1
+        for cam_id in (0, 3):
+            for i in range(5):
+                rows.append((
+                    session_id,
+                    None,        # session_raw_id
+                    cam_id,
+                    side_int,
+                    1000 + i,    # frame_id
+                    i * 0.025,   # timestamp_s
+                    1.0 + side_offset + cam_id + i * 0.1,  # bfi
+                    10.0 + side_offset + cam_id + i * 0.1, # bvi
+                    0.30 + i * 0.01,                       # contrast
+                    100.0 + side_offset + cam_id + i,      # mean
+                ))
+    conn.executemany(
+        "INSERT INTO session_data "
+        "(session_id, session_raw_id, cam_id, side, frame_id, timestamp_s, "
+        " bfi, bvi, contrast, mean) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    return _FakeScanDatabase(conn), session_id
+
+
+def test_past_scan_source_live_flag_false(session_data_db):
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+    assert src.live is False
+
+
+def test_past_scan_source_bucketizes_rows_into_per_metric_buffers(session_data_db):
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+
+    # 4 (side, cam) combos × 4 metrics = 16 buffers expected
+    expected_keys = {
+        (side, cam, metric)
+        for side in ("left", "right")
+        for cam in (0, 3)
+        for metric in ("bfi", "bvi", "mean", "contrast")
+    }
+    assert set(src.buffers.keys()) == expected_keys
+
+    # Each buffer holds the 5 rows for its (side, cam)
+    for key, buf in src.buffers.items():
+        assert buf.n == 5
+
+
+def test_past_scan_source_normalizes_side_integer_to_string(session_data_db):
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+    # No integer-keyed entries; all side keys are strings.
+    for (side, _, _) in src.buffers.keys():
+        assert side in ("left", "right")
+
+
+def test_past_scan_source_preserves_frame_ids(session_data_db):
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+    buf = src.buffers[("left", 0, "bfi")]
+    # frame_ids 1000..1004 in input order
+    assert list(int(x) for x in buf.frame_id[:5]) == [1000, 1001, 1002, 1003, 1004]
+
+
+def test_past_scan_source_live_edge_is_max_timestamp(session_data_db):
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+    assert src.liveEdge == pytest.approx(0.025 * 4)  # last timestamp = 0.100
+
+
+def test_past_scan_source_empty_session_yields_empty_source(tmp_path):
+    db_path = tmp_path / "scan.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SESSION_DATA_DDL)
+    conn.commit()
+    db = _FakeScanDatabase(conn)
+
+    src = PastScanSource(scan_db=db, session_id=42)
+    assert src.buffers == {}
+    assert src.liveEdge == 0.0
+
+
+def test_past_scan_source_skips_null_metric_values(tmp_path):
+    """A row with NULL bfi/bvi/mean/contrast must not crash and must not
+    insert a NaN where the SQL was NULL — that metric just isn't recorded
+    for that frame."""
+    db_path = tmp_path / "scan.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SESSION_DATA_DDL)
+    # One row with all metrics NULL except bfi
+    conn.execute(
+        "INSERT INTO session_data "
+        "(session_id, cam_id, side, frame_id, timestamp_s, bfi, bvi, contrast, mean) "
+        "VALUES (1, 0, 0, 100, 0.5, 4.0, NULL, NULL, NULL)"
+    )
+    conn.commit()
+    db = _FakeScanDatabase(conn)
+
+    src = PastScanSource(scan_db=db, session_id=1)
+    assert src.buffers[("left", 0, "bfi")].n == 1
+    assert src.buffers[("left", 0, "bfi")].v[0] == np.float32(4.0)
+    # NULL metrics yield no buffer entry at all
+    assert ("left", 0, "bvi") not in src.buffers
+    assert ("left", 0, "mean") not in src.buffers
+    assert ("left", 0, "contrast") not in src.buffers

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -38,6 +38,24 @@ def test_camera_buffer_append_grows_high_water_mark():
     assert buf.frame_id[1] == 11
 
 
+def test_camera_buffer_small_max_capacity_ring_trims():
+    """A small max_capacity (test/debug live cache) ring-trims the
+    oldest half and flags ring_trimmed once it fills — the trigger for
+    the LiveScanSource DB tail."""
+    buf = _CameraBuffer(max_capacity=10)
+    for i in range(10):
+        buf.append(t=float(i), v=float(i), frame_id=i)
+    assert buf.n == 10
+    assert not buf.ring_trimmed
+    # 11th append fills past cap → ring-trim drops oldest half.
+    buf.append(t=10.0, v=10.0, frame_id=10)
+    assert buf.ring_trimmed
+    assert buf.n == 6  # kept most-recent 5 + the new one
+    # Oldest retained sample is t=5 (0..4 dropped).
+    assert float(buf.t[0]) == 5.0
+    assert float(buf.t[buf.n - 1]) == 10.0
+
+
 def test_camera_buffer_doubles_capacity_on_overflow():
     buf = _CameraBuffer(initial_capacity=2)
     for i in range(5):

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -588,14 +588,28 @@ def test_live_scan_source_mark_dropped_multiple_metric_buffers():
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_camera_buffer_window_decimated_returns_unstrided_when_under_max():
+def test_camera_buffer_window_decimated_smooths_even_when_under_max():
+    """Always-on smoothing: even when n_window < max_points the source
+    applies stride-aligned causal smoothing (min stride=2) so the
+    visual quality is consistent from t=0, with no jarring transition
+    when the window finally fills."""
     buf = _CameraBuffer(initial_capacity=64)
     for i in range(20):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=0.5, max_points=100)
-    # 20 samples in window, max_points=100 → no decimation
-    assert len(t_dec) == 20
-    assert list(v_dec) == [np.float32(i) for i in range(20)]
+    # 20 samples; stride=max(2, ceil(20/100))=2; window=6.
+    # abs_idxs = [0,2,4,...,18] → 10 outputs.
+    assert len(t_dec) == 10
+    # abs=0:  window [0..0]   → 0/1 = 0.0
+    # abs=2:  window [0..2]   → 3/3 = 1.0
+    # abs=4:  window [0..4]   → 10/5 = 2.0
+    # abs=6:  window [1..6]   → 21/6 = 3.5
+    # abs=8:  window [3..8]   → 33/6 = 5.5
+    expected_head = [
+        np.float32(0.0), np.float32(1.0), np.float32(2.0),
+        np.float32(3.5), np.float32(5.5),
+    ]
+    assert list(v_dec[:5]) == expected_head
 
 
 def test_camera_buffer_window_decimated_strides_when_over_max():
@@ -657,10 +671,20 @@ def test_camera_buffer_window_decimated_partial_window():
     buf = _CameraBuffer(initial_capacity=64)
     for i in range(40):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
-    # Window covers indices [10, 21) per the existing window_indices test.
+    # Window covers indices [10, 21). Stride=2, window=6. abs_idxs are
+    # stride-aligned indices in that range → [10, 12, 14, 16, 18, 20].
     t_dec, v_dec = buf.window_decimated(t_lo=0.250, t_hi=0.500, max_points=100)
-    assert len(t_dec) == 11  # indices 10..20 inclusive
-    assert list(v_dec) == [np.float32(i) for i in range(10, 21)]
+    assert len(t_dec) == 6
+    # abs=10: window [5..10]  → mean 45/6 = 7.5
+    # abs=12: window [7..12]  → mean 57/6 = 9.5
+    # abs=14: window [9..14]  → 69/6 = 11.5
+    # abs=16: window [11..16] → 81/6 = 13.5
+    # abs=18: window [13..18] → 93/6 = 15.5
+    # abs=20: window [15..20] → 105/6 = 17.5
+    assert list(v_dec) == [
+        np.float32(7.5), np.float32(9.5), np.float32(11.5),
+        np.float32(13.5), np.float32(15.5), np.float32(17.5),
+    ]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -676,10 +700,13 @@ def test_scan_data_source_points_for_window_returns_pairs():
 
     pts = src.points_for_window("left", 0, "bfi", 0.0, 0.25, max_points=100)
 
-    # Window covers indices 0..10 (right-exclusive), so 10 pairs
-    assert len(pts) == 10
+    # 10 samples in window; stride=2 (minimum), window=6. abs_idxs =
+    # [0, 2, 4, 6, 8] → 5 output pairs.
+    assert len(pts) == 5
+    # abs=0: window [v[0]] = [4.0]; mean = 4.0; t = 0.0
     assert pts[0] == pytest.approx([0.0, 4.0])
-    assert pts[-1] == pytest.approx([0.225, 4.9])
+    # abs=8: window [v[3..8]] = [4.3..4.8]; mean = 4.55; t = 0.2
+    assert pts[-1] == pytest.approx([0.2, 4.55])
 
 
 def test_scan_data_source_points_for_window_missing_buffer_returns_empty():

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -603,30 +603,40 @@ def test_camera_buffer_window_decimated_strides_when_over_max():
     for i in range(400):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
     # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4.
-    # Mean-binned: each output value = mean of `stride` adjacent samples.
-    # Bin 0 averages [0,1,2,3] → 1.5; bin 1 averages [4,5,6,7] → 5.5; etc.
+    # Overlap-smoothing with kernel width stride*3 = 12 → half = 6 → each
+    # output is the mean of 2*half+1 = 13 samples centred on the index.
+    # Linspace puts outputs at indices [0, 4, 8, 12, 16, ...]. Edge bins
+    # at low indices average fewer samples (clipped at 0).
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=100)
     assert len(t_dec) == 100
+    # idx=0:  samples [0..6]    → mean 21/7   = 3.0
+    # idx=4:  samples [0..10]   → mean 55/11  = 5.0
+    # idx=8:  samples [2..14]   → mean 104/13 = 8.0
+    # idx=12: samples [6..18]   → mean 156/13 = 12.0
+    # idx=16: samples [10..22]  → mean 208/13 = 16.0
     assert list(v_dec[:5]) == [
-        np.float32(1.5), np.float32(5.5), np.float32(9.5),
-        np.float32(13.5), np.float32(17.5),
+        np.float32(3.0), np.float32(5.0), np.float32(8.0),
+        np.float32(12.0), np.float32(16.0),
     ]
 
 
-def test_camera_buffer_window_decimated_mean_binning_smooths_alternation():
-    """The whole reason we mean-bin instead of stride-subsample: at
-    stride=2 a plain subsample shows odd-or-even samples depending on
-    which paint catches the window-scroll boundary, producing visible
-    flicker. With mean-binning the per-bin value is the mean of both
-    samples — no alternating-phase aliasing."""
+def test_camera_buffer_window_decimated_smoothing_kills_alternation():
+    """At stride=2 a plain subsample alternates between odd-index and
+    even-index samples as the window scrolls, producing per-paint
+    flicker on noisy data. Overlap-smoothing (kernel wider than stride)
+    pulls each output toward the local mean so alternation can't
+    surface."""
     buf = _CameraBuffer(initial_capacity=1024)
     # Strong noise pattern: alternating 0 and 10.
     for i in range(400):
         buf.append(t=i * 0.025, v=10.0 if (i % 2) else 0.0, frame_id=i)
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=200)
-    # stride = 2 → each bin averages one 0 and one 10 → 5.0
     assert len(t_dec) == 200
-    assert all(v == np.float32(5.0) for v in v_dec)
+    # Each output averages a 7-sample window (stride=2 → kernel=6 → 13
+    # samples centred). On alternating 0/10 the per-output mean is
+    # always within (4.0, 6.0) — pulled tight around the true mean 5.
+    for v in v_dec:
+        assert 4.0 < float(v) < 6.0
 
 
 def test_camera_buffer_window_decimated_empty_window_returns_empty_arrays():
@@ -688,13 +698,14 @@ def test_scan_data_source_points_for_window_decimates_when_over_max():
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
 
     pts = src.points_for_window("right", 3, "mean", 0.0, 5.0, max_points=50)
-    # 200 samples, max=50 → stride=4. Mean-binned: each output's v is the
-    # mean of 4 consecutive samples, t is the mean of their t values.
+    # 200 samples, max=50 → stride=4. Overlap-smoothed: each output's v
+    # is the mean of a 13-sample window centred on a linspace index; t
+    # is the actual sample t at the centre.
     assert len(pts) == 50
-    # Bin 0: mean of indices 0,1,2,3 → t=0.0375, v=1.5
-    assert pts[0] == pytest.approx([0.0375, 1.5])
-    # Bin 1: mean of indices 4,5,6,7 → t=0.1375, v=5.5
-    assert pts[1] == pytest.approx([0.1375, 5.5])
+    # idx=0: window [0..6] (edge-clipped), mean = 21/7 = 3.0, t = 0.0
+    assert pts[0] == pytest.approx([0.0, 3.0])
+    # idx=4: window [0..10], mean = 55/11 = 5.0, t = 0.1
+    assert pts[1] == pytest.approx([0.1, 5.0])
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -588,65 +588,59 @@ def test_live_scan_source_mark_dropped_multiple_metric_buffers():
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_camera_buffer_window_decimated_smooths_even_when_under_max():
-    """Always-on smoothing: even when n_window < max_points the source
-    applies stride-aligned causal smoothing (min stride=2) so the
-    visual quality is consistent from t=0, with no jarring transition
-    when the window finally fills."""
+def test_camera_buffer_window_decimated_returns_raw_when_window_fits():
+    """When the time window times the nominal sample rate is ≤ max_points
+    (zoomed in tight enough that every sample fits), stride drops to 1
+    and we short-circuit to raw samples. Earlier code forced a minimum
+    stride of 2 + 6-sample causal smoothing, which over-filtered the
+    tightest zoom views and hid real signal detail."""
     buf = _CameraBuffer(initial_capacity=64)
     for i in range(20):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    # 0.5 s window × 40 Hz nominal = 20 expected samples ≤ max_points=100
+    # → stride=1 → raw return path.
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=0.5, max_points=100)
-    # 20 samples; stride=max(2, ceil(20/100))=2; window=6.
-    # abs_idxs = [0,2,4,...,18] → 10 outputs.
-    assert len(t_dec) == 10
-    # abs=0:  window [0..0]   → 0/1 = 0.0
-    # abs=2:  window [0..2]   → 3/3 = 1.0
-    # abs=4:  window [0..4]   → 10/5 = 2.0
-    # abs=6:  window [1..6]   → 21/6 = 3.5
-    # abs=8:  window [3..8]   → 33/6 = 5.5
-    expected_head = [
-        np.float32(0.0), np.float32(1.0), np.float32(2.0),
-        np.float32(3.5), np.float32(5.5),
-    ]
-    assert list(v_dec[:5]) == expected_head
+    assert len(t_dec) == 20
+    assert list(v_dec) == [np.float32(i) for i in range(20)]
 
 
 def test_camera_buffer_window_decimated_strides_when_over_max():
     buf = _CameraBuffer(initial_capacity=1024)
     for i in range(400):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
-    # Whole window (10 s), max_points=100 → stride = ceil(400/100) = 4,
-    # window = stride*3 = 12. Stride-aligned abs idxs [0, 4, 8, 12, 16, ...].
-    # Causal window per output: [abs_idx - window + 1, abs_idx], clipped at 0.
+    # Time-keyed stride: 10 s window × 40 Hz / max_points=100 = 4.
+    # window = stride = 4 (Nyquist-minimum). Stride-aligned abs idxs
+    # [0, 4, 8, 12, 16, ...]. Causal window per output:
+    # [abs_idx - stride + 1, abs_idx], clipped at 0.
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=100)
     assert len(t_dec) == 100
-    # abs=0:  window [0..0]   → mean 0/1   = 0.0
-    # abs=4:  window [0..4]   → mean 10/5  = 2.0
-    # abs=8:  window [0..8]   → mean 36/9  = 4.0
-    # abs=12: window [1..12]  → mean 78/12 = 6.5
-    # abs=16: window [5..16]  → mean 126/12 = 10.5
+    # abs=0:  window [0..0]   → mean v[0]                = 0.0
+    # abs=4:  window [1..4]   → mean(1,2,3,4)            = 2.5
+    # abs=8:  window [5..8]   → mean(5,6,7,8)            = 6.5
+    # abs=12: window [9..12]  → mean(9,10,11,12)         = 10.5
+    # abs=16: window [13..16] → mean(13,14,15,16)        = 14.5
     assert list(v_dec[:5]) == [
-        np.float32(0.0), np.float32(2.0), np.float32(4.0),
-        np.float32(6.5), np.float32(10.5),
+        np.float32(0.0), np.float32(2.5), np.float32(6.5),
+        np.float32(10.5), np.float32(14.5),
     ]
 
 
 def test_camera_buffer_window_decimated_smoothing_kills_alternation():
     """At stride=2 a plain subsample alternates between odd-index and
     even-index samples as the window scrolls, producing per-paint
-    flicker on noisy data. Causal smoothing pulls each output toward
-    the local mean so alternation can't surface."""
+    flicker on noisy data. The Nyquist-minimum causal smoothing
+    (window = stride) averages each pair so alternation collapses to
+    the local mean."""
     buf = _CameraBuffer(initial_capacity=1024)
     # Strong noise pattern: alternating 0 and 10.
     for i in range(400):
         buf.append(t=i * 0.025, v=10.0 if (i % 2) else 0.0, frame_id=i)
+    # 10 s × 40 Hz / max_points=200 → stride=2, window=2.
     t_dec, v_dec = buf.window_decimated(t_lo=0.0, t_hi=10.0, max_points=200)
     assert len(t_dec) == 200
-    # Stride=2 → kernel=6. Once the causal window has fully filled
-    # (abs_idx >= 5 → 3 outputs in) each 6-sample window over alternating
-    # 0/10 contains exactly 3 zeros + 3 tens → mean = 5.0 EXACTLY.
-    for v in v_dec[3:]:
+    # abs=0: window [0..0] = v[0] = 0  (edge — single-sample only)
+    # abs=2 onward: window [N-1, N] over alternating 10/0 → mean = 5.0
+    for v in v_dec[1:]:
         assert v == np.float32(5.0)
 
 
@@ -671,20 +665,13 @@ def test_camera_buffer_window_decimated_partial_window():
     buf = _CameraBuffer(initial_capacity=64)
     for i in range(40):
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
-    # Window covers indices [10, 21). Stride=2, window=6. abs_idxs are
-    # stride-aligned indices in that range → [10, 12, 14, 16, 18, 20].
+    # Window time range = 0.25 s × 40 Hz nominal = 10 expected samples.
+    # max_points=100 → stride=1 → raw return path. window_indices for
+    # [0.25, 0.5] returns (10, 21) (searchsorted right at 0.5 includes
+    # samples up through index 20 at t=0.500). 11 raw samples 10..20.
     t_dec, v_dec = buf.window_decimated(t_lo=0.250, t_hi=0.500, max_points=100)
-    assert len(t_dec) == 6
-    # abs=10: window [5..10]  → mean 45/6 = 7.5
-    # abs=12: window [7..12]  → mean 57/6 = 9.5
-    # abs=14: window [9..14]  → 69/6 = 11.5
-    # abs=16: window [11..16] → 81/6 = 13.5
-    # abs=18: window [13..18] → 93/6 = 15.5
-    # abs=20: window [15..20] → 105/6 = 17.5
-    assert list(v_dec) == [
-        np.float32(7.5), np.float32(9.5), np.float32(11.5),
-        np.float32(13.5), np.float32(15.5), np.float32(17.5),
-    ]
+    assert len(t_dec) == 11
+    assert list(v_dec) == [np.float32(i) for i in range(10, 21)]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -700,13 +687,11 @@ def test_scan_data_source_points_for_window_returns_pairs():
 
     pts = src.points_for_window("left", 0, "bfi", 0.0, 0.25, max_points=100)
 
-    # 10 samples in window; stride=2 (minimum), window=6. abs_idxs =
-    # [0, 2, 4, 6, 8] → 5 output pairs.
-    assert len(pts) == 5
-    # abs=0: window [v[0]] = [4.0]; mean = 4.0; t = 0.0
+    # 0.25 s × 40 Hz = 10 expected samples ≤ max_points=100 → stride=1,
+    # raw return. All 10 samples pass through.
+    assert len(pts) == 10
     assert pts[0] == pytest.approx([0.0, 4.0])
-    # abs=8: window [v[3..8]] = [4.3..4.8]; mean = 4.55; t = 0.2
-    assert pts[-1] == pytest.approx([0.2, 4.55])
+    assert pts[-1] == pytest.approx([0.225, 4.9])
 
 
 def test_scan_data_source_points_for_window_missing_buffer_returns_empty():
@@ -722,13 +707,14 @@ def test_scan_data_source_points_for_window_decimates_when_over_max():
         buf.append(t=i * 0.025, v=float(i), frame_id=i)
 
     pts = src.points_for_window("right", 3, "mean", 0.0, 5.0, max_points=50)
-    # 200 samples, max=50 → stride=4, window=12. Stride-aligned abs
-    # idxs [0, 4, 8, ...]. Causal window per output (clipped at 0).
+    # Time-keyed stride: 5 s × 40 Hz / max=50 = 4. window = stride = 4.
+    # Stride-aligned abs idxs [0, 4, 8, ...]. Causal window per output:
+    # [abs_idx - stride + 1, abs_idx] clipped at 0.
     assert len(pts) == 50
-    # abs=0: window [0..0], mean = 0/1 = 0.0, t = 0.0
+    # abs=0: window [0..0]  → v[0]                = 0.0,  t = 0.0
     assert pts[0] == pytest.approx([0.0, 0.0])
-    # abs=4: window [0..4], mean = 10/5 = 2.0, t = 0.1
-    assert pts[1] == pytest.approx([0.1, 2.0])
+    # abs=4: window [1..4]  → mean(1,2,3,4)       = 2.5,  t = 0.1
+    assert pts[1] == pytest.approx([0.1, 2.5])
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -534,3 +534,38 @@ def test_set_current_scan_source_dedupes_same_instance():
     holder._set_current_scan_source(src)
     holder._set_current_scan_source(src)  # no-op — same instance
     assert received == [src]
+
+
+def test_live_scan_source_mark_dropped_no_buffers_yet_is_noop():
+    """If a camera drops before any sample arrived, mark_dropped silently
+    does nothing — no buffer to mark. Phase 2's PlotViewer won't have a
+    cell for a camera with no samples anyway."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.mark_dropped(side="left", cam_id=0, t=1.5)
+    assert src.buffers == {}  # nothing created
+
+
+def test_live_scan_source_mark_dropped_multiple_metric_buffers():
+    """When a camera has samples in all 4 metric buffers, mark_dropped
+    sets dropped_at on all 4 — the marker is per-(side, cam), per-metric
+    bookkeeping just mirrors it."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(
+        side="left", cam_id=1, frame_id=10, t=0.0,
+        bfi=4.0, bvi=3.0, mean=120.0, contrast=0.3,
+    )
+    src.append_uncorrected(  # second sample without mean — only 3 metrics
+        side="left", cam_id=2, frame_id=11, t=0.025,
+        bfi=4.1, bvi=3.1, mean=None, contrast=0.31,
+    )
+
+    src.mark_dropped(side="left", cam_id=1, t=2.5)
+    src.mark_dropped(side="left", cam_id=2, t=2.7)
+
+    # cam 1: all 4 buffers exist, all marked at 2.5
+    for metric in ("bfi", "bvi", "mean", "contrast"):
+        assert src.buffers[("left", 1, metric)].dropped_at == 2.5
+    # cam 2: 3 buffers exist (no mean), all marked at 2.7
+    for metric in ("bfi", "bvi", "contrast"):
+        assert src.buffers[("left", 2, metric)].dropped_at == 2.7
+    assert ("left", 2, "mean") not in src.buffers

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1117,6 +1117,48 @@ def test_live_scan_source_pretrim_window_before_start_skips_db(session_data_db):
     assert all(abs(p[1] - 5.0) < 0.01 for p in pts)
 
 
+def test_live_scan_source_straddle_stitches_db_and_memory(session_data_db):
+    """A window whose left edge is in the DB tail but whose right edge
+    reaches the in-memory live data must STITCH: old portion from the DB,
+    recent portion from memory. Serving the whole window from the DB (the
+    old behavior) froze the live trace, because the cached DB window only
+    reloads when the in-memory boundary advances. session_data_db has
+    (left,0) bfi ≈1.0..1.4 at t≈0..0.1; in-memory holds 99.0 at t≈10."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
+    src._db = db
+    src._db_session_id = sid
+
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 10.1, max_points=200)
+    vals = [p[1] for p in pts]
+    assert any(v < 50 for v in vals), "DB-tail (old) portion missing from stitch"
+    assert any(v > 50 for v in vals), "in-memory (recent) portion missing from stitch"
+
+
+def test_live_scan_source_db_window_not_padded_into_future(session_data_db):
+    """_ensure_db_window must not claim coverage past the newest sample.
+    Padding want_hi into the future used to make the staleness check
+    short-circuit and serve a stale window while live data piled up unshown."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
+    src._db = db
+    src._db_session_id = sid
+
+    src.points_for_window("left", 0, "bfi", 0.0, 10.1, max_points=200)
+    # The DB window's claimed upper bound never exceeds the newest sample.
+    assert src._db_window_hi <= src.liveEdge + 1e-9
+
+
 def test_live_scan_source_value_at_uses_db_tail(session_data_db):
     """value_at also falls through to the DB tail for times before the
     in-memory window."""

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -812,3 +812,104 @@ def test_compute_bounds_expands_when_lo_equals_hi():
     # When lo == hi, expand by ±0.5; with pad_frac=0 the result is [4.5, 5.5]
     assert b["yMin"] == pytest.approx(4.5)
     assert b["yMax"] == pytest.approx(5.5)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource.value_at (Phase 2b-ii — hover tooltip)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_value_at_returns_nearest_sample():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    for i in range(10):
+        buf.append(t=i * 0.1, v=float(i), frame_id=i)
+
+    # Exact match
+    assert src.value_at("left", 0, "bfi", 0.3) == pytest.approx(3.0)
+    # Nearest-left wins on tie-break (0.35 is equidistant; searchsorted
+    # left returns idx=4 then the elif prefers idx=3 because abs equal)
+    v = src.value_at("left", 0, "bfi", 0.35)
+    assert v in (pytest.approx(3.0), pytest.approx(4.0))
+    # Past the live edge — returns last sample
+    assert src.value_at("left", 0, "bfi", 99.0) == pytest.approx(9.0)
+    # Before the first sample — returns first sample
+    assert src.value_at("left", 0, "bfi", -1.0) == pytest.approx(0.0)
+
+
+def test_value_at_missing_buffer_returns_nan():
+    src = ScanDataSource(plot_t0=0.0)
+    assert math.isnan(src.value_at("left", 7, "bfi", 0.1))
+
+
+def test_value_at_empty_buffer_returns_nan():
+    src = ScanDataSource(plot_t0=0.0)
+    src.get_or_create_buffer("left", 0, "bfi")  # exists but n=0
+    assert math.isnan(src.value_at("left", 0, "bfi", 0.1))
+
+
+def test_value_at_nan_sample_returns_nan():
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    buf.append(t=0.1, v=float("nan"), frame_id=1)
+    assert math.isnan(src.value_at("left", 0, "bfi", 0.1))
+
+
+def test_value_at_handles_searchsorted_at_buffer_end():
+    """Regression for the race-condition fix — searchsorted("left")
+    can return idx == n when t equals or exceeds every sample's
+    timestamp. Without the snapshot, a stale-n bounds check could let
+    idx-1 reach an out-of-bounds slot. We test the snapshot path
+    behaves correctly even at the boundary."""
+    src = ScanDataSource(plot_t0=0.0)
+    buf = src.get_or_create_buffer("left", 0, "bfi")
+    for i in range(5):
+        buf.append(t=float(i), v=float(i) * 2.0, frame_id=i)
+    # t equal to the last timestamp → searchsorted left returns idx=4
+    # (insert before the last). We clamp via the elif tie-break.
+    v = src.value_at("left", 0, "bfi", 4.0)
+    assert v == pytest.approx(8.0)
+    # t past every sample → searchsorted returns idx=5 (== n);
+    # the >= n clamp pulls back to last sample.
+    v = src.value_at("left", 0, "bfi", 1000.0)
+    assert v == pytest.approx(8.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource.dropped_at_for (Phase 2b-ii — dropout marker)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_dropped_at_for_returns_dropout_time():
+    """mark_dropped lives on LiveScanSource (only live streams can
+    drop mid-scan). After appending one sample to create a buffer,
+    marking that (side, cam) dropped should surface the timestamp."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(side="left", cam_id=0, frame_id=1, t=0.1,
+                           bfi=4.0, bvi=2.0)
+    src.mark_dropped(side="left", cam_id=0, t=12.5)
+    assert src.dropped_at_for("left", 0) == pytest.approx(12.5)
+
+
+def test_dropped_at_for_returns_nan_when_no_dropout():
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(side="left", cam_id=0, frame_id=1, t=0.1,
+                           bfi=4.0, bvi=2.0)
+    assert math.isnan(src.dropped_at_for("left", 0))
+
+
+def test_dropped_at_for_returns_nan_when_buffer_missing():
+    src = LiveScanSource(plot_t0=0.0)
+    # No samples appended → no buffers for (left, 7)
+    assert math.isnan(src.dropped_at_for("left", 7))
+
+
+def test_dropped_at_for_finds_dropout_under_any_metric_key():
+    """dropped_at_for walks all 4 metric buffers for (side, cam) and
+    returns the first dropout it finds — so the marker still surfaces
+    even if mean/contrast happen to be absent for early samples."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(side="left", cam_id=3, frame_id=1, t=0.1,
+                           bfi=4.0, bvi=2.0)  # mean/contrast omitted
+    src.mark_dropped(side="left", cam_id=3, t=8.0)
+    assert src.dropped_at_for("left", 3) == pytest.approx(8.0)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -163,3 +163,137 @@ def test_scan_data_source_flush_clears_pending():
     src._flush()
     src._flush()  # nothing pending now
     assert received == [("left", 0, "bfi", 1)]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LiveScanSource
+# ─────────────────────────────────────────────────────────────────────────────
+
+from data_sources import LiveScanSource
+
+
+def test_live_scan_source_live_flag_true():
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.live is True
+
+
+def test_live_scan_source_append_uncorrected_populates_all_metrics():
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(
+        side="left", cam_id=2, frame_id=42, t=0.025,
+        bfi=4.5, bvi=3.1, mean=120.0, contrast=0.31,
+    )
+    assert src.buffers[("left", 2, "bfi")].v[0] == np.float32(4.5)
+    assert src.buffers[("left", 2, "bvi")].v[0] == np.float32(3.1)
+    assert src.buffers[("left", 2, "mean")].v[0] == np.float32(120.0)
+    assert src.buffers[("left", 2, "contrast")].v[0] == np.float32(0.31)
+    for metric in ("bfi", "bvi", "mean", "contrast"):
+        assert src.buffers[("left", 2, metric)].n == 1
+        assert src.buffers[("left", 2, metric)].t[0] == 0.025
+        assert src.buffers[("left", 2, metric)].frame_id[0] == 42
+
+
+def test_live_scan_source_skips_none_mean_or_contrast():
+    """mean/contrast are optional — None means 'this sample's value wasn't
+    available' and the buffer for that metric is not appended to."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(
+        side="left", cam_id=0, frame_id=1, t=0.0,
+        bfi=4.0, bvi=3.0, mean=None, contrast=None,
+    )
+    assert src.buffers[("left", 0, "bfi")].n == 1
+    assert src.buffers[("left", 0, "bvi")].n == 1
+    assert ("left", 0, "mean") not in src.buffers
+    assert ("left", 0, "contrast") not in src.buffers
+
+
+def test_live_scan_source_stores_nan_values():
+    """NaN survives. The renderer filters non-finite, not the source."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(
+        side="left", cam_id=0, frame_id=1, t=0.0,
+        bfi=float("nan"), bvi=3.0,
+    )
+    assert math.isnan(float(src.buffers[("left", 0, "bfi")].v[0]))
+    assert src.buffers[("left", 0, "bfi")].n == 1
+
+
+def test_live_scan_source_append_uncorrected_notes_dirty():
+    src = LiveScanSource(plot_t0=0.0)
+    received: list = []
+    src.samplesAppended.connect(lambda s, c, m, n: received.append((s, c, m, n)))
+
+    src.append_uncorrected(
+        side="left", cam_id=0, frame_id=1, t=0.0,
+        bfi=4.0, bvi=3.0, mean=120.0, contrast=0.3,
+    )
+    src.append_uncorrected(
+        side="left", cam_id=0, frame_id=2, t=0.025,
+        bfi=4.2, bvi=3.1, mean=121.0, contrast=0.31,
+    )
+    src._flush()
+
+    # One emit per (side, cam, metric), with added=2 each
+    assert sorted(received) == [
+        ("left", 0, "bfi", 2),
+        ("left", 0, "bvi", 2),
+        ("left", 0, "contrast", 2),
+        ("left", 0, "mean", 2),
+    ]
+
+
+def test_live_scan_source_apply_corrected_batch_overwrites_in_place():
+    src = LiveScanSource(plot_t0=0.0)
+    # Seed live samples for frame_ids 100, 101, 102.
+    for i, fid in enumerate((100, 101, 102)):
+        src.append_uncorrected(
+            side="left", cam_id=0, frame_id=fid, t=i * 0.025,
+            bfi=1.0 + i, bvi=10.0 + i, mean=100.0 + i, contrast=0.30 + i * 0.01,
+        )
+    src._flush()  # drain seed dirty state
+
+    batch = [
+        {"side": "left", "camId": 0, "frameId": 101, "ts": 0.025,
+         "bfi": 99.0, "bvi": 88.0, "mean": 77.0, "contrast": 0.66},
+    ]
+    src.apply_corrected_batch(batch)
+
+    bfi_buf = src.buffers[("left", 0, "bfi")]
+    bvi_buf = src.buffers[("left", 0, "bvi")]
+    mean_buf = src.buffers[("left", 0, "mean")]
+    contrast_buf = src.buffers[("left", 0, "contrast")]
+
+    assert bfi_buf.v[1] == np.float32(99.0)   # overwritten
+    assert bfi_buf.v[0] == np.float32(1.0)    # untouched
+    assert bfi_buf.v[2] == np.float32(3.0)    # untouched
+    assert bvi_buf.v[1] == np.float32(88.0)
+    assert mean_buf.v[1] == np.float32(77.0)
+    assert contrast_buf.v[1] == np.float32(0.66)
+
+
+def test_live_scan_source_apply_corrected_batch_unknown_frame_silently_skipped():
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(
+        side="left", cam_id=0, frame_id=100, t=0.0,
+        bfi=1.0, bvi=10.0,
+    )
+    # frame_id 999 was never seen on the live path (race window)
+    src.apply_corrected_batch([
+        {"side": "left", "camId": 0, "frameId": 999, "ts": 0.0,
+         "bfi": 99.0, "bvi": 88.0, "mean": 77.0, "contrast": 0.66},
+    ])
+    assert src.buffers[("left", 0, "bfi")].v[0] == np.float32(1.0)
+    assert ("left", 0, "mean") not in src.buffers
+
+
+def test_live_scan_source_mark_dropped_sets_buffer_dropped_at():
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(
+        side="right", cam_id=5, frame_id=1, t=0.0,
+        bfi=4.0, bvi=3.0, mean=120.0, contrast=0.3,
+    )
+    src.mark_dropped(side="right", cam_id=5, t=2.5)
+    # All 4 metrics share the dropped_at — the marker is per-(side, cam),
+    # not per-metric, so we set it on every existing metric buffer.
+    for metric in ("bfi", "bvi", "mean", "contrast"):
+        assert src.buffers[("right", 5, metric)].dropped_at == 2.5

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,0 +1,109 @@
+"""Unit tests for data_sources.py — ScanDataSource + helpers."""
+
+import math
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from data_sources import _CameraBuffer
+
+pytestmark = pytest.mark.unit
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _CameraBuffer
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_camera_buffer_starts_empty():
+    buf = _CameraBuffer(initial_capacity=8)
+    assert buf.n == 0
+    assert buf.t.shape == (8,)
+    assert buf.v.shape == (8,)
+    assert buf.frame_id.shape == (8,)
+    assert buf.dropped_at is None
+
+
+def test_camera_buffer_append_grows_high_water_mark():
+    buf = _CameraBuffer(initial_capacity=8)
+    buf.append(t=0.025, v=1.5, frame_id=10)
+    buf.append(t=0.050, v=2.5, frame_id=11)
+    assert buf.n == 2
+    assert buf.t[0] == 0.025
+    assert buf.t[1] == 0.050
+    assert buf.v[0] == np.float32(1.5)
+    assert buf.v[1] == np.float32(2.5)
+    assert buf.frame_id[0] == 10
+    assert buf.frame_id[1] == 11
+
+
+def test_camera_buffer_doubles_capacity_on_overflow():
+    buf = _CameraBuffer(initial_capacity=2)
+    for i in range(5):
+        buf.append(t=float(i), v=float(i), frame_id=i)
+    assert buf.n == 5
+    # Capacity doubled 2 → 4 → 8 to fit 5 samples
+    assert buf.t.shape[0] >= 5
+    assert buf.t.shape[0] == 8  # 2 doubled to 4 (still too small) doubled to 8
+    # Values preserved across resize
+    assert list(buf.v[:5]) == [np.float32(i) for i in range(5)]
+
+
+def test_camera_buffer_window_indices_binary_search():
+    buf = _CameraBuffer(initial_capacity=64)
+    for i in range(40):
+        buf.append(t=i * 0.025, v=float(i), frame_id=i)
+    # Window covering t in [0.250, 0.500] should give indices [10, 20] (right-exclusive)
+    i_lo, i_hi = buf.window_indices(0.250, 0.500)
+    assert i_lo == 10
+    assert i_hi == 21  # searchsorted right-side gives one past the last match
+
+
+def test_camera_buffer_window_indices_empty_buffer():
+    buf = _CameraBuffer(initial_capacity=8)
+    i_lo, i_hi = buf.window_indices(0.0, 1.0)
+    assert i_lo == 0
+    assert i_hi == 0
+
+
+def test_camera_buffer_apply_corrected_overwrites_in_place():
+    buf = _CameraBuffer(initial_capacity=8)
+    buf.append(t=0.0, v=1.0, frame_id=100)
+    buf.append(t=0.025, v=2.0, frame_id=101)
+    buf.append(t=0.050, v=3.0, frame_id=102)
+
+    buf.apply_corrected(frame_id=101, value=99.9)
+
+    assert buf.v[0] == np.float32(1.0)
+    assert buf.v[1] == np.float32(99.9)
+    assert buf.v[2] == np.float32(3.0)
+
+
+def test_camera_buffer_apply_corrected_unknown_frame_is_noop():
+    buf = _CameraBuffer(initial_capacity=8)
+    buf.append(t=0.0, v=1.0, frame_id=100)
+    # frame_id 999 was never appended — must not raise, must not corrupt state
+    buf.apply_corrected(frame_id=999, value=42.0)
+    assert buf.n == 1
+    assert buf.v[0] == np.float32(1.0)
+
+
+def test_camera_buffer_apply_corrected_skips_sentinel_frame_id():
+    """frame_id=-1 means 'unknown'; we don't index it, so apply_corrected(-1, ...)
+    must not silently overwrite the most-recent -1 sample."""
+    buf = _CameraBuffer(initial_capacity=8)
+    buf.append(t=0.0, v=1.0, frame_id=-1)
+    buf.append(t=0.025, v=2.0, frame_id=-1)
+    buf.apply_corrected(frame_id=-1, value=99.9)
+    assert buf.v[0] == np.float32(1.0)
+    assert buf.v[1] == np.float32(2.0)
+
+
+def test_camera_buffer_mark_dropped_sets_timestamp_once():
+    buf = _CameraBuffer(initial_capacity=8)
+    buf.mark_dropped(t=1.5)
+    assert buf.dropped_at == 1.5
+    # Idempotent — second call doesn't overwrite the first dropout time
+    buf.mark_dropped(t=2.7)
+    assert buf.dropped_at == 1.5

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -20,6 +20,7 @@ class _RecorderLiveSource:
     def __init__(self):
         self.appended = []
         self.dropped = []
+        self.corrected_batches = []  # NEW
 
     def append_uncorrected(self, *, side, cam_id, frame_id, t, bfi, bvi,
                            mean=None, contrast=None):
@@ -30,6 +31,9 @@ class _RecorderLiveSource:
 
     def mark_dropped(self, *, side, cam_id, t):
         self.dropped.append({"side": side, "cam_id": cam_id, "t": t})
+
+    def apply_corrected_batch(self, payload):  # NEW
+        self.corrected_batches.append(payload)
 
 
 def _connector():
@@ -118,40 +122,64 @@ def test_live_plot_sink_uses_per_frame_sdk_timestamps():
     assert [call[3] for call in conn.scanBviSampled.calls] == [1.25, 1.275]
 
 
+def _make_final_sink(conn, live_source=None):
+    if live_source is None:
+        live_source = _RecorderLiveSource()
+    return _FinalBatchSink(connector=conn, plot_t0=0.0, live_source=live_source), live_source
+
+
 def test_final_batch_sink_accepts_enriched_interval_frames():
     conn = _connector()
-    sink = _FinalBatchSink(connector=conn, plot_t0=0.0)
+    sink, _src = _make_final_sink(conn)
     interval = SimpleNamespace(
         frames=[
-            SimpleNamespace(
-                side="left",
-                cam_id=1,
-                abs_frame_id=42,
-                bfi=2.5,
-                bvi=6.5,
-                mean=125.0,
-                contrast=0.31,
-            ),
-            SimpleNamespace(
-                side="right",
-                cam_id=6,
-                abs_frame_id=43,
-                bfi=3.5,
-                bvi=7.5,
-                mean=140.0,
-                contrast=0.29,
-            ),
+            SimpleNamespace(side="left",  cam_id=1, abs_frame_id=42,
+                            bfi=2.5, bvi=6.5, mean=125.0, contrast=0.31),
+            SimpleNamespace(side="right", cam_id=6, abs_frame_id=43,
+                            bfi=3.5, bvi=7.5, mean=140.0, contrast=0.29),
         ]
     )
-
     sink.consume("final", interval)
-
     assert len(conn.scanCorrectedBatch.calls) == 1
     payload = conn.scanCorrectedBatch.calls[0][0]
     assert [(p["side"], p["camId"], p["frameId"], p["bfi"], p["bvi"], p["mean"], p["contrast"]) for p in payload] == [
         ("left", 1, 42, 2.5, 6.5, 125.0, 0.31),
         ("right", 6, 43, 3.5, 7.5, 140.0, 0.29),
     ]
+
+
+def test_final_batch_sink_forwards_payload_to_live_source():
+    conn = _connector()
+    sink, src = _make_final_sink(conn)
+    interval = SimpleNamespace(
+        frames=[
+            SimpleNamespace(side="left", cam_id=1, abs_frame_id=42,
+                            bfi=2.5, bvi=6.5, mean=125.0, contrast=0.31),
+        ]
+    )
+    sink.consume("final", interval)
+    assert len(src.corrected_batches) == 1
+    payload = src.corrected_batches[0]
+    assert payload[0]["frameId"] == 42
+    assert payload[0]["bfi"] == 2.5
+
+
+def test_final_batch_sink_skips_live_source_when_payload_empty():
+    """Empty payload (no samples passed the dropout gate) shouldn't even
+    call apply_corrected_batch."""
+    conn = _connector()
+    # Pre-populate dropped set so the dropout gate filters everything.
+    conn._camera_dropped.add(("left", 1))
+    sink, src = _make_final_sink(conn)
+    interval = SimpleNamespace(
+        frames=[
+            SimpleNamespace(side="left", cam_id=1, abs_frame_id=42,
+                            bfi=2.5, bvi=6.5, mean=125.0, contrast=0.31),
+        ]
+    )
+    sink.consume("final", interval)
+    assert src.corrected_batches == []
+    assert conn.scanCorrectedBatch.calls == []
 
 
 def test_live_plot_sink_appends_to_live_source():

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -1,4 +1,3 @@
-import math
 from types import SimpleNamespace
 
 import numpy as np
@@ -189,9 +188,10 @@ def test_final_batch_sink_skips_live_source_when_payload_empty():
 
 
 def test_live_plot_sink_appends_side_averaged_under_cam_id_minus_1():
-    """Reduced-mode side-averaged samples (bfi_live_side / bvi_live_side
-    set by SDK's SideAveragingStage) must land in cam_id=-1 buffers,
-    one per side per non-dark frame."""
+    """Reduced-mode side-averaged samples (bfi_live_side / bvi_live_side set by
+    SDK's SideAveragingStage) land in cam_id=-1 buffers — one per frame_id, for
+    the frame's OWN side only (so the cam_id=-1 buffer stays at the ~40 Hz
+    capture cadence, not N_cams×40 Hz)."""
     conn = _connector()
     sink, src = _make_sink(conn)
     batch = SimpleNamespace(
@@ -212,26 +212,58 @@ def test_live_plot_sink_appends_side_averaged_under_cam_id_minus_1():
     sink.consume("live", batch)
 
     side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    # 2 frames × 2 sides = 4 side-avg records
-    assert len(side_avg_records) == 4
-    # First frame, left side
-    rec = next(r for r in side_avg_records if r["t"] == 0.5 and r["side"] == "left")
-    assert rec["bfi"] == pytest.approx(0.42)
+    # frame 100 is a LEFT frame, frame 101 is a RIGHT frame → one record each,
+    # each carrying its own side's average.
+    assert len(side_avg_records) == 2
+    rec = next(r for r in side_avg_records if r["side"] == "left")
+    assert rec["bfi"] == pytest.approx(0.42)   # bfi_live_side[0, 0]
     assert rec["bvi"] == pytest.approx(5.0)
     assert rec["frame_id"] == 100
+    assert rec["t"] == 0.5
     assert rec["mean"] is None
     assert rec["contrast"] is None
-    # Second frame, right side
-    rec = next(r for r in side_avg_records if r["t"] == 0.525 and r["side"] == "right")
-    assert rec["bfi"] == pytest.approx(0.32)
+    rec = next(r for r in side_avg_records if r["side"] == "right")
+    assert rec["bfi"] == pytest.approx(0.32)   # bfi_live_side[1, 1]
     assert rec["bvi"] == pytest.approx(4.95)
+    assert rec["frame_id"] == 101
 
 
-def test_live_plot_sink_side_averaged_appends_even_when_nan():
-    """Regression: the renderer skips non-finite points per-segment,
-    so dropping NaN side-avg samples here leaves the buffer empty when
-    a single camera's NaN poisons the np.mean. Append NaN samples
-    so timestamps stay aligned."""
+def test_live_plot_sink_side_average_deduped_per_frame_id():
+    """All synced cameras of one capture arrive as separate frame rows sharing
+    a frame_id. The side average must be appended ONCE per frame_id, not once
+    per camera row — otherwise the cam_id=-1 buffer fills at N_cams×40 Hz."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    # 4 left-side cameras (0,1,6,7) of ONE capture: same frame_id, same t.
+    n = 4
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((n, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((n, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((n, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((n, 2, 8), dtype=np.float32),
+        temperature_c=np.full((n, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light"] * n, dtype="<U8"),
+        timestamp_s=np.full(n, 0.5, dtype=np.float64),
+        abs_frame_ids=np.full(n, 200, dtype=np.int64),
+        side_ids=np.zeros(n, dtype=np.int8),
+        cam_ids=np.array([0, 1, 6, 7], dtype=np.int8),
+        # Running average refines across the 4 rows; first row's value wins.
+        bfi_live_side=np.array([[1.0, np.nan]] * n, dtype=np.float32),
+        bvi_live_side=np.array([[10.0, np.nan]] * n, dtype=np.float32),
+    )
+
+    sink.consume("live", batch)
+
+    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
+    assert len(side_avg_records) == 1, "side average must be deduped per frame_id"
+    assert side_avg_records[0]["side"] == "left"
+    assert side_avg_records[0]["frame_id"] == 200
+    assert side_avg_records[0]["bfi"] == pytest.approx(1.0)
+
+
+def test_live_plot_sink_side_average_appends_only_own_side():
+    """Only the frame's OWN side is appended (the opposite side's value for
+    this row is a stale/NaN carry belonging to that side's own frames)."""
     conn = _connector()
     sink, src = _make_sink(conn)
     batch = SimpleNamespace(
@@ -243,24 +275,19 @@ def test_live_plot_sink_side_averaged_appends_even_when_nan():
         frame_type=np.array(["light"], dtype="<U8"),
         timestamp_s=np.array([0.25], dtype=np.float64),
         abs_frame_ids=np.array([5], dtype=np.int64),
-        side_ids=np.array([0], dtype=np.int8),
+        side_ids=np.array([0], dtype=np.int8),  # LEFT frame
         cam_ids=np.array([0], dtype=np.int8),
-        # Left side BFI is NaN (one camera was non-finite upstream);
-        # right side is finite.
-        bfi_live_side=np.array([[float("nan"), 0.5]], dtype=np.float32),
-        bvi_live_side=np.array([[float("nan"), 5.0]], dtype=np.float32),
+        bfi_live_side=np.array([[0.42, 0.5]], dtype=np.float32),
+        bvi_live_side=np.array([[5.0, 4.9]], dtype=np.float32),
     )
 
     sink.consume("live", batch)
 
     side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    # Both sides appended — even the NaN one — so timestamps stay aligned.
-    assert len(side_avg_records) == 2
-    left = next(r for r in side_avg_records if r["side"] == "left")
-    assert math.isnan(left["bfi"])
-    assert math.isnan(left["bvi"])
-    right = next(r for r in side_avg_records if r["side"] == "right")
-    assert right["bfi"] == pytest.approx(0.5)
+    # Only the LEFT (own) side is appended, not the RIGHT carry value.
+    assert len(side_avg_records) == 1
+    assert side_avg_records[0]["side"] == "left"
+    assert side_avg_records[0]["bfi"] == pytest.approx(0.42)
 
 
 def test_live_plot_sink_side_averaged_skipped_during_dark_frames():

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -187,140 +187,34 @@ def test_final_batch_sink_skips_live_source_when_payload_empty():
     assert conn.scanCorrectedBatch.calls == []
 
 
-def test_live_plot_sink_appends_side_averaged_under_cam_id_minus_1():
-    """Reduced-mode side-averaged samples (bfi_live_side / bvi_live_side set by
-    SDK's SideAveragingStage) land in cam_id=-1 buffers — one per frame_id, for
-    the frame's OWN side only (so the cam_id=-1 buffer stays at the ~40 Hz
-    capture cadence, not N_cams×40 Hz)."""
+def test_live_plot_sink_subscribes_to_live_side_channel():
+    sink, _ = _make_sink(_connector())
+    assert "live" in sink.channels
+    assert "live_side" in sink.channels
+
+
+def test_live_plot_sink_live_side_appends_under_cam_id_minus_1():
+    """A SideAverageSample on the 'live_side' channel (one per capture per side
+    from the SDK's LiveSideAverageStage) is appended under cam_id=-1 for its
+    side. No dedup/skip here — the stage already produced one per capture."""
     conn = _connector()
     sink, src = _make_sink(conn)
-    batch = SimpleNamespace(
-        bfi_live=np.zeros((2, 2, 8), dtype=np.float32),
-        bvi_live=np.zeros((2, 2, 8), dtype=np.float32),
-        mean_dc_rt=np.zeros((2, 2, 8), dtype=np.float32),
-        contrast_sn_rt=np.zeros((2, 2, 8), dtype=np.float32),
-        temperature_c=np.full((2, 2, 8), 35.0, dtype=np.float32),
-        frame_type=np.array(["light", "light"], dtype="<U8"),
-        timestamp_s=np.array([0.5, 0.525], dtype=np.float64),
-        abs_frame_ids=np.array([100, 101], dtype=np.int64),
-        side_ids=np.array([0, 1], dtype=np.int8),
-        cam_ids=np.array([0, 0], dtype=np.int8),
-        bfi_live_side=np.array([[0.42, 0.31], [0.43, 0.32]], dtype=np.float32),
-        bvi_live_side=np.array([[5.0, 4.9], [5.1, 4.95]], dtype=np.float32),
-    )
+    sink.consume("live_side", SimpleNamespace(t=0.5, frame_id=100, side=0, bfi=0.42, bvi=5.0))
+    sink.consume("live_side", SimpleNamespace(t=0.5, frame_id=100, side=1, bfi=0.31, bvi=4.9))
 
-    sink.consume("live", batch)
-
-    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    # frame 100 is a LEFT frame, frame 101 is a RIGHT frame → one record each,
-    # each carrying its own side's average.
-    assert len(side_avg_records) == 2
-    rec = next(r for r in side_avg_records if r["side"] == "left")
-    assert rec["bfi"] == pytest.approx(0.42)   # bfi_live_side[0, 0]
-    assert rec["bvi"] == pytest.approx(5.0)
-    assert rec["frame_id"] == 100
-    assert rec["t"] == 0.5
-    assert rec["mean"] is None
-    assert rec["contrast"] is None
-    rec = next(r for r in side_avg_records if r["side"] == "right")
-    assert rec["bfi"] == pytest.approx(0.32)   # bfi_live_side[1, 1]
-    assert rec["bvi"] == pytest.approx(4.95)
-    assert rec["frame_id"] == 101
+    recs = [r for r in src.appended if r["cam_id"] == -1]
+    assert len(recs) == 2
+    left = next(r for r in recs if r["side"] == "left")
+    assert left["bfi"] == pytest.approx(0.42) and left["bvi"] == pytest.approx(5.0)
+    assert left["frame_id"] == 100 and left["t"] == pytest.approx(0.5)
+    assert left["mean"] is None and left["contrast"] is None
+    right = next(r for r in recs if r["side"] == "right")
+    assert right["bfi"] == pytest.approx(0.31)
 
 
-def test_live_plot_sink_side_average_deduped_per_frame_id():
-    """All synced cameras of one capture arrive as separate frame rows sharing
-    a frame_id. The side average must be appended ONCE per frame_id, not once
-    per camera row — otherwise the cam_id=-1 buffer fills at N_cams×40 Hz."""
-    conn = _connector()
-    sink, src = _make_sink(conn)
-    # 4 left-side cameras (0,1,6,7) of ONE capture: same frame_id, same t.
-    n = 4
-    batch = SimpleNamespace(
-        bfi_live=np.zeros((n, 2, 8), dtype=np.float32),
-        bvi_live=np.zeros((n, 2, 8), dtype=np.float32),
-        mean_dc_rt=np.zeros((n, 2, 8), dtype=np.float32),
-        contrast_sn_rt=np.zeros((n, 2, 8), dtype=np.float32),
-        temperature_c=np.full((n, 2, 8), 35.0, dtype=np.float32),
-        frame_type=np.array(["light"] * n, dtype="<U8"),
-        timestamp_s=np.full(n, 0.5, dtype=np.float64),
-        abs_frame_ids=np.full(n, 200, dtype=np.int64),
-        side_ids=np.zeros(n, dtype=np.int8),
-        cam_ids=np.array([0, 1, 6, 7], dtype=np.int8),
-        # Running average refines across the 4 rows; first row's value wins.
-        bfi_live_side=np.array([[1.0, np.nan]] * n, dtype=np.float32),
-        bvi_live_side=np.array([[10.0, np.nan]] * n, dtype=np.float32),
-    )
-
-    sink.consume("live", batch)
-
-    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    assert len(side_avg_records) == 1, "side average must be deduped per frame_id"
-    assert side_avg_records[0]["side"] == "left"
-    assert side_avg_records[0]["frame_id"] == 200
-    assert side_avg_records[0]["bfi"] == pytest.approx(1.0)
-
-
-def test_live_plot_sink_side_average_appends_only_own_side():
-    """Only the frame's OWN side is appended (the opposite side's value for
-    this row is a stale/NaN carry belonging to that side's own frames)."""
-    conn = _connector()
-    sink, src = _make_sink(conn)
-    batch = SimpleNamespace(
-        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
-        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
-        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
-        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
-        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
-        frame_type=np.array(["light"], dtype="<U8"),
-        timestamp_s=np.array([0.25], dtype=np.float64),
-        abs_frame_ids=np.array([5], dtype=np.int64),
-        side_ids=np.array([0], dtype=np.int8),  # LEFT frame
-        cam_ids=np.array([0], dtype=np.int8),
-        bfi_live_side=np.array([[0.42, 0.5]], dtype=np.float32),
-        bvi_live_side=np.array([[5.0, 4.9]], dtype=np.float32),
-    )
-
-    sink.consume("live", batch)
-
-    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    # Only the LEFT (own) side is appended, not the RIGHT carry value.
-    assert len(side_avg_records) == 1
-    assert side_avg_records[0]["side"] == "left"
-    assert side_avg_records[0]["bfi"] == pytest.approx(0.42)
-
-
-def test_live_plot_sink_side_averaged_skipped_during_dark_frames():
-    """Dark frames don't carry meaningful per-side BFI/BVI display
-    values — the side-avg block is gated on `not is_dark` so the
-    cam_id=-1 buffer stays clean of dark-frame entries."""
-    conn = _connector()
-    sink, src = _make_sink(conn)
-    batch = SimpleNamespace(
-        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
-        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
-        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
-        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
-        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
-        frame_type=np.array(["dark"], dtype="<U8"),
-        timestamp_s=np.array([0.5], dtype=np.float64),
-        abs_frame_ids=np.array([1], dtype=np.int64),
-        side_ids=np.array([0], dtype=np.int8),
-        cam_ids=np.array([0], dtype=np.int8),
-        bfi_live_side=np.array([[0.42, 0.31]], dtype=np.float32),
-        bvi_live_side=np.array([[5.0, 4.9]], dtype=np.float32),
-    )
-
-    sink.consume("live", batch)
-
-    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    assert side_avg_records == []
-
-
-def test_live_plot_sink_no_side_averaged_appends_when_arrays_missing():
-    """When the SDK's SideAveragingStage is disabled (reduced_mode=False),
-    batches don't carry bfi_live_side / bvi_live_side. The sink must
-    not synthesize cam_id=-1 entries."""
+def test_live_plot_sink_live_channel_appends_no_side_average():
+    """The 'live' channel feeds only per-camera buffers; the cam_id=-1 side
+    average comes solely from the 'live_side' channel now."""
     conn = _connector()
     sink, src = _make_sink(conn)
     batch = SimpleNamespace(
@@ -334,13 +228,39 @@ def test_live_plot_sink_no_side_averaged_appends_when_arrays_missing():
         abs_frame_ids=np.array([1], dtype=np.int64),
         side_ids=np.array([0], dtype=np.int8),
         cam_ids=np.array([0], dtype=np.int8),
-        # No bfi_live_side / bvi_live_side attributes at all.
     )
+    batch.bfi_live[0, 0, 0] = 0.3
+    batch.bvi_live[0, 0, 0] = 5.0
 
     sink.consume("live", batch)
 
-    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
-    assert side_avg_records == []
+    assert [r for r in src.appended if r["cam_id"] == -1] == []
+    assert [r for r in src.appended if r["cam_id"] == 0]  # per-cam still appended
+
+
+def test_live_plot_sink_live_channel_updates_dropout_heartbeat():
+    """Per-camera BFI arrival on the 'live' channel still updates the
+    dropout-watchdog heartbeat — reduced mode shows only the average, but
+    liveness detection must keep seeing each camera."""
+    conn = _connector()
+    sink, _ = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light"], dtype="<U8"),
+        timestamp_s=np.array([0.5], dtype=np.float64),
+        abs_frame_ids=np.array([1], dtype=np.int64),
+        side_ids=np.array([0], dtype=np.int8),
+        cam_ids=np.array([3], dtype=np.int8),
+    )
+    batch.bfi_live[0, 0, 3] = 0.3
+    batch.bvi_live[0, 0, 3] = 5.0
+
+    sink.consume("live", batch)
+    assert ("left", 3) in conn._camera_last_seen
 
 
 def test_live_plot_sink_appends_to_live_source():

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -1,3 +1,4 @@
+import math
 from types import SimpleNamespace
 
 import numpy as np
@@ -185,6 +186,134 @@ def test_final_batch_sink_skips_live_source_when_payload_empty():
     sink.consume("final", interval)
     assert src.corrected_batches == []
     assert conn.scanCorrectedBatch.calls == []
+
+
+def test_live_plot_sink_appends_side_averaged_under_cam_id_minus_1():
+    """Reduced-mode side-averaged samples (bfi_live_side / bvi_live_side
+    set by SDK's SideAveragingStage) must land in cam_id=-1 buffers,
+    one per side per non-dark frame."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((2, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((2, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((2, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((2, 2, 8), dtype=np.float32),
+        temperature_c=np.full((2, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light", "light"], dtype="<U8"),
+        timestamp_s=np.array([0.5, 0.525], dtype=np.float64),
+        abs_frame_ids=np.array([100, 101], dtype=np.int64),
+        side_ids=np.array([0, 1], dtype=np.int8),
+        cam_ids=np.array([0, 0], dtype=np.int8),
+        bfi_live_side=np.array([[0.42, 0.31], [0.43, 0.32]], dtype=np.float32),
+        bvi_live_side=np.array([[5.0, 4.9], [5.1, 4.95]], dtype=np.float32),
+    )
+
+    sink.consume("live", batch)
+
+    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
+    # 2 frames × 2 sides = 4 side-avg records
+    assert len(side_avg_records) == 4
+    # First frame, left side
+    rec = next(r for r in side_avg_records if r["t"] == 0.5 and r["side"] == "left")
+    assert rec["bfi"] == pytest.approx(0.42)
+    assert rec["bvi"] == pytest.approx(5.0)
+    assert rec["frame_id"] == 100
+    assert rec["mean"] is None
+    assert rec["contrast"] is None
+    # Second frame, right side
+    rec = next(r for r in side_avg_records if r["t"] == 0.525 and r["side"] == "right")
+    assert rec["bfi"] == pytest.approx(0.32)
+    assert rec["bvi"] == pytest.approx(4.95)
+
+
+def test_live_plot_sink_side_averaged_appends_even_when_nan():
+    """Regression: the renderer skips non-finite points per-segment,
+    so dropping NaN side-avg samples here leaves the buffer empty when
+    a single camera's NaN poisons the np.mean. Append NaN samples
+    so timestamps stay aligned."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light"], dtype="<U8"),
+        timestamp_s=np.array([0.25], dtype=np.float64),
+        abs_frame_ids=np.array([5], dtype=np.int64),
+        side_ids=np.array([0], dtype=np.int8),
+        cam_ids=np.array([0], dtype=np.int8),
+        # Left side BFI is NaN (one camera was non-finite upstream);
+        # right side is finite.
+        bfi_live_side=np.array([[float("nan"), 0.5]], dtype=np.float32),
+        bvi_live_side=np.array([[float("nan"), 5.0]], dtype=np.float32),
+    )
+
+    sink.consume("live", batch)
+
+    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
+    # Both sides appended — even the NaN one — so timestamps stay aligned.
+    assert len(side_avg_records) == 2
+    left = next(r for r in side_avg_records if r["side"] == "left")
+    assert math.isnan(left["bfi"])
+    assert math.isnan(left["bvi"])
+    right = next(r for r in side_avg_records if r["side"] == "right")
+    assert right["bfi"] == pytest.approx(0.5)
+
+
+def test_live_plot_sink_side_averaged_skipped_during_dark_frames():
+    """Dark frames don't carry meaningful per-side BFI/BVI display
+    values — the side-avg block is gated on `not is_dark` so the
+    cam_id=-1 buffer stays clean of dark-frame entries."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["dark"], dtype="<U8"),
+        timestamp_s=np.array([0.5], dtype=np.float64),
+        abs_frame_ids=np.array([1], dtype=np.int64),
+        side_ids=np.array([0], dtype=np.int8),
+        cam_ids=np.array([0], dtype=np.int8),
+        bfi_live_side=np.array([[0.42, 0.31]], dtype=np.float32),
+        bvi_live_side=np.array([[5.0, 4.9]], dtype=np.float32),
+    )
+
+    sink.consume("live", batch)
+
+    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
+    assert side_avg_records == []
+
+
+def test_live_plot_sink_no_side_averaged_appends_when_arrays_missing():
+    """When the SDK's SideAveragingStage is disabled (reduced_mode=False),
+    batches don't carry bfi_live_side / bvi_live_side. The sink must
+    not synthesize cam_id=-1 entries."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light"], dtype="<U8"),
+        timestamp_s=np.array([0.5], dtype=np.float64),
+        abs_frame_ids=np.array([1], dtype=np.int64),
+        side_ids=np.array([0], dtype=np.int8),
+        cam_ids=np.array([0], dtype=np.int8),
+        # No bfi_live_side / bvi_live_side attributes at all.
+    )
+
+    sink.consume("live", batch)
+
+    side_avg_records = [r for r in src.appended if r["cam_id"] == -1]
+    assert side_avg_records == []
 
 
 def test_live_plot_sink_appends_to_live_source():

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -148,7 +148,12 @@ def test_final_batch_sink_accepts_enriched_interval_frames():
     ]
 
 
-def test_final_batch_sink_forwards_payload_to_live_source():
+def test_final_batch_sink_does_not_forward_to_live_source():
+    """The new viewer is intentionally NOT fed corrected values — the
+    in-place buffer rewrite at every dark-interval close caused visible
+    mid-scan disruption. Legacy plot still gets the scanCorrectedBatch
+    Qt signal; the LiveScanSource is left at uncorrected live values.
+    Re-flip this test if/when corrected handoff is reintroduced."""
     conn = _connector()
     sink, src = _make_final_sink(conn)
     interval = SimpleNamespace(
@@ -158,10 +163,10 @@ def test_final_batch_sink_forwards_payload_to_live_source():
         ]
     )
     sink.consume("final", interval)
-    assert len(src.corrected_batches) == 1
-    payload = src.corrected_batches[0]
-    assert payload[0]["frameId"] == 42
-    assert payload[0]["bfi"] == 2.5
+    # Legacy emit still fires.
+    assert len(conn.scanCorrectedBatch.calls) == 1
+    # New viewer source not touched.
+    assert src.corrected_batches == []
 
 
 def test_final_batch_sink_skips_live_source_when_payload_empty():

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -16,6 +16,22 @@ class _Signal:
         self.calls.append(args)
 
 
+class _RecorderLiveSource:
+    def __init__(self):
+        self.appended = []
+        self.dropped = []
+
+    def append_uncorrected(self, *, side, cam_id, frame_id, t, bfi, bvi,
+                           mean=None, contrast=None):
+        self.appended.append({
+            "side": side, "cam_id": cam_id, "frame_id": frame_id, "t": t,
+            "bfi": bfi, "bvi": bvi, "mean": mean, "contrast": contrast,
+        })
+
+    def mark_dropped(self, *, side, cam_id, t):
+        self.dropped.append({"side": side, "cam_id": cam_id, "t": t})
+
+
 def _connector():
     return SimpleNamespace(
         _camera_temp_alert_threshold_c=100.0,
@@ -33,9 +49,16 @@ def _connector():
     )
 
 
+def _make_sink(conn, live_source=None):
+    """Helper: build a _LivePlotSink with a stub live_source if not provided."""
+    if live_source is None:
+        live_source = _RecorderLiveSource()
+    return _LivePlotSink(connector=conn, plot_t0=0.0, live_source=live_source), live_source
+
+
 def test_live_plot_sink_emits_only_source_camera_for_each_row():
     conn = _connector()
-    sink = _LivePlotSink(connector=conn, plot_t0=0.0)
+    sink, _ = _make_sink(conn)
     batch = SimpleNamespace(
         bfi_live=np.zeros((2, 2, 8), dtype=np.float32),
         bvi_live=np.zeros((2, 2, 8), dtype=np.float32),
@@ -72,7 +95,7 @@ def test_live_plot_sink_emits_only_source_camera_for_each_row():
 
 def test_live_plot_sink_uses_per_frame_sdk_timestamps():
     conn = _connector()
-    sink = _LivePlotSink(connector=conn, plot_t0=0.0)
+    sink, _ = _make_sink(conn)
     batch = SimpleNamespace(
         bfi_live=np.zeros((2, 2, 8), dtype=np.float32),
         bvi_live=np.zeros((2, 2, 8), dtype=np.float32),
@@ -129,3 +152,36 @@ def test_final_batch_sink_accepts_enriched_interval_frames():
         ("left", 1, 42, 2.5, 6.5, 125.0, 0.31),
         ("right", 6, 43, 3.5, 7.5, 140.0, 0.29),
     ]
+
+
+def test_live_plot_sink_appends_to_live_source():
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.full((1, 2, 8), 0.25, dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light"], dtype="<U8"),
+        timestamp_s=np.array([1.5], dtype=np.float64),
+        abs_frame_ids=np.array([77], dtype=np.int64),
+        side_ids=np.array([1], dtype=np.int8),
+        cam_ids=np.array([4], dtype=np.int8),
+    )
+    batch.bfi_live[0, 1, 4] = 4.4
+    batch.bvi_live[0, 1, 4] = 3.3
+    batch.mean_dc_rt[0, 1, 4] = 125.0
+
+    sink.consume("live", batch)
+
+    assert len(src.appended) == 1
+    rec = src.appended[0]
+    assert rec["side"] == "right"
+    assert rec["cam_id"] == 4
+    assert rec["frame_id"] == 77
+    assert rec["t"] == 1.5
+    assert rec["bfi"] == pytest.approx(4.4)
+    assert rec["bvi"] == pytest.approx(3.3)
+    assert rec["mean"] == pytest.approx(125.0)
+    assert rec["contrast"] == pytest.approx(0.25)

--- a/tests/test_scan_history_list.py
+++ b/tests/test_scan_history_list.py
@@ -1,0 +1,66 @@
+"""get_scan_list — History must list DB-backed scans, not just corrected CSVs."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MOTIONConnector
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path  # explicit: MagicMock default would be truthy
+    return MOTIONConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _session(db_path, label, start):
+    db = ScanDatabase(db_path=db_path)
+    db.create_session(session_label=label, session_start=start,
+                      session_notes=None, session_meta={})
+    db.close()
+
+
+def test_get_scan_list_includes_db_session_without_csv(tmp_path):
+    """A reduced-mode scan writes no corrected CSV — it must still appear,
+    sourced from the scan DB's sessions."""
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, "20260528_211930_ow6I2NJL", 1.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+    assert "20260528_211930_ow6I2NJL" in c.get_scan_list()
+
+
+def test_get_scan_list_merges_csv_and_db_without_duplicates(tmp_path):
+    # CSV-backed scan on disk.
+    (tmp_path / "20260528_120000_subjA.csv").write_text("frame_id,timestamp_s\n", encoding="utf-8")
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, "20260528_120000_subjA", 1.0)   # same scan, also in DB
+    _session(db_path, "20260528_130000_subjB", 2.0)   # DB-only scan
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    scans = c.get_scan_list()
+    assert scans.count("20260528_120000_subjA") == 1  # merged, not duplicated
+    assert "20260528_130000_subjB" in scans
+    # newest first
+    assert scans.index("20260528_130000_subjB") < scans.index("20260528_120000_subjA")
+
+
+def test_get_scan_list_csv_only_when_no_db(tmp_path):
+    (tmp_path / "20260528_120000_subjA.csv").write_text("x\n", encoding="utf-8")
+    c = _connector(tmp_path, scan_db_path=None)
+    assert c.get_scan_list() == ["20260528_120000_subjA"]
+
+
+def test_get_scan_list_skips_aux_csvs(tmp_path):
+    (tmp_path / "20260528_120000_subjA_telemetry.csv").write_text("x\n", encoding="utf-8")
+    (tmp_path / "20260528_120000_subjA_left_mask66_raw.csv").write_text("x\n", encoding="utf-8")
+    c = _connector(tmp_path, scan_db_path=None)
+    assert c.get_scan_list() == []


### PR DESCRIPTION
## Summary

Replaces the bloodflow app's three separate BFI/BVI views — `EmbeddedRealtimePlot.qml`
(dev grid), `ReducedPlotView.qml` (clinical side-averages), and the matplotlib
history popouts — with **one Saleae-Logic-style in-app viewer**: DVR scrollback
during a live scan, mouse + touch pan/zoom, a synced crosshair + tooltip across
all cells, and on-demand replay of any past scan straight from the scan DB —
all without leaving the BloodFlow page.

Pairs with **openmotion-sdk #61** — this consumes the SDK's `live_side` /
`final_side` events and the `session_data` rows `ScanDBSink` writes. **They must
land together.**

## Highlights

### Unified viewer (`PlotViewer.qml` + `PlotCell.qml` + `PlotScrubber.qml`)
- One component renders both the per-camera grid (dev) and the per-side layout
  (reduced) — no second plot.
- **DVR scrollback**: pan/zoom in time without stopping the scan; explicit
  "Back to live" restores live-edge tracking.
- Synced vertical **crosshair + single tooltip** across cells; shared time axis,
  independent Y axes.
- **Touch** (pinch-zoom) and **keyboard** shortcuts (pan/zoom/home/end/reset).
- Corner-overlay toolbar: window-length pill + `⋯` menu (Autoscale, display-mode
  switches), dev-only profiler HUD.
- Decimation: time-keyed, stride-aligned **causal** smoothing — no "morph" as the
  window scrolls, smooth from start-of-scan.

### Data layer (`data_sources.py`)
- `ScanDataSource` / `LiveScanSource` / `PastScanSource` over a growable
  `_CameraBuffer`.
- **DB-backed past-scan replay**; **DB-tail lazy-load** — panning before the
  in-memory window pulls older samples from the scan DB (WAL, concurrent-read
  safe); straddle-stitches the DB tail with the in-memory edge; historical
  buffers are unbounded so a long load never trims itself. In-memory cache bound
  by `liveCacheMaxSeconds` (default 60 s).

### Reduced-mode side average (with SDK #61)
- `_LivePlotSink` consumes the SDK's `live_side` event (realtime per-side
  average); replay reads the corrected per-side average from the DB at
  `cam_id=-1`. The derive-on-read path is gone.
- Hide the BFI/BVI ↔ Mean/Contrast switch in reduced mode.

### Storage & History
- Corrected CSV is opt-in (the scan DB is the store).
- **History lists DB-backed scans**, not just corrected CSVs (reduced-mode scans
  write no CSV) — merges DB sessions with on-disk CSVs.
- Surface the scan-abort reason when `start_scan` refuses (e.g. DB unavailable).

## Test plan
- App unit suite: **116 passing** (`test_data_sources`, `test_live_plot_sink`,
  `test_scan_history_list`, lifecycle gates).
- **Hardware-verified**: live dev + reduced scans (smooth side average), pan-back
  into the DB tail, History listing + past-scan replay.

## Notes for review
- **Merge together with openmotion-sdk #61.**
- Suggest **squash-merge** — 90+ commits of iterative UI tuning and a few
  superseded interim fixes.
- `useNewPlotViewer` defaults true; the legacy Loaders (`EmbeddedRealtimePlot` /
  `ReducedPlotView`) and `PlotToolbar.qml` are kept one release as a fallback and
  can be removed next.
- Design / plan / status docs under `docs/superpowers/`.