### PR TITLE
feat: spacebar opens timestamped scan note during a scan

### DIFF
--- a/components/NotesModal.qml
+++ b/components/NotesModal.qml
@@ -19,6 +19,18 @@ Item {
         root.visible = true
         notesArea.forceActiveFocus()
     }
+    // Open with a timestamped entry pre-inserted. `stamp` is the bracketed
+    // contents (e.g. "00:04:32 / 14:32:05"). Existing notes get a newline
+    // before the new entry; an empty note gets no leading blank line. Cursor
+    // is parked after the timestamp, ready for the operator to type.
+    function openWithTimestamp(stamp) {
+        var existing = MotionInterface.scanNotes
+        var prefix = existing.length > 0 ? existing.replace(/\s+$/, "") + "\n" : ""
+        notesArea.text = prefix + "[" + stamp + "] "
+        root.visible = true
+        notesArea.forceActiveFocus()
+        notesArea.cursorPosition = notesArea.text.length
+    }
     function close() {
         MotionInterface.scanNotes = notesArea.text
         MotionInterface.notify("Note saved.", "success", 4000, true)

--- a/components/NotesModal.qml
+++ b/components/NotesModal.qml
@@ -26,7 +26,7 @@ Item {
     function openWithTimestamp(stamp) {
         var existing = MotionInterface.scanNotes
         var prefix = existing.length > 0 ? existing.replace(/\s+$/, "") + "\n" : ""
-        notesArea.text = prefix + "[" + stamp + "] "
+        notesArea.text = prefix + "[" + stamp + "] - "
         root.visible = true
         notesArea.forceActiveFocus()
         notesArea.cursorPosition = notesArea.text.length

--- a/docs/superpowers/plans/2026-06-11-spacebar-timestamped-scan-notes.md
+++ b/docs/superpowers/plans/2026-06-11-spacebar-timestamped-scan-notes.md
@@ -93,7 +93,7 @@ before `close()`, add:
     // before the new entry; an empty note gets no leading blank line. Cursor
     // is parked after the timestamp, ready for the operator to type.
     function openWithTimestamp(stamp) {
-        var existing = MOTIONInterface.scanNotes
+        var existing = MotionInterface.scanNotes
         var prefix = existing.length > 0 ? existing.replace(/\s+$/, "") + "\n" : ""
         notesArea.text = prefix + "[" + stamp + "] "
         root.visible = true
@@ -142,15 +142,15 @@ block (after line 313), add:
                  && MOTIONInterface.triggerState === "ON"
                  && modalManager.current === null
         onActivated: {
-            var elapsed = MOTIONInterface.scanElapsedStr()
+            var elapsed = MotionInterface.scanElapsedStr()
             var wall = Qt.formatTime(new Date(), "HH:mm:ss")
             notesModal.openWithTimestamp(elapsed + " / " + wall)
         }
     }
 ```
 
-`modalManager` is the `ModalManager` declared in this file (lines ~227); `notesModal` is the
-`NotesModal` above; `bloodFlow` is the root id; `MOTIONInterface` is the registered singleton.
+`modalManager` is the `ModalManager` declared in this file (lines ~229); `notesModal` is the
+`NotesModal` above; `bloodFlow` is the root id; `MotionInterface` is the registered singleton.
 All are already in scope here.
 
 - [ ] **Step 2: Verify the file parses (syntax sanity)**

--- a/docs/superpowers/plans/2026-06-11-spacebar-timestamped-scan-notes.md
+++ b/docs/superpowers/plans/2026-06-11-spacebar-timestamped-scan-notes.md
@@ -1,0 +1,216 @@
+# Spacebar Timestamped Scan Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** While a scan is running, pressing Spacebar pops the Notes modal with a fresh newline + `[elapsed / wall-clock]` timestamp inserted, cursor ready to type.
+
+**Architecture:** A QML `Shortcut` in `pages/BloodFlow.qml` (gated to active scans, disabled while any modal is open) reads elapsed scan time from a new one-line `@pyqtSlot` on the connector and wall-clock time from QML's `Date`, then calls a new `openWithTimestamp()` on the existing `NotesModal`. Persistence is unchanged — `NotesModal.close()` already saves the text back to `scanNotes`.
+
+**Tech Stack:** PyQt6, QML (QtQuick Controls 6), pytest (Python-side unit test). Mock hardware via `cameraFakeData: true` for the manual run.
+
+**Spec:** [docs/superpowers/specs/2026-06-11-spacebar-timestamped-scan-notes-design.md](../specs/2026-06-11-spacebar-timestamped-scan-notes-design.md)
+
+---
+
+### Task 1: Expose elapsed scan time to QML
+
+**Files:**
+- Modify: `motion_connector.py` (add slot near the other `@pyqtSlot` methods; `_scan_elapsed_str` is defined at line ~2880)
+- Test: `tests/test_scan_elapsed_slot.py` (create)
+
+The connector already has the private `_scan_elapsed_str()` returning trigger-ON elapsed time
+as `HH:MM:SS`, and it is safe to call any time (returns `00:00:00` when no scan is active,
+because `_trigger_cumulative_s` is `0.0` and `_trigger_on_mono` is `None` at construction).
+We add a public slot wrapper so QML can read it.
+
+- [ ] **Step 1: Write the failing test**
+
+This test constructs the connector and asserts the new public slot delegates to the existing
+elapsed-time computation. We avoid touching hardware by only calling the pure string method.
+
+```python
+# tests/test_scan_elapsed_slot.py
+"""Unit test for the QML-facing scanElapsedStr slot (no hardware)."""
+from motion_connector import MotionConnector
+
+
+def test_scan_elapsed_str_slot_delegates(monkeypatch):
+    # Build the object without running __init__ (avoids hardware/Qt setup).
+    conn = MotionConnector.__new__(MotionConnector)
+    monkeypatch.setattr(conn, "_scan_elapsed_str", lambda: "01:02:03")
+    assert conn.scanElapsedStr() == "01:02:03"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_scan_elapsed_slot.py -v`
+Expected: FAIL with `AttributeError: 'MotionConnector' object has no attribute 'scanElapsedStr'`
+
+- [ ] **Step 3: Add the slot**
+
+Add immediately above the `_scan_elapsed_str` definition (around line 2880 in
+`motion_connector.py`):
+
+```python
+    @pyqtSlot(result=str)
+    def scanElapsedStr(self) -> str:
+        """QML-facing accessor for trigger-ON elapsed time (HH:MM:SS)."""
+        return self._scan_elapsed_str()
+```
+
+`pyqtSlot` is already imported in this file (used by `notify` and many others) — no new import.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_scan_elapsed_slot.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_scan_elapsed_slot.py
+git commit -m "feat: expose scan elapsed time to QML via scanElapsedStr slot"
+```
+
+---
+
+### Task 2: Add `openWithTimestamp()` to NotesModal
+
+**Files:**
+- Modify: `components/NotesModal.qml` (add a function next to existing `open()` / `close()` at lines 17-26)
+
+No automated test — QML behavior is verified by the manual run in Task 4. This task is a
+self-contained, committable change.
+
+- [ ] **Step 1: Add the function**
+
+In `components/NotesModal.qml`, directly after the existing `open()` function (line 21) and
+before `close()`, add:
+
+```qml
+    // Open with a timestamped entry pre-inserted. `stamp` is the bracketed
+    // contents (e.g. "00:04:32 / 14:32:05"). Existing notes get a newline
+    // before the new entry; an empty note gets no leading blank line. Cursor
+    // is parked after the timestamp, ready for the operator to type.
+    function openWithTimestamp(stamp) {
+        var existing = MOTIONInterface.scanNotes
+        var prefix = existing.length > 0 ? existing.replace(/\s+$/, "") + "\n" : ""
+        notesArea.text = prefix + "[" + stamp + "] "
+        root.visible = true
+        notesArea.forceActiveFocus()
+        notesArea.cursorPosition = notesArea.text.length
+    }
+```
+
+`close()` is unchanged — it already does `MOTIONInterface.scanNotes = notesArea.text`, so the
+inserted entry persists on close exactly like a manually typed note.
+
+- [ ] **Step 2: Verify the file parses (syntax sanity)**
+
+Run: `python -c "import sys; src=open('components/NotesModal.qml',encoding='utf-8').read(); assert src.count('{')==src.count('}'), 'brace mismatch'; print('braces balanced')"`
+Expected: `braces balanced`
+(Full QML validation happens when the app loads in Task 4.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/NotesModal.qml
+git commit -m "feat: add openWithTimestamp entry point to NotesModal"
+```
+
+---
+
+### Task 3: Wire the Spacebar shortcut in BloodFlow.qml
+
+**Files:**
+- Modify: `pages/BloodFlow.qml` (add a `Shortcut` next to the `NotesModal { id: notesModal }` block at lines 311-313)
+
+- [ ] **Step 1: Add the Shortcut**
+
+In `pages/BloodFlow.qml`, immediately after the closing brace of the `NotesModal { id: notesModal }`
+block (after line 313), add:
+
+```qml
+    // Spacebar during an active scan pops the Notes modal with a fresh
+    // newline + [elapsed / wall-clock] timestamp, cursor ready to type.
+    // Gated so it only fires mid-scan and never over another modal; once
+    // NotesModal opens, modalManager.current is non-null so the shortcut
+    // disables itself and Space types a literal space in the textarea.
+    Shortcut {
+        sequence: "Space"
+        enabled: bloodFlow.scanning
+                 && MOTIONInterface.triggerState === "ON"
+                 && modalManager.current === null
+        onActivated: {
+            var elapsed = MOTIONInterface.scanElapsedStr()
+            var wall = Qt.formatTime(new Date(), "HH:mm:ss")
+            notesModal.openWithTimestamp(elapsed + " / " + wall)
+        }
+    }
+```
+
+`modalManager` is the `ModalManager` declared in this file (lines ~227); `notesModal` is the
+`NotesModal` above; `bloodFlow` is the root id; `MOTIONInterface` is the registered singleton.
+All are already in scope here.
+
+- [ ] **Step 2: Verify the file parses (syntax sanity)**
+
+Run: `python -c "import sys; src=open('pages/BloodFlow.qml',encoding='utf-8').read(); assert src.count('{')==src.count('}'), 'brace mismatch'; print('braces balanced')"`
+Expected: `braces balanced`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pages/BloodFlow.qml
+git commit -m "feat: spacebar opens timestamped scan note during a scan"
+```
+
+---
+
+### Task 4: Manual verification (real run + screenshot)
+
+**Files:** none (verification only). QML does not hot-reload, so the app must be launched fresh.
+
+This is the real test of the feature — QML interaction has no unit-test harness in this repo,
+and per project convention layout/behavior changes need a real run + screenshot.
+
+- [ ] **Step 1: Enable mock hardware**
+
+In `config/app_config.json`, set `cameraFakeData: true` (note the current value first so you can
+restore it). Do NOT commit this change.
+
+- [ ] **Step 2: Launch the app**
+
+Run: `python main.py`
+Expected: app window opens on the Blood Flow page, no QML errors in the console (watch for
+`ReferenceError` / `Cannot assign` lines, which would mean a wiring typo from Task 3).
+
+- [ ] **Step 3: Start a scan and trigger the shortcut**
+
+Start a scan via the Start button. Once the trigger is ON (countdown running), press Spacebar.
+Expected: the Notes modal opens with a line like `[00:00:07 / 14:32:05] ` inserted on its own
+line and the cursor positioned right after it.
+
+- [ ] **Step 4: Screenshot to confirm**
+
+Capture the app window (PrintWindow flag 2) and visually confirm the timestamped line is present
+and well-formed. (Per memory `feedback_qml_changes_need_visual_check`, a boot-log grep is not
+sufficient for geometry/behavior.)
+
+- [ ] **Step 5: Confirm re-trigger and persistence**
+
+Type a note. Press Spacebar again *inside the modal* — expected: a literal space is inserted, NOT
+a new timestamp. Close the modal, reopen via the Notes icon — expected: the note persisted.
+Confirm Spacebar does nothing note-related when not scanning.
+
+- [ ] **Step 6: Watch for the focus-conflict risk**
+
+If pressing Space while scanning re-activates the Start/Stop button (or does nothing) instead of
+opening the modal, that is the keyboard-focus routing risk noted in the spec. If observed, stop
+and report — the fix is clearing button focus on scan start, or falling back to spec approach B
+(a `QApplication` event filter). If the modal opens correctly, no action needed.
+
+- [ ] **Step 7: Restore config**
+
+Revert `cameraFakeData` in `config/app_config.json` to its original value. Confirm
+`git status` shows no changes to `config/app_config.json`.

--- a/docs/superpowers/specs/2026-06-11-spacebar-timestamped-scan-notes-design.md
+++ b/docs/superpowers/specs/2026-06-11-spacebar-timestamped-scan-notes-design.md
@@ -1,0 +1,132 @@
+# Spacebar timestamped scan notes — design
+
+**Date:** 2026-06-11
+**Status:** Approved (design); pending implementation
+
+## Problem
+
+While a scan is running, the operator often wants to mark a moment — "patient moved",
+"adjusted headset", etc. Today that requires clicking the Notes icon, finding the end of
+the text, and manually typing the time. The goal is a single keystroke: **press Spacebar
+during a scan to pop the Notes modal with a fresh newline + timestamp already inserted, cursor
+ready to type.**
+
+## Scope
+
+In scope:
+- A Spacebar shortcut, active only while a scan is actively running, that opens the existing
+  `NotesModal` and inserts a timestamped line.
+- The inserted timestamp is **both** elapsed scan time and wall-clock time:
+  `[HH:MM:SS / HH:MM:SS]` → e.g. `[00:04:32 / 14:32:05] `.
+
+Out of scope:
+- Any change to how notes are persisted (the existing `scanNotes` property + on-close save and
+  the post-scan notes-file write are unchanged).
+- Multiple-timestamp-while-modal-open behavior. Once the modal is open the user is typing, so
+  Spacebar inserts a literal space. To add another timestamped entry, close and reopen.
+
+## Chosen approach (A)
+
+QML `Shortcut` for the keystroke + a one-line Python accessor to expose elapsed scan time.
+Contained, idiomatic, and adds essentially nothing to the oversized `motion_connector.py`.
+
+Rejected alternatives:
+- **B — `QApplication` event filter in Python.** More robust against keyboard-focus conflicts,
+  but adds global input handling into the 4031-line connector. Kept only as a fallback if the
+  QML `Shortcut` shows focus-routing problems during testing.
+- **C — hidden focused Item + `Keys.onPressed`.** Fragile focus management. Rejected.
+
+## Components
+
+### 1. `motion_connector.py` — expose elapsed scan time
+
+The connector already computes trigger-ON elapsed time in `_scan_elapsed_str()` (`HH:MM:SS`,
+the same value used for the on-screen countdown, camera-dropout messages, and the
+`duration:` line appended to notes at scan end). Add a thin public slot so QML can read it:
+
+```python
+@pyqtSlot(result=str)
+def scanElapsedStr(self) -> str:
+    return self._scan_elapsed_str()
+```
+
+No new state; `_scan_elapsed_str()` is already safe to call any time (returns `00:00:00`
+when no scan is active).
+
+### 2. `components/NotesModal.qml` — timestamped entry point
+
+Add a new function alongside the existing `open()` / `close()`:
+
+```qml
+function openWithTimestamp(stamp) {
+    var existing = MOTIONInterface.scanNotes
+    var prefix = existing.length > 0 ? existing.replace(/\s+$/, "") + "\n" : ""
+    notesArea.text = prefix + "[" + stamp + "] "
+    root.visible = true
+    notesArea.forceActiveFocus()
+    notesArea.cursorPosition = notesArea.text.length
+}
+```
+
+- Existing content gets a trailing-whitespace trim + a single newline before the timestamp, so
+  the new entry always starts on its own line ("does a \n"). An empty note gets no leading blank
+  line.
+- Cursor lands immediately after `[stamp] `, ready to type.
+- `close()` is unchanged — it already saves `notesArea.text` back to `MOTIONInterface.scanNotes`,
+  which persists to disk. No new save path.
+
+### 3. `pages/BloodFlow.qml` — the Spacebar shortcut
+
+Placed next to the existing `NotesModal { id: notesModal }` block:
+
+```qml
+Shortcut {
+    sequence: "Space"
+    enabled: bloodFlow.scanning
+             && MOTIONInterface.triggerState === "ON"
+             && modalManager.current === null
+    onActivated: {
+        var elapsed = MOTIONInterface.scanElapsedStr()
+        var wall = Qt.formatTime(new Date(), "HH:mm:ss")
+        notesModal.openWithTimestamp(elapsed + " / " + wall)
+    }
+}
+```
+
+Gating rationale:
+- `bloodFlow.scanning && triggerState === "ON"` — only fires during an active scan.
+- `modalManager.current === null` — don't pop notes over another open modal, and (crucially)
+  once `NotesModal` itself opens, `current` becomes non-null, so the shortcut disables and
+  Spacebar types a literal space in the textarea (the chosen re-trigger behavior).
+
+## Data flow
+
+1. Operator presses Space while a scan runs and no modal is open.
+2. `Shortcut.onActivated` reads `scanElapsedStr()` from the connector and formats wall-clock in QML.
+3. `notesModal.openWithTimestamp("00:04:32 / 14:32:05")` appends a newline + `[stamp] ` to the
+   current notes text, shows the modal, focuses the textarea, parks the cursor at the end.
+4. Operator types the note. On close (X, Esc, backdrop click, or app teardown via ModalManager),
+   the existing `close()` saves the text to `scanNotes`.
+
+## Error / edge handling
+
+- **No active scan:** shortcut `enabled` is false → Spacebar behaves normally elsewhere.
+- **Empty notes:** no leading blank line; the timestamp is the first line.
+- **Empty timestamped entry (user opens then closes without typing):** persists a `[stamp] ` line
+  with no note. Acceptable — it still records that the operator marked a moment. Not specially trimmed.
+- **Keyboard-focus conflict (risk to verify):** if the Start/Stop button retains keyboard focus
+  during a scan, Qt could route Space to the button. To be confirmed during testing; if it
+  occurs, fix by clearing button focus on scan start or falling back to approach B.
+
+## Testing
+
+Per repo convention QML does not hot-reload and layout/behavior changes need a real run + screenshot.
+
+1. Set `cameraFakeData: true` in `config/app_config.json`, run `python main.py`.
+2. Start a scan; once trigger is ON, press Space.
+3. Screenshot the Notes modal — verify a `[elapsed / wall]` line was inserted on a fresh line and
+   the cursor is ready to type.
+4. Type a note; press Space again inside the modal — verify it inserts a literal space (no new
+   timestamp).
+5. Close the modal, reopen via the Notes icon — verify the note persisted.
+6. Verify Spacebar does nothing note-related when not scanning.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2826,6 +2826,11 @@ class MotionConnector(QObject):
                 if src is not None and getattr(src, "live", False):
                     src.mark_dropped(side=side, cam_id=cam_id, t=now - self._plot_t0)
 
+    @pyqtSlot(result=str)
+    def scanElapsedStr(self) -> str:
+        """QML-facing accessor for trigger-ON elapsed time (HH:MM:SS)."""
+        return self._scan_elapsed_str()
+
     def _scan_elapsed_str(self) -> str:
         """Return current scan elapsed trigger-ON time as HH:MM:SS."""
         elapsed = self._trigger_cumulative_s

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -294,6 +294,23 @@ Rectangle {
         id: notesModal
     }
 
+    // Spacebar during an active scan pops the Notes modal with a fresh
+    // newline + [elapsed / wall-clock] timestamp, cursor ready to type.
+    // Gated so it only fires mid-scan and never over another modal; once
+    // NotesModal opens, modalManager.current is non-null so the shortcut
+    // disables itself and Space types a literal space in the textarea.
+    Shortcut {
+        sequence: "Space"
+        enabled: bloodFlow.scanning
+                 && MotionInterface.triggerState === "ON"
+                 && modalManager.current === null
+        onActivated: {
+            var elapsed = MotionInterface.scanElapsedStr()
+            var wall = Qt.formatTime(new Date(), "HH:mm:ss")
+            notesModal.openWithTimestamp(elapsed + " / " + wall)
+        }
+    }
+
     // Open the notes modal exactly when the connector signals that
     // scanNotes has been finalized for the just-completed scan (duration
     // line appended, notes.txt written). This is the only path that

--- a/tests/test_scan_elapsed_slot.py
+++ b/tests/test_scan_elapsed_slot.py
@@ -1,0 +1,9 @@
+"""Unit test for the QML-facing scanElapsedStr slot (no hardware)."""
+from motion_connector import MotionConnector
+
+
+def test_scan_elapsed_str_slot_delegates(monkeypatch):
+    # Build the object without running __init__ (avoids hardware/Qt setup).
+    conn = MotionConnector.__new__(MotionConnector)
+    monkeypatch.setattr(conn, "_scan_elapsed_str", lambda: "01:02:03")
+    assert conn.scanElapsedStr() == "01:02:03"


### PR DESCRIPTION
@
## What

While a scan is running, pressing **Spacebar** pops the Session Notes modal with a fresh newline + a timestamp inserted (`[elapsed / wall-clock] - `), cursor ready to type. Lets the operator quickly mark a moment mid-scan without reaching for the mouse.

## Behavior

- Active **only** while a scan is running (`scanning && triggerState === "ON"`) and **no** modal is already open.
- Inserts `[HH:MM:SS / HH:MM:SS] - ` — elapsed scan time (matches the on-screen countdown / the duration line appended at scan end) and wall-clock time.
- Existing notes get a newline before the new entry; an empty note gets no leading blank line.
- Once the modal opens the shortcut disables itself, so Space types a literal space while you write. Close + Space again to add another timestamped entry.
- Persistence is unchanged — relies on the existing `NotesModal.close()` save path.

## Changes

| Change | File |
|---|---|
| `scanElapsedStr()` slot exposing trigger-ON elapsed time, + unit test | `motion_connector.py`, `tests/test_scan_elapsed_slot.py` |
| `openWithTimestamp()` entry point | `components/NotesModal.qml` |
| Gated `Space` `Shortcut` | `pages/BloodFlow.qml` |

Design + plan docs included under `docs/superpowers/`.

## Testing

- `tests/test_scan_elapsed_slot.py` passes (`python -m pytest tests/test_scan_elapsed_slot.py`).
- Manually verified live with `cameraFakeData: true`: Space mid-scan opens the modal with the timestamp line and the cursor positioned to type. (The shortcut is a `WindowShortcut`, so it only fires while the app window is OS-focused — expected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@