### PR TITLE
fix: remove startup FPGA auto-flash and the autoConfigureOnStartup flag

### DIFF
--- a/components/ButtonPanel.qml
+++ b/components/ButtonPanel.qml
@@ -15,8 +15,8 @@ Rectangle {
     border.width: 1
 
     property bool scanning: false
-    property bool waiting: false       // true while cameras are flashing / scan is arming
-    property bool camerasReady: false  // true when camera flash is complete
+    property bool waiting: false       // true while a scan start is armed (pipeline-idle gate)
+    property bool camerasReady: false  // gates Start/Check enablement
     property bool reducedMode: false       // FDA mode hides scan-settings button
 
     // Connection state — drives start button icon and enablement.

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -8,7 +8,6 @@
   "reducedMode": true,
   "reducedModeLeftMask": 195,
   "reducedModeRightMask": 195,
-  "autoConfigureOnStartup": false,
   "uncorrectedOnly": true,
 
   "showBfiBvi": true,

--- a/main.py
+++ b/main.py
@@ -90,7 +90,6 @@ def _load_app_config() -> dict:
         "leftMask": 0x66,   # 0b01100110 — cameras 2,3,6,7 (Middle pattern)
         "rightMask": 0x66,
         "uncorrectedOnly": False,
-        "autoConfigureOnStartup": True,
         "developerMode": False,
         "showBfiBvi": True,
         "bfiMin": 0.0,

--- a/main.qml
+++ b/main.qml
@@ -21,14 +21,13 @@ ApplicationWindow {
     // to interrupt mid-flight by accident counts.
     readonly property bool _anyInProgress:
         bloodFlowPage.scanning ||
-        bloodFlowPage.configuring ||
         bloodFlowPage.checkRunning ||
         MotionInterface.calibrationRunning ||
         MotionInterface.testScanRunning
 
     // Most-specific in-progress label for the warn-toast text. First
     // match wins — calibration is rarest + costliest to interrupt,
-    // scan next, configuration / contact-quality check after.
+    // scan next, contact-quality check after.
     //
     // If a non-dismissable modal is on screen at click time
     // (ContactQualityModal mid-check, etc.), prefer its declared
@@ -41,7 +40,6 @@ ApplicationWindow {
         if (MotionInterface.calibrationRunning) return "Calibration"
         if (MotionInterface.testScanRunning)    return "Test scan"
         if (bloodFlowPage.scanning)             return "Scan"
-        if (bloodFlowPage.configuring)          return "Camera configuration"
         if (bloodFlowPage.checkRunning)         return "Contact-quality check"
         return ""
     }

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -16,8 +16,7 @@ Rectangle {
     AppTheme { id: theme }
 
     property bool scanning: false
-    property bool camerasReady: true  // starts true, goes false when camera selection changes
-    property bool configuring: false  // true during camera flash
+    property bool camerasReady: true  // gates Start/Check; false only while no sensor is connected
 
     // Aggregate live state of the contact-quality runners so main.qml
     // can detect 'check in progress' for the close-while-busy warning
@@ -104,18 +103,10 @@ Rectangle {
             rightMask = defRight;
             _rightMaskInitialApplied = true;
         }
-        if (cfg.autoConfigureOnStartup !== false &&
-                (MotionInterface.leftSensorConnected || MotionInterface.rightSensorConnected)) {
-            flashDefaultCameras();
-        }
-    }
-
-    function flashDefaultCameras() {
-        if (configuring || scanning) return;
-        camerasReady = false;
-        configuring = true;
-        console.log("Auto-flashing cameras: left=0x" + leftMask.toString(16) + " right=0x" + rightMask.toString(16));
-        MotionInterface.startConfigureCameraSensors(leftMask, rightMask);
+        // No FPGA flash here (issue #154): ScanRunner runs
+        // FlashSensorsTask unconditionally on every Start/Check, so a
+        // startup flash would only block the Start button for ~2 min
+        // doing redundant work.
     }
 
     function beginScanNow() {
@@ -176,8 +167,8 @@ Rectangle {
         z: 10000
 
         scanning: bloodFlow.scanning
-        waiting: bloodFlow.configuring || bloodFlow.scanStartPending
-        camerasReady: bloodFlow.camerasReady && !bloodFlow.configuring
+        waiting: bloodFlow.scanStartPending
+        camerasReady: bloodFlow.camerasReady
         reducedMode: bloodFlow.reducedMode
 
         // Action buttons — close any open modal first (which by
@@ -446,13 +437,13 @@ Rectangle {
         target: MotionInterface
 
         function onSignalConnected(descriptor, port) {
-            // Auto-flash default cameras when sensors connect.
+            // Adopt the config default camera masks when sensors connect.
             // Descriptor is the handle name from the SDK ("console" / "left" / "right").
             // The SDK already logs the state transition at INFO; no need
             // to duplicate it from QML.
             if (descriptor === "left" || descriptor === "right") {
                 Qt.callLater(function() {
-                    if (!bloodFlow.scanning && !bloodFlow.configuring) {
+                    if (!bloodFlow.scanning) {
                         var cfg      = MotionInterface.appConfig;
                         var defLeft  = bloodFlow.reducedMode ? (cfg.reducedModeLeftMask  !== undefined ? cfg.reducedModeLeftMask  : 0xC3) : (cfg.leftMask  !== undefined ? cfg.leftMask  : 0x99);
                         var defRight = bloodFlow.reducedMode ? (cfg.reducedModeRightMask !== undefined ? cfg.reducedModeRightMask : 0xC3) : (cfg.rightMask !== undefined ? cfg.rightMask : 0x99);
@@ -460,9 +451,7 @@ Rectangle {
                         // default. Subsequent reconnects (e.g. console power
                         // cycle) preserve whatever's already in *Mask —
                         // either the cfg default already adopted earlier or
-                        // the user's Scan Settings choice (issue #127). The
-                        // re-flash below still runs because the FPGA loses
-                        // its camera-enable state on power cycle.
+                        // the user's Scan Settings choice (issue #127).
                         if (MotionInterface.leftSensorConnected && !bloodFlow._leftMaskInitialApplied) {
                             bloodFlow.leftMask  = defLeft;
                             bloodFlow._leftMaskInitialApplied = true;
@@ -471,8 +460,9 @@ Rectangle {
                             bloodFlow.rightMask = defRight;
                             bloodFlow._rightMaskInitialApplied = true;
                         }
-                        if (cfg.autoConfigureOnStartup !== false)
-                            flashDefaultCameras()
+                        // No FPGA flash on connect (issue #154): ScanRunner
+                        // runs FlashSensorsTask on every Start/Check, so the
+                        // post-power-cycle FPGA state is restored there.
                     }
                 })
             }
@@ -491,7 +481,6 @@ Rectangle {
         }
 
         function onConfigFinished(ok, err) {
-            bloodFlow.configuring = false
             bloodFlow.camerasReady = true  // always unblock; allConnected is the real gate
             if (ok) {
                 console.log("Camera configuration complete")

--- a/tests/test_app_config_defaults.py
+++ b/tests/test_app_config_defaults.py
@@ -1,0 +1,101 @@
+"""Unit tests for _load_app_config resolution paths — issue #154.
+
+The startup camera-FPGA auto-flash (`autoConfigureOnStartup`) used to
+keep the Start button orange/disabled for ~2 minutes while every camera
+FPGA was programmed sequentially — redundant work, since ScanRunner runs
+FlashSensorsTask unconditionally on every Start/Check. The flag and the
+startup-flash machinery were removed entirely; these tests pin the
+config-loader fallback behavior and tombstone the removed flag so it is
+never silently reintroduced.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import main as app_main
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _patch_config_path(monkeypatch, path):
+    """Point main._load_app_config at ``path`` for config/app_config.json."""
+    real_resource_path = app_main.resource_path
+
+    def fake_resource_path(*parts):
+        if parts == ("config", "app_config.json"):
+            return path
+        return real_resource_path(*parts)
+
+    monkeypatch.setattr(app_main, "resource_path", fake_resource_path)
+
+
+def test_missing_config_falls_back_to_defaults(tmp_path, monkeypatch):
+    """No app_config.json at all -> pure in-code defaults."""
+    _patch_config_path(monkeypatch, tmp_path / "app_config.json")
+    cfg = app_main._load_app_config()
+    assert cfg["leftMask"] == 0x66
+    assert cfg["developerMode"] is False
+
+
+def test_corrupt_config_falls_back_to_defaults(tmp_path, monkeypatch):
+    """Corrupt JSON falls back to in-code defaults instead of crashing."""
+    config_path = tmp_path / "app_config.json"
+    config_path.write_text("{not valid json", encoding="utf-8")
+    _patch_config_path(monkeypatch, config_path)
+    cfg = app_main._load_app_config()
+    assert cfg["leftMask"] == 0x66
+    assert cfg["developerMode"] is False
+
+
+def test_unknown_keys_are_dropped(tmp_path, monkeypatch):
+    """Keys not in the in-code defaults are filtered out on load.
+
+    This is what retires removed flags in the field: a persisted config
+    that still carries `autoConfigureOnStartup` from an older build loses
+    it on load, so no QML/Python code can ever see it again.
+    """
+    config_path = tmp_path / "app_config.json"
+    config_path.write_text(
+        json.dumps({"developerMode": True, "autoConfigureOnStartup": True}),
+        encoding="utf-8",
+    )
+    _patch_config_path(monkeypatch, config_path)
+    cfg = app_main._load_app_config()
+    assert cfg["developerMode"] is True
+    assert "autoConfigureOnStartup" not in cfg
+
+
+def test_auto_configure_flag_is_gone():
+    """Tombstone for issue #154: the startup auto-flash flag must not
+    come back — not in the in-code defaults, not in the shipped config,
+    not in any source file."""
+    assert "autoConfigureOnStartup" not in app_main._load_app_config()
+
+    shipped = app_main.resource_path("config", "app_config.json")
+    with open(shipped, "r", encoding="utf-8") as f:
+        assert "autoConfigureOnStartup" not in json.load(f)
+
+    offenders = []
+    for pattern in ("*.py", "*.qml", "*.json"):
+        for path in REPO_ROOT.rglob(pattern):
+            rel = path.relative_to(REPO_ROOT)
+            # Skip this test file, virtualenvs and build output.
+            if rel == Path("tests") / "test_app_config_defaults.py":
+                continue
+            skip_dirs = (
+                ".venv", "venv", ".git", ".claude",
+                "build", "dist", "__pycache__",
+            )
+            if any(part in skip_dirs for part in rel.parts):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if "autoConfigureOnStartup" in text:
+                offenders.append(str(rel))
+    assert offenders == []


### PR DESCRIPTION
Fixes #154

> **Rebased 2026-06-11 (2):** re-rebased after #159/#160 merged. One conflict in BloodFlow.qml — #160 removed the adjacent dead patternToMask() that sat in this commit's context; resolved by deleting both it and flashDefaultCameras() as before. 136 unit tests pass.

## Root cause

On sensor connect, `pages/BloodFlow.qml` auto-ran a sequential camera-FPGA flash (`flashDefaultCameras()`) unless `autoConfigureOnStartup` was disabled. The flash takes ~10 s per camera FPGA (~2 min for 8 positions) and holds the QML `configuring` flag the whole time, keeping the Start button orange/disabled. The shipped `config/app_config.json` had the flag `false`, but the in-code fallback default in `main.py::_load_app_config` was `True` — so any install whose persisted config predated the key silently re-enabled the blocking flash at every launch.

## What this PR does

Per maintainer decision, the startup auto-flash feature is **removed entirely** rather than defaulted off — it is pure redundancy, because `pages/scan/ScanRunner.qml` runs `FlashSensorsTask` unconditionally as stage 1 of every Start and contact-quality Check, so the FPGAs are (re)flashed at scan time regardless (including after a console power cycle).

Deleted:

- `config/app_config.json` — the `autoConfigureOnStartup` key
- `main.py` — the in-code default. The config loader filters unknown keys on load, so persisted configs in the field that still carry the key lose it automatically.
- `pages/BloodFlow.qml` — `flashDefaultCameras()` and both flag-gated call sites (startup via `applyDefaultCameras()` and the `onSignalConnected` reconnect path). The mask-default adoption on first connect (issue #127 behavior) is untouched. Also removed the now-dead `configuring` property — its only true-setter was the startup flash.
- `main.qml` — `configuring` in the close-while-busy aggregate and its "Camera configuration" toast label

Kept:

- `components/ButtonPanel.qml` — `waiting` and the orange Start-circle state **stay** (changed from the pre-rebase version of this PR): since the pipeline-idle scan-start gate landed on next (0c69416), they also indicate a briefly armed scan start, and that is now their only driver — `BloodFlow.qml` binds `waiting: scanStartPending`. Only stale comments change in this file.
- The pipeline-idle scan-start gate itself (`beginScanWhenReady()` / `scanStartGate` / the `scanStartPending` click guard) — untouched.
- `pages/scan/ScanRunner.qml` `FlashSensorsTask` stage — the scan-time flash that makes this removal safe
- `camerasReady` and the `onConfigFinished` handler — still gate Start/Check on sensor connection state and still fire during the scan-pipeline flash

Tests (`tests/test_app_config_defaults.py`): config-loader fallback paths (missing config, corrupt JSON, unknown-key filtering) plus a tombstone test asserting `autoConfigureOnStartup` appears nowhere in code or shipped config.

## Rebase note (2026-06-10)

Rebased onto `next` after #155, #157, #162 and 0c69416 (pipeline-idle scan-start gate) merged. One textual conflict in `pages/BloodFlow.qml` (the ButtonPanel `waiting`/`camerasReady` bindings); resolved by dropping only the `configuring` terms and keeping `scanStartPending`. The ButtonPanel `waiting`/orange deletion was reverted because 0c69416 made that state live again (see Kept above) — reviewers should re-look at that file and the `waiting: bloodFlow.scanStartPending` binding.

## Verification (post-rebase)

- `pytest tests -m unit` — 126 passed, 124 deselected
- `flake8` on changed Python files — no new findings (pre-existing `main.py` E501/E303 identical on `next`)
- `pyside6-qmllint` on the three edited QML files — no errors (only pre-existing unqualified-access warnings and the runtime-registered `OpenMotion` import warning)
- `grep -ri autoConfigureOnStartup|flashDefaultCameras|configuring` — zero live references in .py/.qml/.json (only the tombstone test)

**On-hardware verification is pending.** To test: launch the app with sensors connected — the Start button should be ready (green) a few seconds after launch instead of orange for ~2 min; starting the first scan (or Check) should still flash the camera FPGAs via the pipeline before capture begins. The Start circle may still flash orange for up to ~8 s if Start is clicked while a previous check's worker is unwinding — that is the (kept) pipeline-idle gate, not the startup flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

