### PR TITLE
fix: arrange plot grid as upside-down U matching physical camera layout

### DIFF
--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -154,34 +154,37 @@ Rectangle {
 
     // ── Grid model ─────────────────────────────────────────────────────
     // Dev mode (default) — one cell per active camera (bits set in
-    // leftMask / rightMask). 4 columns max; left-side cams fill the
-    // top rows, right-side cams fill the rows below.
+    // leftMask / rightMask), arranged to mirror the physical U-shape of
+    // each sensor module displayed upside-down (issue #164). Cameras 1-8
+    // run down one arm of the U and back up the other — 1|8 at the top
+    // of the U, 4|5 at the bottom — so display row r pairs 1-based cams
+    // (4-r | 5+r): row 0 is 4|5, row 3 is 1|8. Left module owns columns
+    // 0-1, right module 2-3 (a module with nothing selected gives up its
+    // column pair). Rows empty on both sides are dropped and the rest
+    // compact upward; an unselected camera in a kept row just leaves its
+    // slot blank.
     readonly property var _devCellModel: {
-        var lm = viewer.leftMask & 0xFF
-        var rm = viewer.rightMask & 0xFF
-        var leftCams = []
-        var rightCams = []
-        for (var i = 0; i < 8; i++) {
-            if (lm & (1 << i)) leftCams.push(i)
-            if (rm & (1 << i)) rightCams.push(i)
-        }
+        var masks = [viewer.leftMask & 0xFF, viewer.rightMask & 0xFF]
+        var sides = ["left", "right"]
+        var colBase = [0, masks[0] !== 0 ? 2 : 0]
         var entries = []
-        var leftRows = Math.ceil(leftCams.length / 4)
-        for (var li = 0; li < leftCams.length; li++) {
-            entries.push({
-                side: "left",
-                camId: leftCams[li],
-                row: Math.floor(li / 4),
-                col: li % 4
-            })
-        }
-        for (var ri = 0; ri < rightCams.length; ri++) {
-            entries.push({
-                side: "right",
-                camId: rightCams[ri],
-                row: leftRows + Math.floor(ri / 4),
-                col: ri % 4
-            })
+        var displayRow = 0
+        for (var r = 0; r < 4; r++) {
+            var armA = 3 - r   // zero-based camId, 1-based cam 4-r
+            var armB = 4 + r   // zero-based camId, 1-based cam 5+r
+            var rowBits = (1 << armA) | (1 << armB)
+            if (!((masks[0] | masks[1]) & rowBits)) continue
+            for (var s = 0; s < 2; s++) {
+                if (masks[s] & (1 << armA)) {
+                    entries.push({ side: sides[s], camId: armA,
+                                   row: displayRow, col: colBase[s] })
+                }
+                if (masks[s] & (1 << armB)) {
+                    entries.push({ side: sides[s], camId: armB,
+                                   row: displayRow, col: colBase[s] + 1 })
+                }
+            }
+            displayRow++
         }
         return entries
     }

--- a/tests/test_plot_viewer_masks.py
+++ b/tests/test_plot_viewer_masks.py
@@ -216,3 +216,96 @@ def test_zero_masks_render_empty_grid(viewer_factory):
     viewer.setProperty("leftMask", 0x00)
     viewer.setProperty("rightMask", 0x00)
     assert _cells(viewer) == []
+
+
+# ── Issue #164 — grid mirrors the physical U-shape ─────────────────────
+# A sensor module arranges cameras 1-8 in a U: 1 and 8 at the top of the
+# U, 4 and 5 at the bottom. The grid displays an upside-down U — row 0
+# pairs cams 4|5, then 3|6, 2|7, and 1|8 at the bottom. Left module owns
+# columns 0-1, right module columns 2-3; rows with no selected camera on
+# either side are dropped (the remaining rows compact upward).
+
+
+def _pos(cells, side, cam_id):
+    matches = [(c["row"], c["col"]) for c in cells
+               if c["side"] == side and c["camId"] == cam_id]
+    assert len(matches) == 1, \
+        f"expected exactly one cell for {side} cam {cam_id}"
+    return matches[0]
+
+
+def test_all_masks_lay_out_as_upside_down_u(viewer_factory):
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", ALL_MASK)
+    viewer.setProperty("rightMask", ALL_MASK)
+    cells = _cells(viewer)
+    assert len(cells) == 16
+    # Row r pairs 1-based cams (4-r | 5+r): zero-based camIds 3-r | 4+r.
+    for r in range(4):
+        assert _pos(cells, "left", 3 - r) == (r, 0)
+        assert _pos(cells, "left", 4 + r) == (r, 1)
+        assert _pos(cells, "right", 3 - r) == (r, 2)
+        assert _pos(cells, "right", 4 + r) == (r, 3)
+
+
+def test_middle_masks_compact_to_4x2(viewer_factory):
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", MIDDLE_MASK)
+    viewer.setProperty("rightMask", MIDDLE_MASK)
+    cells = _cells(viewer)
+    assert len(cells) == 8
+    # Middle = cams 3,6 (U row 1) and 2,7 (U row 2) — rows compact to 0,1.
+    assert _pos(cells, "left", 2) == (0, 0)
+    assert _pos(cells, "left", 5) == (0, 1)
+    assert _pos(cells, "right", 2) == (0, 2)
+    assert _pos(cells, "right", 5) == (0, 3)
+    assert _pos(cells, "left", 1) == (1, 0)
+    assert _pos(cells, "left", 6) == (1, 1)
+    assert _pos(cells, "right", 1) == (1, 2)
+    assert _pos(cells, "right", 6) == (1, 3)
+
+
+def test_right_module_alone_takes_first_column_pair(viewer_factory):
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", 0x00)
+    viewer.setProperty("rightMask", MIDDLE_MASK)
+    cells = _cells(viewer)
+    assert len(cells) == 4
+    assert _pos(cells, "right", 2) == (0, 0)
+    assert _pos(cells, "right", 5) == (0, 1)
+    assert _pos(cells, "right", 1) == (1, 0)
+    assert _pos(cells, "right", 6) == (1, 1)
+
+
+def test_unselected_slot_leaves_gap_in_its_row(viewer_factory):
+    viewer = viewer_factory()
+    # Left: only cam 4 (camId 3). Right: only cam 5 (camId 4). Both live
+    # on U row 0; the unselected partners leave their slots empty.
+    viewer.setProperty("leftMask", 0x08)
+    viewer.setProperty("rightMask", 0x10)
+    cells = _cells(viewer)
+    assert len(cells) == 2
+    assert _pos(cells, "left", 3) == (0, 0)
+    assert _pos(cells, "right", 4) == (0, 3)
+
+
+def test_row_compaction_is_shared_across_modules(viewer_factory):
+    viewer = viewer_factory()
+    # Left "Far" 0xC3 = cams 1,2,7,8 → U rows 2 and 3.
+    # Right "Middle" 0x66 = cams 3,6 and 2,7 → U rows 1 and 2.
+    # Union {1,2,3} compacts to display rows 0,1,2 shared by both sides.
+    viewer.setProperty("leftMask", 0xC3)
+    viewer.setProperty("rightMask", MIDDLE_MASK)
+    cells = _cells(viewer)
+    assert len(cells) == 8
+    # U row 1 (cams 3|6) → display row 0: right side only.
+    assert _pos(cells, "right", 2) == (0, 2)
+    assert _pos(cells, "right", 5) == (0, 3)
+    # U row 2 (cams 2|7) → display row 1: both sides.
+    assert _pos(cells, "left", 1) == (1, 0)
+    assert _pos(cells, "left", 6) == (1, 1)
+    assert _pos(cells, "right", 1) == (1, 2)
+    assert _pos(cells, "right", 6) == (1, 3)
+    # U row 3 (cams 1|8) → display row 2: left side only.
+    assert _pos(cells, "left", 0) == (2, 0)
+    assert _pos(cells, "left", 7) == (2, 1)


### PR DESCRIPTION
Closes #164

## What

The dev-mode plot grid packed selected cameras left-to-right in ascending order (left module rows on top, right module below), which bore no relation to where the cameras physically sit on the sensor module.

Each module arranges cameras 1-8 in a U — 1 and 8 at the top, 4 and 5 at the bottom. The grid now displays that U upside-down:

- Display row r pairs 1-based cams (4-r | 5+r): row 0 is 4|5, row 3 is 1|8.
- Left module owns columns 0-1, right module columns 2-3; a module with nothing selected gives up its column pair.
- Rows with no selected camera on either side are dropped and the rest compact upward; an unselected camera in a kept row leaves its slot blank so the two modules stay row-aligned.

So All/All renders the 4x4 grid with L4 L5 R4 R5 across the top, and Middle/Middle renders L3 L6 R3 R6 over L2 L7 R2 R7 in a 4x2 grid — exactly the examples from the issue.

## Tests

Five new cases in `tests/test_plot_viewer_masks.py` pin the (row, col) of every cell for All, Middle, single-module, partial-row, and cross-module row-compaction masks, using the existing offscreen QML harness. All 9 pass; layouts also verified visually via offscreen renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)