### PR TITLE
feat: per-metric y-axis tick labels on plot cells

### DIFF
--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -1,10 +1,10 @@
 import QtQuick 6.0
 
 // Phase 2a — single-trace Canvas bound to one (side, cam_id, metric) key
-// on a ScanDataSource. No pan/zoom, no crosshair, no axis labels —
-// those land in Phase 2b. The cell tracks the live edge of the source
+// on a ScanDataSource. The cell tracks the live edge of the source
 // and renders the last `windowSeconds` of samples, strided to at most
-// 2 * width samples per paint.
+// 2 * width samples per paint. Y-axis tick labels (max/mid/min) render
+// per metric: primary on the left edge, secondary on the right.
 Item {
     id: cell
 
@@ -71,6 +71,13 @@ Item {
     onWidthChanged: traceCanvas.requestPaint()
     onHeightChanged: traceCanvas.requestPaint()
     onSourceChanged: traceCanvas.requestPaint()
+    // Bound changes must repaint directly — on a static (past-scan)
+    // source no samplesAppended tick arrives to flush a Settings edit
+    // or an autoscale recompute into the axis labels / trace mapping.
+    onYMinChanged: traceCanvas.requestPaint()
+    onYMaxChanged: traceCanvas.requestPaint()
+    onSecondaryYMinChanged: traceCanvas.requestPaint()
+    onSecondaryYMaxChanged: traceCanvas.requestPaint()
     // Note: cursorT changes do NOT trigger a direct repaint — that
     // would spam paints on every mouse-move event. Instead the viewer
     // sets _dirty on cursorAt() so the next paintThrottle tick
@@ -83,6 +90,38 @@ Item {
         if (cell.panZoomTarget && cell.panZoomTarget.clampForDisplay)
             return cell.panZoomTarget.clampForDisplay(metricName, v)
         return v
+    }
+
+    // Y-axis tick decimals chosen per axis from its span so all three
+    // ticks format consistently — whole numbers for wide ranges (mean's
+    // 0–500), one decimal for BFI/BVI's 0–10, two for contrast's 0–1
+    // (where the 0.35 midpoint would otherwise round to "0.3").
+    function _fmtAxis(v, span) {
+        return v.toFixed(span >= 100 ? 0 : span >= 2 ? 1 : 2)
+    }
+
+    // Y-axis tick labels — primary bounds down the left edge, secondary
+    // down the right, colored to match their traces. Drawn even when no
+    // source is bound so an idle grid still shows its scale. Skipped for
+    // very narrow cells alongside the midline gridline.
+    function _drawAxisLabels(ctx, w, h) {
+        if (w < 60) return
+        ctx.font = "9px 'Roboto Mono'"
+        var midY = Math.floor(h / 2)
+        var span = cell.yMax - cell.yMin
+        ctx.fillStyle = cell.traceColor
+        ctx.textAlign = "left"
+        ctx.fillText(_fmtAxis(cell.yMax, span), 2, 9)
+        ctx.fillText(_fmtAxis((cell.yMin + cell.yMax) / 2, span), 2, midY - 3)
+        ctx.fillText(_fmtAxis(cell.yMin, span), 2, h - 3)
+        if (cell.secondaryMetric.length > 0) {
+            span = cell.secondaryYMax - cell.secondaryYMin
+            ctx.fillStyle = cell.secondaryColor
+            ctx.textAlign = "right"
+            ctx.fillText(_fmtAxis(cell.secondaryYMax, span), w - 2, 9)
+            ctx.fillText(_fmtAxis((cell.secondaryYMin + cell.secondaryYMax) / 2, span), w - 2, midY - 3)
+            ctx.fillText(_fmtAxis(cell.secondaryYMin, span), w - 2, h - 3)
+        }
     }
 
     // Render one trace inside the current Canvas context using the given
@@ -152,6 +191,7 @@ Item {
             }
 
             if (!cell.source) {
+                cell._drawAxisLabels(ctx, width, height)
                 if (profOn) cell.panZoomTarget.recordCellPaint(Date.now() - profT0, 0)
                 return
             }
@@ -207,6 +247,9 @@ Item {
                 ctx.stroke()
             }
 
+            // Last so the tick labels stay readable over the traces.
+            cell._drawAxisLabels(ctx, width, height)
+
             if (profOn) cell.panZoomTarget.recordCellPaint(Date.now() - profT0, profPts)
         }
     }
@@ -218,6 +261,8 @@ Item {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.margins: 8
+        // Clear the primary metric's top tick label in the corner above.
+        anchors.topMargin: 18
         spacing: 1
 
         Text {
@@ -283,6 +328,8 @@ Item {
         anchors.top: parent.top
         anchors.right: parent.right
         anchors.margins: 8
+        // Clear the secondary metric's top tick label in the corner above.
+        anchors.topMargin: 18
         text: isFinite(tempC) ? tempC.toFixed(1) + "°C" : ""
         color: theme.readableInk(theme.accentOrange)
         font.pixelSize: 10


### PR DESCRIPTION
## Summary
- Each `PlotCell` now draws **max / mid / min y-axis tick labels** per metric: the primary metric (BFI or Mean) down the left edge and the secondary (BVI or Contrast) down the right edge, colored to match their traces. Labels render even on idle/unbound cells so the grid always shows its scale.
- Tick decimals are chosen per axis from its span, so BFI/BVI read `9.0 / 5.0 / 1.0`, Mean reads `200 / 100 / 0`, and Contrast reads `0.70 / 0.35 / 0.00` (one-decimal formatting would round the 0.35 midpoint to 0.3).
- The top-left camera/value label block and the dev-mode temperature readout shift down 10 px so the top tick labels own the corners.
- Fix: the canvas now repaints directly when any y-bound property changes. Previously, editing a min/max in Settings or an autoscale recompute while viewing a **static (past-scan) source** left the traces and labels on the stale mapping until the next data tick.

The bounds shown are exactly the configured ones: with `autoScale: false`, `PlotViewer` feeds `bfiMin/bfiMax`, `bviMin/bviMax`, `meanMin/meanMax`, `contrastMin/contrastMax` from `app_config.json` (via SettingsModal → BloodFlow bindings) straight into these labels and the trace mapping.

## Verification
Offscreen-rendered `PlotViewer` against a fake `LiveScanSource` (same harness pattern as #165) in three configurations:
- dev grid, BFI/BVI mode → left edge `9.0/5.0/1.0` red, right edge `9.0/4.5/0.0` blue, no overlap with camera labels or temp readouts
- dev grid, Mean/Contrast mode → `200/100/0` and `0.70/0.35/0.00`
- reduced (clinical) mode → labels render on both side-averaged cells, side panels untouched

Runtime-checked that `primaryYMin/Max` / `secondaryYMin/Max` resolve to the config values (`[1.0, 9.0]` / `[0.0, 9.0]` etc.) when autoScale is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)