### PR TITLE
fix: GUI freeze after returning to live view from zoom during an active scan (#151)

### DIFF
--- a/data_sources.py
+++ b/data_sources.py
@@ -606,7 +606,20 @@ class LiveScanSource(ScanDataSource):
         false coverage used to make the staleness check short-circuit and
         serve a stale window while live data piled up unshown. Callers only
         pass t_hi up to the in-memory boundary anyway (the recent portion is
-        served from memory), so this cap is a belt-and-suspenders guard."""
+        served from memory), so this cap is a belt-and-suspenders guard.
+
+        t_lo is clamped to >= 0 BEFORE the staleness check: scan timestamps
+        start at 0, so no rows can ever exist below it, and the stored
+        _db_window_lo is itself floored at 0 (want_lo). A followLive window
+        wider than the elapsed scan — wheel-zoom out to e.g. 600 s, then
+        "Back to live" mid-scan — requests t_lo = liveEdge - windowSeconds
+        < 0 on EVERY paint; unclamped, that request can never be satisfied
+        by the cache, so every points_for_window call (cells × metrics,
+        ~30 Hz) re-queried and re-bucketized the whole DB window on the GUI
+        thread, freezing the app until liveEdge outgrew the window or the
+        scan ended (issue #151)."""
+        t_lo = max(0.0, float(t_lo))
+        t_hi = max(t_lo, float(t_hi))
         if t_lo >= self._db_window_lo and t_hi <= self._db_window_hi:
             return
         span = max(1.0, t_hi - t_lo)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1155,6 +1155,83 @@ def test_live_scan_source_db_window_not_padded_into_future(session_data_db):
     assert src._db_window_hi <= src.liveEdge + 1e-9
 
 
+def test_live_scan_source_negative_t_lo_paint_loop_hits_cache(session_data_db):
+    """Regression (issue #151): after "Back to live" with a wheel-zoomed-out
+    window WIDER than the elapsed scan, followLive requests
+    t_lo = liveEdge - windowSeconds < 0 on every paint. _db_window_lo is
+    floored at 0 when stored, so an unclamped negative t_lo could never
+    satisfy the staleness check — every points_for_window call re-queried
+    and re-bucketized the DB window synchronously on the GUI thread
+    (cells × metrics × 30 Hz), freezing the app until the scan ended.
+    The clamp in _ensure_db_window must make the second-and-later paints
+    cache hits."""
+    db, sid = session_data_db
+
+    class _CountingDb:
+        def __init__(self, inner):
+            self._inner = inner
+            self.calls = 0
+
+        def iter_session_data(self, *a, **k):
+            self.calls += 1
+            return self._inner.iter_session_data(*a, **k)
+
+    counting = _CountingDb(db)
+    src = LiveScanSource(plot_t0=0.0)
+    # Post-ring-trim in-memory state: data from t=10 onward only.
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
+    src._db = counting
+    src._db_session_id = sid
+
+    # Simulate the followLive paint loop: windowSeconds=600 ≫ liveEdge,
+    # so t_lo is negative and creeps up as the live edge advances.
+    edge = src.liveEdge
+    for tick in range(20):
+        t_hi = edge + tick * 0.033
+        src.points_for_window("left", 0, "bfi", t_hi - 600.0, t_hi,
+                              max_points=200)
+
+    # One initial load (per metric buffer touched) — NOT one per paint.
+    assert counting.calls <= 2, (
+        f"DB re-queried {counting.calls} times across 20 paints — "
+        "negative-t_lo staleness thrash is back"
+    )
+
+    # And the stitched result still contains both DB and memory data.
+    pts = src.points_for_window("left", 0, "bfi", -590.0, 10.1, max_points=200)
+    vals = [p[1] for p in pts]
+    assert any(v < 50 for v in vals)
+    assert any(v > 50 for v in vals)
+
+
+def test_live_scan_source_value_at_negative_t_cache_valid(session_data_db):
+    """Companion to the paint-loop regression: value_at with a negative
+    cursor time (hover over the empty left margin of a wider-than-scan
+    window) goes through the same _ensure_db_window clamp and must not
+    shrink/clobber the cached window into an unsatisfiable range."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
+    src._db = db
+    src._db_session_id = sid
+
+    v = src.value_at("left", 0, "bfi", -5.0)
+    # Cache bounds remain a valid (lo <= hi), non-negative range.
+    assert src._db_window_lo >= 0.0
+    assert src._db_window_hi >= src._db_window_lo
+    # Nearest stored sample (t≈0) is served — finite, from the DB.
+    assert math.isfinite(v)
+    assert v < 50
+
+
 def test_live_scan_source_value_at_uses_db_tail(session_data_db):
     """value_at also falls through to the DB tail for times before the
     in-memory window."""


### PR DESCRIPTION
Fixes #151

## Root cause

A hard GUI-thread block (not a dead update path), self-sustained by the `LiveScanSource` DB-tail window cache in `data_sources.py`.

Once the in-memory ring buffers have trimmed (DB tail engaged — visible in the attached log at `16:02:49 LiveScanSource: DB tail engaged`), clicking **Back to live** with a wheel-zoomed-out window **wider than the elapsed scan** makes every followLive paint request `t_lo = liveEdge - windowSeconds < 0`. `_ensure_db_window` stores its cached lower bound floored at 0 (`want_lo = max(0.0, t_lo - span)`) but compares the staleness check against the **unclamped** `t_lo`:

```python
if t_lo >= self._db_window_lo and t_hi <= self._db_window_hi:   # never true for t_lo < 0
    return
```

So the cache can never satisfy the request, and **every** `points_for_window` call — cells × metrics, ~32 calls per 33 ms paint tick — synchronously re-queries the scan DB and re-bucketizes the whole window on the GUI thread. The app stays frozen until `liveEdge` outgrows the window or the scan ends, which matches the issue log exactly: frozen from the back-to-live click at 16:03:06, recovered precisely at scan end 16:06:50 (when histogram appends — and therefore paint ticks — stopped).

While zoomed (pinned), `setWindow` clamps `windowStartT >= 0`, so the bug cannot trigger in zoom mode — only the followLive window after "Back to live" produces a negative `t_lo`. That's why the freeze appears only on the way back.

Verified by replaying the paint loop against the real `LiveScanSource` with a counting fake DB (360 s cache, 600 s window, followLive): **4,360 DB reloads / 137M rows re-bucketized in 42 simulated seconds** before the fix; **0 reloads** after.

Note: the reporter's build trimmed at ~360 s into a 10-min scan, so their deployed `app_config.json` had a reduced `liveCacheMaxSeconds` (default is 1800 s). With the default config the same freeze needs a >30-min scan; the fix removes it in both cases.

## Changes

- `data_sources.py` — `LiveScanSource._ensure_db_window`: clamp `t_lo` (and degenerate `t_hi`) to `>= 0` before the staleness check. Scan timestamps start at 0, so no rows can exist below it; the clamp loses nothing and turns the per-paint reload storm back into a single cached load.
- `tests/test_data_sources.py` — two regression tests:
  - `test_live_scan_source_negative_t_lo_paint_loop_hits_cache`: 20 simulated followLive paints with negative `t_lo` must produce at most one DB query (fails with 20 queries before the fix), and the stitched DB+memory result stays correct.
  - `test_live_scan_source_value_at_negative_t_cache_valid`: `value_at` with a negative cursor time (hover over the empty left margin of a wider-than-scan window) keeps the cache bounds valid and serves the nearest stored sample.

## How to test (manual, on hardware)

1. Set `liveCacheMaxSeconds: 120` in `config/app_config.json` (so the ring-trim/DB-tail engages quickly) and make sure the new plot viewer is active (`useNewPlotViewer: true`).
2. Power on the console, start a 10-minute scan.
3. After ~2.5 minutes (past the trim point), wheel-zoom **out** on the plot until the window is wider than the elapsed scan (e.g. 600 s), pan around the history.
4. Click **● Back to live**.
5. Before the fix: UI freezes within seconds and stays frozen until the scan ends. After the fix: live traces keep scrolling, UI stays responsive; the log shows at most one `DB tail` window load instead of a continuous stream.
6. Also re-check the normal paths: zoom in/out + Back to live early in a scan (pre-trim), pan into the deep past and back, and History → View in Plot → Back to live scan.

## Verification performed

- Static analysis of the zoom / Back-to-live signal and source-swap flow (`PlotViewer.qml`, `PlotCell.qml`, `PlotScrubber.qml`, `motion_connector.py`, `data_sources.py`).
- Offline replay of the 30 Hz paint loop against the real `LiveScanSource` reproducing the freeze and confirming the fix (numbers above).
- `pytest tests -m unit`: 127 passed.
- `flake8` on the two changed files: no new violations (pre-existing count unchanged).
- **On-hardware verification is pending** — not run because the rig may be in use and demo mode is currently broken.

## Overlap with open PRs

- #159 (issue #152, History → View in Plot freeze): different root cause (synchronous `PastScanSource` bulk load in `loadPastScan`); no file overlap in the fix itself — both touch `data_sources.py`-adjacent territory but distinct code paths. The #152 investigation's note that #151's `showLiveSource` swap is trivial was correct — the freeze lives in the DB-tail cache, not the source swap.
- #155 (delete legacy plots) / #156 (filter cam_id=-1 from scanCorrectedBatch): no overlap; this change is confined to `LiveScanSource._ensure_db_window` and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
