### PR TITLE
fix: load past scans off the GUI thread so View in Plot can't freeze the app (#152)

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -20,6 +20,10 @@ Item {
 
     property var scans: []
     property var selected: ({})
+    // True while an async "View in plot" load is in flight (issue #152):
+    // the heavy DB/CSV walk runs on a worker thread in the connector, and
+    // this drives the busy overlay until pastScanLoadFinished fires.
+    property bool loadingPlot: false
 
     function open() {
         refreshScans()
@@ -318,8 +322,12 @@ Item {
                             }
                             onClicked: {
                                 console.warn("[History] View in plot → clicked → " + (scans[scanPicker.currentIndex] || "?"))
+                                // Async load (issue #152): the heavy DB/CSV walk runs on a
+                                // worker thread. Show the busy overlay and keep the modal
+                                // open; onPastScanLoadFinished clears it and closes the
+                                // modal only when the scan actually loaded.
+                                root.loadingPlot = true
                                 MotionInterface.loadPastScan(scans[scanPicker.currentIndex] || "")
-                                root.close()
                             }
                         }
 
@@ -367,6 +375,20 @@ Item {
             }
         }
 
+        // Busy overlay while an async "View in plot" load is in flight
+        // (issue #152). Blocks clicks on the panel so the selection can't
+        // change under the in-flight load.
+        Rectangle {
+            anchors.fill: parent; color: "#000"; opacity: 0.45
+            visible: root.loadingPlot; z: 9999; radius: 12
+            MouseArea { anchors.fill: parent }
+            Column {
+                anchors.centerIn: parent; spacing: 12
+                BusyIndicator { running: root.loadingPlot; width: 48; height: 48 }
+                Text { text: "Loading scan..."; color: theme.textPrimary; font.pixelSize: 14 }
+            }
+        }
+
         // Match the other modals (SettingsModal, ScanSettingsModal):
         // Escape closes. Without this, ``pyautogui.press('escape')`` is
         // a no-op for History, which left the modal stuck open between
@@ -384,8 +406,16 @@ Item {
 
     Connections {
         target: MotionInterface
+        // Async "View in plot" completion (issue #152). On success the
+        // modal closes to reveal the PlotViewer; on failure it stays
+        // open (onErrorOccurred below pops the error dialog).
+        function onPastScanLoadFinished(label, ok) {
+            root.loadingPlot = false
+            if (ok) root.close()
+        }
         function onDirectoryChanged() { if (root.visible) refreshScans() }
         function onErrorOccurred(msg) {
+            root.loadingPlot = false
             histErrDialog.text = msg || "Unknown error."
             histErrDialog.visible = true
         }

--- a/data_sources.py
+++ b/data_sources.py
@@ -763,10 +763,128 @@ def _bucketize_session_rows(
     return buffers, has_bfi
 
 
+def _get_or_create_unbounded(
+    buffers: dict, side: str, cam_id: int, metric: str
+) -> _CameraBuffer:
+    """Fetch-or-create an UNBOUNDED _CameraBuffer in a plain buffers dict.
+    Used by the bulk loaders (past scan / CSV fallback), which load a
+    finite, already-known result set and must never ring-trim it."""
+    key = (side, int(cam_id), metric)
+    buf = buffers.get(key)
+    if buf is None:
+        buf = _CameraBuffer(max_capacity=None)
+        buffers[key] = buf
+    return buf
+
+
+def _load_corrected_csv_into(buffers: dict, csv_path: str) -> None:
+    """Load per-(side, cam, metric) samples from the corrected CSV
+    written by SDK's CsvSink into `buffers`. Two formats:
+
+    - Normal (dev) mode — 82 cols: frame_id, timestamp_s,
+      bfi_l1..bfi_r8, bvi_l1..bvi_r8, mean_l1..mean_r8,
+      contrast_l1..contrast_r8, temp_l1..temp_r8. Each metric
+      column populates (side, cam_id=0..7, metric).
+    - Reduced mode — 6 cols: frame_id, timestamp_s, bfi_left,
+      bfi_right, bvi_left, bvi_right. Each side column populates
+      (side, cam_id=-1, metric).
+
+    This CSV is written unconditionally for every scan (SDK's
+    CsvSink isn't gated by writeRawCsv). Empty cells are skipped.
+    Best-effort load — a missing or malformed file just means the
+    viewer shows whatever else made it into `buffers`.
+    """
+    import csv as _csv
+
+    try:
+        with open(csv_path, "r", encoding="utf-8") as f:
+            reader = _csv.DictReader(f)
+            fieldnames = reader.fieldnames or []
+            # Detect format by presence of the per-cam column for
+            # cam 1 in either format.
+            is_per_cam = any(c == "bfi_l1" for c in fieldnames)
+            is_reduced = any(c == "bfi_left" for c in fieldnames)
+            if not (is_per_cam or is_reduced):
+                return
+            for row in reader:
+                try:
+                    frame_id = int(row.get("frame_id", -1))
+                    t = float(row["timestamp_s"])
+                except (ValueError, KeyError, TypeError):
+                    continue
+                if is_per_cam:
+                    for metric in ("bfi", "bvi", "mean", "contrast"):
+                        for side, prefix in (("left", "l"), ("right", "r")):
+                            for cam_idx in range(8):
+                                # Columns are 1-indexed (l1..l8) so add 1
+                                # for the column name but store 0-indexed.
+                                col = f"{metric}_{prefix}{cam_idx + 1}"
+                                raw = row.get(col, "")
+                                if raw is None or raw == "":
+                                    continue
+                                try:
+                                    v = float(raw)
+                                except ValueError:
+                                    continue
+                                buf = _get_or_create_unbounded(
+                                    buffers, side, cam_idx, metric
+                                )
+                                buf.append(t=t, v=v, frame_id=frame_id)
+                elif is_reduced:
+                    for metric in ("bfi", "bvi"):
+                        for side in ("left", "right"):
+                            col = f"{metric}_{side}"
+                            raw = row.get(col, "")
+                            if raw is None or raw == "":
+                                continue
+                            try:
+                                v = float(raw)
+                            except ValueError:
+                                continue
+                            buf = _get_or_create_unbounded(
+                                buffers, side, -1, metric
+                            )
+                            buf.append(t=t, v=v, frame_id=frame_id)
+    except OSError:
+        pass
+
+
+def load_past_scan_buffers(
+    scan_db,
+    session_id: int,
+    corrected_csv_path: Optional[str] = None,
+) -> tuple[dict, bool]:
+    """Bulk-load a past scan's samples into a plain
+    {(side, cam_id, metric): _CameraBuffer} dict. Returns (buffers, has_bfi).
+
+    This is the HEAVY part of opening a past scan — a multi-hour scan is
+    millions of session_data rows (issue #152 measured ~8.3M samples ≈ 20 s).
+    It is deliberately Qt-free (pure Python + numpy + sqlite) so callers can
+    run it on a worker thread and hand the finished dict to
+    PastScanSource(preloaded_buffers=...) on the GUI thread.
+
+    session_data carries, by cam_id:
+      - cam_id 0..7  — per-camera BFI/BVI/mean/contrast (normal-mode scans).
+      - cam_id == -1 — the reduced-mode dark-corrected per-side average
+        (cam_id=-1 frames on the "final" channel, persisted by ScanDBSink).
+        Reduced cells query cam_id=-1, so replay reads it straight from the
+        DB — no derivation.
+    Pre-pipeline scans carry no BFI/BVI in the DB; the corrected-CSV
+    fallback covers those (CsvSink writes it for every scan)."""
+    buffers, has_bfi = _bucketize_session_rows(scan_db, int(session_id))
+    if not has_bfi and corrected_csv_path:
+        _load_corrected_csv_into(buffers, corrected_csv_path)
+    return buffers, has_bfi
+
+
 class PastScanSource(ScanDataSource):
     """ScanDataSource constructed from an SDK ScanDatabase session_id.
     Bucketizes session_data rows into per-(side, cam, metric) buffers
-    using the same layout as LiveScanSource."""
+    using the same layout as LiveScanSource.
+
+    Pass `preloaded_buffers` (built off-thread via load_past_scan_buffers)
+    to skip the synchronous DB/CSV walk entirely — constructing the QObject
+    itself is cheap and stays on the GUI thread (issue #152)."""
 
     def __init__(
         self,
@@ -774,6 +892,7 @@ class PastScanSource(ScanDataSource):
         session_id: int,
         corrected_csv_path: Optional[str] = None,
         parent: Optional[QObject] = None,
+        preloaded_buffers: Optional[dict] = None,
     ) -> None:
         # Unbounded buffers: a past scan is a finite, already-known result set
         # loaded in bulk (DB rows and/or the corrected CSV). With a finite
@@ -783,84 +902,13 @@ class PastScanSource(ScanDataSource):
         self._live = False
         self.session_id = int(session_id)
 
-        # session_data carries, by cam_id:
-        #   - cam_id 0..7  — per-camera BFI/BVI/mean/contrast (normal-mode scans).
-        #   - cam_id == -1 — the reduced-mode dark-corrected per-side average
-        #     (cam_id=-1 frames on the "final" channel, persisted by
-        #     ScanDBSink). Reduced cells query
-        #     cam_id=-1, so replay reads it straight from the DB — no derivation.
-        # Pre-pipeline scans carry no BFI/BVI in the DB; the CSV fallback covers
-        # those.
-        self.buffers, has_bfi = _bucketize_session_rows(scan_db, self.session_id)
+        if preloaded_buffers is not None:
+            # Already bulk-loaded on a worker thread — adopt as-is.
+            self.buffers = preloaded_buffers
+            return
 
-        # CSV fallback — only when the DB carried no BFI/BVI at all (old scans).
-        # CsvSink writes the corrected CSV for those.
-        if not has_bfi and corrected_csv_path:
-            self._load_corrected_csv(corrected_csv_path)
-
-    def _load_corrected_csv(self, csv_path: str) -> None:
-        """Load per-(side, cam, metric) samples from the corrected CSV
-        written by SDK's CsvSink. Two formats:
-
-        - Normal (dev) mode — 82 cols: frame_id, timestamp_s,
-          bfi_l1..bfi_r8, bvi_l1..bvi_r8, mean_l1..mean_r8,
-          contrast_l1..contrast_r8, temp_l1..temp_r8. Each metric
-          column populates (side, cam_id=0..7, metric).
-        - Reduced mode — 6 cols: frame_id, timestamp_s, bfi_left,
-          bfi_right, bvi_left, bvi_right. Each side column populates
-          (side, cam_id=-1, metric).
-
-        This CSV is written unconditionally for every scan (SDK's
-        CsvSink isn't gated by writeRawCsv). Empty cells are skipped.
-        Best-effort load — a missing or malformed file just means the
-        viewer shows whatever else PastScanSource managed to read.
-        """
-        import csv as _csv
-
-        try:
-            with open(csv_path, "r", encoding="utf-8") as f:
-                reader = _csv.DictReader(f)
-                fieldnames = reader.fieldnames or []
-                # Detect format by presence of the per-cam column for
-                # cam 1 in either format.
-                is_per_cam = any(c == "bfi_l1" for c in fieldnames)
-                is_reduced = any(c == "bfi_left" for c in fieldnames)
-                if not (is_per_cam or is_reduced):
-                    return
-                for row in reader:
-                    try:
-                        frame_id = int(row.get("frame_id", -1))
-                        t = float(row["timestamp_s"])
-                    except (ValueError, KeyError, TypeError):
-                        continue
-                    if is_per_cam:
-                        for metric in ("bfi", "bvi", "mean", "contrast"):
-                            for side, side_prefix in (("left", "l"), ("right", "r")):
-                                for cam_idx in range(8):
-                                    # Columns are 1-indexed (l1..l8) so add 1
-                                    # for the column name but store 0-indexed.
-                                    col = f"{metric}_{side_prefix}{cam_idx + 1}"
-                                    raw = row.get(col, "")
-                                    if raw is None or raw == "":
-                                        continue
-                                    try:
-                                        v = float(raw)
-                                    except ValueError:
-                                        continue
-                                    buf = self.get_or_create_buffer(side, cam_idx, metric)
-                                    buf.append(t=t, v=v, frame_id=frame_id)
-                    elif is_reduced:
-                        for metric in ("bfi", "bvi"):
-                            for side in ("left", "right"):
-                                col = f"{metric}_{side}"
-                                raw = row.get(col, "")
-                                if raw is None or raw == "":
-                                    continue
-                                try:
-                                    v = float(raw)
-                                except ValueError:
-                                    continue
-                                buf = self.get_or_create_buffer(side, -1, metric)
-                                buf.append(t=t, v=v, frame_id=frame_id)
-        except OSError:
-            pass
+        # Synchronous load (tests / small scans): see load_past_scan_buffers
+        # for the layout and the CSV-fallback rules.
+        self.buffers, _ = load_past_scan_buffers(
+            scan_db, self.session_id, corrected_csv_path
+        )

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -426,6 +426,13 @@ class MotionConnector(QObject):
     # Real-time plot viewer source — see data_sources.py.
     currentScanSourceChanged = pyqtSignal()
     liveSourceAvailableChanged = pyqtSignal()
+    # History → "View in plot": fires on the GUI thread when an async
+    # loadPastScan completes. (session_label, ok). HistoryModal uses it
+    # to clear its busy overlay and close only on success (issue #152).
+    pastScanLoadFinished = pyqtSignal(str, bool)
+    # Private worker→main marshalling for loadPastScan results:
+    # (seq, session_label, session_id, buffers-or-None, source_tag)
+    _pastScanBuffersReady = pyqtSignal(int, str, int, object, str)
 
     configProgress = pyqtSignal(int)
     configLog = pyqtSignal(str)
@@ -588,6 +595,9 @@ class MotionConnector(QObject):
         # navigates to a past scan, so "Back to live" can reassign without
         # reconstructing. None when no scan has run this session.
         self._live_scan_source: LiveScanSource | None = None
+        # Monotonic token for async past-scan loads — a result whose seq
+        # doesn't match the latest request is stale and dropped.
+        self._past_scan_load_seq = 0
 
         self._tec_voltage_default = load_tec_params(config_dir)
         self._console_mutex = QRecursiveMutex()
@@ -1528,37 +1538,122 @@ class MotionConnector(QObject):
         display it in the PlotViewer. The held live source is left
         intact so a subsequent showLiveSource() can return to it.
 
-        Synchronous load — for a typical 30-min scan the SQLite walk
-        completes in well under a second, but if this becomes too slow
-        on long scans we can move it onto a QThread."""
+        Asynchronous load (issue #152): the bulk SQLite walk / CSV parse
+        is multi-second for long scans (a ~70-min scan measured ~8.3M
+        samples ≈ 20 s) and used to freeze the GUI thread. The heavy
+        load now runs on a daemon worker thread; the finished buffers
+        are marshalled back to the GUI thread via _pastScanBuffersReady,
+        where the PastScanSource QObject is constructed and bound to the
+        viewer. pastScanLoadFinished(label, ok) fires on completion
+        either way so the History modal can clear its busy state."""
         if not session_label:
             logger.warning("loadPastScan: empty session_label")
+            self.pastScanLoadFinished.emit("", False)
             return
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            logger.warning(
+                "loadPastScan: scan_db_path unavailable on interface"
+            )
+            self.pastScanLoadFinished.emit(session_label, False)
+            return
+        # Per-cam corrected CSV ({scan_id}.csv, 82-col wide format)
+        # is the only source of per-cam BFI/BVI/mean/contrast for
+        # past replay — the DB's session_data only holds side-
+        # aggregated corrected-frame placeholders. CsvSink writes
+        # this CSV unconditionally for every scan, so it's reliably
+        # available. Resolving the path is a cheap directory glob —
+        # fine on the GUI thread (the modal already does it per
+        # selection); the heavy parse happens on the worker.
+        details = self.get_scan_details(session_label) or {}
+        corrected_csv = details.get("correctedPath") or None
+        self._past_scan_load_seq += 1
+        seq = self._past_scan_load_seq
+        threading.Thread(
+            target=self._load_past_scan_worker,
+            args=(seq, session_label, str(db_path), corrected_csv),
+            name=f"past-scan-load-{seq}",
+            daemon=True,
+        ).start()
+
+    def _load_past_scan_worker(
+        self,
+        seq: int,
+        session_label: str,
+        db_path: str,
+        corrected_csv: Optional[str],
+    ) -> None:
+        """Worker thread: bulk-load a past scan's samples (the heavy,
+        Qt-free part of loadPastScan). Opens its own ScanDatabase handle;
+        results cross back to the GUI thread via _pastScanBuffersReady
+        (cross-thread signal → queued delivery)."""
         try:
             from omotion.ScanDatabase import ScanDatabase
-            db_path = getattr(self._interface, "scan_db_path", None)
-            if not db_path:
-                logger.warning("loadPastScan: scan_db_path unavailable on interface")
-                return
+            from data_sources import load_past_scan_buffers
             db = ScanDatabase(db_path)
-            session = db.get_session_by_label(session_label)
-            if not session:
-                logger.warning("loadPastScan: no session found for label %r", session_label)
-                return
-            session_id = int(session["id"])
-            # Per-cam corrected CSV ({scan_id}.csv, 82-col wide format)
-            # is the only source of per-cam BFI/BVI/mean/contrast for
-            # past replay — the DB's session_data only holds side-
-            # aggregated corrected-frame placeholders. CsvSink writes
-            # this CSV unconditionally for every scan, so it's reliably
-            # available.
-            details = self.get_scan_details(session_label) or {}
-            corrected_csv = details.get("correctedPath") or None
+            try:
+                session = db.get_session_by_label(session_label)
+                if not session:
+                    logger.warning(
+                        "loadPastScan: no session found for label %r",
+                        session_label,
+                    )
+                    self._pastScanBuffersReady.emit(
+                        seq, session_label, -1, None, ""
+                    )
+                    return
+                session_id = int(session["id"])
+                buffers, _ = load_past_scan_buffers(
+                    db, session_id, corrected_csv
+                )
+            finally:
+                db.close()
+            # Detect which source actually populated per-cam BFI: if
+            # any (side, cam_id != -1, bfi) buffer exists, the DB was
+            # sufficient and the CSV fallback was skipped.
+            db_had_per_cam = any(k[1] >= 0 and k[2] == "bfi" for k in buffers)
+            source_tag = (
+                "db" if db_had_per_cam
+                else ("csv" if corrected_csv else "db-only-sentinel")
+            )
+            self._pastScanBuffersReady.emit(
+                seq, session_label, session_id, buffers, source_tag
+            )
+        except Exception:
+            logger.exception("loadPastScan failed for label %r", session_label)
+            self._pastScanBuffersReady.emit(seq, session_label, -1, None, "")
+
+    def _on_past_scan_buffers_ready(
+        self,
+        seq: int,
+        session_label: str,
+        session_id: int,
+        buffers,
+        source_tag: str,
+    ) -> None:
+        """GUI thread: bind a worker-loaded past scan to the viewer.
+        Results from a superseded request (user clicked another scan
+        while this one was loading) are dropped."""
+        if seq != self._past_scan_load_seq:
+            logger.info(
+                "loadPastScan: dropping stale result for %r "
+                "(seq %d, latest %d)",
+                session_label, seq, self._past_scan_load_seq,
+            )
+            return
+        if buffers is None:
+            self.errorOccurred.emit(
+                f"Could not load scan '{session_label}' for plotting.\n"
+                "See the app log for details."
+            )
+            self.pastScanLoadFinished.emit(session_label, False)
+            return
+        try:
             past = PastScanSource(
-                scan_db=db,
+                scan_db=None,
                 session_id=session_id,
-                corrected_csv_path=corrected_csv,
                 parent=self,
+                preloaded_buffers=buffers,
             )
             self._set_current_scan_source(past)
             # Diagnostic — left in for now so we can spot regressions
@@ -1566,21 +1661,16 @@ class MotionConnector(QObject):
             n_buffers = len(past.buffers)
             n_samples = sum(b.n for b in past.buffers.values())
             sample_keys = sorted(past.buffers.keys())[:8]
-            # Detect which source actually populated per-cam BFI: if
-            # any (side, cam_id != -1, bfi) buffer exists, the DB was
-            # sufficient and the CSV fallback was skipped.
-            db_had_per_cam = any(
-                k[1] >= 0 and k[2] == "bfi" for k in past.buffers
-            )
             logger.info(
                 "[Plot] loaded past scan %r (session_id=%d) source=%s: "
                 "buffers=%d samples=%d liveEdge=%.3f sample_keys=%s",
-                session_label, session_id,
-                "db" if db_had_per_cam else ("csv" if corrected_csv else "db-only-sentinel"),
+                session_label, session_id, source_tag,
                 n_buffers, n_samples, past.liveEdge, sample_keys,
             )
+            self.pastScanLoadFinished.emit(session_label, True)
         except Exception:
             logger.exception("loadPastScan failed for label %r", session_label)
+            self.pastScanLoadFinished.emit(session_label, False)
 
     @pyqtSlot(str, str, result=bool)
     def exportScanCsv(self, session_label: str, output_path: str) -> bool:
@@ -3109,6 +3199,8 @@ class MotionConnector(QObject):
         self._testScanCompleteSignal.connect(self._on_test_scan_complete)
         # Worker → Qt main thread for the CQ workflow result.
         self._cq_result_signal.connect(self._on_cq_result_ready)
+        # Worker → Qt main thread for async past-scan loads (issue #152).
+        self._pastScanBuffersReady.connect(self._on_past_scan_buffers_ready)
 
     @pyqtSlot()
     @pyqtSlot(str)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -498,6 +498,84 @@ def test_past_scan_source_skips_null_metric_values(tmp_path):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# load_past_scan_buffers + PastScanSource(preloaded_buffers=...) — the
+# off-thread bulk-load path used by the async loadPastScan (issue #152).
+# ─────────────────────────────────────────────────────────────────────────────
+
+from data_sources import load_past_scan_buffers
+
+
+def test_load_past_scan_buffers_matches_sync_constructor(session_data_db):
+    """The Qt-free bulk loader must produce exactly what the synchronous
+    PastScanSource constructor path produces."""
+    db, sid = session_data_db
+    buffers, has_bfi = load_past_scan_buffers(db, sid)
+    sync_src = PastScanSource(scan_db=db, session_id=sid)
+
+    assert has_bfi is True
+    assert set(buffers.keys()) == set(sync_src.buffers.keys())
+    for key, buf in buffers.items():
+        sync_buf = sync_src.buffers[key]
+        assert buf.n == sync_buf.n
+        np.testing.assert_array_equal(buf.t[:buf.n], sync_buf.t[:sync_buf.n])
+        np.testing.assert_array_equal(buf.v[:buf.n], sync_buf.v[:sync_buf.n])
+
+
+def test_load_past_scan_buffers_csv_fallback(tmp_path):
+    """No BFI/BVI in the DB → the corrected-CSV fallback populates the
+    reduced-mode cam_id=-1 side buffers, same as the sync path."""
+    db_path = tmp_path / "scan.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SESSION_DATA_DDL)
+    conn.commit()
+    db = _FakeScanDatabase(conn)  # empty DB → no BFI → CSV fallback
+
+    csv_path = tmp_path / "reduced.csv"
+    csv_path.write_text(
+        "frame_id,timestamp_s,bfi_left,bfi_right,bvi_left,bvi_right\n"
+        "0,0.0,2.5,3.5,12.0,13.0\n"
+        "1,0.025,2.6,3.6,12.1,13.1\n",
+        encoding="utf-8",
+    )
+    buffers, has_bfi = load_past_scan_buffers(db, 1, str(csv_path))
+    assert has_bfi is False  # DB itself carried no BFI
+    left_bfi = buffers[("left", -1, "bfi")]
+    assert left_bfi.n == 2
+    assert float(left_bfi.v[0]) == pytest.approx(2.5)
+    # CSV-fallback buffers must be unbounded too.
+    for buf in buffers.values():
+        assert buf._max_capacity is None
+
+
+def test_past_scan_source_adopts_preloaded_buffers(session_data_db):
+    """preloaded_buffers skips the DB walk entirely — scan_db=None must
+    never be touched — and the source exposes the adopted buffers."""
+    db, sid = session_data_db
+    buffers, _ = load_past_scan_buffers(db, sid)
+
+    src = PastScanSource(
+        scan_db=None,  # would raise if the constructor tried to walk it
+        session_id=sid,
+        preloaded_buffers=buffers,
+    )
+    assert src.live is False
+    assert src.session_id == sid
+    assert src.buffers is buffers
+    assert src.liveEdge == pytest.approx(0.025 * 4)
+    # QML-facing window query works against the adopted buffers.
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 1.0, 100)
+    assert len(pts) == 5
+
+
+def test_past_scan_source_preloaded_empty_dict_is_empty_source():
+    """An empty preloaded dict (failed/empty session) still yields a
+    valid, empty source — no fallback to the (None) scan_db."""
+    src = PastScanSource(scan_db=None, session_id=3, preloaded_buffers={})
+    assert src.buffers == {}
+    assert src.liveEdge == 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # currentScanSource holder pattern — verified via a parallel mini-class
 # (MotionConnector uses the same pattern; see motion_connector.py)
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #152

> **Rebased 2026-06-10 (2nd time)** onto `next` after #155 (legacy-plot deletion), #162 (matplotlib popout removal + plotviewer fix), #157, and the pipeline-idle gate landed. `next` still had the synchronous GUI-thread `loadPastScan`, so the fix remains necessary. Conflicts: `data_sources.py` (comment rewording vs. the `preloaded_buffers` restructure — took the restructure, carried next's wording into the moved docstring) and `HistoryModal.qml` — next deleted the legacy `visualizing` property, busy overlay, and `onVizFinished`/`onVisualizingChanged` handlers along with the matplotlib popout buttons, so the async flow now uses its own `loadingPlot` property and a dedicated busy overlay, keeping only the `onPastScanLoadFinished` handler. `motion_connector.py` and the tests auto-merged; the merged hunks were audited by hand (the worker/marshalling code, signal declarations, and connect wiring all landed intact in the refactored file).
>
> *(Previous rebase, also 2026-06-10: onto the #161 `MOTION*` → `Motion*` rename; the click-handler conflict was resolved by re-fitting the async flow onto the renamed context property.)*

## Root cause

History → "View in plot" calls `MotionConnector.loadPastScan`, which built the `PastScanSource` **synchronously on the GUI thread**: it walks every `session_data` row for the session (plus the corrected-CSV fallback for pre-pipeline scans) and appends them one by one into numpy buffers. The attached log from the issue shows the cost directly — for the most recent scan (~72 min, `samples=8290392`) the gap between `[History] View in plot → clicked` and `[Plot] loaded past scan` is **14–22 seconds**, repeated on every click. During that window the Qt event loop is blocked, so Windows marks the app "Not Responding" (the reported freeze). The History modal "closing unexpectedly" is the button's unconditional `root.close()` finally executing after the freeze — from the user's perspective the modal vanishes uncommanded.

The docstring even anticipated this: *"Synchronous load — … if this becomes too slow on long scans we can move it onto a QThread."* Long scans arrived; it did. (The 4e16df4 camera-config change is not involved — masks only affect which grid cells render, not the load.)

## Changes

- **`data_sources.py`** — extracted the heavy, Qt-free bulk load into module-level `load_past_scan_buffers()` (and `_load_corrected_csv_into()` for the CSV fallback). `PastScanSource` gains a `preloaded_buffers` parameter to adopt an off-thread load; the synchronous constructor path is preserved for tests/small loads and now delegates to the same function.
- **`motion_connector.py`** — `loadPastScan` now spawns a daemon worker thread that opens its own `ScanDatabase` handle, resolves the session, and bulk-loads the buffers. Results are marshalled back to the GUI thread via a private `_pastScanBuffersReady` signal (queued delivery — same worker→main pattern as `_calibrationCompleteSignal` / `_cq_result_signal`), where the `PastScanSource` QObject is constructed and bound to the viewer. A monotonic sequence token drops stale results if the user picks another scan mid-load. New public `pastScanLoadFinished(label, ok)` signal; failures now surface to the user via `errorOccurred` instead of only a log line.
- **`components/HistoryModal.qml`** — "View in plot →" shows a busy overlay (new `loadingPlot` property — the legacy `visualizing` overlay died with the matplotlib popouts on `next`) and keeps the modal open while loading; `onPastScanLoadFinished` clears the overlay and closes the modal **only on success**. On failure the modal stays open and the existing error dialog pops.
- **`tests/test_data_sources.py`** — 4 new unit tests: loader/sync-constructor equivalence, corrected-CSV fallback (incl. unbounded buffers), preloaded-buffer adoption (asserts the `scan_db=None` path never touches the DB), and empty-preload behavior.

## How to test

Without hardware:
1. `python -m pytest tests -m unit` — 126 passed on the rebased branch (includes the 4 new tests; `next` removed the legacy `apply_corrected` tests, hence fewer than before).
2. `python -m flake8 motion_connector.py data_sources.py tests/test_data_sources.py` — no net-new violations vs `next` (repo has no flake8 config; the only finding on added lines is an E402 section-local import in the test file, matching that file's existing convention). `pyside6-qmllint components/HistoryModal.qml` — 0 errors, warning profile identical to `next`'s version of the file.

With the app (against a data directory containing a long scan, ideally >30 min):
1. Open History, select the longest scan, click "View in plot →".
2. Expected: the modal shows the busy spinner but the app stays responsive (window can be moved, UI repaints); when the load completes the modal closes and the PlotViewer shows the scan.
3. Click "View in plot" and immediately select a different scan and click again — only the latest selection should land in the viewer (stale-result guard).
4. Pick a scan label with no DB session (or temporarily rename `scans.db`) — the modal should stay open and show the error dialog instead of silently doing nothing.

## Verification pending

- Unit tests, byte-compilation, and a standalone smoke script exercising the exact worker-thread → queued-signal → `PastScanSource(preloaded_buffers=…)` path all pass locally (re-run after both rebases).
- **Not yet verified:** full app run against real scan data / hardware (hardware is shared and demo mode is broken). The QML change passes `pyside6-qmllint` with no new findings but manual UI verification of the steps above is pending.

## Note on #151

#151 (freeze returning to Live View from Zoom during an active scan) also involves the PlotViewer, but its path (`showLiveSource` / zoom navigation) does no bulk loading — this PR's root cause is specific to the past-scan bulk load and this change does not touch the live-source or zoom paths. If #151's freeze turns out to be DB-tail or repaint cost on huge buffers, it is a separate root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
