### PR TITLE
Filter cam_id=-1 side-average frames from scanCorrectedBatch

### DIFF
--- a/data_sources.py
+++ b/data_sources.py
@@ -792,7 +792,8 @@ def _bucketize_session_rows(
     Rows are bucketed by their stored cam_id verbatim:
       - cam_id 0..7 — per-camera BFI/BVI/mean/contrast (normal-mode scans).
       - cam_id == -1 — the reduced-mode dark-corrected per-side average
-        (bfi/bvi/mean/contrast), written by ScanDBSink's "final_side" path.
+        (bfi/bvi/mean/contrast), persisted by ScanDBSink from the "final"
+        channel's cam_id=-1 side-average frames.
     has_bfi reflects whether ANY finite BFI/BVI landed (either layout) — the
     caller uses it to decide whether to fall back to the corrected CSV (only
     pre-pipeline scans, which carry no BFI/BVI in the DB)."""
@@ -846,8 +847,9 @@ class PastScanSource(ScanDataSource):
         # session_data carries, by cam_id:
         #   - cam_id 0..7  — per-camera BFI/BVI/mean/contrast (normal-mode scans).
         #   - cam_id == -1 — the reduced-mode dark-corrected per-side average
-        #     (written by ScanDBSink's "final_side" path). Reduced cells query
-        #     cam_id=-1, so replay reads it straight from the DB — no derivation.
+        #     (persisted by ScanDBSink from the "final" channel's cam_id=-1
+        #     side-average frames). Reduced cells query cam_id=-1, so replay
+        #     reads it straight from the DB — no derivation.
         # Pre-pipeline scans carry no BFI/BVI in the DB; the CSV fallback covers
         # those.
         self.buffers, has_bfi = _bucketize_session_rows(scan_db, self.session_id)

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -365,6 +365,15 @@ class _FinalBatchSink:
         for s in samples:
             side = str(getattr(s, "side", ""))
             cam_id = int(getattr(s, "cam_id", -1))
+            if cam_id < 0:
+                # Reduced-mode side-average frames (cam_id=-1) ride the
+                # "final" channel since SDK PR #67. No live consumer wants
+                # them: ReducedPlotView deliberately ignores corrected
+                # batches, and reduced replay reads the cam_id=-1 rows
+                # straight from the scan DB. Skipping avoids misindexing
+                # the legacy per-camera plot and pointless cross-thread
+                # fan-out (in reduced mode it is the whole payload).
+                continue
             should_emit, recovery_msg = _check_dropped_camera_emit(
                 side, cam_id,
                 connector._camera_dropped,

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -187,6 +187,36 @@ def test_final_batch_sink_skips_live_source_when_payload_empty():
     assert conn.scanCorrectedBatch.calls == []
 
 
+def test_final_batch_sink_skips_side_average_frames():
+    """Reduced-mode side averages ride the "final" channel as cam_id=-1
+    EnrichedCorrectedFrames (SDK PR #67). No live consumer wants them
+    (ReducedPlotView ignores corrected batches; reduced replay reads the
+    DB), so the sink must filter them out of the per-camera payload."""
+    conn = _connector()
+    sink, src = _make_final_sink(conn)
+    interval = SimpleNamespace(
+        frames=[
+            SimpleNamespace(side="left", cam_id=-1, abs_frame_id=42,
+                            bfi=2.5, bvi=6.5, mean=float("nan"), contrast=0.31),
+            SimpleNamespace(side="left", cam_id=1, abs_frame_id=42,
+                            bfi=2.0, bvi=6.0, mean=120.0, contrast=0.30),
+        ]
+    )
+    sink.consume("final", interval)
+    assert len(conn.scanCorrectedBatch.calls) == 1
+    payload = conn.scanCorrectedBatch.calls[0][0]
+    assert [(p["side"], p["camId"]) for p in payload] == [("left", 1)]
+
+    # All-side-average payload (reduced mode): nothing emitted at all.
+    conn.scanCorrectedBatch.calls.clear()
+    sink.consume("final", SimpleNamespace(frames=[
+        SimpleNamespace(side="right", cam_id=-1, abs_frame_id=50,
+                        bfi=3.0, bvi=7.0, mean=float("nan"), contrast=0.2),
+    ]))
+    assert conn.scanCorrectedBatch.calls == []
+    assert src.corrected_batches == []
+
+
 def test_live_plot_sink_subscribes_to_live_side_channel():
     sink, _ = _make_sink(_connector())
     assert "live" in sink.channels


### PR DESCRIPTION
## What changed

`_FinalBatchSink` now filters `cam_id < 0` frames out of the `scanCorrectedBatch` payload, with a regression test, and the stale `final_side` comments in `data_sources.py` are updated to the new channel model.

## Why

Since SDK [openmotion-sdk#67](https://github.com/OpenwaterHealth/openmotion-sdk/pull/67), the reduced-mode corrected side averages ride the `"final"` channel as `EnrichedCorrectedFrame`s with `cam_id=-1` (the `final_side` channel was removed). No live consumer wants those frames:

- `ReducedPlotView` deliberately ignores corrected batches (FDA mode),
- the new viewer's `apply_corrected_batch` is disabled,
- reduced replay reads the `cam_id=-1` rows straight from the scan DB.

Forwarding them risked misindexing the legacy per-camera plot (`-1 % 8` aliasing) and wasted cross-thread fan-out — in reduced mode the side averages are the *entire* payload, so those emits now disappear completely.

## Verification

`tests/test_live_plot_sink.py` + `tests/test_data_sources.py`: 87 passed, including the new `test_final_batch_sink_skips_side_average_frames` (mixed payload keeps per-camera rows only; all-side-average payload emits nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
