### PR TITLE
Release 1.1.3

### DIFF
--- a/components/DeveloperUnlockModal.qml
+++ b/components/DeveloperUnlockModal.qml
@@ -1,0 +1,152 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import OpenMotion 1.0
+
+// Small password prompt for unlocking developer mode. Opened from
+// main.qml on a logo double-click. On the correct password it persists
+// developerMode=true via setConfig and emits unlocked().
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 10000
+
+    AppTheme { id: theme }
+
+    signal unlocked()
+
+    function open() {
+        pwField.text = ""
+        errorLabel.visible = false
+        root.visible = true
+        pwField.forceActiveFocus()
+    }
+    function close() {
+        root.visible = false
+    }
+
+    function _submit() {
+        if (MOTIONInterface.checkDeveloperPassword(pwField.text)) {
+            MOTIONInterface.setConfig("developerMode", true)
+            MOTIONInterface.notify("Developer mode enabled.", "info", 3000, false, "dev-mode")
+            root.unlocked()
+            root.close()
+        } else {
+            errorLabel.visible = true
+            pwField.text = ""
+            pwField.forceActiveFocus()
+        }
+    }
+
+    // Backdrop — click outside closes.
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000B0"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    // Panel
+    Rectangle {
+        width: 360
+        height: contentCol.implicitHeight + 48
+        radius: 14
+        color: theme.bgContainer
+        border.color: theme.borderStrong
+        border.width: 1
+        anchors.centerIn: parent
+
+        // Absorb clicks so they don't reach the backdrop.
+        MouseArea { anchors.fill: parent }
+
+        ColumnLayout {
+            id: contentCol
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 16
+
+            Text {
+                text: "Developer Access"
+                color: theme.textPrimary
+                font.pixelSize: 18
+                font.weight: Font.DemiBold
+            }
+
+            Text {
+                text: "Enter the developer password to enable developer mode."
+                color: theme.textSecondary
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            TextField {
+                id: pwField
+                Layout.fillWidth: true
+                Layout.preferredHeight: 34
+                echoMode: TextInput.Password
+                placeholderText: "Password"
+                color: theme.textPrimary
+                font.pixelSize: 14
+                background: Rectangle {
+                    color: theme.bgInput
+                    radius: 4
+                    border.color: pwField.activeFocus ? theme.accentBlue : theme.borderSoft
+                    border.width: 1
+                }
+                onAccepted: root._submit()
+            }
+
+            Text {
+                id: errorLabel
+                text: "Incorrect password"
+                color: theme.accentRed
+                font.pixelSize: 12
+                visible: false
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 12
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Cancel"
+                    Layout.preferredHeight: 32
+                    onClicked: root.close()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSoft; border.width: 1
+                    }
+                }
+
+                Button {
+                    text: "Unlock"
+                    Layout.preferredHeight: 32
+                    onClicked: root._submit()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Qt.lighter(theme.accentBlue, 1.1) : theme.accentBlue
+                        radius: 4
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+}

--- a/components/DeveloperUnlockModal.qml
+++ b/components/DeveloperUnlockModal.qml
@@ -83,11 +83,17 @@ Item {
             TextField {
                 id: pwField
                 Layout.fillWidth: true
-                Layout.preferredHeight: 34
+                Layout.preferredHeight: 38
                 echoMode: TextInput.Password
-                placeholderText: "Password"
+                placeholderText: ""
                 color: theme.textPrimary
+                placeholderTextColor: theme.textSecondary
                 font.pixelSize: 14
+                verticalAlignment: TextInput.AlignVCenter
+                leftPadding: 10
+                rightPadding: 10
+                topPadding: 0
+                bottomPadding: 0
                 background: Rectangle {
                     color: theme.bgInput
                     radius: 4

--- a/components/DeveloperUnlockModal.qml
+++ b/components/DeveloperUnlockModal.qml
@@ -6,153 +6,17 @@ import OpenMotion 1.0
 // Small password prompt for unlocking developer mode. Opened from
 // main.qml on a logo double-click. On the correct password it persists
 // developerMode=true via setConfig and emits unlocked().
-Item {
+PasswordPromptModal {
     id: root
-    anchors.fill: parent
-    visible: false
-    z: 10000
-
-    AppTheme { id: theme }
+    title: "Developer Access"
+    description: "Enter the developer password to enable developer mode."
+    confirmLabel: "Unlock"
 
     signal unlocked()
 
-    function open() {
-        pwField.text = ""
-        errorLabel.visible = false
-        root.visible = true
-        pwField.forceActiveFocus()
-    }
-    function close() {
-        root.visible = false
-    }
-
-    function _submit() {
-        if (MOTIONInterface.checkDeveloperPassword(pwField.text)) {
-            MOTIONInterface.setConfig("developerMode", true)
-            MOTIONInterface.notify("Developer mode enabled.", "info", 3000, false, "dev-mode")
-            root.unlocked()
-            root.close()
-        } else {
-            errorLabel.visible = true
-            pwField.text = ""
-            pwField.forceActiveFocus()
-        }
-    }
-
-    // Backdrop — click outside closes.
-    Rectangle {
-        anchors.fill: parent
-        color: "#000000B0"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
-    }
-
-    // Panel
-    Rectangle {
-        width: 360
-        height: contentCol.implicitHeight + 48
-        radius: 14
-        color: theme.bgContainer
-        border.color: theme.borderStrong
-        border.width: 1
-        anchors.centerIn: parent
-
-        // Absorb clicks so they don't reach the backdrop.
-        MouseArea { anchors.fill: parent }
-
-        ColumnLayout {
-            id: contentCol
-            anchors.fill: parent
-            anchors.margins: 24
-            spacing: 16
-
-            Text {
-                text: "Developer Access"
-                color: theme.textPrimary
-                font.pixelSize: 18
-                font.weight: Font.DemiBold
-            }
-
-            Text {
-                text: "Enter the developer password to enable developer mode."
-                color: theme.textSecondary
-                font.pixelSize: 13
-                wrapMode: Text.WordWrap
-                Layout.fillWidth: true
-            }
-
-            TextField {
-                id: pwField
-                Layout.fillWidth: true
-                Layout.preferredHeight: 38
-                echoMode: TextInput.Password
-                placeholderText: ""
-                color: theme.textPrimary
-                placeholderTextColor: theme.textSecondary
-                font.pixelSize: 14
-                verticalAlignment: TextInput.AlignVCenter
-                leftPadding: 10
-                rightPadding: 10
-                topPadding: 0
-                bottomPadding: 0
-                background: Rectangle {
-                    color: theme.bgInput
-                    radius: 4
-                    border.color: pwField.activeFocus ? theme.accentBlue : theme.borderSoft
-                    border.width: 1
-                }
-                onAccepted: root._submit()
-            }
-
-            Text {
-                id: errorLabel
-                text: "Incorrect password"
-                color: theme.accentRed
-                font.pixelSize: 12
-                visible: false
-            }
-
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: 12
-                Item { Layout.fillWidth: true }
-
-                Button {
-                    text: "Cancel"
-                    Layout.preferredHeight: 32
-                    onClicked: root.close()
-                    contentItem: Text {
-                        text: parent.text; font.pixelSize: 13
-                        color: theme.textSecondary
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                    }
-                    background: Rectangle {
-                        color: parent.hovered ? theme.bgHover : theme.bgInput
-                        radius: 4
-                        border.color: theme.borderSoft; border.width: 1
-                    }
-                }
-
-                Button {
-                    text: "Unlock"
-                    Layout.preferredHeight: 32
-                    onClicked: root._submit()
-                    contentItem: Text {
-                        text: parent.text; font.pixelSize: 13
-                        color: "#FFFFFF"
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                    }
-                    background: Rectangle {
-                        color: parent.hovered ? Qt.lighter(theme.accentBlue, 1.1) : theme.accentBlue
-                        radius: 4
-                    }
-                }
-            }
-        }
-
-        Keys.onReleased: function(event) {
-            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
-        }
+    onAccepted: {
+        MOTIONInterface.setConfig("developerMode", true)
+        MOTIONInterface.notify("Developer mode enabled.", "info", 3000, false, "dev-mode")
+        root.unlocked()
     }
 }

--- a/components/PasswordPromptModal.qml
+++ b/components/PasswordPromptModal.qml
@@ -1,0 +1,160 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import OpenMotion 1.0
+
+// Reusable password prompt modal. Checks against the developer password
+// and emits accepted() on success. Caller sets title, description, and
+// confirmLabel to customise the appearance.
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 10000
+
+    AppTheme { id: theme }
+
+    property string title: "Password Required"
+    property string description: "Enter the password to continue."
+    property string confirmLabel: "Confirm"
+
+    signal accepted()
+
+    function open() {
+        pwField.text = ""
+        errorLabel.visible = false
+        root.visible = true
+        pwField.forceActiveFocus()
+    }
+    function close() {
+        root.visible = false
+    }
+
+    function _submit() {
+        if (MOTIONInterface.checkDeveloperPassword(pwField.text)) {
+            root.accepted()
+            root.close()
+        } else {
+            errorLabel.visible = true
+            pwField.text = ""
+            pwField.forceActiveFocus()
+        }
+    }
+
+    // Backdrop — click outside closes.
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000B0"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    // Panel
+    Rectangle {
+        width: 360
+        height: contentCol.implicitHeight + 48
+        radius: 14
+        color: theme.bgContainer
+        border.color: theme.borderStrong
+        border.width: 1
+        anchors.centerIn: parent
+
+        // Absorb clicks so they don't reach the backdrop.
+        MouseArea { anchors.fill: parent }
+
+        ColumnLayout {
+            id: contentCol
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 16
+
+            Text {
+                text: root.title
+                color: theme.textPrimary
+                font.pixelSize: 18
+                font.weight: Font.DemiBold
+            }
+
+            Text {
+                text: root.description
+                color: theme.textSecondary
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            TextField {
+                id: pwField
+                Layout.fillWidth: true
+                Layout.preferredHeight: 38
+                echoMode: TextInput.Password
+                placeholderText: ""
+                color: theme.textPrimary
+                placeholderTextColor: theme.textSecondary
+                font.pixelSize: 14
+                verticalAlignment: TextInput.AlignVCenter
+                leftPadding: 10
+                rightPadding: 10
+                topPadding: 0
+                bottomPadding: 0
+                background: Rectangle {
+                    color: theme.bgInput
+                    radius: 4
+                    border.color: pwField.activeFocus ? theme.accentBlue : theme.borderSoft
+                    border.width: 1
+                }
+                onAccepted: root._submit()
+            }
+
+            Text {
+                id: errorLabel
+                text: "Incorrect password"
+                color: theme.accentRed
+                font.pixelSize: 12
+                visible: false
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 12
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Cancel"
+                    Layout.preferredHeight: 32
+                    onClicked: root.close()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSoft; border.width: 1
+                    }
+                }
+
+                Button {
+                    text: root.confirmLabel
+                    Layout.preferredHeight: 32
+                    onClicked: root._submit()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Qt.lighter(theme.accentBlue, 1.1) : theme.accentBlue
+                        radius: 4
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+}

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -725,6 +725,21 @@ Item {
                     }
 
                     FieldRow {
+                        label: "Console fans"
+                        PillSwitch {
+                            checked: MOTIONInterface.consoleFanOn
+                            enabled: MOTIONInterface.consoleConnected
+                            onToggled: MOTIONInterface.setConsoleFan(checked)
+                        }
+                        Text {
+                            text: MOTIONInterface.consoleFanOn ? "On" : "Off"
+                            color: MOTIONInterface.consoleFanOn ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    FieldRow {
                         label: "Save raw CSV"
                         PillSwitch {
                             checked: root.writeRawCsv
@@ -768,11 +783,16 @@ Item {
                         }
                         Item { Layout.fillWidth: true }
                     }
-                }
 
-                // ── Calibration ──────────────────────────────────────────────
-                SectionCard {
-                    title: "Calibration"
+                    // ── Calibration / Test (moved here from the former
+                    //    standalone Calibration card; now developer-only) ──
+                    Rectangle { Layout.fillWidth: true; height: 1; color: root.colBorderSoft }
+                    Text {
+                        text: "Calibration"
+                        color: root.colTextPri
+                        font.pixelSize: 13
+                        font.weight: Font.DemiBold
+                    }
 
                     RowLayout {
                         Layout.fillWidth: true
@@ -905,6 +925,21 @@ Item {
                                 testResultsWindow.requestActivate()
                             }
                         }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: root.colBorderSoft }
+                    FieldRow {
+                        label: "Developer mode"
+                        ActionButton {
+                            text: "Disable developer mode"
+                            Layout.preferredWidth: 200
+                            hoverColor: "#C0392B"
+                            onClicked: {
+                                MOTIONInterface.setConfig("developerMode", false)
+                                MOTIONInterface.notify("Developer mode disabled.", "info", 3000, false, "dev-mode")
+                            }
+                        }
+                        Item { Layout.fillWidth: true }
                     }
                 }
 

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -52,6 +52,17 @@ Item {
 
     signal settingsChanged()
 
+    // Password gate for the Calibrate action.
+    PasswordPromptModal {
+        id: calibrationPasswordModal
+        title: "Calibration"
+        description: "Enter the password to start calibration."
+        confirmLabel: "Calibrate"
+        onAccepted: MOTIONInterface.runCalibration(
+            calibrationTargetCombo.currentText.toLowerCase()
+        )
+    }
+
     // ── Lifecycle ───────────────────────────────────────────────────────────
     function _loadFromConfig() {
         var cfg = MOTIONInterface.appConfig
@@ -830,9 +841,7 @@ Item {
                             enabled: MOTIONInterface.consoleConnected
                                   && !MOTIONInterface.calibrationRunning
                                   && !MOTIONInterface.testScanRunning
-                            onClicked: MOTIONInterface.runCalibration(
-                                calibrationTargetCombo.currentText.toLowerCase()
-                            )
+                            onClicked: calibrationPasswordModal.open()
                         }
 
                         Rectangle {

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -488,7 +488,7 @@ Item {
                         visible: !root.reducedMode
                         label: "Display mode"
                         Text {
-                            text: "Mean / C"
+                            text: "Mean / Contrast"
                             color: !root.showBfiBvi ? root.colAccent : root.colTextSec
                             font.pixelSize: 13
                             font.weight: !root.showBfiBvi ? Font.DemiBold : Font.Normal
@@ -670,7 +670,7 @@ Item {
                 // ── Reduced Mode ─────────────────────────────────────────────
                 SectionCard {
                     title: "Reduced Mode"
-                    visible: !root.reducedMode
+                    visible: !root.reducedMode || (MOTIONInterface.appConfig.developerMode ? true : false)
 
                     FieldRow {
                         label: "Enable"
@@ -763,7 +763,7 @@ Item {
                             enabled: root.writeRawCsv
                             text: root.rawCsvDurationSec !== null && root.rawCsvDurationSec !== undefined
                                   ? root.rawCsvDurationSec.toString() : ""
-                            placeholderText: "unlimited"
+                            placeholderText: ""
                             inputMethodHints: Qt.ImhDigitsOnly
                             color: root.colTextPri
                             background: Rectangle {
@@ -794,15 +794,39 @@ Item {
                         font.weight: Font.DemiBold
                     }
 
+                    // Row 1: Target | [Both ▾]
+                    // Issue #117: test stations don't always have two
+                    // static phantoms — let the operator calibrate one
+                    // side at a time. "Both" preserves the prior default.
+                    FieldRow {
+                        label: "Target"
+                        StyledCombo {
+                            id: calibrationTargetCombo
+                            Layout.preferredWidth: 130
+                            model: ["Both", "Left", "Right"]
+                            currentIndex: 0
+                            enabled: !MOTIONInterface.calibrationRunning
+                                  && !MOTIONInterface.testScanRunning
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    // Row 2: [Calibrate] ● status text  (aligned under Both combo)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: 12
 
+                        // Spacer matching FieldRow label width to align with combo
+                        Item {
+                            Layout.preferredWidth: 140
+                            Layout.minimumWidth: 140
+                        }
+
                         ActionButton {
                             id: runCalibrationButton
                             text: "Calibrate"
-                            Layout.preferredWidth: 110
-                            Layout.preferredHeight: 40
+                            Layout.preferredWidth: 130
+                            Layout.preferredHeight: 34
                             enabled: MOTIONInterface.consoleConnected
                                   && !MOTIONInterface.calibrationRunning
                                   && !MOTIONInterface.testScanRunning
@@ -811,37 +835,12 @@ Item {
                             )
                         }
 
-                        ActionButton {
-                            id: runTestButton
-                            text: "Test"
-                            Layout.preferredWidth: 110
-                            Layout.preferredHeight: 40
-                            enabled: MOTIONInterface.consoleConnected
-                                  && !MOTIONInterface.calibrationRunning
-                                  && !MOTIONInterface.testScanRunning
-                            onClicked: MOTIONInterface.runTestScan(
-                                calibrationTargetCombo.currentText.toLowerCase()
-                            )
-                        }
-
-                        // Issue #117: test stations don't always have two
-                        // static phantoms — let the operator calibrate one
-                        // side at a time. "Both" preserves the prior default.
-                        StyledCombo {
-                            id: calibrationTargetCombo
-                            Layout.preferredWidth: 110
-                            model: ["Both", "Left", "Right"]
-                            currentIndex: 0
-                            enabled: !MOTIONInterface.calibrationRunning
-                                  && !MOTIONInterface.testScanRunning
-                        }
-
-                        // Indicator light
                         Rectangle {
                             id: calibLight
-                            width: 14
-                            height: 14
-                            radius: 7
+                            width: 10
+                            height: 10
+                            radius: 5
+                            Layout.alignment: Qt.AlignVCenter
                             border.width: 1
                             border.color: root.colBorderSoft
                             color: {
@@ -865,9 +864,7 @@ Item {
                         TextArea {
                             id: calibStatusLabel
                             Layout.fillWidth: true
-                            // Match the buttons' 40px height for single-line
-                            // statuses; grow for multi-line failure breakdown.
-                            Layout.preferredHeight: Math.max(40, implicitHeight)
+                            Layout.preferredHeight: Math.max(34, implicitHeight)
                             readOnly: true
                             selectByMouse: false
                             activeFocusOnTab: false
@@ -876,7 +873,7 @@ Item {
                             wrapMode: TextEdit.Wrap
                             verticalAlignment: TextEdit.AlignVCenter
                             color: root.colTextPri
-                            font.pixelSize: 13
+                            font.pixelSize: 12
                             text: {
                                 switch (MOTIONInterface.calibrationStatus) {
                                 case "running":
@@ -893,6 +890,32 @@ Item {
                                 }
                             }
                         }
+                    }
+
+                    // Row 3: [Test] aligned under Calibrate
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        Item {
+                            Layout.preferredWidth: 140
+                            Layout.minimumWidth: 140
+                        }
+
+                        ActionButton {
+                            id: runTestButton
+                            text: "Test"
+                            Layout.preferredWidth: 130
+                            Layout.preferredHeight: 34
+                            enabled: MOTIONInterface.consoleConnected
+                                  && !MOTIONInterface.calibrationRunning
+                                  && !MOTIONInterface.testScanRunning
+                            onClicked: MOTIONInterface.runTestScan(
+                                calibrationTargetCombo.currentText.toLowerCase()
+                            )
+                        }
+
+                        Item { Layout.fillWidth: true }
                     }
 
                     // 1 Hz tick driving the elapsed counter while running.

--- a/components/WindowMenu.qml
+++ b/components/WindowMenu.qml
@@ -15,6 +15,10 @@ Rectangle {
     // close-while-busy warning before tearing down (issue #75).
     signal closeRequested()
 
+    // Emitted on double-click of the logo. main.qml owns the behavior
+    // (opens the developer-unlock prompt) — this component stays dumb.
+    signal logoDoubleClicked()
+
     // Properties to configure the logo
     property string logoSource: "" // Default to no logo
 
@@ -110,6 +114,15 @@ Rectangle {
                         ctx.fillRect(0, 0, width, height)
                     }
                 }
+            }
+
+            // Double-click → developer-mode unlock prompt (dev gate).
+            // Sits above the header drag MouseArea so only the logo area
+            // captures the double-click; the rest of the bar still drags.
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton
+                onDoubleClicked: windowMenu.logoDoubleClicked()
             }
         }
 

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -87,7 +87,7 @@
   "rightMask": 102,
   "uncorrectedOnly": true,
   "autoConfigureOnStartup": false,
-  "developerMode": false,
+  "developerMode": true,
   "showBfiBvi": true,
   "bfiMin": 1.0,
   "bfiMax": 9.0,
@@ -97,7 +97,7 @@
   "meanMax": 200.0,
   "contrastMin": 0.0,
   "contrastMax": 0.7,
-  "dataDirectory": null,
+  "dataDirectory": "C:\\Users\\ethan\\Projects\\openmotion-bloodflow-app\\scan_data",
   "writeRawCsv": false,
   "rawCsvDurationSec": 60.0,
   "autoScale": false,
@@ -136,5 +136,6 @@
     15.0,
     15.0,
     15.0
-  ]
+  ],
+  "triggerConfig": null
 }

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -87,7 +87,7 @@
   "rightMask": 102,
   "uncorrectedOnly": true,
   "autoConfigureOnStartup": false,
-  "developerMode": true,
+  "developerMode": false,
   "showBfiBvi": true,
   "bfiMin": 1.0,
   "bfiMax": 9.0,
@@ -97,7 +97,7 @@
   "meanMax": 200.0,
   "contrastMin": 0.0,
   "contrastMax": 0.7,
-  "dataDirectory": "C:\\Users\\ethan\\Projects\\openmotion-bloodflow-app\\scan_data",
+  "dataDirectory": null,
   "writeRawCsv": false,
   "rawCsvDurationSec": 60.0,
   "autoScale": false,
@@ -136,6 +136,5 @@
     15.0,
     15.0,
     15.0
-  ],
-  "triggerConfig": null
+  ]
 }

--- a/docs/superpowers/plans/2026-05-28-developer-mode-gate.md
+++ b/docs/superpowers/plans/2026-05-28-developer-mode-gate.md
@@ -12,7 +12,7 @@
 
 **Spec:** `docs/superpowers/specs/2026-05-28-developer-mode-gate-design.md`
 
-> **Password value:** This plan uses the constant `"openwater-dev"`. Change `_DEVELOPER_PASSWORD` in Task 1 if a different value is wanted — it is the only place it is defined.
+> **Password value:** This plan uses the constant `"OnePointOne"`. Change `_DEVELOPER_PASSWORD` in Task 1 if a different value is wanted — it is the only place it is defined.
 
 ---
 
@@ -67,7 +67,7 @@ In `motion_connector.py`, add near the other module-level constants (top of file
 # opens a prompt; entering this value sets developerMode=true (persisted).
 # This is the ONLY place the literal is defined. The check lives in Python
 # (not QML) so the literal never ships inside readable QML text.
-_DEVELOPER_PASSWORD = "openwater-dev"
+_DEVELOPER_PASSWORD = "OnePointOne"
 
 
 def developer_password_matches(pw) -> bool:
@@ -726,7 +726,7 @@ Verify: no "Log" button in the side panel; open Settings → no "Developer" card
 
 - [ ] **Step 3: Unlock**
 
-Double-click the Openwater logo (top-left). The password modal appears. Enter a wrong password → "Incorrect password", no change. Enter `openwater-dev` → toast "Developer mode enabled."; modal closes.
+Double-click the Openwater logo (top-left). The password modal appears. Enter a wrong password → "Incorrect password", no change. Enter `OnePointOne` → toast "Developer mode enabled."; modal closes.
 
 - [ ] **Step 4: Confirm unlocked state**
 

--- a/docs/superpowers/plans/2026-05-28-developer-mode-gate.md
+++ b/docs/superpowers/plans/2026-05-28-developer-mode-gate.md
@@ -1,0 +1,810 @@
+# Developer-Mode Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the bloodflow-app locked (`developerMode: false`) and gate all engineering features behind a hidden unlock — double-click the Openwater logo, enter a password — while moving Calibrate/Test into the Developer settings card and adding a console-fan switch there.
+
+**Architecture:** `developerMode` is already a reactive config flag read across the QML via `MOTIONInterface.appConfig.developerMode`; flipping it through `setConfig` re-evaluates every gated `visible:` binding with no restart. We add: (1) a Python password check + QML unlock modal triggered by a logo double-click that persists `developerMode=true`; (2) a console-fan connector slot/property surfaced as a switch in the Developer card; (3) relocation of the always-visible Calibration card's contents into the `developerMode`-gated Developer card, deleting the standalone card.
+
+**Tech Stack:** Python 3.13 + PyQt6 (connector slots/properties), QML 6 (UI), pytest HIL suite (UIA-tree coordinate tests).
+
+**Worktree:** `C:\Users\ethan\Projects\openmotion-bloodflow-app\.claude\worktrees\developer-mode-gate` on branch `feature/developer-mode-gate`. **All paths below are relative to that worktree.** Run all `git` commands from there.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-developer-mode-gate-design.md`
+
+> **Password value:** This plan uses the constant `"openwater-dev"`. Change `_DEVELOPER_PASSWORD` in Task 1 if a different value is wanted — it is the only place it is defined.
+
+---
+
+## Task 1: Developer-password check (Python, TDD)
+
+**Files:**
+- Modify: `motion_connector.py` (add module-level constant + helper near the top of the file, after the existing imports/module constants; add a `@pyqtSlot` on `MOTIONConnector`)
+- Test: `tests/test_developer_password.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_developer_password.py`:
+
+```python
+"""Pure-software unit test for the developer-mode password check.
+
+Does NOT request the ``app`` fixture, so the bloodflow app is not
+launched and no hardware is touched — only the lightweight
+session-autouse QCoreApplication fixture runs.
+"""
+from motion_connector import developer_password_matches, _DEVELOPER_PASSWORD
+
+
+def test_correct_password_matches():
+    assert developer_password_matches(_DEVELOPER_PASSWORD) is True
+
+
+def test_wrong_password_rejected():
+    assert developer_password_matches("nope") is False
+
+
+def test_empty_password_rejected():
+    assert developer_password_matches("") is False
+
+
+def test_none_password_rejected():
+    assert developer_password_matches(None) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_developer_password.py -p no:cacheprovider -v`
+Expected: FAIL at import — `ImportError: cannot import name 'developer_password_matches' from 'motion_connector'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `motion_connector.py`, add near the other module-level constants (top of file, after imports). Find a sensible spot among existing module-level definitions:
+
+```python
+# ── Developer-mode unlock ────────────────────────────────────────────────
+# Hardcoded developer-mode password. Double-clicking the Openwater logo
+# opens a prompt; entering this value sets developerMode=true (persisted).
+# This is the ONLY place the literal is defined. The check lives in Python
+# (not QML) so the literal never ships inside readable QML text.
+_DEVELOPER_PASSWORD = "openwater-dev"
+
+
+def developer_password_matches(pw) -> bool:
+    """Return True iff ``pw`` equals the developer-mode password."""
+    return isinstance(pw, str) and pw == _DEVELOPER_PASSWORD
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_developer_password.py -p no:cacheprovider -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Add the QML-facing slot**
+
+In `motion_connector.py`, add a slot on `MOTIONConnector` next to `setConfig` (~line 1701). Use the module helper so there is one source of truth:
+
+```python
+    @pyqtSlot(str, result=bool)
+    def checkDeveloperPassword(self, pw: str) -> bool:
+        """Return True if ``pw`` matches the developer-mode password.
+
+        Comparison lives in Python so the literal is not present in
+        shipped QML source. QML calls this from the unlock modal and,
+        on True, sets developerMode via setConfig.
+        """
+        ok = developer_password_matches(pw)
+        if not ok:
+            logger.info("[Connector] Developer unlock attempt failed")
+        return ok
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_developer_password.py
+git commit -m "feat(bloodflow-app): developer-mode password check (Python)"
+```
+
+---
+
+## Task 2: Console-fan connector slot + property (Python)
+
+**Files:**
+- Modify: `motion_connector.py` — `__init__` (~line 670), connect-time fan set (~line 1247), new signal + property + slot (near `consoleConnected` ~line 1097 and `setFanControl` ~line 3148)
+
+There is no clean headless unit test for this (it drives `self._interface.console`); it is verified manually in Task 8 and exercised by hardware. Keep the slot defensive like the sibling console slots.
+
+- [ ] **Step 1: Seed the cache in `__init__`**
+
+In `motion_connector.py`, after `self._last_fan_status = {...}` (line 670), add:
+
+```python
+        # Console fan on/off cache. Seeded True because the connector
+        # forces set_fan_speed(100) at console-connect time (see the
+        # connect handler below). Surfaced to QML as ``consoleFanOn`` and
+        # toggled via ``setConsoleFan``.
+        self._console_fan_on: bool = True
+```
+
+- [ ] **Step 2: Add the notify signal**
+
+Find the block of `pyqtSignal()` declarations (near `appConfigChanged = pyqtSignal()` ~line 570) and add:
+
+```python
+    consoleFanChanged = pyqtSignal()
+```
+
+- [ ] **Step 3: Keep the cache truthful at connect time**
+
+In the connect handler, the existing block (~line 1247) reads:
+
+```python
+                    if self._interface.console.set_fan_speed(fan_speed=100):
+                        logger.info("Console fan speed set to 100%")
+                    else:
+                        logger.error("Failed to set console fan speed")
+```
+
+Replace it with a version that updates the cache + notifies on success:
+
+```python
+                    if self._interface.console.set_fan_speed(fan_speed=100):
+                        logger.info("Console fan speed set to 100%")
+                        self._console_fan_on = True
+                        self.consoleFanChanged.emit()
+                    else:
+                        logger.error("Failed to set console fan speed")
+```
+
+- [ ] **Step 4: Add the property + slot**
+
+Add near the other console members (e.g. just after the `consoleConnected` property ~line 1099):
+
+```python
+    @pyqtProperty(bool, notify=consoleFanChanged)
+    def consoleFanOn(self) -> bool:
+        """Cached last-set console-fan state (True=on). Reflects the
+        connect-time 100% default and any setConsoleFan call. Read by the
+        Developer settings switch when the Settings modal opens."""
+        return self._console_fan_on
+
+    @pyqtSlot(bool, result=bool)
+    def setConsoleFan(self, on: bool) -> bool:
+        """Drive the console fan to 100% (on) or 0% (off).
+
+        Updates the cached state + notifies QML on success. Guarded and
+        wrapped like the other console slots so a mid-flight disconnect
+        can't raise out of the Qt slot and kill the process.
+        """
+        if not self._consoleConnected:
+            logger.error("Console not connected — cannot set console fan")
+            return False
+        try:
+            speed = 100 if on else 0
+            if self._interface.console.set_fan_speed(fan_speed=speed):
+                self._console_fan_on = bool(on)
+                self.consoleFanChanged.emit()
+                logger.info("Console fan set to %s", "ON" if on else "OFF")
+                return True
+            logger.error("Failed to set console fan")
+            return False
+        except Exception as e:  # noqa: BLE001 — slot must not raise
+            logger.error("Error setting console fan: %s", e)
+            return False
+```
+
+> Note: `pyqtProperty` and `pyqtSlot` are already imported in this file (used throughout). No new imports needed.
+
+- [ ] **Step 5: Smoke-import to catch syntax/typo errors**
+
+Run: `python -c "import motion_connector; print('ok')"`
+Expected: prints `ok` (no traceback).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py
+git commit -m "feat(bloodflow-app): console-fan slot + cached consoleFanOn property"
+```
+
+---
+
+## Task 3: Default `developerMode` to false
+
+**Files:**
+- Modify: `config/app_config.json:89`
+
+- [ ] **Step 1: Flip the default**
+
+In `config/app_config.json`, change line 89 from:
+
+```json
+  "developerMode": true,
+```
+
+to:
+
+```json
+  "developerMode": false,
+```
+
+- [ ] **Step 2: Verify it is valid JSON**
+
+Run: `python -c "import json; json.load(open('config/app_config.json', encoding='utf-8')); print('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/app_config.json
+git commit -m "chore(bloodflow-app): ship with developerMode disabled by default"
+```
+
+---
+
+## Task 4: Logo double-click signal (QML)
+
+**Files:**
+- Modify: `components/WindowMenu.qml` — add signal (~line 16) and a `MouseArea` inside the logo `Rectangle` (~lines 57–114)
+
+- [ ] **Step 1: Declare the signal**
+
+In `components/WindowMenu.qml`, next to the existing `signal closeRequested()` (~line 16), add:
+
+```qml
+    // Emitted on double-click of the logo. main.qml owns the behavior
+    // (opens the developer-unlock prompt) — this component stays dumb.
+    signal logoDoubleClicked()
+```
+
+- [ ] **Step 2: Add the MouseArea over the logo**
+
+In the logo `Rectangle` (the one with `width: 185; height: 42`, ~line 57), add a `MouseArea` as the LAST child (after the dark/light Image/Item blocks, before the `Rectangle`'s closing brace at ~line 114) so it sits on top:
+
+```qml
+            // Double-click → developer-mode unlock prompt (issue: dev gate).
+            // Sits above the header drag MouseArea so only the logo area
+            // captures the double-click; the rest of the bar still drags.
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton
+                onDoubleClicked: windowMenu.logoDoubleClicked()
+            }
+```
+
+- [ ] **Step 3: Verify (deferred to Task 8 launch)**
+
+QML has no standalone unit test here; correctness is confirmed in the Task 8 manual launch (double-click opens the modal; bar still drags elsewhere).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/WindowMenu.qml
+git commit -m "feat(bloodflow-app): emit logoDoubleClicked from WindowMenu logo"
+```
+
+---
+
+## Task 5: Developer-unlock modal (QML)
+
+**Files:**
+- Create: `components/DeveloperUnlockModal.qml`
+
+- [ ] **Step 1: Create the modal**
+
+Create `components/DeveloperUnlockModal.qml`:
+
+```qml
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import OpenMotion 1.0
+
+// Small password prompt for unlocking developer mode. Opened from
+// main.qml on a logo double-click. On the correct password it persists
+// developerMode=true via setConfig and emits unlocked().
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 10000
+
+    AppTheme { id: theme }
+
+    signal unlocked()
+
+    function open() {
+        pwField.text = ""
+        errorLabel.visible = false
+        root.visible = true
+        pwField.forceActiveFocus()
+    }
+    function close() {
+        root.visible = false
+    }
+
+    function _submit() {
+        if (MOTIONInterface.checkDeveloperPassword(pwField.text)) {
+            MOTIONInterface.setConfig("developerMode", true)
+            MOTIONInterface.notify("Developer mode enabled.", "info", 3000, false, "dev-mode")
+            root.unlocked()
+            root.close()
+        } else {
+            errorLabel.visible = true
+            pwField.text = ""
+            pwField.forceActiveFocus()
+        }
+    }
+
+    // Backdrop — click outside closes.
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000B0"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    // Panel
+    Rectangle {
+        width: 360
+        height: contentCol.implicitHeight + 48
+        radius: 14
+        color: theme.bgContainer
+        border.color: theme.borderStrong
+        border.width: 1
+        anchors.centerIn: parent
+
+        // Absorb clicks so they don't reach the backdrop.
+        MouseArea { anchors.fill: parent }
+
+        ColumnLayout {
+            id: contentCol
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 16
+
+            Text {
+                text: "Developer Access"
+                color: theme.textPrimary
+                font.pixelSize: 18
+                font.weight: Font.DemiBold
+            }
+
+            Text {
+                text: "Enter the developer password to enable developer mode."
+                color: theme.textSecondary
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            TextField {
+                id: pwField
+                Layout.fillWidth: true
+                Layout.preferredHeight: 34
+                echoMode: TextInput.Password
+                placeholderText: "Password"
+                color: theme.textPrimary
+                font.pixelSize: 14
+                background: Rectangle {
+                    color: theme.bgInput
+                    radius: 4
+                    border.color: pwField.activeFocus ? theme.accentBlue : theme.borderSoft
+                    border.width: 1
+                }
+                onAccepted: root._submit()
+            }
+
+            Text {
+                id: errorLabel
+                text: "Incorrect password"
+                color: theme.accentRed
+                font.pixelSize: 12
+                visible: false
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 12
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Cancel"
+                    Layout.preferredHeight: 32
+                    onClicked: root.close()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSoft; border.width: 1
+                    }
+                }
+
+                Button {
+                    text: "Unlock"
+                    Layout.preferredHeight: 32
+                    onClicked: root._submit()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Qt.lighter(theme.accentBlue, 1.1) : theme.accentBlue
+                        radius: 4
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+}
+```
+
+> **Verify before relying on these tokens:** `theme.accentRed`, `theme.accentBlue`, `theme.bgHover`, `theme.bgInput`, `theme.borderSoft`, `theme.borderStrong`, `theme.bgContainer` are all referenced elsewhere in `components/SettingsModal.qml` (e.g. `colAccent: theme.accentBlue`, `colBorderSoft: theme.borderSoft`). If any token name differs in `components/AppTheme.qml`, use the AppTheme name. `MOTIONInterface.notify(message, level, durationMs, persistent, tag)` signature matches the call in `main.qml:106`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/DeveloperUnlockModal.qml
+git commit -m "feat(bloodflow-app): add DeveloperUnlockModal password prompt"
+```
+
+---
+
+## Task 6: Wire the modal into main.qml
+
+**Files:**
+- Modify: `main.qml` — add `onLogoDoubleClicked` to `headerMenu` (~line 96 area) and instantiate the modal (near `TestResultsWindow` ~line 198)
+
+- [ ] **Step 1: Handle the signal on the header**
+
+In `main.qml`, inside the `WindowMenu { id: headerMenu ... }` block, after the `onCloseRequested: {...}` handler (closes at ~line 116), add:
+
+```qml
+            onLogoDoubleClicked: developerUnlockModal.open()
+```
+
+- [ ] **Step 2: Instantiate the modal**
+
+The modal must be a child of the top-level fill `Rectangle` so its `anchors.fill: parent` covers the whole window and its `z: 10000` sits above content. Add it as the last child of the main `Rectangle { anchors.fill: parent; color: theme.bgBase ... }` block — i.e. just after the inner `Item { ... BloodFlow {} }` block (closes ~line 145), before that `Rectangle`'s closing brace:
+
+```qml
+        // Developer-mode unlock prompt (opened by logo double-click).
+        DeveloperUnlockModal {
+            id: developerUnlockModal
+        }
+```
+
+- [ ] **Step 3: Verify (deferred to Task 8 launch)**
+
+Confirmed in the Task 8 manual launch.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main.qml
+git commit -m "feat(bloodflow-app): open DeveloperUnlockModal on logo double-click"
+```
+
+---
+
+## Task 7: Move Calibration into Developer card; add fan switch + disable button; delete Calibration card
+
+**Files:**
+- Modify: `components/SettingsModal.qml` — Developer card (~lines 712–771) and Calibration card (~lines 773–909)
+
+This is the largest edit. Do it as: (a) extend the Developer card, (b) delete the Calibration card. Keep all calibration element `id`s and status strings byte-identical so the HIL UIA contract holds.
+
+- [ ] **Step 1: Add the console-fan switch to the Developer card**
+
+In `components/SettingsModal.qml`, inside the `SectionCard { title: "Developer" ... }` (~line 712), after the existing "Console" `FieldRow` with the Soft Reset button (~line 725), add:
+
+```qml
+                    FieldRow {
+                        label: "Console fans"
+                        PillSwitch {
+                            checked: MOTIONInterface.consoleFanOn
+                            enabled: MOTIONInterface.consoleConnected
+                            onToggled: MOTIONInterface.setConsoleFan(checked)
+                        }
+                        Text {
+                            text: MOTIONInterface.consoleFanOn ? "On" : "Off"
+                            color: MOTIONInterface.consoleFanOn ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+```
+
+- [ ] **Step 2: Move the calibration controls into the Developer card**
+
+Cut the **inner content** of the Calibration `SectionCard` — everything between `SectionCard { title: "Calibration"` and its matching closing brace (the `RowLayout` with Calibrate/Test/target/light/status, the `calibTimer` Timer, and BOTH `Connections` blocks; ~lines 777–908) — and paste it at the END of the Developer `SectionCard`, after the "Raw CSV duration" `FieldRow` (~line 770), inside the Developer card's closing brace. Prepend a small labeled separator so it reads as a sub-group:
+
+```qml
+                    // ── Calibration / Test (moved here from the former
+                    //    standalone Calibration card; now developer-only) ──
+                    Rectangle { Layout.fillWidth: true; height: 1; color: root.colBorderSoft }
+                    Text {
+                        text: "Calibration"
+                        color: root.colTextPri
+                        font.pixelSize: 13
+                        font.weight: Font.DemiBold
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        ActionButton {
+                            id: runCalibrationButton
+                            text: "Calibrate"
+                            Layout.preferredWidth: 110
+                            Layout.preferredHeight: 40
+                            enabled: MOTIONInterface.consoleConnected
+                                  && !MOTIONInterface.calibrationRunning
+                                  && !MOTIONInterface.testScanRunning
+                            onClicked: MOTIONInterface.runCalibration(
+                                calibrationTargetCombo.currentText.toLowerCase()
+                            )
+                        }
+
+                        ActionButton {
+                            id: runTestButton
+                            text: "Test"
+                            Layout.preferredWidth: 110
+                            Layout.preferredHeight: 40
+                            enabled: MOTIONInterface.consoleConnected
+                                  && !MOTIONInterface.calibrationRunning
+                                  && !MOTIONInterface.testScanRunning
+                            onClicked: MOTIONInterface.runTestScan(
+                                calibrationTargetCombo.currentText.toLowerCase()
+                            )
+                        }
+
+                        StyledCombo {
+                            id: calibrationTargetCombo
+                            Layout.preferredWidth: 110
+                            model: ["Both", "Left", "Right"]
+                            currentIndex: 0
+                            enabled: !MOTIONInterface.calibrationRunning
+                                  && !MOTIONInterface.testScanRunning
+                        }
+
+                        Rectangle {
+                            id: calibLight
+                            width: 14
+                            height: 14
+                            radius: 7
+                            border.width: 1
+                            border.color: root.colBorderSoft
+                            color: {
+                                switch (MOTIONInterface.calibrationStatus) {
+                                case "running": return "#2196F3"
+                                case "passed":  return "#4CAF50"
+                                case "failed":  return "#F44336"
+                                case "aborted": return "#FF9800"
+                                default:        return "#9E9E9E"
+                                }
+                            }
+                        }
+
+                        TextArea {
+                            id: calibStatusLabel
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Math.max(40, implicitHeight)
+                            readOnly: true
+                            selectByMouse: false
+                            activeFocusOnTab: false
+                            background: null
+                            padding: 0
+                            wrapMode: TextEdit.Wrap
+                            verticalAlignment: TextEdit.AlignVCenter
+                            color: root.colTextPri
+                            font.pixelSize: 13
+                            text: {
+                                switch (MOTIONInterface.calibrationStatus) {
+                                case "running":
+                                    return "Calibrating... (" + calibTimer.elapsedSec
+                                           + "s / " + MOTIONInterface.maxCalibrationTimeSec + "s)"
+                                case "passed":  return "Calibration Passed"
+                                case "failed":
+                                    var reason = MOTIONInterface.calibrationFailureReason
+                                    return reason
+                                        ? "Calibration Failed — " + reason
+                                        : "Calibration Failed"
+                                case "aborted": return "Calibration Aborted"
+                                default:        return ""
+                                }
+                            }
+                        }
+                    }
+
+                    Timer {
+                        id: calibTimer
+                        property int elapsedSec: 0
+                        interval: 1000
+                        repeat: true
+                        running: MOTIONInterface.calibrationRunning
+                        onTriggered: elapsedSec += 1
+                    }
+
+                    Connections {
+                        target: MOTIONInterface
+                        function onCalibrationStateChanged() {
+                            if (MOTIONInterface.calibrationStatus === "running") {
+                                calibTimer.elapsedSec = 0
+                            }
+                        }
+                    }
+
+                    Connections {
+                        target: MOTIONInterface
+                        function onTestScanStateChanged() {
+                            var s = MOTIONInterface.testScanStatus
+                            if (s === "running" || s === "done"
+                                || s === "failed" || s === "aborted") {
+                                testResultsWindow.show()
+                                testResultsWindow.raise()
+                                testResultsWindow.requestActivate()
+                            }
+                        }
+                    }
+```
+
+- [ ] **Step 3: Add the "Disable developer mode" button at the end of the Developer card**
+
+After the moved calibration block (still inside the Developer `SectionCard`), add:
+
+```qml
+                    Rectangle { Layout.fillWidth: true; height: 1; color: root.colBorderSoft }
+                    FieldRow {
+                        label: "Developer mode"
+                        ActionButton {
+                            text: "Disable developer mode"
+                            Layout.preferredWidth: 200
+                            hoverColor: "#C0392B"
+                            onClicked: {
+                                MOTIONInterface.setConfig("developerMode", false)
+                                MOTIONInterface.notify("Developer mode disabled.", "info", 3000, false, "dev-mode")
+                            }
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+```
+
+- [ ] **Step 4: Delete the now-empty standalone Calibration card**
+
+Remove the entire `SectionCard { title: "Calibration" ... }` block (its opening line through its matching closing brace). After Step 2 it contains only the header/divider scaffolding from `SectionCard`; delete the whole `SectionCard {...}`. Confirm no other `SectionCard` was disturbed (the next one is `title: "About"`).
+
+- [ ] **Step 5: Brace/region sanity check**
+
+Run a quick structural check that braces still balance and the markers exist:
+
+```bash
+python - <<'PY'
+src = open('components/SettingsModal.qml', encoding='utf-8').read()
+assert src.count('{') == src.count('}'), (src.count('{'), src.count('}'))
+assert 'title: "Calibration"' not in src, "standalone Calibration card still present"
+assert 'id: runCalibrationButton' in src and 'id: calibStatusLabel' in src
+assert 'Console fans' in src and 'Disable developer mode' in src
+print('ok')
+PY
+```
+Expected: prints `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/SettingsModal.qml
+git commit -m "feat(bloodflow-app): move calibration into developer card; add console-fan switch and dev-mode disable"
+```
+
+---
+
+## Task 8: Manual verification (fake-data, no hardware)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Launch the app locked**
+
+Ensure `config/app_config.json` has `cameraFakeData: true` and `developerMode: false` (temporarily set `cameraFakeData: true` for this check; revert before commit if you changed it).
+Run: `python main.py`
+
+- [ ] **Step 2: Confirm locked state**
+
+Verify: no "Log" button in the side panel; open Settings → no "Developer" card, no "Calibration" card.
+
+- [ ] **Step 3: Unlock**
+
+Double-click the Openwater logo (top-left). The password modal appears. Enter a wrong password → "Incorrect password", no change. Enter `openwater-dev` → toast "Developer mode enabled."; modal closes.
+
+- [ ] **Step 4: Confirm unlocked state**
+
+Open Settings → the "Developer" card is present and contains: Soft Reset, Console fans switch, Save raw CSV, Raw CSV duration, the Calibrate/Test/target/status group, and "Disable developer mode". No separate "Calibration" card exists.
+
+- [ ] **Step 5: Console-fan switch reflects state on open**
+
+With a console connected the switch shows On (cached 100% default). Without hardware, confirm the switch renders and is disabled when `consoleConnected` is false. Toggling with hardware drives the fan and the On/Off text follows.
+
+- [ ] **Step 6: Persistence + disable**
+
+Restart the app → developer mode is still on (persisted). Open Settings → "Disable developer mode" → Developer card disappears; toast shown. Restart → locked again.
+
+- [ ] **Step 7: Revert any temporary config**
+
+If `cameraFakeData`/`developerMode` were changed for testing, restore `developerMode: false` (and `cameraFakeData` to its committed value). `git diff config/app_config.json` should show ONLY the `developerMode` default flip from Task 3.
+
+---
+
+## Task 9: Update calibration HIL tests for the dev gate
+
+**Files:**
+- Modify: `tests/test_calibration_ui.py`
+- Modify: `tests/test_calibration_target_isolation.py`
+
+Both tests drive calibration but assume `developerMode` defaults true and locate the controls under a "Calibration" heading. With the new default they must force `developerMode=True` before launch and locate the controls under "Developer".
+
+- [ ] **Step 1: Inspect each test's current config-forcing + locator**
+
+Read both files. Identify: (a) whether they already import from `hil_helpers`; (b) any module-level `force_app_config_value(...)` calls + restore fixtures; (c) where they scroll/locate the calibration section (look for the string `"Calibration"` used as a scroll target, e.g. a `_scroll_until_label_visible("Calibration")` or coordinate anchor).
+
+- [ ] **Step 2: Force developerMode at module-import time**
+
+In each file, near the top (module scope, after imports), mirror the `test_raw_csv_save.py` pattern:
+
+```python
+from hil_helpers import force_app_config_value, write_app_config_value
+
+_INITIAL_DEVELOPER_MODE = force_app_config_value("developerMode", True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_developer_mode():
+    yield
+    write_app_config_value("developerMode", _INITIAL_DEVELOPER_MODE)
+```
+
+If the file already imports some of these helpers, extend the existing import rather than duplicating it.
+
+- [ ] **Step 3: Re-point the section locator**
+
+Wherever the test scrolls to or anchors on the "Calibration" section heading to reach the Calibrate/Test buttons, change the target to the "Developer" section heading (the controls now live under "Developer"). Button labels ("Calibrate", "Test") and status strings ("Calibration Passed", etc.) are unchanged — leave those locators as-is. If the test already scrolls to a button label (not the section title), no locator change is needed.
+
+- [ ] **Step 4: Verify collection (no hardware)**
+
+Run: `python -m pytest tests/test_calibration_ui.py tests/test_calibration_target_isolation.py --collect-only -q`
+Expected: tests collect with no import/syntax errors. (Execution needs hardware + the `app` fixture; run on the self-hosted runner or locally with hardware attached.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_calibration_ui.py tests/test_calibration_target_isolation.py
+git commit -m "test(bloodflow-app): force developerMode for calibration HIL tests under dev gate"
+```
+
+---
+
+## Task 10: Final review + branch finish
+
+- [ ] **Step 1: Full diff review**
+
+Run: `git -C . diff next --stat` and skim each file. Confirm: connector slots/property/signal added; `app_config.json` only flips `developerMode`; WindowMenu signal + MouseArea; new DeveloperUnlockModal; main.qml wiring; SettingsModal restructure; two HIL tests updated; spec + plan docs present.
+
+- [ ] **Step 2: Re-run the pure-software unit test**
+
+Run: `python -m pytest tests/test_developer_password.py -p no:cacheprovider -v`
+Expected: 4 passed.
+
+- [ ] **Step 3: Hand off via finishing-a-development-branch**
+
+Use `superpowers:finishing-a-development-branch` to decide merge/PR. Target PR base is `next` (per repo branching: feature → `next`).

--- a/docs/superpowers/specs/2026-05-28-developer-mode-gate-design.md
+++ b/docs/superpowers/specs/2026-05-28-developer-mode-gate-design.md
@@ -1,0 +1,182 @@
+# Developer-Mode Gate — Design
+
+**Date:** 2026-05-28
+**Target release:** bloodflow-app 1.1.3
+**Branch:** `feature/developer-mode-gate` (based on `next`)
+
+## Summary
+
+Hide developer/engineering features behind a deliberate unlock. Today
+`developerMode` defaults to `true` in `config/app_config.json`, so every
+build ships with calibration, test, log-viewer, soft-reset, and raw-CSV
+controls visible. This change ships **locked** (`developerMode: false`) and
+adds a hidden entry point: double-clicking the Openwater logo opens a
+password prompt; the correct password turns developer mode on (persisted).
+
+Three user-facing changes:
+
+1. **Logo double-click → password → developer mode.**
+2. **Console-fan on/off switch** added to the Developer settings card, with
+   its state shown when the Settings window opens.
+3. **Calibrate / Test controls move into the Developer card**, and the
+   standalone "Calibration" card is removed — so calibration is developer-only.
+
+## Background (current state)
+
+- `developerMode` is read reactively across the QML via
+  `MOTIONInterface.appConfig.developerMode`. Flipping it through
+  `setConfig("developerMode", value)` emits `appConfigChanged`, which
+  re-evaluates every `visible:` binding — no restart needed to reveal/hide UI.
+- The logo is rendered in `components/WindowMenu.qml` (the `Rectangle` at
+  ~lines 57–114); `main.qml:77` passes `logoSource`. There is no click
+  handler today. A full-width drag `MouseArea` sits behind the header.
+- All calibration UI lives in `components/SettingsModal.qml`:
+  - an **always-visible** "Calibration" `SectionCard` (~lines 773–909):
+    Calibrate + Test buttons, a Both/Left/Right target `StyledCombo`, a status
+    indicator light, a status `TextArea`, a 1 Hz `calibTimer`, and two
+    `Connections` blocks (one resets the timer on state change; one raises
+    `TestResultsWindow` on test-scan state change).
+  - a **`developerMode`-gated** "Developer" `SectionCard` (~lines 712–771):
+    console Soft Reset, Save-raw-CSV switch, raw-CSV duration.
+- Console fan: the SDK exposes `console.set_fan_speed(0..100)` (duty cycle)
+  and `console.get_fan_rpm(1..3)` (tach RPM). On console connect the connector
+  forces `set_fan_speed(fan_speed=100)` (`motion_connector.py:1247`). There is
+  **no** console-fan connector slot yet; the existing `setFanControl` /
+  `getFanControlStatus` slots are for *sensor* fans, not the console.
+
+## Decisions (confirmed with user)
+
+- **Password storage:** hardcoded constant, compared in Python (not exposed
+  to QML source).
+- **Persistence:** unlocking persists via `setConfig("developerMode", true)`
+  (survives restart) — matching how the flag already behaves.
+- **Default:** `developerMode` defaults to `false` in `app_config.json`.
+- **Fan semantics:** on → `set_fan_speed(100)`, off → `set_fan_speed(0)`.
+  State is read from a connector-cached last-set value (no hardware
+  round-trip), seeded to reflect the connect-time 100% default.
+- **Exit path:** a "Disable developer mode" button in the Developer card
+  (needed because the flag now persists).
+
+## Feature 1 — Logo double-click → password → developer mode
+
+### Components
+
+- **`components/WindowMenu.qml`** — add `signal logoDoubleClicked()` and a
+  `MouseArea` over just the logo `Rectangle` with `onDoubleClicked:
+  windowMenu.logoDoubleClicked()`. The logo `MouseArea` sits above the
+  header-drag `MouseArea`, so dragging the rest of the bar is unaffected.
+  Keep the component dumb — it only emits; `main.qml` owns behavior.
+
+- **`components/DeveloperUnlockModal.qml`** (new) — a small modal styled like
+  the existing modals (backdrop + centered panel, Escape-to-close,
+  click-outside-to-close). Contents: a title, a masked password `TextField`
+  (`echoMode: TextInput.Password`), an inline error label, and
+  Unlock / Cancel buttons. Exposes `open()` / `close()` and a
+  `signal unlocked()`. Pressing Enter in the field submits.
+  - On submit → `if (MOTIONInterface.checkDeveloperPassword(field.text))`:
+    success → `MOTIONInterface.setConfig("developerMode", true)`, emit
+    `unlocked()`, close, and show a confirmation toast via
+    `MOTIONInterface.notify(...)`. Failure → show inline "Incorrect password",
+    clear the field, leave state unchanged.
+
+- **`main.qml`** — instantiate `DeveloperUnlockModal` and wire
+  `headerMenu.onLogoDoubleClicked: developerUnlockModal.open()`. If already in
+  developer mode, the prompt still opens (harmless); no special-casing.
+
+- **`motion_connector.py`** — add
+  `@pyqtSlot(str, result=bool) def checkDeveloperPassword(self, pw)` that
+  compares against a module-level hardcoded constant
+  (e.g. `_DEVELOPER_PASSWORD`). Comparison in Python keeps the literal out of
+  shipped QML text. (Constant equality compare is sufficient; no hashing was
+  requested.)
+
+### Exit mechanism
+
+- In the Developer `SectionCard` (`SettingsModal.qml`), add a "Disable
+  developer mode" `ActionButton` → `MOTIONInterface.setConfig("developerMode",
+  false)` plus a toast. Because the Developer card is itself gated by
+  `developerMode`, the whole card (including this button) disappears the
+  instant it's pressed — acceptable; the Settings modal stays open.
+
+## Feature 2 — Console-fan switch in Developer settings
+
+### Connector (`motion_connector.py`)
+
+- Add `self._console_fan_on = True` in `__init__` (seeded `True` to match the
+  connect-time `set_fan_speed(100)` default).
+- At the connect-time fan set (`~line 1247`), set
+  `self._console_fan_on = True` on success so the cache tracks reality.
+- Add a notify signal `consoleFanChanged = pyqtSignal()`.
+- Add `@pyqtProperty(bool, notify=consoleFanChanged) def consoleFanOn(self)`
+  returning `self._console_fan_on`.
+- Add `@pyqtSlot(bool, result=bool) def setConsoleFan(self, on)`:
+  guard on `self._consoleConnected`; call
+  `self._interface.console.set_fan_speed(100 if on else 0)`; on success update
+  `self._console_fan_on` and emit `consoleFanChanged`; return success.
+  Wrap in try/except (consistent with other console slots) so a mid-flight
+  disconnect can't crash the Qt slot.
+
+### UI (`SettingsModal.qml`, Developer card)
+
+- A `FieldRow { label: "Console fans" }` containing a `PillSwitch`:
+  `checked: MOTIONInterface.consoleFanOn`,
+  `enabled: MOTIONInterface.consoleConnected`,
+  `onToggled: MOTIONInterface.setConsoleFan(checked)`, plus an On/Off text.
+- **State read on open:** the switch binds to `consoleFanOn`; `open()` already
+  re-runs each time the modal opens, so the displayed state reflects the
+  cached value whenever Settings opens. No extra wiring needed.
+
+## Feature 3 — Move Calibrate/Test into Developer card; remove Calibration card
+
+- Move the **entire** body of the "Calibration" `SectionCard` into the
+  "Developer" `SectionCard`: the Calibrate + Test buttons, the
+  Both/Left/Right target `StyledCombo`, the status indicator light, the status
+  `TextArea`, the `calibTimer`, and **both** `Connections` blocks
+  (calibration-state timer reset and test-scan-state `TestResultsWindow`
+  raise). All element `id`s and the status strings ("Calibrating… (Ns/Ns)",
+  "Calibration Passed", "Calibration Failed — …", "Calibration Aborted")
+  are preserved verbatim so the UIA-tree contract used by HIL tests is intact.
+- Delete the standalone "Calibration" `SectionCard`.
+- Net effect: Calibrate/Test/target/status appear only when
+  `developerMode === true`.
+
+## Test impact (must update in this change)
+
+`test_calibration_ui.py` and `test_calibration_target_isolation.py` drive the
+calibration UI but **do not** force `developerMode` — they rely on the old
+default of `true`. With the new default `false` and calibration gated, they
+will fail (the Developer/Calibration section won't render). Both must:
+
+- Force `developerMode = True` before launch at module-import time, using the
+  established `hil_helpers.force_app_config_value("developerMode", True)`
+  pattern, with a module-scoped fixture restoring the prior value (mirror
+  `test_raw_csv_save.py`'s approach).
+- Re-point any "scroll until the Calibration card title is visible" locator to
+  the **Developer** card (the calibration controls now live under the
+  "Developer" heading, not a "Calibration" heading). Button labels
+  ("Calibrate", "Test") and status strings are unchanged, so label-based
+  locators for those keep working.
+
+`test_raw_csv_save.py` already forces `developerMode=True`, so it is
+unaffected by the default flip. `test_reducedmode.py` references
+`developerMode` only in a comment.
+
+## Out of scope
+
+- No hashing / per-deployment password (hardcoded constant per decision).
+- No change to sensor-fan controls (`setFanControl`/`getFanControlStatus`).
+- No change to reduced-mode behavior beyond what the dev gate implies.
+- No new release tag — versioning is tag-driven; 1.1.3 is just the target.
+
+## Verification plan
+
+- **Static:** app launches with `cameraFakeData: true` and
+  `developerMode: false` → no Calibrate/Test/Developer UI; double-click logo →
+  password modal; correct password → Developer card (with calibration + fan
+  switch) appears; "Disable developer mode" hides it again; value persists
+  across a restart.
+- **Tests:** update the two calibration HIL tests as above. Full HIL run
+  requires hardware (run on the self-hosted runner / locally when hardware is
+  attached). Pure-software portions and app launch verified locally in
+  fake-data mode.
+- QML has no hot-reload — restart the app to pick up `.qml` changes.

--- a/main.qml
+++ b/main.qml
@@ -114,6 +114,9 @@ ApplicationWindow {
                 window._exitArmed = true
                 exitDisarmTimer.restart()
             }
+
+            // Hidden developer-mode entry point.
+            onLogoDoubleClicked: developerUnlockModal.open()
         }
 
         // Update available banner (slides in below header)
@@ -142,6 +145,11 @@ ApplicationWindow {
                 id: bloodFlowPage
                 anchors.fill: parent
             }
+        }
+
+        // Developer-mode unlock prompt (opened by logo double-click).
+        DeveloperUnlockModal {
+            id: developerUnlockModal
         }
     }
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -317,6 +317,7 @@ class MOTIONConnector(QObject):
     tecStatusChanged = pyqtSignal()
     tecDacChanged = pyqtSignal()
     appConfigChanged = pyqtSignal()
+    consoleFanChanged = pyqtSignal()
 
     # App update signals
     updateAvailable = pyqtSignal(str, str)   # (latest_version, download_url)
@@ -415,6 +416,11 @@ class MOTIONConnector(QObject):
         self._trigger_state = "OFF"
         self._state = DISCONNECTED
         self._last_fan_status: dict[str, bool | None] = {"left": None, "right": None}
+        # Console fan on/off cache. Seeded True because the connector
+        # forces set_fan_speed(100) at console-connect time (see the
+        # connect handler below). Surfaced to QML as ``consoleFanOn`` and
+        # toggled via ``setConsoleFan``.
+        self._console_fan_on: bool = True
         # Track console connection time for safety grace period (issue #107 follow-up)
         self._console_connected_at: float | None = None
 
@@ -867,6 +873,37 @@ class MOTIONConnector(QObject):
         """Expose Console connection status to QML."""
         return self._consoleConnected
 
+    @pyqtProperty(bool, notify=consoleFanChanged)
+    def consoleFanOn(self) -> bool:
+        """Cached last-set console-fan state (True=on). Reflects the
+        connect-time 100% default and any setConsoleFan call. Read by the
+        Developer settings switch when the Settings modal opens."""
+        return self._console_fan_on
+
+    @pyqtSlot(bool, result=bool)
+    def setConsoleFan(self, on: bool) -> bool:
+        """Drive the console fan to 100% (on) or 0% (off).
+
+        Updates the cached state + notifies QML on success. Guarded and
+        wrapped like the other console slots so a mid-flight disconnect
+        can't raise out of the Qt slot and kill the process.
+        """
+        if not self._consoleConnected:
+            logger.error("Console not connected — cannot set console fan")
+            return False
+        try:
+            speed = 100 if on else 0
+            if self._interface.console.set_fan_speed(fan_speed=speed):
+                self._console_fan_on = bool(on)
+                self.consoleFanChanged.emit()
+                logger.info("Console fan set to %s", "ON" if on else "OFF")
+                return True
+            logger.error("Failed to set console fan")
+            return False
+        except Exception as e:  # noqa: BLE001 — slot must not raise
+            logger.error("Error setting console fan: %s", e)
+            return False
+
     @pyqtProperty(bool, notify=laserStateChanged)
     def laserOn(self):
         """Expose Console connection status to QML."""
@@ -1009,6 +1046,8 @@ class MOTIONConnector(QObject):
                         )
                     if self._interface.console.set_fan_speed(fan_speed=100):
                         logger.info("Console fan speed set to 100%")
+                        self._console_fan_on = True
+                        self.consoleFanChanged.emit()
                     else:
                         logger.error("Failed to set console fan speed")
                 except Exception as e:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -64,6 +64,19 @@ _CQ_DEFAULT_DARK_THRESHOLD_DN = 3.0
 _CQ_DEFAULT_LIGHT_THRESHOLD_DN = 15.0
 _CQ_DEFAULT_ROLLING_WINDOW = 10
 
+# ── Developer-mode unlock ────────────────────────────────────────────────
+# Hardcoded developer-mode password. Double-clicking the Openwater logo
+# opens a prompt; entering this value sets developerMode=true (persisted).
+# This is the ONLY place the literal is defined. The check lives in Python
+# (not QML) so the literal never ships inside readable QML text.
+_DEVELOPER_PASSWORD = "openwater-dev"
+
+
+def developer_password_matches(pw) -> bool:
+    """Return True iff ``pw`` equals the developer-mode password."""
+    return isinstance(pw, str) and pw == _DEVELOPER_PASSWORD
+
+
 # Global loggers - will be configured by _configure_logging method
 logger = logging.getLogger("openmotion.bloodflow-app.connector")
 run_logger = logging.getLogger("bloodflow-app.runlog")
@@ -1423,6 +1436,19 @@ class MOTIONConnector(QObject):
                 json.dump(out, f, indent=2)
         except OSError as e:
             logger.warning(f"[Connector] Could not write app_config.json: {e}")
+
+    @pyqtSlot(str, result=bool)
+    def checkDeveloperPassword(self, pw: str) -> bool:
+        """Return True if ``pw`` matches the developer-mode password.
+
+        Comparison lives in Python so the literal is not present in
+        shipped QML source. QML calls this from the unlock modal and,
+        on True, sets developerMode via setConfig.
+        """
+        ok = developer_password_matches(pw)
+        if not ok:
+            logger.info("[Connector] Developer unlock attempt failed")
+        return ok
 
     @pyqtSlot(str, 'QVariant')
     def setConfig(self, key: str, value):

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -69,7 +69,7 @@ _CQ_DEFAULT_ROLLING_WINDOW = 10
 # opens a prompt; entering this value sets developerMode=true (persisted).
 # This is the ONLY place the literal is defined. The check lives in Python
 # (not QML) so the literal never ships inside readable QML text.
-_DEVELOPER_PASSWORD = "openwater-dev"
+_DEVELOPER_PASSWORD = "OnePointOne"
 
 
 def developer_password_matches(pw) -> bool:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -69,7 +69,7 @@ _CQ_DEFAULT_ROLLING_WINDOW = 10
 # opens a prompt; entering this value sets developerMode=true (persisted).
 # This is the ONLY place the literal is defined. The check lives in Python
 # (not QML) so the literal never ships inside readable QML text.
-_DEVELOPER_PASSWORD = "OnePointOne"
+_DEVELOPER_PASSWORD = "OpenwaterHealth"
 
 
 def developer_password_matches(pw) -> bool:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -893,7 +893,11 @@ class MOTIONConnector(QObject):
             return False
         try:
             speed = 100 if on else 0
-            if self._interface.console.set_fan_speed(fan_speed=speed):
+            # set_fan_speed returns the duty cycle that was set (0..100),
+            # or -1 on OW_ERROR. Check against the -1 sentinel — NOT
+            # truthiness — because turning the fan off returns 0, which
+            # is falsy but successful.
+            if self._interface.console.set_fan_speed(fan_speed=speed) != -1:
                 self._console_fan_on = bool(on)
                 self.consoleFanChanged.emit()
                 logger.info("Console fan set to %s", "ON" if on else "OFF")

--- a/tests/test_calibration_target_isolation.py
+++ b/tests/test_calibration_target_isolation.py
@@ -68,11 +68,25 @@ from hil_helpers import (
     RE_CONNECTED,
     click_panel,
     find_app_log,
+    force_app_config_value,
     recalibrate_panel_buttons,
     wait_for_pattern,
+    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
+
+# Calibration controls live in the developerMode-gated "Developer" card
+# of the Settings modal. The app ships with developerMode=false, so force
+# it true on disk before the test's app relaunches read the config;
+# restore the original value when the module finishes.
+_INITIAL_DEVELOPER_MODE = force_app_config_value("developerMode", True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_developer_mode():
+    yield
+    write_app_config_value("developerMode", _INITIAL_DEVELOPER_MODE)
 
 # Calibration on real hardware: phase-0 flash (~5–15 s) + 2 sub-scans
 # of ~6 s each + compute + write + validation. Field runs settle

--- a/tests/test_calibration_ui.py
+++ b/tests/test_calibration_ui.py
@@ -43,9 +43,20 @@ import pytest
 from pywinauto import findwindows
 
 from conftest import SLEEP, ensure_visible, log, uia_window
-from hil_helpers import click_panel
+from hil_helpers import click_panel, force_app_config_value, write_app_config_value
 
 pytestmark = pytest.mark.dev
+
+# Calibration controls live in the developerMode-gated "Developer" card
+# of the Settings modal. The app ships with developerMode=false, so force
+# it true before the session ``app`` fixture launches; restore afterward.
+_INITIAL_DEVELOPER_MODE = force_app_config_value("developerMode", True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_developer_mode():
+    yield
+    write_app_config_value("developerMode", _INITIAL_DEVELOPER_MODE)
 
 # Calibration on real hardware: phase-0 flash (~5-15 s) + 2 sub-scans
 # of ~6 s each + compute + write_calibration. Field runs settle around

--- a/tests/test_developer_password.py
+++ b/tests/test_developer_password.py
@@ -1,0 +1,23 @@
+"""Pure-software unit test for the developer-mode password check.
+
+Does NOT request the ``app`` fixture, so the bloodflow app is not
+launched and no hardware is touched — only the lightweight
+session-autouse QCoreApplication fixture runs.
+"""
+from motion_connector import developer_password_matches, _DEVELOPER_PASSWORD
+
+
+def test_correct_password_matches():
+    assert developer_password_matches(_DEVELOPER_PASSWORD) is True
+
+
+def test_wrong_password_rejected():
+    assert developer_password_matches("nope") is False
+
+
+def test_empty_password_rejected():
+    assert developer_password_matches("") is False
+
+
+def test_none_password_rejected():
+    assert developer_password_matches(None) is False


### PR DESCRIPTION
## Summary

Release 1.1.3 — merges `next` into `main` for tagging.

### Features
- **Developer mode gate** (#148): logo double-click unlock with password prompt, calibration moved behind developer card, console fan switch, dev-mode disable
- **Differentiated orange CQ indicators** (#128): `CameraDot` component with per-camera ambient/contact warning types, dot legend in CQ modal (dev mode)
- **Separate Calibrate / Test buttons** (#132): dedicated test scan with configurable duration, `TestResultsWindow` with clipboard copy, calibration status centering fixes
- **Reusable PasswordPromptModal**: extracted for use beyond dev-mode gate (calibration button gating)

### Fixes
- Console fan-off path checks `set_fan_speed != -1` instead of truthiness
- HIL tests force `developerMode` for calibration under the new dev gate

### Chore
- `.superpowers/` added to `.gitignore`
- Config file revert (cleaning up dev artifacts)

### RC history
- `1.1.3-dev.0` → `1.1.3-rc.0` → `1.1.3-rc.1` → `1.1.3-rc.2`

## Test plan
- [x] HIL test suite passes on `next` (CI: `hil-tests.yml`)
- [x] Verify developer mode gate: logo double-click → password prompt → dev card visible
- [ ] Verify differentiated CQ dots show ambient vs contact warnings
- [x] Verify separate Calibrate/Test buttons work independently
- [ ] Tag `1.1.3` on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)