### PR TITLE
fix: gate telemetry/raw CSV output on developer mode (regression)

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -650,7 +650,10 @@ class MotionConnector(QObject):
         # ft-test-csvs) live under self._directory.
         resolved_dir = data_dir or cfg.get("dataDirectory") or self._default_data_dir()
         self._power_off_unused_cameras    = bool(cfg.get("powerOffUnusedCameras", False))
-        self._write_raw_csv               = bool(cfg.get("writeRawCsv", True))
+        # Raw CSV is a developer feature (Settings → Developer → "Save raw
+        # CSV"); default False so a config missing the key fails closed for
+        # clinical use (#43).
+        self._write_raw_csv               = bool(cfg.get("writeRawCsv", False))
         raw_csv                           = cfg.get("rawCsvDurationSec")
         self._raw_csv_duration_sec        = float(raw_csv) if raw_csv is not None else None
         self._uncorrected_only            = bool(cfg.get("uncorrectedOnly", False))
@@ -1958,6 +1961,10 @@ class MotionConnector(QObject):
             self.captureFinished.emit(True, "", "", "")
             self.scanNotesReady.emit()
 
+        # Issue #43: telemetry and raw CSVs are developer diagnostics —
+        # clinical users must not get them. Default False (fail closed).
+        developer_mode = self._app_config.get("developerMode", False)
+
         req = ScanRequest(
             subject_id=subject_id,
             duration_sec=duration_sec,
@@ -1971,11 +1978,20 @@ class MotionConnector(QObject):
             # writeCorrectedCsv:true in app_config to keep exporting it.
             # The SDK still forces it on if no DB is configured.
             write_corrected_csv=self._app_config.get("writeCorrectedCsv", False),
+            # Issue #43 (regression): the SDK defaults write_telemetry_csv
+            # to True, so the per-scan {scan_id}_{subject}_telemetry.csv
+            # must be explicitly gated on developerMode here. The original
+            # gate was dropped in the sink-refactor follow-up (93c2feb).
+            write_telemetry_csv=developer_mode,
             # Raw CSV duration forwarded to the pipeline's Tee("raw") gate
             # via raw_save_max_duration_s. None means unbounded (write entire
-            # scan); 0 omits raw tee entirely.
+            # scan); 0 omits raw tee entirely. The writeRawCsv toggle lives
+            # in the developer-only Settings card, so its persisted value is
+            # additionally gated on developerMode (#43) — flipping dev mode
+            # off must stop raw output even if the toggle was left on.
             raw_save_max_duration_s=(
-                self._raw_csv_duration_sec if self._write_raw_csv else 0
+                self._raw_csv_duration_sec
+                if (developer_mode and self._write_raw_csv) else 0
             ),
             sinks=[
                 _LivePlotSink(connector=self, plot_t0=plot_t0, live_source=live_source),

--- a/tests/test_telemetry_dev_gate.py
+++ b/tests/test_telemetry_dev_gate.py
@@ -1,0 +1,107 @@
+"""Issue #43 (regression): telemetry / raw CSV output must be gated on
+developerMode.
+
+The SDK's ``ScanRequest`` defaults ``write_telemetry_csv=True``, so the
+connector must explicitly pass ``developerMode`` (default False — fail
+closed for clinical use) when building the main scan request. The raw
+histogram CSV tee is a developer-only Settings toggle, so its persisted
+``writeRawCsv`` value must additionally be gated on developerMode.
+
+These tests mock the hardware seam (``interface.start_scan``) and assert
+on the captured ``ScanRequest`` — no hardware, no app launch.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _make_connector(tmp_path, app_config):
+    iface = MagicMock()
+    iface.console = MagicMock()
+    iface.left = MagicMock()
+    iface.right = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow = MagicMock()
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.start_scan.return_value = True
+    # LiveScanSource treats scan_db_path as an optional path string; a
+    # bare MagicMock attribute would leak into os.path calls.
+    iface.scan_db_path = None
+
+    c = MotionConnector(
+        interface=iface,
+        app_config=app_config,
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._rightSensorConnected = True
+    return c
+
+
+def _captured_request(connector, tmp_path):
+    ok = connector.startCapture("subj", 5, 0x66, 0x66, str(tmp_path), False)
+    assert ok is True
+    connector._interface.start_scan.assert_called_once()
+    return connector._interface.start_scan.call_args.args[0]
+
+
+def test_clinical_mode_disables_telemetry_and_raw_csv(tmp_path):
+    """developerMode=False → no telemetry CSV, no raw CSV tee — even if a
+    prior developer session left writeRawCsv enabled in the config."""
+    connector = _make_connector(
+        tmp_path,
+        {"developerMode": False, "writeRawCsv": True},
+    )
+    req = _captured_request(connector, tmp_path)
+    assert req.write_telemetry_csv is False
+    assert req.raw_save_max_duration_s == 0
+
+
+def test_missing_developer_mode_key_fails_closed(tmp_path):
+    """No developerMode key at all → same as clinical mode (fail closed)."""
+    connector = _make_connector(tmp_path, {"writeRawCsv": True})
+    req = _captured_request(connector, tmp_path)
+    assert req.write_telemetry_csv is False
+    assert req.raw_save_max_duration_s == 0
+
+
+def test_developer_mode_enables_telemetry_and_raw_csv(tmp_path):
+    """developerMode=True restores both developer outputs."""
+    connector = _make_connector(
+        tmp_path,
+        {
+            "developerMode": True,
+            "writeRawCsv": True,
+            "rawCsvDurationSec": 60,
+        },
+    )
+    req = _captured_request(connector, tmp_path)
+    assert req.write_telemetry_csv is True
+    assert req.raw_save_max_duration_s == 60.0
+
+
+def test_developer_mode_respects_raw_csv_toggle_off(tmp_path):
+    """developerMode=True but writeRawCsv off → raw tee still omitted."""
+    connector = _make_connector(
+        tmp_path,
+        {"developerMode": True, "writeRawCsv": False},
+    )
+    req = _captured_request(connector, tmp_path)
+    assert req.write_telemetry_csv is True
+    assert req.raw_save_max_duration_s == 0
+
+
+def test_write_raw_csv_defaults_false(tmp_path):
+    """writeRawCsv missing from config → fail closed (no raw output)."""
+    connector = _make_connector(tmp_path, {"developerMode": True})
+    assert connector._write_raw_csv is False
+    req = _captured_request(connector, tmp_path)
+    assert req.raw_save_max_duration_s == 0


### PR DESCRIPTION
Fixes #43

> **Rebased onto `next` (post-#161 cleanup merge).** The fix re-applied cleanly to the refactored connector (`MOTIONConnector` → `MotionConnector` rename, run-*.csv / per-run .log removal); the new tests were updated for the class rename. The gate is still absent on `next` — the cleanup commits did not fix #43 — so this PR is still needed. See the **Scope note** below.

## Root cause

The original #43 fix (`df8227c`) passed `write_telemetry_csv=developerMode` on the main `ScanRequest`. The sink-refactor (`2877341`) replaced that flag with a developerMode-gated `TelemetrySink` in the request's `sinks` list. A follow-up (`93c2feb`, a trigger-state fix) then removed that `TelemetrySink` block as collateral — leaving **no telemetry gate at all**. Since the SDK's `ScanRequest` defaults `write_telemetry_csv=True`, every clinical scan silently regained `{scan_id}_{subject}_telemetry.csv` (confirmed against the attached `1.2.0-dev.1` log: a normal-mode scan with the `ConsoleTelemetryPoller` running, which feeds the SDK-side telemetry writer).

The **raw CSVs** in the screenshot come from a separate hole: the "Save raw CSV" toggle lives in the developer-only Settings card, but the connector fed `raw_save_max_duration_s` from the persisted `writeRawCsv` value unconditionally — and defaulted it to `True` when the key was missing from an older persisted config. So a toggle flipped on during a dev session (or simply an old config file) kept writing raw histogram CSVs after developer mode was turned off, with no UI left to switch it off. Since raw CSV output is squarely a developer feature (its only control is dev-gated), gating it on `developerMode` matches the issue's intent — the report explicitly complains about both file types in normal mode.

## What changed (`motion_connector.py`, `startCapture`)

- `write_telemetry_csv=self._app_config.get("developerMode", False)` restored on the main `ScanRequest` (fail closed — missing key means clinical).
- `raw_save_max_duration_s` is now `0` (raw tee omitted) unless **both** `developerMode` and `writeRawCsv` are true.
- `writeRawCsv` defaults to `False` when absent from config (it ships `false`; previous fail-open `True` default removed).

**Not changed (verified already safe on current `next`):**
- Contact-quality check and calibration/test sub-scans go through the SDK's `run_collection_scan`, which sets `skip_default_storage=True` — the SDK skips the telemetry writer entirely, so no `*_cq_telemetry.csv` is produced (the `5e30d10` gate became obsolete with the `ContactQualityWorkflow` refactor).
- The corrected `*_cq.csv` / scan-data `_corrected` outputs stay ungated, per the issue history.
- `motion_connector.py` has exactly one `ScanRequest(` construction site after the rename refactor (`62195e8`), and it is the one gated here; `runTestScan`/calibration build `CalibrationRequest` instead.

## Scope note (decision confirmed)

The intent of #43 stands as written: the rich SDK `*_telemetry.csv` is a developer artifact and must only be written in developer mode — confirmed by @boringethan (2026-06-10). One consequence reviewers should be aware of: the #161 cleanup dropped the per-run `.log` and the app-side `run-*.csv` in favor of this CSV, so with this gate merged, clinical (non-dev) scans persist no console-telemetry file at all — telemetry lines remain in the app log at DEBUG only. That matches the pre-regression #43 design (the dropped `run-*.csv` was itself dev-only); if a clinical-triage telemetry artifact is ever wanted, that's a new feature, not a reason to leave #43 open.

## Tests

New `tests/test_telemetry_dev_gate.py` (marked `unit`, hardware seam mocked via `MagicMock` interface — no hardware, no app launch): asserts the `ScanRequest` captured by `start_scan` has `write_telemetry_csv=False` / `raw_save_max_duration_s=0` in clinical mode (including when `developerMode` is absent and when `writeRawCsv` was left `true`), and that dev mode restores both. Full unit suite on the rebased branch: **130 passed**. flake8: no new findings vs. `next` (276 pre-existing before and after on `motion_connector.py`; the new test file is clean).

## How to test (on hardware)

With `"developerMode": false` in `app_config.json` (leave `writeRawCsv: true` to prove the override):
1. Run a scan to completion and stop it.
2. Inspect the data directory — `_notes.txt` / DB / (optional `_corrected.csv`) appear, but **no** `*_telemetry.csv` and **no** `*_raw*.csv`.
3. Trigger a contact-quality check — no `*_cq_telemetry.csv`.

With `"developerMode": true` and the Save raw CSV toggle on, all of the above reappear as before.

> **Note:** verified by static analysis + mocked unit tests only; on-hardware verification of the steps above is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
