### PR TITLE
feat: store scan notes in scans.db instead of notes.txt files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ The `dataDirectory` config key controls the root (defaults to cwd if unset — f
 - `app-logs/` — app log files (one per launch)
 - `app-logs/ft-test-csvs/` — factory-test CSVs
 - `calibrations/` — saved calibration JSONs (also written here)
-- The scan output files (raw / corrected / notes / telemetry CSV + `scans.db`) land directly in the root
+- The scan output files (raw / corrected / telemetry CSV + `scans.db`) land directly in the root. Scan notes live in `scans.db` (`sessions.session_notes`), not as files; `*_notes.txt` files are legacy read-only fallbacks.
 
 **Important:** the runner is fail-soft. `ScanRunner._safe_consume` catches sink exceptions and logs them as `sink %r raised on channel ...` at ERROR; `pipeline.process` exceptions log as `pipeline.process raised — resetting and continuing` at ERROR. **Neither aborts the scan**, so the app may report "complete" while every interval was actually broken. Always grep for `raised|exception` even on apparent successes when something downstream looks wrong.
 

--- a/DATA_STRUCTURES.md
+++ b/DATA_STRUCTURES.md
@@ -263,12 +263,14 @@ CONSOLE_CONNECTED (2) ──► READY (3) ──► RUNNING (4)
 
 ```
 scan_{subjectId}_{YYYYMMDD_HHMMSS}_{side}_mask{XX}.csv   # histogram data
-scan_{subjectId}_{YYYYMMDD_HHMMSS}_notes.txt              # scan notes
+scan_{subjectId}_{YYYYMMDD_HHMMSS}_notes.txt              # scan notes (legacy — read-only fallback)
 scan_{subjectId}_{YYYYMMDD_HHMMSS}_bfi_results.csv        # computed BFI/BVI
 ```
 
 **Structure type:** Filesystem directory listing, glob-matched  
-**Access pattern:** `get_scan_list()` globs for `scan_*_notes.txt`, extracts `{subjectId}_{timestamp}`, sorts by timestamp descending.
+**Access pattern:** `get_scan_list()` merges corrected-CSV stems on disk with `sessions.session_label` rows from `scans.db`, sorted by timestamp descending.
+
+**Notes storage:** scan notes live in `scans.db` (`sessions.session_notes`, keyed by `session_label = {YYYYMMDD_HHMMSS}_{sessionId}`). The connector writes them there at scan end and on every Notes-modal edit; `get_scan_details()` reads them from the DB, falling back to a legacy `*_notes.txt` only for scans that predate the migration. New scans write no notes file.
 
 ### 4.10 Real-Time Correction State (Per-Camera)
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -653,7 +653,9 @@ class MotionConnector(QObject):
         self._capture_left_path = ""
         self._capture_right_path = ""
         self._scan_notes = ""
-        self._scan_notes_path = ""  # path to current scan's notes file on disk
+        # session_label of the just-completed scan's DB session — notes edits
+        # persist there (sessions.session_notes); empty until a scan completes.
+        self._scan_notes_session_label = ""
         self.connect_signals()
 
         self._tec_voltage = 0.0
@@ -1374,11 +1376,29 @@ class MotionConnector(QObject):
             if m:
                 right_mask = m.group(1)
 
+        # Notes live in the scan DB (sessions.session_notes, keyed by
+        # session_label == scan_id). Scans from before the DB migration
+        # only have a *_notes.txt on disk — fall back to that.
         notes = ""
-        try:
-            notes = notes_path.read_text(encoding="utf-8")
-        except Exception:
-            pass
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if db_path:
+            try:
+                from omotion.ScanDatabase import ScanDatabase
+                db = ScanDatabase(db_path)
+                try:
+                    session = db.get_session_by_label(scan_id)
+                    if session and session.get("session_notes"):
+                        notes = session["session_notes"]
+                finally:
+                    db.close()
+            except Exception:
+                logger.warning("get_scan_details: could not read notes from DB",
+                               exc_info=True)
+        if not notes:
+            try:
+                notes = notes_path.read_text(encoding="utf-8")
+            except Exception:
+                pass
 
         return {
             "userLabel": subject,
@@ -1498,15 +1518,41 @@ class MotionConnector(QObject):
         if value != self._scan_notes:
             self._scan_notes = value
             self.scanNotesChanged.emit()
-        # Always persist to disk when a notes file path exists, even if the
+        # Always persist when a scan's DB session exists, even if the
         # in-memory value didn't change (covers the first save after capture).
-        if self._scan_notes_path:
+        if self._scan_notes_session_label:
+            self._persist_scan_notes(self._scan_notes_session_label)
+
+    def _persist_scan_notes(self, session_label: str) -> bool:
+        """Write the in-memory notes buffer to sessions.session_notes of the
+        scan DB session whose session_label matches. Returns True on success.
+        ScanDBSink (critical) creates the session at scan start, so every scan
+        that ran has a row to update."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path or not session_label:
+            return False
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
             try:
-                with open(self._scan_notes_path, "w", encoding="utf-8") as nf:
-                    nf.write(self._scan_notes.strip() + "\n")
-                logger.info(f"Notes saved to disk: {self._scan_notes_path}")
-            except Exception as e:
-                logger.error(f"Failed to update scan notes on disk: {e}")
+                session = db.get_session_by_label(session_label)
+                if session is None:
+                    logger.error(
+                        "Scan notes: no DB session with label %r", session_label
+                    )
+                    return False
+                db.update_session(session["id"],
+                                  session_notes=self._scan_notes.strip())
+                logger.info("Scan notes saved to DB session %r",
+                            session_label)
+                return True
+            finally:
+                db.close()
+        except Exception:
+            logger.exception(
+                "Failed to save scan notes to DB (label %r)", session_label
+            )
+            return False
 
     @pyqtProperty(QObject, notify=currentScanSourceChanged)
     def currentScanSource(self) -> ScanDataSource | None:
@@ -1845,7 +1891,7 @@ class MotionConnector(QObject):
         self._capture_stop = threading.Event()
         # Each new scan starts with a fresh notes buffer
         self._scan_notes = ""
-        self._scan_notes_path = ""
+        self._scan_notes_session_label = ""
         self.scanNotesChanged.emit()
         self._capture_running = True
         self._capture_start_time = time.time()
@@ -1932,17 +1978,13 @@ class MotionConnector(QObject):
             self._scan_notes = (self._scan_notes.strip() + duration_line)
             self.scanNotesChanged.emit()
 
-            # Write scan notes file using scan_id from metadata.
+            # Persist notes to the scan DB session ScanDBSink created at
+            # scan start (label = scan_id_subject_id). Later edits via the
+            # Notes modal update the same row through the scanNotes setter.
             scan_id = getattr(meta, "scan_id", "") if meta else ""
-            try:
-                notes_filename = f"{scan_id}_{subject_id}_notes.txt"
-                notes_path = os.path.join(data_dir, notes_filename)
-                with open(notes_path, "w", encoding="utf-8") as nf:
-                    nf.write(self._scan_notes.strip() + "\n")
-                self._scan_notes_path = notes_path
-                logger.info(f"Saved scan notes to {notes_path}")
-            except Exception as e:
-                logger.error(f"Failed to save scan notes: {e}")
+            session_label = f"{scan_id}_{subject_id}" if scan_id else ""
+            self._scan_notes_session_label = session_label
+            self._persist_scan_notes(session_label)
 
             # New pipeline writes CSVs directly; no .raw→.csv post-processing
             # needed.  Pass empty paths to captureFinished so startPostProcess

--- a/tests/test_scan_notes_db.py
+++ b/tests/test_scan_notes_db.py
@@ -1,0 +1,129 @@
+"""Scan notes — persisted to the scan DB session, not a notes.txt file."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    # explicit: MagicMock default would be truthy
+    iface.scan_db_path = scan_db_path
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _session(db_path, label, start=1.0, notes=None):
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label=label, session_start=start,
+                            session_notes=notes, session_meta={})
+    db.close()
+    return sid
+
+
+def _db_notes(db_path, label):
+    db = ScanDatabase(db_path=db_path)
+    try:
+        session = db.get_session_by_label(label)
+        return session["session_notes"] if session else None
+    finally:
+        db.close()
+
+
+LABEL = "20260610_163915_ow3SW4HD"
+
+
+class TestPersistScanNotes:
+    def test_persist_writes_notes_to_db_session(self, tmp_path):
+        db_path = str(tmp_path / "scans.db")
+        _session(db_path, LABEL)
+        c = _connector(tmp_path, scan_db_path=db_path)
+        c._scan_notes = ("subject reports headache\n---\n"
+                         "Scan completed — duration: 00:05:00")
+
+        assert c._persist_scan_notes(LABEL) is True
+        assert _db_notes(db_path, LABEL) == c._scan_notes.strip()
+
+    def test_persist_returns_false_when_session_missing(self, tmp_path):
+        db_path = str(tmp_path / "scans.db")
+        _session(db_path, "20260101_000000_other")
+        c = _connector(tmp_path, scan_db_path=db_path)
+        c._scan_notes = "orphan notes"
+        assert c._persist_scan_notes(LABEL) is False
+
+    def test_persist_returns_false_without_db_path(self, tmp_path):
+        c = _connector(tmp_path, scan_db_path=None)
+        c._scan_notes = "notes"
+        assert c._persist_scan_notes(LABEL) is False
+
+
+class TestScanNotesSetter:
+    def test_setter_persists_to_db_and_writes_no_file(self, tmp_path):
+        """Editing notes in the modal after a scan must update the DB
+        session and must NOT create any *_notes.txt file."""
+        db_path = str(tmp_path / "scans.db")
+        _session(db_path, LABEL)
+        c = _connector(tmp_path, scan_db_path=db_path)
+        c._scan_notes_session_label = LABEL
+
+        c.scanNotes = "edited after scan"
+
+        assert _db_notes(db_path, LABEL) == "edited after scan"
+        assert list(tmp_path.glob("*_notes.txt")) == []
+
+    def test_setter_clears_notes_in_db(self, tmp_path):
+        db_path = str(tmp_path / "scans.db")
+        _session(db_path, LABEL, notes="old text")
+        c = _connector(tmp_path, scan_db_path=db_path)
+        c._scan_notes_session_label = LABEL
+
+        c.scanNotes = ""
+
+        assert _db_notes(db_path, LABEL) == ""
+
+    def test_setter_without_session_is_memory_only(self, tmp_path):
+        """Typing notes before any scan completes keeps them in memory."""
+        c = _connector(tmp_path, scan_db_path=None)
+        c.scanNotes = "pre-scan notes"
+        assert c.scanNotes == "pre-scan notes"
+        assert list(tmp_path.glob("*_notes.txt")) == []
+
+
+class TestGetScanDetailsNotes:
+    def test_details_read_notes_from_db(self, tmp_path):
+        db_path = str(tmp_path / "scans.db")
+        _session(db_path, LABEL, notes="db-stored notes")
+        c = _connector(tmp_path, scan_db_path=db_path)
+
+        details = c.get_scan_details(LABEL)
+        assert details["notes"] == "db-stored notes"
+
+    def test_details_fall_back_to_legacy_notes_txt(self, tmp_path):
+        """Scans from before the DB migration only have a notes.txt —
+        History must still show their notes."""
+        (tmp_path / f"{LABEL}_notes.txt").write_text("legacy file notes\n",
+                                                     encoding="utf-8")
+        c = _connector(tmp_path, scan_db_path=None)
+
+        details = c.get_scan_details(LABEL)
+        assert details["notes"] == "legacy file notes\n"
+
+    def test_db_notes_win_over_legacy_file(self, tmp_path):
+        db_path = str(tmp_path / "scans.db")
+        _session(db_path, LABEL, notes="db notes")
+        (tmp_path / f"{LABEL}_notes.txt").write_text("stale file notes\n",
+                                                     encoding="utf-8")
+        c = _connector(tmp_path, scan_db_path=db_path)
+
+        details = c.get_scan_details(LABEL)
+        assert details["notes"] == "db notes"


### PR DESCRIPTION
## Summary

Scan notes were written as `{scan_id}_{subject_id}_notes.txt` files into the data directory at scan end (and rewritten on every Notes-modal edit), steadily filling the directory — while the scan DB has had a `sessions.session_notes` column all along that nothing ever populated (`ScanDBSink` creates every session with `session_notes=NULL`).

Notes now live in the database:

- New `_persist_scan_notes()` helper on the connector finds the scan DB session by `session_label` (`{scan_id}_{subject_id}` — the exact label `ScanDBSink` writes at scan start) and updates `sessions.session_notes`.
- Scan completion and the `scanNotes` setter (Notes-modal edits) both write through it. **No `*_notes.txt` file is created anymore.**
- `get_scan_details()` reads notes from the DB first and falls back to a legacy `*_notes.txt`, so scans from before this change still show their notes in History — no migration needed.
- `DATA_STRUCTURES.md` / `CLAUDE.md` updated to match.

## Testing

- New unit suite `tests/test_scan_notes_db.py` (9 tests, written first): persist at scan end, modal edit updates the same row, clearing notes, no file created, DB read, legacy-file fallback, DB-wins-over-stale-file, missing-session and missing-DB-path failure paths.
- Full `-m unit` suite: 154 passed; the only failure is the pre-existing `test_auto_configure_flag_is_gone` (stale `.worktrees\` copy of an old `app_config.json` on the dev machine — fails on a clean checkout of `next` too, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)