### PR TITLE
fix: replay past scans with their own camera config (#175)

### DIFF
--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -157,6 +157,22 @@ Rectangle {
     // ── Source subscription ────────────────────────────────────────────
     readonly property var scanSource: MotionInterface.currentScanSource
 
+    // ── Effective camera masks ─────────────────────────────────────────
+    // The grid lays out from the camera config of whatever's being shown.
+    // A replayed past scan exposes the masks it actually recorded
+    // (leftMask/rightMask >= 0); use those so its layout doesn't inherit
+    // the operator's current Scan Settings selection (issue #175). A live
+    // source — or no source, before the first scan — reports -1 (unknown),
+    // so the grid keeps following the live leftMask/rightMask selection.
+    readonly property int _effLeftMask:
+        (viewer.scanSource && viewer.scanSource.leftMask !== undefined
+         && viewer.scanSource.leftMask >= 0)
+            ? viewer.scanSource.leftMask : viewer.leftMask
+    readonly property int _effRightMask:
+        (viewer.scanSource && viewer.scanSource.rightMask !== undefined
+         && viewer.scanSource.rightMask >= 0)
+            ? viewer.scanSource.rightMask : viewer.rightMask
+
     // ── Grid model ─────────────────────────────────────────────────────
     // Dev mode (default) — one cell per active camera (bits set in
     // leftMask / rightMask), arranged to mirror the physical U-shape of
@@ -169,7 +185,7 @@ Rectangle {
     // compact upward; an unselected camera in a kept row just leaves its
     // slot blank.
     readonly property var _devCellModel: {
-        var masks = [viewer.leftMask & 0xFF, viewer.rightMask & 0xFF]
+        var masks = [viewer._effLeftMask & 0xFF, viewer._effRightMask & 0xFF]
         var sides = ["left", "right"]
         var colBase = [0, masks[0] !== 0 ? 2 : 0]
         var entries = []

--- a/data_sources.py
+++ b/data_sources.py
@@ -261,6 +261,14 @@ class ScanDataSource(QObject):
         # plain attribute) for QML to read it; plain Python attributes
         # are invisible to QML and read as `undefined`.
         self._live: bool = False
+        # Camera configuration this source represents, as left/right 8-bit
+        # masks (bit c set ⇒ camera c recorded). -1 means "unknown" — the
+        # default for live sources, which leave the plot grid following the
+        # operator's live Scan Settings selection. PastScanSource overrides
+        # these with the config the replayed scan actually recorded (issue
+        # #175) so its grid doesn't inherit the current selection.
+        self._left_mask: int = -1
+        self._right_mask: int = -1
         self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
         # Ring-trim threshold for buffers this source creates. Live sources
         # pass a finite value (config) to bound memory; past sources pass None
@@ -290,6 +298,23 @@ class ScanDataSource(QObject):
         broke the toolbar's source-type label and the "Back to live"
         button's variant selection (both branched on `scanSource.live`)."""
         return self._live
+
+    @pyqtProperty(int, constant=True)
+    def leftMask(self) -> int:
+        """Left-sensor camera mask this source represents, or -1 if unknown.
+
+        Exposed as ``pyqtProperty`` (not a plain attribute) so QML can read
+        it — PlotViewer prefers this over the live selection when it's a
+        real mask (>= 0), so a replayed scan lays its grid out from its own
+        configuration (issue #175). ``constant=True``: set once at
+        construction, never changes for the life of the source."""
+        return self._left_mask
+
+    @pyqtProperty(int, constant=True)
+    def rightMask(self) -> int:
+        """Right-sensor camera mask this source represents, or -1 if unknown.
+        See ``leftMask``."""
+        return self._right_mask
 
     @pyqtProperty(float)
     def liveEdge(self) -> float:
@@ -866,6 +891,26 @@ def _load_corrected_csv_into(buffers: dict, csv_path: str) -> None:
         pass
 
 
+def _derive_masks_from_buffers(buffers: dict) -> tuple[int, int]:
+    """Reconstruct (left_mask, right_mask) from which per-camera streams a
+    loaded scan carries — bit c set ⇒ camera c (cam_id 0..7) recorded data.
+
+    Returns (-1, -1) when no per-camera streams exist (e.g. a reduced-mode
+    scan whose only buffers are the cam_id=-1 side average) so the viewer
+    falls back to its live/preview masks rather than rendering an empty
+    normal-mode grid. A side that recorded nothing yields mask 0 as long as
+    the other side has cameras — preserving an asymmetric/one-sided scan's
+    true per-side configuration (issue #175)."""
+    masks = {"left": 0, "right": 0}
+    for key in buffers:
+        side, cam_id = key[0], key[1]
+        if side in masks and 0 <= cam_id < 8:
+            masks[side] |= (1 << cam_id)
+    if masks["left"] == 0 and masks["right"] == 0:
+        return -1, -1
+    return masks["left"], masks["right"]
+
+
 def load_past_scan_buffers(
     scan_db,
     session_id: int,
@@ -922,10 +967,15 @@ class PastScanSource(ScanDataSource):
         if preloaded_buffers is not None:
             # Already bulk-loaded on a worker thread — adopt as-is.
             self.buffers = preloaded_buffers
-            return
+        else:
+            # Synchronous load (tests / small scans): see
+            # load_past_scan_buffers for the layout and CSV-fallback rules.
+            self.buffers, _ = load_past_scan_buffers(
+                scan_db, self.session_id, corrected_csv_path
+            )
 
-        # Synchronous load (tests / small scans): see load_past_scan_buffers
-        # for the layout and the CSV-fallback rules.
-        self.buffers, _ = load_past_scan_buffers(
-            scan_db, self.session_id, corrected_csv_path
+        # Lay the plot grid out from THIS scan's recorded cameras, not the
+        # operator's live selection (issue #175).
+        self._left_mask, self._right_mask = _derive_masks_from_buffers(
+            self.buffers
         )

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -601,6 +601,73 @@ def test_past_scan_source_preloaded_empty_dict_is_empty_source():
     assert src.liveEdge == 0.0
 
 
+# ── Issue #175 — past scan carries its own camera configuration ────────
+# The plot viewer lays its grid out from leftMask/rightMask. When a past
+# scan is replayed, the viewer must use THAT scan's camera config (which
+# cameras actually recorded), not the operator's live Scan Settings
+# selection. PastScanSource reconstructs the masks from which per-camera
+# (cam_id 0..7) streams it loaded so the viewer can prefer them.
+
+
+def test_past_scan_source_derives_masks_from_buffer_cam_ids(session_data_db):
+    db, sid = session_data_db
+    src = PastScanSource(scan_db=db, session_id=sid)
+    # Fixture records cams 0 and 3 on both sides → bits 0 and 3 → 0x09.
+    assert src.leftMask == 0x09
+    assert src.rightMask == 0x09
+
+
+def test_past_scan_source_derives_masks_for_far_config():
+    """A 'Far' (0xC3 = cams 1,2,7,8 → camIds 0,1,6,7) scan recorded only
+    those cameras; the derived masks reflect that regardless of any live
+    selection."""
+    buffers = {}
+    for side in ("left", "right"):
+        for cam_id in (0, 1, 6, 7):
+            buf = _CameraBuffer(max_capacity=None)
+            buf.append(t=0.0, v=1.0, frame_id=0)
+            buffers[(side, cam_id, "bfi")] = buf
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.leftMask == 0xC3
+    assert src.rightMask == 0xC3
+
+
+def test_past_scan_source_derives_per_side_masks_independently():
+    """Left and right masks are reconstructed separately — a one-sided or
+    asymmetric scan keeps each side's true configuration."""
+    buffers = {}
+    for cam_id in (0, 1, 6, 7):  # left = Far
+        buf = _CameraBuffer(max_capacity=None)
+        buf.append(t=0.0, v=1.0, frame_id=0)
+        buffers[("left", cam_id, "bfi")] = buf
+    # right side: no cameras recorded
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.leftMask == 0xC3
+    assert src.rightMask == 0x00
+
+
+def test_live_scan_source_masks_unknown():
+    """A live source reports unknown (-1) masks so the viewer keeps using
+    the operator's live Scan Settings selection during a live scan."""
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.leftMask == -1
+    assert src.rightMask == -1
+
+
+def test_past_scan_source_masks_unknown_when_no_per_cam_streams():
+    """Reduced-mode scans only carry the cam_id=-1 side average; with no
+    per-camera streams there is no normal-mode mask to derive, so the
+    masks read -1 (unknown) and the viewer falls back to its live masks."""
+    buffers = {}
+    for side in ("left", "right"):
+        buf = _CameraBuffer(max_capacity=None)
+        buf.append(t=0.0, v=1.0, frame_id=0)
+        buffers[(side, -1, "bfi")] = buf
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.leftMask == -1
+    assert src.rightMask == -1
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # currentScanSource holder pattern — verified via a parallel mini-class
 # (MotionConnector uses the same pattern; see motion_connector.py)

--- a/tests/test_plot_viewer_masks.py
+++ b/tests/test_plot_viewer_masks.py
@@ -68,11 +68,67 @@ MIDDLE_MASK = 0x66  # cams 2,3,6,7 (1-based) — the persisted config default
 ALL_MASK = 0xFF
 
 
+FAR_MASK = 0xC3  # cams 1,2,7,8 (1-based) → camIds 0,1,6,7
+
+
+class _StubPastScanSource(QObject):
+    """Minimal past-scan source exposing the camera-config masks the way
+    data_sources.PastScanSource does. live=False marks it as a replayed
+    scan; leftMask/rightMask carry the configuration that scan recorded."""
+
+    _neverEmitted = pyqtSignal()
+
+    def __init__(self, left_mask: int, right_mask: int, parent=None):
+        super().__init__(parent)
+        self._left = int(left_mask)
+        self._right = int(right_mask)
+
+    @pyqtProperty(bool, notify=_neverEmitted)
+    def live(self):
+        return False
+
+    @pyqtProperty(int, notify=_neverEmitted)
+    def leftMask(self):
+        return self._left
+
+    @pyqtProperty(int, notify=_neverEmitted)
+    def rightMask(self):
+        return self._right
+
+    @pyqtProperty(float, notify=_neverEmitted)
+    def liveEdge(self):
+        return 0.0
+
+    # Slots PlotViewer / PlotCell invoke during paint. Neutral returns —
+    # this stub has no data; the test only inspects the grid model.
+    @pyqtSlot(str, result="QVariantMap")
+    @pyqtSlot(str, float, float, float, result="QVariantMap")
+    def compute_bounds_for_metric(self, metric, lo=2.0, hi=98.0, pad=0.25):
+        return {"yMin": 0.0, "yMax": 1.0}
+
+    @pyqtSlot(str, int, str, float, float, int, result="QVariantList")
+    def points_for_window(self, side, cam_id, metric, t_lo, t_hi, max_points):
+        return []
+
+    @pyqtSlot(str, int, str, float, result=float)
+    def value_at(self, side, cam_id, metric, t):
+        return float("nan")
+
+    @pyqtSlot(str, int, result=float)
+    def dropped_at_for(self, side, cam_id):
+        return float("nan")
+
+
 class _StubMotionInterface(QObject):
     """Minimal MotionInterface stand-in covering every property/slot
     PlotViewer.qml (and its child components) actually reference."""
 
+    currentScanSourceChanged = pyqtSignal()
     _neverEmitted = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._scan_source = None
 
     @pyqtProperty("QVariantMap", notify=_neverEmitted)
     def appConfig(self):
@@ -87,9 +143,13 @@ class _StubMotionInterface(QObject):
             "showProfiling": False,
         }
 
-    @pyqtProperty(QObject, notify=_neverEmitted)
+    @pyqtProperty(QObject, notify=currentScanSourceChanged)
     def currentScanSource(self):
-        return None
+        return self._scan_source
+
+    def setScanSource(self, source):
+        self._scan_source = source
+        self.currentScanSourceChanged.emit()
 
     @pyqtProperty(bool, notify=_neverEmitted)
     def liveSourceAvailable(self):
@@ -150,6 +210,11 @@ def viewer_factory():
         created.append(obj)
         return obj
 
+    # Tests that need to drive currentScanSource reach the singleton stub
+    # through the factory; reset it to None in a finally so the shared
+    # module-scoped singleton can't leak a source into other tests.
+    make.stub = stub
+
     yield make
 
     for obj in created:
@@ -209,6 +274,49 @@ def test_single_side_all_keeps_other_side_unchanged(viewer_factory):
     assert _cam_ids(cells, "left") == list(range(8))
     assert _cam_ids(cells, "right") == [1, 2, 5, 6]
     assert len(cells) == 12
+
+
+# ── Issue #175 — replayed scan keeps its own camera configuration ──────
+# Loading a past scan must lay the grid out from the camera config that
+# scan recorded, not the operator's current Scan Settings selection.
+# PlotViewer reads the active source's leftMask/rightMask when the source
+# exposes them (a past scan does); a live source reports -1 so the grid
+# keeps following the live selection.
+
+
+def test_past_scan_config_overrides_live_mask_selection(viewer_factory):
+    viewer = viewer_factory()
+    try:
+        # Operator's live selection is All → 16-cell grid.
+        viewer.setProperty("leftMask", ALL_MASK)
+        viewer.setProperty("rightMask", ALL_MASK)
+        assert len(_cells(viewer)) == 16
+
+        # Replay a Far scan; the grid must adopt the Far config (cams
+        # 1,2,7,8 → camIds 0,1,6,7, 8 cells), not stay at All.
+        past = _StubPastScanSource(FAR_MASK, FAR_MASK)
+        viewer_factory.stub.setScanSource(past)
+
+        cells = _cells(viewer)
+        assert _cam_ids(cells, "left") == [0, 1, 6, 7]
+        assert _cam_ids(cells, "right") == [0, 1, 6, 7]
+        assert len(cells) == 8
+    finally:
+        viewer_factory.stub.setScanSource(None)
+
+
+def test_unknown_source_masks_fall_back_to_live_selection(viewer_factory):
+    """A source reporting -1 masks (e.g. a live source) leaves the grid
+    following the operator's live Scan Settings selection."""
+    viewer = viewer_factory()
+    try:
+        viewer.setProperty("leftMask", ALL_MASK)
+        viewer.setProperty("rightMask", ALL_MASK)
+        unknown = _StubPastScanSource(-1, -1)
+        viewer_factory.stub.setScanSource(unknown)
+        assert len(_cells(viewer)) == 16
+    finally:
+        viewer_factory.stub.setScanSource(None)
 
 
 def test_zero_masks_render_empty_grid(viewer_factory):


### PR DESCRIPTION
Closes #175.

## Problem

History → **"View in plot →"** loaded a past scan's data correctly, but the plot grid was laid out from the **live Scan Settings** masks (`PlotViewer.leftMask/rightMask`, bound to the current selection in `BloodFlow.qml`). A scan recorded with a **Far** config was rendered in the current **All** layout — cameras compacted into the wrong rows with empty rows above, which reads as "data mapped to incorrect plot positions."

The per-cell data was never mislabeled (each `PlotCell` queries its own `camId`); only the grid *arrangement* followed the wrong configuration.

## Fix

A scan source now carries its own camera configuration, and the viewer prefers it:

- **`data_sources.py`** — `ScanDataSource` exposes `leftMask`/`rightMask` (default `-1` = unknown). `PastScanSource` derives them from the `cam_id`s its loaded buffers actually carry (`_derive_masks_from_buffers`). Live sources stay `-1`.
- **`PlotViewer.qml`** — new `_effLeftMask`/`_effRightMask`: use the source's masks when known (a replayed scan), else fall back to the live selection (live scan / pre-scan preview). `_devCellModel` uses the effective masks.

## Design note

The replayed layout is derived from **cameras that recorded data**, not the stored `session_meta` config mask. For any completed scan these are identical; they differ only if a configured camera produced zero finite samples (e.g. a full-scan dropout) — then its cell is omitted rather than shown empty. Easy to switch to strict `session_meta` fidelity if preferred.

## Testing

- TDD: 6 tests written failing first (reproducing the exact bug — grid showed `[0,1,2,3,4,5,…]` instead of Far's `[0,1,6,7]`), then made green.
- **All 185 unit tests pass**, including the existing issue-#150/#164 regression tests that lock in live-mask behavior. Lint clean for changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)