### PR TITLE
feat: reduced-mode plot UI nitpicks (incl. #178)

### DIFF
--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -1,10 +1,10 @@
 import QtQuick 6.0
 
 // Phase 2a — single-trace Canvas bound to one (side, cam_id, metric) key
-// on a ScanDataSource. No pan/zoom, no crosshair, no axis labels —
-// those land in Phase 2b. The cell tracks the live edge of the source
+// on a ScanDataSource. The cell tracks the live edge of the source
 // and renders the last `windowSeconds` of samples, strided to at most
-// 2 * width samples per paint.
+// 2 * width samples per paint. Y-axis tick labels (max/mid/min) render
+// per metric: primary on the left edge, secondary on the right.
 Item {
     id: cell
 
@@ -71,6 +71,13 @@ Item {
     onWidthChanged: traceCanvas.requestPaint()
     onHeightChanged: traceCanvas.requestPaint()
     onSourceChanged: traceCanvas.requestPaint()
+    // Bound changes must repaint directly — on a static (past-scan)
+    // source no samplesAppended tick arrives to flush a Settings edit
+    // or an autoscale recompute into the axis labels / trace mapping.
+    onYMinChanged: traceCanvas.requestPaint()
+    onYMaxChanged: traceCanvas.requestPaint()
+    onSecondaryYMinChanged: traceCanvas.requestPaint()
+    onSecondaryYMaxChanged: traceCanvas.requestPaint()
     // Note: cursorT changes do NOT trigger a direct repaint — that
     // would spam paints on every mouse-move event. Instead the viewer
     // sets _dirty on cursorAt() so the next paintThrottle tick
@@ -83,6 +90,38 @@ Item {
         if (cell.panZoomTarget && cell.panZoomTarget.clampForDisplay)
             return cell.panZoomTarget.clampForDisplay(metricName, v)
         return v
+    }
+
+    // Y-axis tick decimals chosen per axis from its span so all three
+    // ticks format consistently — whole numbers for wide ranges (mean's
+    // 0–500), one decimal for BFI/BVI's 0–10, two for contrast's 0–1
+    // (where the 0.35 midpoint would otherwise round to "0.3").
+    function _fmtAxis(v, span) {
+        return v.toFixed(span >= 100 ? 0 : span >= 2 ? 1 : 2)
+    }
+
+    // Y-axis tick labels — primary bounds down the left edge, secondary
+    // down the right, colored to match their traces. Drawn even when no
+    // source is bound so an idle grid still shows its scale. Skipped for
+    // very narrow cells alongside the midline gridline.
+    function _drawAxisLabels(ctx, w, h) {
+        if (w < 60) return
+        ctx.font = "9px 'Roboto Mono'"
+        var midY = Math.floor(h / 2)
+        var span = cell.yMax - cell.yMin
+        ctx.fillStyle = cell.traceColor
+        ctx.textAlign = "left"
+        ctx.fillText(_fmtAxis(cell.yMax, span), 2, 9)
+        ctx.fillText(_fmtAxis((cell.yMin + cell.yMax) / 2, span), 2, midY - 3)
+        ctx.fillText(_fmtAxis(cell.yMin, span), 2, h - 3)
+        if (cell.secondaryMetric.length > 0) {
+            span = cell.secondaryYMax - cell.secondaryYMin
+            ctx.fillStyle = cell.secondaryColor
+            ctx.textAlign = "right"
+            ctx.fillText(_fmtAxis(cell.secondaryYMax, span), w - 2, 9)
+            ctx.fillText(_fmtAxis((cell.secondaryYMin + cell.secondaryYMax) / 2, span), w - 2, midY - 3)
+            ctx.fillText(_fmtAxis(cell.secondaryYMin, span), w - 2, h - 3)
+        }
     }
 
     // Render one trace inside the current Canvas context using the given
@@ -152,6 +191,7 @@ Item {
             }
 
             if (!cell.source) {
+                cell._drawAxisLabels(ctx, width, height)
                 if (profOn) cell.panZoomTarget.recordCellPaint(Date.now() - profT0, 0)
                 return
             }
@@ -207,6 +247,9 @@ Item {
                 ctx.stroke()
             }
 
+            // Last so the tick labels stay readable over the traces.
+            cell._drawAxisLabels(ctx, width, height)
+
             if (profOn) cell.panZoomTarget.recordCellPaint(Date.now() - profT0, profPts)
         }
     }
@@ -218,6 +261,8 @@ Item {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.margins: 8
+        // Clear the primary metric's top tick label in the corner above.
+        anchors.topMargin: 18
         spacing: 1
 
         Text {
@@ -283,6 +328,8 @@ Item {
         anchors.top: parent.top
         anchors.right: parent.right
         anchors.margins: 8
+        // Clear the secondary metric's top tick label in the corner above.
+        anchors.topMargin: 18
         text: isFinite(tempC) ? tempC.toFixed(1) + "°C" : ""
         color: theme.readableInk(theme.accentOrange)
         font.pixelSize: 10

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -106,7 +106,11 @@ Item {
     // very narrow cells alongside the midline gridline.
     function _drawAxisLabels(ctx, w, h) {
         if (w < 60) return
-        ctx.font = "9px 'Roboto Mono'"
+        // Context2D validates font families strictly (unlike Text, which
+        // silently falls back), so an unregistered "Roboto Mono" warns on
+        // every paint. Keep it as the preferred family but add a generic
+        // monospace fallback to satisfy the parser and silence the spam.
+        ctx.font = "9px 'Roboto Mono', monospace"
         var midY = Math.floor(h / 2)
         var span = cell.yMax - cell.yMin
         ctx.fillStyle = cell.traceColor

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -988,6 +988,12 @@ Rectangle {
 
         Rectangle {
             id: settingsMenuButton
+            // In reduced mode the popup's only rows (display mode +
+            // autoscale) are hidden and Cell values is gone, leaving the
+            // dev-only Profiler as the sole possible entry. Hide the
+            // button entirely when it would open an empty card.
+            visible: !viewer.reducedMode
+                     || MotionInterface.appConfig.developerMode === true
             width: 36
             height: 36
             radius: 18
@@ -1081,6 +1087,10 @@ Rectangle {
                         }
                     }
                     Row {
+                        // Hidden in reduced (clinical) mode — autoscale is
+                        // not offered there; the view always uses the
+                        // configured manual bounds.
+                        visible: !viewer.reducedMode
                         spacing: 8
                         PopupPillSwitch {
                             id: autoScaleSwitch
@@ -1090,21 +1100,6 @@ Rectangle {
                         Text {
                             anchors.verticalCenter: autoScaleSwitch.verticalCenter
                             text: "Autoscale"
-                            color: theme.textPrimary
-                            font.pixelSize: 12
-                            font.family: "Roboto Mono"
-                        }
-                    }
-                    Row {
-                        spacing: 8
-                        PopupPillSwitch {
-                            id: cellValuesSwitch
-                            checked: viewer.showCellValues
-                            onToggled: viewer.showCellValues = checked
-                        }
-                        Text {
-                            anchors.verticalCenter: cellValuesSwitch.verticalCenter
-                            text: "Cell values"
                             color: theme.textPrimary
                             font.pixelSize: 12
                             font.family: "Roboto Mono"

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -551,6 +551,7 @@ Item {
                     }
 
                     FieldRow {
+                        visible: !root.reducedMode
                         label: "Auto-scale Y-axes"
                         PillSwitch {
                             checked: root.autoScale
@@ -622,7 +623,10 @@ Item {
                     title: "Manual Plot Bounds"
 
                     Text {
-                        text: "Used when auto-scale is off."
+                        // Reduced mode hides the auto-scale toggle and always
+                        // uses these bounds, so don't reference it there.
+                        text: root.reducedMode ? "Y-axis range for the plots."
+                                               : "Used when auto-scale is off."
                         color: root.colTextMuted
                         font.pixelSize: 11
                         font.italic: true
@@ -671,35 +675,43 @@ Item {
                         }
                         Item { Layout.fillWidth: true }
 
-                        Text { text: "Mean"; color: "#2ECC71"; font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
+                        // Mean / Contrast bounds only apply to the Mean/Contrast
+                        // display mode, which reduced mode never shows — hide
+                        // these two rows there. GridLayout skips invisible
+                        // children, so the grid reflows to just BFI / BVI.
+                        Text { visible: !root.reducedMode; text: "Mean"; color: "#2ECC71"; font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
                         StyledNumberField {
+                            visible: !root.reducedMode
                             Layout.preferredWidth: 90
                             decimals: 0
                             text: root.meanMin.toFixed(0)
                             onEditingFinished: { var v = parseFloat(text); if (!isNaN(v)) root.meanMin = Math.round(v); text = root.meanMin.toFixed(0) }
                         }
                         StyledNumberField {
+                            visible: !root.reducedMode
                             Layout.preferredWidth: 90
                             decimals: 0
                             text: root.meanMax.toFixed(0)
                             onEditingFinished: { var v = parseFloat(text); if (!isNaN(v)) root.meanMax = Math.round(v); text = root.meanMax.toFixed(0) }
                         }
-                        Item { Layout.fillWidth: true }
+                        Item { visible: !root.reducedMode; Layout.fillWidth: true }
 
-                        Text { text: "Contrast"; color: "#9B59B6"; font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
+                        Text { visible: !root.reducedMode; text: "Contrast"; color: "#9B59B6"; font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
                         StyledNumberField {
+                            visible: !root.reducedMode
                             Layout.preferredWidth: 90
                             decimals: 2
                             text: root.contrastMin.toFixed(2)
                             onEditingFinished: { var v = parseFloat(text); if (!isNaN(v)) root.contrastMin = root._roundTo(v, 2); text = root.contrastMin.toFixed(2) }
                         }
                         StyledNumberField {
+                            visible: !root.reducedMode
                             Layout.preferredWidth: 90
                             decimals: 2
                             text: root.contrastMax.toFixed(2)
                             onEditingFinished: { var v = parseFloat(text); if (!isNaN(v)) root.contrastMax = root._roundTo(v, 2); text = root.contrastMax.toFixed(2) }
                         }
-                        Item { Layout.fillWidth: true }
+                        Item { visible: !root.reducedMode; Layout.fillWidth: true }
                     }
                 }
 

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -241,7 +241,10 @@ Rectangle {
         anchors.margins: 8
         anchors.leftMargin: 16
         reducedMode: bloodFlow.reducedMode
-        autoScale: settingsModal.autoScale
+        // Reduced mode never autoscales: the toggle is hidden in both the
+        // Settings modal and the viewer's three-dot popup, so a stale
+        // autoScale=true in config must not leave it stuck on.
+        autoScale: bloodFlow.reducedMode ? false : settingsModal.autoScale
         displayMode: settingsModal.showBfiBvi ? "bfi_bvi" : "mean_contrast"
         leftMask:  bloodFlow.leftMask
         rightMask: bloodFlow.rightMask

--- a/tests/test_reducedmode.py
+++ b/tests/test_reducedmode.py
@@ -15,9 +15,8 @@ teardown. This mirrors the pattern used by ``test_history`` and
 Three classes:
   TestReducedMode         (05–21) — keyboard-driven Notes / scan / history flow
   TestReducedModeMouse    (22–32) — mouse-driven repeat of the same flow
-  TestReducedModeSettings (33–37) — Settings modal: Time Window dropdown
-                                    parametrized over 3/5/15/30s, plus
-                                    Auto-scale Y-axes toggle ON.
+  TestReducedModeSettings (33)    — Settings modal: Time Window dropdown
+                                    parametrized over 3/5/15/30s.
 """
 
 import time
@@ -354,150 +353,13 @@ def _select_time_window(seconds: int):
     time.sleep(SLEEP)
 
 
-def _scroll_settings_to_top():
-    """Scroll the Settings modal up so Time Window / Auto-scale appear.
-
-    Mirror of ``_scroll_modal_to_bottom`` for the opposite direction;
-    Auto-scale lives near the top of the modal, Time Window just below
-    it. Eight short scroll-up nudges with brief pauses cope with
-    modals that animate.
-    """
-    ensure_visible()
-    w = get_app_window()
-    cx = w.left + w.width // 2
-    cy = w.top + w.height // 2
-    pyautogui.moveTo(cx, cy, duration=0.2)
-    for _ in range(8):
-        pyautogui.scroll(50)   # positive = scroll up
-        time.sleep(0.2)
-    time.sleep(0.5)
-
-
-def _toggle_auto_scale_on():
-    """Toggle the 'Auto-scale Y-axes' Switch ON in the Settings modal.
-
-    QML Switch elements aren't exposed as CheckBox/Button via UIA,
-    so we have two strategies:
-
-      1. Find any Text element whose contents match a known label
-         variant ('auto-scale', 'auto scale', 'autoscale', 'y-axes',
-         'y-axis'). When found, click ~43% across the window — that's
-         where the Switch sits relative to the label per current QML
-         layout. (Style-guide §6 calibrated coord, not a static ratio.)
-      2. Tab navigation fallback: focus the first ComboBox in the
-         modal (Time Window), Tab once to reach the toggle, Space to
-         flip it.
-
-    On total failure we dump the visible UIA texts so the failure is
-    diagnosable from the log alone (style-guide §9).
-    """
-    require_focus()
-    log.info("  Toggling Auto-scale Y-axes ON")
-    _scroll_settings_to_top()
-
-    win = uia_window()
-    label_elem = None
-    seen_texts: list[str] = []
-
-    try:
-        for elem in win.descendants():
-            try:
-                t = (elem.window_text() or "").strip()
-            except Exception:
-                continue
-            if t:
-                seen_texts.append(t)
-            tl = t.lower()
-            if any(tag in tl for tag in (
-                "auto-scale", "autoscale", "auto scale",
-                "y-axes", "y-axis",
-            )):
-                label_elem = elem
-                log.info(f"  Found auto-scale label: '{t}'")
-                break
-    except Exception as e:
-        log.warning(f"  Auto-scale label search failed: {e}")
-
-    if label_elem is not None:
-        rect = label_elem.rectangle()
-        label_cy = (rect.top + rect.bottom) // 2
-        w = get_app_window()
-        toggle_x = int(w.left + 0.43 * w.width)
-        log.info(f"  Clicking Auto-scale toggle at ({toggle_x}, {label_cy})")
-        pyautogui.click(toggle_x, label_cy)
-        time.sleep(SLEEP)
-        return
-
-    log.warning(
-        f"  Auto-scale label not found; first 40 UIA texts: "
-        f"{seen_texts[:40]}"
-    )
-    # Tab+Space fallback. The danger this fallback used to court was
-    # firing in non-reduced-mode Settings, where the first ComboBox is
-    # Default Camera Left Sensor (not Time Window) and Tab from there
-    # lands on Right Sensor — Space then opened a sensor dropdown
-    # instead of toggling Auto-scale, with cascading state corruption.
-    #
-    # Anchoring on the "Time window" label doesn't work either: Qt's
-    # accessibility bridge does not expose FieldRow labels (plain QML
-    # Text) as descendants() titles. Iteration 2 confirmed this — the
-    # title query returned nothing in a real reduced-mode Settings
-    # modal, and the test failed even though Tab+Space would have
-    # worked correctly there.
-    #
-    # The reliable discriminator is ComboBox count:
-    #   - reduced-mode Settings  → 1 ComboBox  (Time Window)
-    #   - non-reduced Settings   → 3 ComboBoxes (Default Camera Left,
-    #     Default Camera Right, Time Window)
-    # Only fire Tab+Space when count == 1; that's the only case where
-    # first-ComboBox = Time Window and the next focusable is the
-    # Auto-scale PillSwitch.
-    log.info("  Label search missed; checking ComboBox count to safely Tab+Space")
-    try:
-        cbs = win.descendants(control_type="ComboBox")
-    except Exception as e:
-        cbs = []
-        log.warning(f"  ComboBox enumeration failed: {e}")
-
-    if len(cbs) == 1:
-        log.info(
-            "  Settings modal exposes 1 ComboBox → reduced-mode layout "
-            "confirmed; firing Tab+Space from Time Window"
-        )
-        try:
-            rect = cbs[0].rectangle()
-            cx = (rect.left + rect.right) // 2
-            cy = (rect.top + rect.bottom) // 2
-            pyautogui.click(cx, cy)
-            time.sleep(0.3)
-            pyautogui.press("tab")
-            time.sleep(0.2)
-            pyautogui.press("space")
-            time.sleep(SLEEP)
-            log.info("  Tab+Space (count-guarded) engaged Auto-scale toggle")
-            return
-        except Exception as e:
-            log.warning(f"  count-guarded Tab+Space failed: {e}")
-
-    raise RuntimeError(
-        f"Could not locate the Auto-scale Y-axes toggle. Label search "
-        f"missed, and the Tab+Space fallback was refused because "
-        f"Settings exposes {len(cbs)} ComboBox(es) — only 1 is safe "
-        f"(reduced-mode layout: Time Window first, Auto-scale PillSwitch "
-        f"on Tab). {len(cbs)} ComboBoxes means the modal is in "
-        f"non-reduced layout and Tab+Space would target the wrong "
-        f"control. See the WARNING above for the UIA text dump."
-    )
-
-
 def _run_scan(label: str, duration_sec: int):
     """Click Start, dismiss the signal-quality dialog (Reduced Mode
     auto-runs it), wait for ``duration_sec``, click Start again to
     stop, dismiss the post-scan modal.
 
     Used by ``TestReducedModeSettings`` to run a scan per Time Window
-    value and per Auto-scale state. Calibrated panel clicks per
-    style-guide §6.
+    value. Calibrated panel clicks per style-guide §6.
     """
     log.info(f"  [{label}] Starting scan for {duration_sec}s")
     click_panel("Start")
@@ -785,16 +647,19 @@ class TestReducedModeMouse:
 
 
 # ─────────────────────────────────────────────
-# Settings feature class — Time Window dropdown + Auto-scale toggle
+# Settings feature class — Time Window dropdown
 # ─────────────────────────────────────────────
 @pytest.mark.incremental
 class TestReducedModeSettings:
-    """Reduced Mode Settings — Time Window dropdown + Auto-scale Y-axes.
+    """Reduced Mode Settings — Time Window dropdown.
 
     For each Time Window value (3, 5, 15, 30 s): open Settings, select
-    the value, close Settings, run a 2-min scan. Then turn Auto-scale
-    Y-axes ON and run one final 2-min scan to verify both feature
-    paths produce a viable scan.
+    the value, close Settings, run a 2-min scan.
+
+    Auto-scale is intentionally NOT covered here: reduced mode removes
+    the option entirely (the Settings row and the plot viewer's
+    three-dot popup entry are hidden, and BloodFlow.qml forces
+    autoScale off), so there is nothing to toggle.
 
     Reduced Mode is forced on in ``app_config.json`` at module-import
     time (see the module docstring); all three classes in this module
@@ -815,25 +680,6 @@ class TestReducedModeSettings:
         pyautogui.press("escape")
         time.sleep(SLEEP)
         _run_scan(f"TimeWindow={seconds}s", SHORT_SCAN_WAIT)
-
-    def test_34_open_settings_for_autoscale(self, app):
-        """Reopen Settings to enable Auto-scale Y-axes."""
-        move_window_on_screen()
-        ensure_visible()
-        click_panel("Settings")
-
-    def test_35_toggle_autoscale_on(self, app):
-        """Flip the Auto-scale Y-axes Switch to ON."""
-        _toggle_auto_scale_on()
-
-    def test_36_close_settings(self, app):
-        require_focus()
-        pyautogui.press("escape")
-        time.sleep(SLEEP)
-
-    def test_37_autoscale_scan(self, app):
-        """One final 2-min scan with Auto-scale enabled."""
-        _run_scan("AutoScale=ON", SHORT_SCAN_WAIT)
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Reduced-mode UI cleanups, bundled with the per-metric y-axis tick labels from #178 so the plot changes can be reviewed together.

## Changes

**Reduced-mode trims** (`732b4e9`):
- **Autoscale removed in reduced mode** — hidden in both the three-dot popup and the Settings modal; `BloodFlow.qml` forces `autoScale` off so a stale `app_config.json` value can't strand it on with no way to toggle it back.
- **Mean/Contrast manual-bounds rows hidden in reduced mode** — the Manual Plot Bounds grid reflows to BFI/BVI only.
- **Cell values switch removed** from the three-dot popup entirely (all modes). `showCellValues` keeps its existing per-mode default (`!reducedMode`), so labels still show normally / stay off in reduced mode — just no longer toggleable.
- **Three-dot button hidden when its popup would be empty** — in reduced mode the display-mode + autoscale rows are hidden and Cell values is gone, leaving only the dev-only Profiler; the button now hides itself in reduced mode unless developer mode is on.
- Dropped the reduced-mode autoscale GUI tests (34–37) + helpers, which toggled a control that no longer exists via a blind Tab+Space fallback.

**Included from #178** (`b6e352a`, cherry-picked): per-metric y-axis tick labels on plot cells. Touches only `components/PlotCell.qml`.

## Verification
- Booted in reduced mode → Settings modal shows Manual Plot Bounds with only BFI/BVI, autoscale row gone, bounds hint updated. No QML errors.
- Isolated render of the three-dot popup confirms: normal mode shows display-mode + autoscale (no Cell values); reduced mode renders empty → confirms the button-hide.
- The live three-dot popup over a real scan was not screenshotted (would require firing the lasers); the popup change is a verbatim row removal + a `visible` binding.

## Note
This PR contains #178's commit. If #178 merges first, the shared commit dedupes; if this merges first, #178 goes empty. Intentional per request to review everything at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)