### PR TITLE
feat: rework History into a data-management tool

### DIFF
--- a/components/HistoryHeaderCell.qml
+++ b/components/HistoryHeaderCell.qml
@@ -1,0 +1,37 @@
+import QtQuick 6.0
+import QtQuick.Layouts 6.0
+
+// One clickable, sort-aware column header in the History table.
+Item {
+    id: cell
+    property string text: ""
+    property string sortName: ""
+    property string activeSort: ""   // the table's current sort key
+    property bool ascending: false
+    signal sortRequested(string name)
+
+    Layout.preferredHeight: 30
+
+    AppTheme { id: theme }
+
+    Row {
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 4
+        Text {
+            text: cell.text
+            color: theme.textSecondary
+            font.pixelSize: 12; font.weight: Font.DemiBold
+        }
+        Text {
+            visible: cell.activeSort === cell.sortName
+            text: cell.ascending ? "▲" : "▼"
+            color: theme.textSecondary; font.pixelSize: 9
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        onClicked: cell.sortRequested(cell.sortName)
+    }
+}

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -12,125 +12,215 @@ Item {
 
     AppTheme { id: theme }
 
-    // Modal interface: the user-visible label for this modal. Single
-    // source of truth — the title Text below binds to this, and the
-    // ModalManager / close-while-busy handler can read it without
-    // hardcoding the string.
+    // Modal interface label (single source of truth — see ModalManager).
     readonly property string label: "Scan History"
 
+    // Full session list from the connector (newest first).
     property var scans: []
-    property var selected: ({})
-    // True while an async "View in plot" load is in flight (issue #152):
-    // the heavy DB/CSV walk runs on a worker thread in the connector, and
-    // this drives the busy overlay until pastScanLoadFinished fires.
+    // Filtered + sorted view actually rendered.
+    property var view: []
+    // Multiselect membership: { sessionId: true }. Reassigned (not mutated)
+    // on every toggle so delegate bindings re-evaluate.
+    property var checked: ({})
+    property int checkedCount: 0
+    // Focused (detail-pane) row.
+    property int focusedSessionId: -1
+    property var focusedRow: null
+    property int focusedSampleCount: -1
+    // Toolbar filters / sort.
+    property string searchText: ""
+    property string configFilter: "All"
+    property string sortKey: "timestamp"
+    property bool sortAsc: false
+    // Async "Load in viewer" busy state (issue #152 pattern).
     property bool loadingPlot: false
 
+    // ── data plumbing ──────────────────────────────────────────────
     function open() {
-        refreshScans()
-        console.warn("[History] opened — " + scans.length + " scan(s) listed")
+        refresh()
+        console.warn("[History] opened — " + scans.length + " scan(s)")
         root.visible = true
     }
-    function close() {
-        root.visible = false
+    function close() { root.visible = false }
+
+    function refresh() {
+        try { scans = MotionInterface.get_scan_sessions() || [] }
+        catch (e) { scans = [] }
+        checked = ({}); checkedCount = 0
+        rebuildView()
+        if (view.length > 0) focusRow(view[0].sessionId)
+        else { focusedSessionId = -1; focusedRow = null; focusedSampleCount = -1 }
     }
 
-    function refreshScans() {
-        try {
-            scans = MotionInterface.get_scan_list() || []
-            if (scans.length > 0) {
-                scanPicker.currentIndex = 0
-                selected = MotionInterface.get_scan_details(scans[0]) || {}
-            } else {
-                selected = {}
-            }
-        } catch (e) {
-            scans = []
-            selected = {}
+    function rebuildView() {
+        var q = (searchText || "").toLowerCase()
+        var cfg = configFilter
+        var arr = scans.filter(function(r) {
+            if (q.length > 0
+                && (r.userLabel || "").toLowerCase().indexOf(q) < 0
+                && (r.label || "").toLowerCase().indexOf(q) < 0)
+                return false
+            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
+                return false
+            return true
+        })
+        var key = sortKey, asc = sortAsc
+        arr.sort(function(a, b) {
+            var av = a[key], bv = b[key]
+            if (av === undefined || av === null) av = ""
+            if (bv === undefined || bv === null) bv = ""
+            if (av < bv) return asc ? -1 : 1
+            if (av > bv) return asc ? 1 : -1
+            return 0
+        })
+        view = arr
+    }
+
+    function setSort(key) {
+        if (sortKey === key) sortAsc = !sortAsc
+        else { sortKey = key; sortAsc = (key === "userLabel") }
+        rebuildView()
+    }
+
+    function focusRow(sid) {
+        focusedSessionId = sid
+        focusedRow = null
+        for (var i = 0; i < view.length; i++)
+            if (view[i].sessionId === sid) { focusedRow = view[i]; break }
+        focusedSampleCount = -1
+        if (sid >= 0) {
+            try { focusedSampleCount = MotionInterface.get_session_stats(sid).sampleCount }
+            catch (e) { focusedSampleCount = -1 }
         }
     }
 
-    function basename(p) {
-        if (!p || p.length === 0) return ""
-        const norm = p.replace(/\\/g, "/")
-        const idx = norm.lastIndexOf("/")
-        return idx >= 0 ? norm.slice(idx + 1) : norm
+    function toggleCheck(sid) {
+        var c = Object.assign({}, checked)
+        if (c[sid]) { delete c[sid]; checkedCount -= 1 }
+        else { c[sid] = true; checkedCount += 1 }
+        checked = c
     }
 
-    function friendlyDate(ts) {
-        if (!ts || ts.length !== 15) return ts || "-"
-        const y = ts.slice(0,4), m = ts.slice(4,6), d = ts.slice(6,8)
-        const hh = ts.slice(9,11), mm = ts.slice(11,13), ss = ts.slice(13,15)
-        return y + "-" + m + "-" + d + " " + hh + ":" + mm + ":" + ss
+    function setAllChecked(on) {
+        var c = {}, n = 0
+        if (on) for (var i = 0; i < view.length; i++) { c[view[i].sessionId] = true; n++ }
+        checked = c; checkedCount = n
     }
 
-    function formatMasks(leftMask, rightMask) {
-        const left = leftMask ? "0x" + leftMask.toUpperCase() : ""
-        const right = rightMask ? "0x" + rightMask.toUpperCase() : ""
-        if (left && right) return left + ", " + right
-        else if (left) return left
-        else if (right) return right
-        else return "-"
+    function requestDelete() {
+        if (checkedCount <= 0) return
+        deletePrompt.open()
     }
 
-    // Dimmed backdrop
+    function doDelete() {
+        var ids = []
+        for (var k in checked) if (checked[k]) ids.push(parseInt(k))
+        var removed = 0
+        try { removed = MotionInterface.deleteScans(ids) } catch (e) {}
+        console.warn("[History] deleted " + removed + " scan(s)")
+        MotionInterface.notify(removed + " scan(s) deleted", "success")
+        refresh()
+    }
+
+    function formatDuration(sec) {
+        if (sec === undefined || sec === null || sec < 0) return "—"
+        var m = Math.floor(sec / 60)
+        var s = Math.round(sec % 60)
+        return m + ":" + (s < 10 ? "0" + s : s)
+    }
+
+    // Re-filter whenever the search/config filter changes.
+    onSearchTextChanged: rebuildView()
+    onConfigFilterChanged: rebuildView()
+
+    // ── backdrop ───────────────────────────────────────────────────
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
         MouseArea { anchors.fill: parent; onClicked: root.close() }
     }
 
+    // Shared column widths (header + rows stay aligned).
+    QtObject {
+        id: col
+        readonly property int chk: 34
+        readonly property int date: 150
+        readonly property int config: 160
+        readonly property int dur: 70
+        readonly property int status: 28
+    }
+
     Rectangle {
-        width: Math.min(parent.width - 80, 900)
-        height: Math.min(parent.height - 80, 600)
+        width: Math.min(parent.width - 60, 960)
+        height: Math.min(parent.height - 60, 680)
         radius: 12
         color: theme.bgContainer
         border.color: theme.borderSubtle
         border.width: 2
         anchors.centerIn: parent
 
-        // Absorb empty-space clicks inside the modal so they don't
-        // propagate to the backdrop and close the modal (issue #106).
+        // Absorb empty-space clicks so they don't reach the backdrop.
         MouseArea { anchors.fill: parent }
-
-        // X close button
-        Rectangle {
-            width: 28; height: 28; radius: 14
-            color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
-            border.color: theme.borderHover; border.width: 1
-            anchors.top: parent.top; anchors.right: parent.right
-            anchors.topMargin: 10; anchors.rightMargin: 10
-            z: 10
-            Behavior on color { ColorAnimation { duration: 120 } }
-            Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
-            MouseArea {
-                id: xArea; anchors.fill: parent; hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onClicked: { console.warn("[History] close (✕) clicked"); root.close() }
-            }
-        }
 
         ColumnLayout {
             anchors.fill: parent
-            anchors.margins: 20
+            anchors.margins: 18
             spacing: 12
 
-            // Header
+            // ── toolbar ────────────────────────────────────────────
             RowLayout {
                 Layout.fillWidth: true
-                spacing: 12
+                spacing: 10
 
                 Text {
                     text: root.label
-                    font.pixelSize: 20
-                    font.weight: Font.Bold
+                    font.pixelSize: 20; font.weight: Font.Bold
                     color: theme.textPrimary
                 }
+                Item { Layout.preferredWidth: 8 }
+
+                TextField {
+                    id: searchField
+                    Layout.preferredWidth: 200
+                    Layout.preferredHeight: 32
+                    placeholderText: "Search label…"
+                    color: theme.textPrimary
+                    placeholderTextColor: theme.textSecondary
+                    font.pixelSize: 13
+                    leftPadding: 10; rightPadding: 10
+                    verticalAlignment: TextInput.AlignVCenter
+                    background: Rectangle {
+                        color: theme.bgInput; radius: 4
+                        border.color: searchField.activeFocus ? theme.accentBlue : theme.borderSubtle
+                        border.width: 1
+                    }
+                    onTextChanged: root.searchText = text
+                }
+
+                ComboBox {
+                    id: configBox
+                    Layout.preferredWidth: 130
+                    Layout.preferredHeight: 32
+                    model: ["All", "Near", "Middle", "Far", "Outer",
+                            "Left", "Right", "Third Row", "None"]
+                    font.pixelSize: 13
+                    contentItem: Text {
+                        leftPadding: 10; text: configBox.displayText
+                        font: configBox.font; color: theme.textPrimary
+                        verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
+                    }
+                    background: Rectangle {
+                        color: theme.bgInput; radius: 4
+                        border.color: theme.borderSubtle; border.width: 1
+                    }
+                    onCurrentTextChanged: root.configFilter = currentText
+                }
+
                 Item { Layout.fillWidth: true }
 
                 Button {
                     text: "Open Folder"
-                    Layout.preferredWidth: 110
-                    Layout.preferredHeight: 32
+                    Layout.preferredWidth: 100; Layout.preferredHeight: 32
                     hoverEnabled: true
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13; color: theme.textSecondary
@@ -140,16 +230,11 @@ Item {
                         color: parent.hovered ? theme.accentBlue : theme.bgInput
                         border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                     }
-                    onClicked: {
-                        console.warn("[History] Open Folder clicked → " + MotionInterface.directory)
-                        Qt.openUrlExternally("file:///" + MotionInterface.directory)
-                    }
+                    onClicked: Qt.openUrlExternally("file:///" + MotionInterface.directory)
                 }
-
                 Button {
                     text: "Refresh"
-                    Layout.preferredWidth: 90
-                    Layout.preferredHeight: 32
+                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
                     hoverEnabled: true
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13; color: theme.textSecondary
@@ -159,241 +244,291 @@ Item {
                         color: parent.hovered ? theme.accentBlue : theme.bgInput
                         border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
                     }
-                    onClicked: {
-                        console.warn("[History] Refresh clicked")
-                        refreshScans()
+                    onClicked: root.refresh()
+                }
+                Rectangle {
+                    width: 28; height: 28; radius: 14
+                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
+                    border.color: theme.borderHover; border.width: 1
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    MouseArea {
+                        id: xArea; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor; onClicked: root.close()
                     }
                 }
             }
 
-            // Data directory
-            RowLayout {
-                Layout.fillWidth: true; spacing: 8
-                Text { text: "Data Directory:"; color: theme.textSecondary; font.pixelSize: 13 }
-                Text { text: MotionInterface.directory; color: theme.textPrimary; font.pixelSize: 13; elide: Text.ElideRight; Layout.fillWidth: true }
-            }
-
-            // Scan selector
-            RowLayout {
-                Layout.fillWidth: true; spacing: 12
-                Text { text: "Scan:"; color: theme.textSecondary; font.pixelSize: 14 }
-                ComboBox {
-                    id: scanPicker
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 36
-                    model: scans
-                    font.pixelSize: 13
-                    contentItem: Text {
-                        leftPadding: 10
-                        text: scanPicker.displayText
-                        font: scanPicker.font
-                        color: theme.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        elide: Text.ElideRight
-                    }
-                    background: Rectangle {
-                        color: theme.bgInput
-                        radius: 4
-                        border.color: scanPicker.activeFocus ? theme.accentBlue : theme.borderSubtle
-                        border.width: 1
-                    }
-                    indicator: Text {
-                        x: scanPicker.width - width - 10
-                        y: (scanPicker.height - height) / 2
-                        text: "\u25BE"
-                        font.pixelSize: 14
-                        color: theme.textSecondary
-                    }
-                    delegate: ItemDelegate {
-                        width: scanPicker.width
-                        height: 32
-                        contentItem: Text {
-                            text: modelData
-                            font.pixelSize: 13
-                            color: theme.textPrimary
-                            verticalAlignment: Text.AlignVCenter
-                            leftPadding: 8
-                        }
-                        background: Rectangle {
-                            color: highlighted ? theme.accentBlue : "transparent"
-                        }
-                        highlighted: scanPicker.highlightedIndex === index
-                    }
-                    popup: Popup {
-                        y: scanPicker.height
-                        width: scanPicker.width
-                        implicitHeight: contentItem.implicitHeight + 2
-                        padding: 1
-                        contentItem: ListView {
-                            clip: true
-                            implicitHeight: contentHeight
-                            model: scanPicker.delegateModel
-                            ScrollIndicator.vertical: ScrollIndicator {}
-                        }
-                        background: Rectangle {
-                            color: theme.bgCard
-                            radius: 4
-                            border.color: theme.borderSubtle
-                            border.width: 1
-                        }
-                    }
-                    onCurrentIndexChanged: {
-                        if (currentIndex >= 0 && currentIndex < scans.length) {
-                            console.warn("[History] scan selected [" + currentIndex + "] " + scans[currentIndex])
-                            try { selected = MotionInterface.get_scan_details(scans[currentIndex]) || {} }
-                            catch (e) { selected = {} }
-                        } else { selected = {} }
-                    }
-                }
-            }
-
-            // Details
+            // ── table header ───────────────────────────────────────
             Rectangle {
                 Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: 8; color: theme.bgCardAlt
+                Layout.preferredHeight: 30
+                color: theme.bgCardAlt; radius: 4
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                    spacing: 8
+
+                    // Select-all checkbox.
+                    Text {
+                        Layout.preferredWidth: col.chk
+                        text: (root.checkedCount > 0 && root.checkedCount === root.view.length) ? "☑" : "☐"
+                        color: theme.textSecondary; font.pixelSize: 15
+                        horizontalAlignment: Text.AlignHCenter
+                        MouseArea {
+                            anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                            onClicked: root.setAllChecked(
+                                !(root.checkedCount > 0 && root.checkedCount === root.view.length))
+                        }
+                    }
+                    HistoryHeaderCell {
+                        text: "User Label"; sortName: "userLabel"; Layout.fillWidth: true
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    HistoryHeaderCell {
+                        text: "Date / Time"; sortName: "timestamp"; Layout.preferredWidth: col.date
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    HistoryHeaderCell {
+                        text: "Config (L / R)"; sortName: "configL"; Layout.preferredWidth: col.config
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    HistoryHeaderCell {
+                        text: "Duration"; sortName: "durationSec"; Layout.preferredWidth: col.dur
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    Item { Layout.preferredWidth: col.status }
+                }
+            }
+
+            // ── table body ─────────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true; Layout.fillHeight: true
+                radius: 6; color: theme.bgCardAlt
                 border.color: theme.borderSubtle; border.width: 1
+                clip: true
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    model: root.view
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Rectangle {
+                        width: ListView.view.width
+                        height: 34
+                        color: modelData.sessionId === root.focusedSessionId
+                               ? Qt.rgba(0.31, 0.55, 1.0, 0.16)
+                               : (root.checked[modelData.sessionId]
+                                  ? Qt.rgba(0.31, 0.55, 1.0, 0.07) : "transparent")
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.focusRow(modelData.sessionId)
+                        }
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 8
+                            spacing: 8
+
+                            Text {
+                                Layout.preferredWidth: col.chk
+                                text: root.checked[modelData.sessionId] ? "☑" : "☐"
+                                color: theme.textPrimary; font.pixelSize: 15
+                                horizontalAlignment: Text.AlignHCenter
+                                MouseArea {
+                                    anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                                    onClicked: function(mouse) {
+                                        root.toggleCheck(modelData.sessionId); mouse.accepted = true
+                                    }
+                                }
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.userLabel || "(unlabeled)"
+                                color: theme.textPrimary; font.pixelSize: 13
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.date
+                                text: modelData.dateTime || "-"
+                                color: theme.textSecondary; font.pixelSize: 13
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.config
+                                text: (modelData.configL || "—") + " / " + (modelData.configR || "—")
+                                color: theme.textSecondary; font.pixelSize: 13
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.dur
+                                text: root.formatDuration(modelData.durationSec)
+                                color: theme.textSecondary; font.pixelSize: 13
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.status
+                                text: modelData.interrupted ? "⚠" : "●"
+                                color: modelData.interrupted ? "#E6A23C" : "#3EC97A"
+                                font.pixelSize: 13
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+
+                    // Empty state.
+                    Text {
+                        anchors.centerIn: parent
+                        visible: root.view.length === 0
+                        text: root.scans.length === 0 ? "No scans yet."
+                                                      : "No scans match the filter."
+                        color: theme.textSecondary; font.pixelSize: 14
+                    }
+                }
+            }
+
+            // ── detail pane (focused row, read-only) ───────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 150
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                visible: root.focusedRow !== null
 
                 RowLayout {
-                    anchors.fill: parent; anchors.margins: 12; spacing: 12
+                    anchors.fill: parent; anchors.margins: 12; spacing: 16
 
-                    // Metadata + Notes
-                    ColumnLayout {
-                        Layout.fillWidth: true; Layout.fillHeight: true
-                        spacing: 8
-
-                        GridLayout {
-                            columns: 4; columnSpacing: 16; rowSpacing: 6; Layout.fillWidth: true
-                            Text { text: "User Label:"; color: theme.textSecondary; font.pixelSize: 13 }
-                            Text { text: selected.userLabel || "-"; color: theme.textPrimary; font.pixelSize: 13 }
-                            Text { text: "Date:"; color: theme.textSecondary; font.pixelSize: 13 }
-                            Text { text: selected.timestamp ? friendlyDate(selected.timestamp) : "-"; color: theme.textPrimary; font.pixelSize: 13 }
-
-                            Text { text: "Left File:"; color: theme.textSecondary; font.pixelSize: 13 }
-                            Text { text: basename(selected.leftPath) || "(none)"; color: theme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
-                            Text { text: "Mask:"; color: theme.textSecondary; font.pixelSize: 13 }
-                            Text { text: formatMasks(selected.leftMask, selected.rightMask); color: theme.textPrimary; font.pixelSize: 13 }
-
-                            Text { text: "Right File:"; color: theme.textSecondary; font.pixelSize: 13 }
-                            Text { text: basename(selected.rightPath) || "(none)"; color: theme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
-                            Text { text: ""; } Text { text: ""; }
-                        }
-
-                        // Interrupted-scan banner (empty scans used to load blank).
-                        // hasData === false only when the connector explicitly
-                        // reported no rows/CSV; undefined (legacy details) stays hidden.
+                    GridLayout {
+                        columns: 2; columnSpacing: 14; rowSpacing: 4
+                        Layout.preferredWidth: 320
+                        Layout.alignment: Qt.AlignTop
+                        Text { text: "Full label:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? root.focusedRow.label : ""; color: theme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
+                        Text { text: "Operator:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? (root.focusedRow.operator || "-") : ""; color: theme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Mask (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
                         Text {
-                            visible: selected.hasData === false
-                            Layout.fillWidth: true
-                            wrapMode: Text.Wrap
-                            text: "⚠ No data recorded — this scan was interrupted "
-                                  + "before any data could be saved."
-                            color: "#E67E22"
-                            font.pixelSize: 13
-                            font.weight: Font.Bold
+                            color: theme.textPrimary; font.pixelSize: 12
+                            text: root.focusedRow
+                                  ? ("0x" + (root.focusedRow.leftMask & 0xFF).toString(16).toUpperCase()
+                                     + " / 0x" + (root.focusedRow.rightMask & 0xFF).toString(16).toUpperCase())
+                                  : ""
                         }
+                        Text { text: "Config (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? (root.focusedRow.configL + " / " + root.focusedRow.configR) : ""; color: theme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Samples:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text {
+                            color: theme.textPrimary; font.pixelSize: 12
+                            text: root.focusedSampleCount < 0 ? "…" : root.focusedSampleCount.toLocaleString()
+                        }
+                    }
 
-                        Text { text: "Notes:"; color: theme.textSecondary; font.pixelSize: 13 }
+                    ColumnLayout {
+                        Layout.fillWidth: true; Layout.fillHeight: true; spacing: 4
+                        Text { text: "Notes (read-only):"; color: theme.textSecondary; font.pixelSize: 12 }
                         Rectangle {
                             Layout.fillWidth: true; Layout.fillHeight: true
-                            radius: 4; color: theme.bgInput; border.color: theme.borderSubtle; border.width: 1
+                            radius: 4; color: theme.bgInput
+                            border.color: theme.borderSubtle; border.width: 1
                             ScrollView {
-                                anchors.fill: parent
+                                anchors.fill: parent; anchors.margins: 2
                                 TextArea {
-                                    readOnly: true; wrapMode: Text.Wrap
-                                    text: selected.notes || ""; color: theme.textPrimary; font.pixelSize: 13; background: null
+                                    readOnly: true; wrapMode: Text.Wrap; background: null
+                                    text: root.focusedRow ? (root.focusedRow.notes || "") : ""
+                                    color: theme.textPrimary; font.pixelSize: 12
                                 }
                             }
                         }
                     }
-
-                    // Actions
-                    ColumnLayout {
-                        Layout.preferredWidth: 200; Layout.fillHeight: true; spacing: 10
-
-                        Text { text: "Actions"; color: theme.textPrimary; font.pixelSize: 15 }
-
-                        // Opens the past scan inside the BloodFlow page's
-                        // PlotViewer (the matplotlib popout buttons that
-                        // lived here died with the legacy plots).
-                        Button {
-                            text: "View in plot →"
-                            Layout.fillWidth: true; Layout.preferredHeight: 36
-                            // `currentIndex` lives on scanPicker (the ComboBox)
-                            // — referencing it bare here resolves to undefined
-                            // at the root scope and `undefined >= 0` is false,
-                            // which left this button perma-greyed.
-                            enabled: scans.length > 0 && scanPicker.currentIndex >= 0
-                                     && selected.hasData !== false
-                            hoverEnabled: enabled
-                            contentItem: Text {
-                                text: parent.text; font.pixelSize: 13
-                                color: parent.enabled ? theme.textSecondary : theme.textTertiary
-                                horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
-                            }
-                            background: Rectangle {
-                                color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
-                                border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
-                            }
-                            onClicked: {
-                                console.warn("[History] View in plot → clicked → " + (scans[scanPicker.currentIndex] || "?"))
-                                // Async load (issue #152): the heavy DB/CSV walk runs on a
-                                // worker thread. Show the busy overlay and keep the modal
-                                // open; onPastScanLoadFinished clears it and closes the
-                                // modal only when the scan actually loaded.
-                                root.loadingPlot = true
-                                MotionInterface.loadPastScan(scans[scanPicker.currentIndex] || "")
-                            }
-                        }
-
-                        Button {
-                            text: "Export CSV"
-                            Layout.fillWidth: true; Layout.preferredHeight: 36
-                            enabled: scans.length > 0 && scanPicker.currentIndex >= 0
-                                     && selected.hasData !== false
-                            hoverEnabled: enabled
-                            contentItem: Text {
-                                text: parent.text; font.pixelSize: 13
-                                color: parent.enabled ? theme.textSecondary : theme.textTertiary
-                                horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
-                            }
-                            background: Rectangle {
-                                color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
-                                border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
-                            }
-                            onClicked: {
-                                var scanId = scans[scanPicker.currentIndex] || ""
-                                console.warn("[History] Export CSV clicked → " + scanId)
-                                exportDialog.selectedScanId = scanId
-                                exportDialog.selectedFile = "file:///" + MotionInterface.directory + "/" + scanId + "_export.csv"
-                                exportDialog.open()
-                            }
-                        }
-
-                        Item { Layout.fillHeight: true }
-                    }
                 }
             }
 
-        }
+            // ── actions ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true; spacing: 10
 
-        Dialogs.FileDialog {
-            id: exportDialog
-            title: "Export Scan CSV"
-            fileMode: Dialogs.FileDialog.SaveFile
-            nameFilters: ["CSV files (*.csv)", "All files (*)"]
-            property string selectedScanId: ""
-            onAccepted: {
-                var path = selectedFile.toString().replace("file:///", "")
-                console.warn("[History] exporting " + selectedScanId + " → " + path)
-                var ok = MotionInterface.exportScanCsv(selectedScanId, path)
-                if (ok) MotionInterface.notify("Exported to " + path, "success")
+                Text {
+                    text: root.checkedCount > 0 ? (root.checkedCount + " selected") : ""
+                    color: theme.textSecondary; font.pixelSize: 12
+                }
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Load in viewer →"
+                    Layout.preferredWidth: 140; Layout.preferredHeight: 34
+                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: parent.enabled ? theme.textSecondary : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        root.loadingPlot = true
+                        MotionInterface.loadPastScan(root.focusedRow.label)
+                    }
+                }
+                Button {
+                    text: "Export CSV"
+                    Layout.preferredWidth: 110; Layout.preferredHeight: 34
+                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: parent.enabled ? theme.textSecondary : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        exportDialog.selectedScanId = root.focusedRow.label
+                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                                    + "/" + root.focusedRow.label + "_export.csv"
+                        exportDialog.open()
+                    }
+                }
+                Button {
+                    text: "🔒 Delete" + (root.checkedCount > 0 ? " (" + root.checkedCount + ")" : "")
+                    Layout.preferredWidth: 120; Layout.preferredHeight: 34
+                    // Don't allow deleting while a scan is running (could be the
+                    // in-flight session).
+                    enabled: root.checkedCount > 0 && MotionInterface.state !== 4
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: parent.enabled ? "#E8786A" : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered && parent.enabled ? "#3A1714" : theme.bgInput
+                        border.color: parent.enabled ? "#C0392B" : theme.textTertiary; radius: 4
+                    }
+                    onClicked: root.requestDelete()
+                }
             }
         }
 
-        // Busy overlay while an async "View in plot" load is in flight
-        // (issue #152). Blocks clicks on the panel so the selection can't
-        // change under the in-flight load.
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+
+        // Busy overlay while "Load in viewer" is in flight.
         Rectangle {
             anchors.fill: parent; color: "#000"; opacity: 0.45
             visible: root.loadingPlot; z: 9999; radius: 12
@@ -404,32 +539,40 @@ Item {
                 Text { text: "Loading scan..."; color: theme.textPrimary; font.pixelSize: 14 }
             }
         }
+    }
 
-        // Match the other modals (SettingsModal, ScanSettingsModal):
-        // Escape closes. Without this, ``pyautogui.press('escape')`` is
-        // a no-op for History, which left the modal stuck open between
-        // tests and broke test_history.test_02 in confusing ways.
-        Keys.onReleased: function(event) {
-            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+    // Reused developer-password prompt for delete confirmation.
+    PasswordPromptModal {
+        id: deletePrompt
+        title: "Confirm Delete"
+        description: "Enter the developer password to permanently delete the "
+                     + "selected scan(s) from the database. This cannot be undone."
+        confirmLabel: "Delete"
+        onAccepted: root.doDelete()
+    }
+
+    Dialogs.FileDialog {
+        id: exportDialog
+        title: "Export Scan CSV"
+        fileMode: Dialogs.FileDialog.SaveFile
+        nameFilters: ["CSV files (*.csv)", "All files (*)"]
+        property string selectedScanId: ""
+        onAccepted: {
+            var path = selectedFile.toString().replace("file:///", "")
+            var ok = MotionInterface.exportScanCsv(selectedScanId, path)
+            if (ok) MotionInterface.notify("Exported to " + path, "success")
         }
     }
 
-    Dialogs.MessageDialog {
-        id: histErrDialog
-        title: "Error"
-        text: ""
-    }
+    Dialogs.MessageDialog { id: histErrDialog; title: "Error"; text: "" }
 
     Connections {
         target: MotionInterface
-        // Async "View in plot" completion (issue #152). On success the
-        // modal closes to reveal the PlotViewer; on failure it stays
-        // open (onErrorOccurred below pops the error dialog).
         function onPastScanLoadFinished(label, ok) {
             root.loadingPlot = false
             if (ok) root.close()
         }
-        function onDirectoryChanged() { if (root.visible) refreshScans() }
+        function onDirectoryChanged() { if (root.visible) root.refresh() }
         function onErrorOccurred(msg) {
             root.loadingPlot = false
             histErrDialog.text = msg || "Unknown error."

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -55,7 +55,13 @@ Item {
     function rebuildView() {
         var q = (searchText || "").toLowerCase()
         var cfg = configFilter
+        // In reduced (clinical) mode, omit scans not shot in reduced mode —
+        // the reduced viewer can't render their per-camera data. Dev mode
+        // lists everything. A scan with no recorded mode counts as non-reduced.
+        var appReduced = MotionInterface.appConfig.reducedMode === true
         var arr = scans.filter(function(r) {
+            if (appReduced && !r.reducedMode)
+                return false
             if (q.length > 0
                 && (r.userLabel || "").toLowerCase().indexOf(q) < 0
                 && (r.label || "").toLowerCase().indexOf(q) < 0)
@@ -581,6 +587,9 @@ Item {
             if (ok) root.close()
         }
         function onDirectoryChanged() { if (root.visible) root.refresh() }
+        // Re-apply the reduced-mode row filter if the app's mode changes
+        // while History is open.
+        function onAppConfigChanged() { if (root.visible) root.rebuildView() }
         function onErrorOccurred(msg) {
             root.loadingPlot = false
             histErrDialog.text = msg || "Unknown error."

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -129,6 +129,14 @@ Item {
         return m + ":" + (s < 10 ? "0" + s : s)
     }
 
+    // Format an 8-bit mask as "0xNN", or "—" when unknown (< 0). Keeps the
+    // detail pane consistent with the Config cell, which also shows "—" for
+    // an unknown mask (a -1 rendered as 0xFF would misread as "All").
+    function maskLabel(m) {
+        if (m === undefined || m === null || m < 0) return "—"
+        return "0x" + (m & 0xFF).toString(16).toUpperCase()
+    }
+
     // Re-filter whenever the search/config filter changes.
     onSearchTextChanged: rebuildView()
     onConfigFilterChanged: rebuildView()
@@ -420,8 +428,8 @@ Item {
                         Text {
                             color: theme.textPrimary; font.pixelSize: 12
                             text: root.focusedRow
-                                  ? ("0x" + (root.focusedRow.leftMask & 0xFF).toString(16).toUpperCase()
-                                     + " / 0x" + (root.focusedRow.rightMask & 0xFF).toString(16).toUpperCase())
+                                  ? (root.maskLabel(root.focusedRow.leftMask)
+                                     + " / " + root.maskLabel(root.focusedRow.rightMask))
                                   : ""
                         }
                         Text { text: "Config (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -69,7 +69,7 @@ Rectangle {
     // Per-cell top-left value labels. Default off in reduced mode — the
     // large side panels show the same numbers there — and toggleable at
     // runtime from the bottom-right ⋯ popup.
-    property bool showCellValues: !viewer.reducedMode
+    property bool showCellValues: !viewer.effectiveReduced
     // Y-axis tick labels (max/mid/min per metric). Config is the single
     // source of truth: the ⋯ popup toggle (hidden in reduced mode) writes
     // through MotionInterface.setConfig, which persists to app_config.json
@@ -173,6 +173,17 @@ Rectangle {
          && viewer.scanSource.rightMask >= 0)
             ? viewer.scanSource.rightMask : viewer.rightMask
 
+    // Replay adopts the loaded scan's recorded mode: when the source reports a
+    // known mode (reducedMode >= 0) use it, else fall back to the live-config
+    // `reducedMode` input. Mirrors _effLeftMask/_effRightMask (#175). Note:
+    // scanSource.reducedMode is an int tri-state (-1/0/1) from Python;
+    // viewer.reducedMode is the bool live-config input.
+    readonly property bool effectiveReduced:
+        (viewer.scanSource && viewer.scanSource.reducedMode !== undefined
+         && viewer.scanSource.reducedMode >= 0)
+            ? (viewer.scanSource.reducedMode === 1)
+            : viewer.reducedMode
+
     // ── Grid model ─────────────────────────────────────────────────────
     // Dev mode (default) — one cell per active camera (bits set in
     // leftMask / rightMask), arranged to mirror the physical U-shape of
@@ -218,7 +229,7 @@ Rectangle {
         { side: "right", camId: -1, row: 1, col: 0 }
     ]
 
-    readonly property var _activeCellModel: viewer.reducedMode
+    readonly property var _activeCellModel: viewer.effectiveReduced
         ? _reducedCellModel
         : _devCellModel
 
@@ -646,7 +657,7 @@ Rectangle {
             // nested layouts default it to true, which would make this
             // column compete with the grid for the whole row width.
             ColumnLayout {
-                visible: viewer.reducedMode
+                visible: viewer.effectiveReduced
                 Layout.fillWidth: false
                 Layout.fillHeight: true
                 Layout.preferredWidth: 250
@@ -671,7 +682,7 @@ Rectangle {
                 Layout.fillHeight: true
                 // Reduced mode: single column, 2 stacked cells. Dev mode:
                 // 4 columns, rows determined by active-cam count.
-                columns: viewer.reducedMode ? 1 : 4
+                columns: viewer.effectiveReduced ? 1 : 4
                 rowSpacing: 6
                 columnSpacing: 6
 
@@ -1014,7 +1025,7 @@ Rectangle {
             // autoscale) are hidden and Cell values is gone, leaving the
             // dev-only Profiler as the sole possible entry. Hide the
             // button entirely when it would open an empty card.
-            visible: !viewer.reducedMode
+            visible: !viewer.effectiveReduced
                      || MotionInterface.appConfig.developerMode === true
             width: 36
             height: 36
@@ -1093,7 +1104,7 @@ Rectangle {
                         // Hidden in reduced (clinical) mode — that view only
                         // ever shows the BFI/BVI side averages, so the
                         // Mean/Contrast alternative isn't offered there.
-                        visible: !viewer.reducedMode
+                        visible: !viewer.effectiveReduced
                         spacing: 8
                         PopupPillSwitch {
                             id: bfiBviSwitch
@@ -1112,7 +1123,7 @@ Rectangle {
                         // Hidden in reduced (clinical) mode — autoscale is
                         // not offered there; the view always uses the
                         // configured manual bounds.
-                        visible: !viewer.reducedMode
+                        visible: !viewer.effectiveReduced
                         spacing: 8
                         PopupPillSwitch {
                             id: autoScaleSwitch
@@ -1128,7 +1139,7 @@ Rectangle {
                         }
                     }
                     Row {
-                        visible: !viewer.reducedMode
+                        visible: !viewer.effectiveReduced
                         spacing: 8
                         PopupPillSwitch {
                             id: axisLabelsSwitch

--- a/data_sources.py
+++ b/data_sources.py
@@ -269,6 +269,10 @@ class ScanDataSource(QObject):
         # #175) so its grid doesn't inherit the current selection.
         self._left_mask: int = -1
         self._right_mask: int = -1
+        # Recorded display mode, tri-state: -1 unknown / 0 per-camera / 1
+        # reduced. -1 for live sources (viewer follows the live config);
+        # PastScanSource derives the real value from its buffer layout.
+        self._reduced_mode: int = -1
         self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
         # Ring-trim threshold for buffers this source creates. Live sources
         # pass a finite value (config) to bound memory; past sources pass None
@@ -315,6 +319,14 @@ class ScanDataSource(QObject):
         """Right-sensor camera mask this source represents, or -1 if unknown.
         See ``leftMask``."""
         return self._right_mask
+
+    @pyqtProperty(int, constant=True)
+    def reducedMode(self) -> int:
+        """Recorded display mode this source represents: -1 unknown, 0
+        per-camera, 1 reduced. Exposed for QML (PlotViewer.effectiveReduced)
+        so a replayed scan renders in its own mode rather than the live config.
+        See ``leftMask`` for why this must be a pyqtProperty."""
+        return self._reduced_mode
 
     @pyqtProperty(float)
     def liveEdge(self) -> float:
@@ -923,6 +935,21 @@ def _derive_masks_from_buffers(buffers: dict) -> tuple[int, int]:
     return masks["left"], masks["right"]
 
 
+def _derive_reduced_from_buffers(buffers) -> int:
+    """Tri-state recorded display mode from a loaded scan's buffer cam_ids:
+    -1 unknown, 0 per-camera, 1 reduced. Reduced-mode scans store only the
+    cam_id=-1 side average; per-camera (dev) scans store cam_id 0..7. Mirrors
+    _derive_masks_from_buffers — the viewer prefers this over the live config
+    so replay renders in the mode the scan was captured in."""
+    if buffers_are_empty(buffers):
+        return -1
+    if any(0 <= key[1] < 8 for key in buffers):
+        return 0
+    if any(key[1] == -1 for key in buffers):
+        return 1
+    return -1
+
+
 def load_past_scan_buffers(
     scan_db,
     session_id: int,
@@ -991,3 +1018,4 @@ class PastScanSource(ScanDataSource):
         self._left_mask, self._right_mask = _derive_masks_from_buffers(
             self.buffers
         )
+        self._reduced_mode = _derive_reduced_from_buffers(self.buffers)

--- a/docs/superpowers/plans/2026-06-15-history-data-management.md
+++ b/docs/superpowers/plans/2026-06-15-history-data-management.md
@@ -1,0 +1,1221 @@
+# History Data-Management Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the History modal into a sortable, searchable, multi-select table of scans driven entirely by the scan DB, with Load / Export / password-gated Delete.
+
+**Architecture:** New DB-only connector slots (`get_scan_sessions`, `get_session_stats`, `deleteScans`) read the `sessions` table and the `session_meta` JSON the SDK already writes; the camera-config name mapping is computed in Python so it's unit-testable. `HistoryModal.qml` is rebuilt around a header + `ListView` table with multiselect checkboxes, a read-only detail pane, and actions; Delete reuses the existing `PasswordPromptModal` (developer password). No SDK changes.
+
+**Tech Stack:** Python 3.13, PyQt6, QML (QtQuick 6), pytest, SQLite (omotion `ScanDatabase`).
+
+**Spec:** [docs/superpowers/specs/2026-06-15-history-data-management-design.md](../specs/2026-06-15-history-data-management-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `motion_connector.py` — add module-level `_CONFIG_NAMES` + `_config_name()`, and three `@pyqtSlot`s + one private `_session_to_row()` helper, inserted right after `get_scan_details` (ends ~line 1559, before the `directory` property at ~1561). The existing `get_scan_list` / `get_scan_details` stay (still used by `loadPastScan` and `test_scan_history_list.py`).
+- **Create** `tests/test_history_sessions.py` — unit tests (no hardware) for the three new slots + the config-name helper.
+- **Rewrite** `components/HistoryModal.qml` — table UI. Same root contract (`label`, `open()`, `close()`, `visible`, busy overlay, `MotionInterface` `Connections`) so `ModalManager` and `BloodFlow.qml` need no changes.
+- **Modify** `tests/test_history.py` — HIL (`@pytest.mark.dev`) UI test; update for the new table (no ComboBox; "Load in viewer →" button). **Cannot be validated in this environment — requires the self-hosted hardware runner.**
+
+---
+
+## Task 1: Connector — `get_scan_sessions()` + config-name helper
+
+**Files:**
+- Modify: `motion_connector.py` (module-level helper near other module helpers ~line 75; `_session_to_row` + `get_scan_sessions` after `get_scan_details` ~line 1559)
+- Test: `tests/test_history_sessions.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_history_sessions.py`:
+
+```python
+"""History data-management connector slots — DB-only, no hardware."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector, _config_name
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _make_session(db_path, label, start, end, left_mask, right_mask,
+                  reduced=True, notes=None, subject=None, operator="ethan"):
+    # Default the subject_id to the label's trailing user-label segment so
+    # rows carry distinct userLabels (matches how scans are really named).
+    if subject is None:
+        parts = label.split("_", 2)
+        subject = parts[2] if len(parts) > 2 else ""
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(
+        session_label=label, session_start=start, session_end=end,
+        session_notes=notes,
+        session_meta={
+            "scan_id": label.rsplit("_", 1)[0], "subject_id": subject,
+            "operator": operator, "duration_sec": (end - start) if end else 0,
+            "sdk_flags": {
+                "reduced_mode": reduced,
+                "left_camera_mask": left_mask,
+                "right_camera_mask": right_mask,
+            },
+        },
+    )
+    db.close()
+    return sid
+
+
+def test_config_name_known_and_unknown():
+    assert _config_name(0x5A) == "Near"
+    assert _config_name(0xC3) == "Far"
+    assert _config_name(0x00) == "None"
+    assert _config_name(0x12) == "0x12"   # unmapped -> hex
+    assert _config_name(-1) == "—"        # unknown
+
+
+def test_get_scan_sessions_rows_and_sort(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _make_session(db_path, "20260612_093100_subjB", 200.0, 215.0, 0x5A, 0x66)
+    c = _connector(tmp_path, db_path)
+
+    rows = c.get_scan_sessions()
+    assert [r["userLabel"] for r in rows] == ["subjB", "subjA"]  # newest first
+    top = rows[0]
+    assert top["configL"] == "Near" and top["configR"] == "Middle"
+    assert top["durationSec"] == 15.0
+    assert top["leftMask"] == 0x5A and top["rightMask"] == 0x66
+    assert top["interrupted"] is False
+    assert top["dateTime"] == "2026-06-12 09:31:00"
+
+
+def test_get_scan_sessions_interrupted_open_session(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_100000_subjC", 300.0, None, 0xFF, 0xFF)
+    c = _connector(tmp_path, db_path)
+    row = c.get_scan_sessions()[0]
+    assert row["interrupted"] is True
+    assert row["durationSec"] == -1.0
+
+
+def test_get_scan_sessions_empty_without_db(tmp_path):
+    c = _connector(tmp_path, None)
+    assert c.get_scan_sessions() == []
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/test_history_sessions.py -v`
+Expected: FAIL — `ImportError: cannot import name '_config_name'` / `AttributeError: ... 'get_scan_sessions'`.
+
+- [ ] **Step 3: Add the module-level config-name helper**
+
+In `motion_connector.py`, just after the `developer_password_matches` function (~line 90, module scope — NOT inside the class), add:
+
+```python
+# Camera-mask → human config name, mirroring CameraSelectionModal's
+# pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
+# reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.
+_CONFIG_NAMES = {
+    0x00: "None", 0x5A: "Near", 0x66: "Middle", 0xC3: "Far",
+    0x99: "Outer", 0x0F: "Left", 0xF0: "Right", 0x42: "Third Row",
+    0xFF: "All",
+}
+
+
+def _config_name(mask) -> str:
+    if mask is None or mask < 0:
+        return "—"
+    m = int(mask) & 0xFF
+    return _CONFIG_NAMES.get(m, f"0x{m:02X}")
+```
+
+- [ ] **Step 4: Add `_session_to_row` + `get_scan_sessions`**
+
+In `motion_connector.py`, immediately after `get_scan_details` returns (~line 1559, before `@pyqtProperty(str, notify=directoryChanged) def directory`), add:
+
+```python
+    @staticmethod
+    def _friendly_ts(ts: str) -> str:
+        """'YYYYMMDD_HHMMSS' -> 'YYYY-MM-DD HH:MM:SS'; pass through otherwise."""
+        if not ts or len(ts) != 15:
+            return ts or "-"
+        return (f"{ts[0:4]}-{ts[4:6]}-{ts[6:8]} "
+                f"{ts[9:11]}:{ts[11:13]}:{ts[13:15]}")
+
+    def _session_to_row(self, s: dict) -> dict:
+        """Flatten one ScanDatabase session dict into the QVariantMap the
+        History table consumes. Masks/operator come from session_meta
+        (written by ScanDBSink); duration from session_start/end."""
+        label = (s.get("session_label") or "").strip()
+        meta = s.get("session_meta")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except Exception:
+                meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        flags = meta.get("sdk_flags") or {}
+
+        left_mask = flags.get("left_camera_mask", -1)
+        right_mask = flags.get("right_camera_mask", -1)
+        if left_mask is None:
+            left_mask = -1
+        if right_mask is None:
+            right_mask = -1
+
+        user_label = meta.get("subject_id") or ""
+        timestamp = ""
+        m = re.match(r"^(\d{8}_\d{6})_?(.*)$", label)
+        if m:
+            timestamp = m.group(1)
+            if not user_label:
+                user_label = m.group(2)
+
+        start = s.get("session_start")
+        end = s.get("session_end")
+        if start is not None and end is not None:
+            duration = float(end) - float(start)
+        else:
+            duration = -1.0
+
+        return {
+            "sessionId": int(s.get("id")),
+            "label": label,
+            "userLabel": user_label,
+            "operator": meta.get("operator") or "",
+            "timestamp": timestamp or label,
+            "dateTime": self._friendly_ts(timestamp),
+            "durationSec": duration,
+            "leftMask": int(left_mask),
+            "rightMask": int(right_mask),
+            "configL": _config_name(left_mask),
+            "configR": _config_name(right_mask),
+            "reducedMode": bool(flags.get("reduced_mode", False)),
+            "notes": s.get("session_notes") or "",
+            "interrupted": end is None,
+        }
+
+    @pyqtSlot(result="QVariantList")
+    def get_scan_sessions(self):
+        """Return one row per scan-DB session, newest first, for the
+        History table. DB-only — does not list CSV-derived scans.
+        Best-effort: a missing/unreadable DB yields []."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return []
+        rows = []
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for s in db.iter_sessions():
+                    rows.append(self._session_to_row(s))
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("get_scan_sessions: could not read scan DB",
+                           exc_info=True)
+            return []
+        rows.sort(key=lambda r: r["timestamp"], reverse=True)
+        return rows
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_history_sessions.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_history_sessions.py
+git commit -m "feat: add get_scan_sessions connector slot for History table"
+```
+
+---
+
+## Task 2: Connector — `get_session_stats()` + `deleteScans()`
+
+**Files:**
+- Modify: `motion_connector.py` (directly after `get_scan_sessions`)
+- Test: `tests/test_history_sessions.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_history_sessions.py`:
+
+```python
+def _insert_rows(db_path, session_id, n):
+    db = ScanDatabase(db_path=db_path)
+    for i in range(n):
+        db.insert_session_data(
+            session_id=session_id, cam_id=0, side=0,
+            timestamp_s=float(i), frame_id=i, bfi=1.0, bvi=2.0,
+        )
+    db.close()
+
+
+def test_get_session_stats_counts_rows(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sid = _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _insert_rows(db_path, sid, 7)
+    c = _connector(tmp_path, db_path)
+    assert c.get_session_stats(sid)["sampleCount"] == 7
+
+
+def test_delete_scans_removes_session_and_cascades(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    keep = _make_session(db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    drop = _make_session(db_path, "20260612_093000_drop", 200.0, 205.0, 0x5A, 0x5A)
+    _insert_rows(db_path, drop, 5)
+    c = _connector(tmp_path, db_path)
+
+    removed = c.deleteScans([drop])
+    assert removed == 1
+    remaining = [r["sessionId"] for r in c.get_scan_sessions()]
+    assert remaining == [keep]
+    # session_data cascade-deleted with the session
+    assert c.get_session_stats(drop)["sampleCount"] == 0
+
+
+def test_delete_scans_empty_list_is_noop(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    c = _connector(tmp_path, db_path)
+    assert c.deleteScans([]) == 0
+    assert len(c.get_scan_sessions()) == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/test_history_sessions.py -k "stats or delete" -v`
+Expected: FAIL — `AttributeError: ... 'get_session_stats'` / `'deleteScans'`.
+
+- [ ] **Step 3: Add the two slots**
+
+In `motion_connector.py`, immediately after `get_scan_sessions`, add:
+
+```python
+    @pyqtSlot(int, result="QVariantMap")
+    def get_session_stats(self, session_id: int):
+        """Lazily fetch heavier per-scan stats (row count) when a History
+        row is focused, so the list query itself stays cheap."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return {"sampleCount": 0}
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                row = next(
+                    db._connection().execute(
+                        "SELECT COUNT(*) FROM session_data WHERE session_id = ?",
+                        (int(session_id),),
+                    ),
+                    None,
+                )
+                return {"sampleCount": int(row[0]) if row else 0}
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("get_session_stats failed for %s", session_id,
+                           exc_info=True)
+            return {"sampleCount": 0}
+
+    @pyqtSlot("QVariantList", result=int)
+    def deleteScans(self, session_ids):
+        """Delete the given scan-DB sessions (CASCADE removes their
+        session_data). Returns the count actually deleted. The developer-
+        password gate is enforced in QML before this is called."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return 0
+        deleted = 0
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for sid in session_ids:
+                    try:
+                        if db.delete_session(int(sid)):
+                            deleted += 1
+                            logger.info("deleteScans: removed session %s", sid)
+                    except Exception:
+                        logger.warning("deleteScans: failed to delete %s", sid,
+                                       exc_info=True)
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("deleteScans: could not open scan DB", exc_info=True)
+        return deleted
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_history_sessions.py -v`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_history_sessions.py
+git commit -m "feat: add get_session_stats and deleteScans connector slots"
+```
+
+---
+
+## Task 3: Rewrite `HistoryModal.qml` as a table
+
+QML can't be unit-tested; verify by launching the app against a seeded DB and screenshotting (per the project's "QML changes need a visual check" rule). The root contract (`label`, `open()`, `close()`, busy overlay, `Connections`) is preserved so `BloodFlow.qml` / `ModalManager` are untouched.
+
+**Files:**
+- Rewrite: `components/HistoryModal.qml`
+
+- [ ] **Step 1: Replace the file contents**
+
+Overwrite `components/HistoryModal.qml` with:
+
+```qml
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import QtQuick.Dialogs as Dialogs
+import OpenMotion 1.0
+
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 9998
+
+    AppTheme { id: theme }
+
+    // Modal interface label (single source of truth — see ModalManager).
+    readonly property string label: "Scan History"
+
+    // Full session list from the connector (newest first).
+    property var scans: []
+    // Filtered + sorted view actually rendered.
+    property var view: []
+    // Multiselect membership: { sessionId: true }. Reassigned (not mutated)
+    // on every toggle so delegate bindings re-evaluate.
+    property var checked: ({})
+    property int checkedCount: 0
+    // Focused (detail-pane) row.
+    property int focusedSessionId: -1
+    property var focusedRow: null
+    property int focusedSampleCount: -1
+    // Toolbar filters / sort.
+    property string searchText: ""
+    property string configFilter: "All"
+    property string sortKey: "timestamp"
+    property bool sortAsc: false
+    // Async "Load in viewer" busy state (issue #152 pattern).
+    property bool loadingPlot: false
+
+    // ── data plumbing ──────────────────────────────────────────────
+    function open() {
+        refresh()
+        console.warn("[History] opened — " + scans.length + " scan(s)")
+        root.visible = true
+    }
+    function close() { root.visible = false }
+
+    function refresh() {
+        try { scans = MotionInterface.get_scan_sessions() || [] }
+        catch (e) { scans = [] }
+        checked = ({}); checkedCount = 0
+        rebuildView()
+        if (view.length > 0) focusRow(view[0].sessionId)
+        else { focusedSessionId = -1; focusedRow = null; focusedSampleCount = -1 }
+    }
+
+    function rebuildView() {
+        var q = (searchText || "").toLowerCase()
+        var cfg = configFilter
+        var arr = scans.filter(function(r) {
+            if (q.length > 0
+                && (r.userLabel || "").toLowerCase().indexOf(q) < 0
+                && (r.label || "").toLowerCase().indexOf(q) < 0)
+                return false
+            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
+                return false
+            return true
+        })
+        var key = sortKey, asc = sortAsc
+        arr.sort(function(a, b) {
+            var av = a[key], bv = b[key]
+            if (av === undefined || av === null) av = ""
+            if (bv === undefined || bv === null) bv = ""
+            if (av < bv) return asc ? -1 : 1
+            if (av > bv) return asc ? 1 : -1
+            return 0
+        })
+        view = arr
+    }
+
+    function setSort(key) {
+        if (sortKey === key) sortAsc = !sortAsc
+        else { sortKey = key; sortAsc = (key === "userLabel") }
+        rebuildView()
+    }
+
+    function focusRow(sid) {
+        focusedSessionId = sid
+        focusedRow = null
+        for (var i = 0; i < view.length; i++)
+            if (view[i].sessionId === sid) { focusedRow = view[i]; break }
+        focusedSampleCount = -1
+        if (sid >= 0) {
+            try { focusedSampleCount = MotionInterface.get_session_stats(sid).sampleCount }
+            catch (e) { focusedSampleCount = -1 }
+        }
+    }
+
+    function toggleCheck(sid) {
+        var c = Object.assign({}, checked)
+        if (c[sid]) { delete c[sid]; checkedCount -= 1 }
+        else { c[sid] = true; checkedCount += 1 }
+        checked = c
+    }
+
+    function setAllChecked(on) {
+        var c = {}, n = 0
+        if (on) for (var i = 0; i < view.length; i++) { c[view[i].sessionId] = true; n++ }
+        checked = c; checkedCount = n
+    }
+
+    function requestDelete() {
+        if (checkedCount <= 0) return
+        deletePrompt.open()
+    }
+
+    function doDelete() {
+        var ids = []
+        for (var k in checked) if (checked[k]) ids.push(parseInt(k))
+        var removed = 0
+        try { removed = MotionInterface.deleteScans(ids) } catch (e) {}
+        console.warn("[History] deleted " + removed + " scan(s)")
+        MotionInterface.notify(removed + " scan(s) deleted", "success")
+        refresh()
+    }
+
+    function formatDuration(sec) {
+        if (sec === undefined || sec === null || sec < 0) return "—"
+        var m = Math.floor(sec / 60)
+        var s = Math.round(sec % 60)
+        return m + ":" + (s < 10 ? "0" + s : s)
+    }
+
+    // Re-filter whenever the search/config filter changes.
+    onSearchTextChanged: rebuildView()
+    onConfigFilterChanged: rebuildView()
+
+    // ── backdrop ───────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000AA"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    // Shared column widths (header + rows stay aligned).
+    QtObject {
+        id: col
+        readonly property int chk: 34
+        readonly property int date: 150
+        readonly property int config: 160
+        readonly property int dur: 70
+        readonly property int status: 28
+    }
+
+    Rectangle {
+        width: Math.min(parent.width - 60, 960)
+        height: Math.min(parent.height - 60, 680)
+        radius: 12
+        color: theme.bgContainer
+        border.color: theme.borderSubtle
+        border.width: 2
+        anchors.centerIn: parent
+
+        // Absorb empty-space clicks so they don't reach the backdrop.
+        MouseArea { anchors.fill: parent }
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 18
+            spacing: 12
+
+            // ── toolbar ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                Text {
+                    text: root.label
+                    font.pixelSize: 20; font.weight: Font.Bold
+                    color: theme.textPrimary
+                }
+                Item { Layout.preferredWidth: 8 }
+
+                TextField {
+                    id: searchField
+                    Layout.preferredWidth: 200
+                    Layout.preferredHeight: 32
+                    placeholderText: "Search label…"
+                    color: theme.textPrimary
+                    placeholderTextColor: theme.textSecondary
+                    font.pixelSize: 13
+                    leftPadding: 10; rightPadding: 10
+                    verticalAlignment: TextInput.AlignVCenter
+                    background: Rectangle {
+                        color: theme.bgInput; radius: 4
+                        border.color: searchField.activeFocus ? theme.accentBlue : theme.borderSubtle
+                        border.width: 1
+                    }
+                    onTextChanged: root.searchText = text
+                }
+
+                ComboBox {
+                    id: configBox
+                    Layout.preferredWidth: 130
+                    Layout.preferredHeight: 32
+                    model: ["All", "Near", "Middle", "Far", "Outer",
+                            "Left", "Right", "Third Row", "None"]
+                    font.pixelSize: 13
+                    contentItem: Text {
+                        leftPadding: 10; text: configBox.displayText
+                        font: configBox.font; color: theme.textPrimary
+                        verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
+                    }
+                    background: Rectangle {
+                        color: theme.bgInput; radius: 4
+                        border.color: theme.borderSubtle; border.width: 1
+                    }
+                    onCurrentTextChanged: root.configFilter = currentText
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Open Folder"
+                    Layout.preferredWidth: 100; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: Qt.openUrlExternally("file:///" + MotionInterface.directory)
+                }
+                Button {
+                    text: "Refresh"
+                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: root.refresh()
+                }
+                Rectangle {
+                    width: 28; height: 28; radius: 14
+                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
+                    border.color: theme.borderHover; border.width: 1
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    MouseArea {
+                        id: xArea; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor; onClicked: root.close()
+                    }
+                }
+            }
+
+            // ── table header ───────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                color: theme.bgCardAlt; radius: 4
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                    spacing: 8
+
+                    // Select-all checkbox.
+                    Text {
+                        Layout.preferredWidth: col.chk
+                        text: (root.checkedCount > 0 && root.checkedCount === root.view.length) ? "☑" : "☐"
+                        color: theme.textSecondary; font.pixelSize: 15
+                        horizontalAlignment: Text.AlignHCenter
+                        MouseArea {
+                            anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                            onClicked: root.setAllChecked(
+                                !(root.checkedCount > 0 && root.checkedCount === root.view.length))
+                        }
+                    }
+                    HistoryHeaderCell {
+                        text: "User Label"; sortName: "userLabel"; Layout.fillWidth: true
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    HistoryHeaderCell {
+                        text: "Date / Time"; sortName: "timestamp"; Layout.preferredWidth: col.date
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    HistoryHeaderCell {
+                        text: "Config (L / R)"; sortName: "configL"; Layout.preferredWidth: col.config
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    HistoryHeaderCell {
+                        text: "Duration"; sortName: "durationSec"; Layout.preferredWidth: col.dur
+                        activeSort: root.sortKey; ascending: root.sortAsc
+                        onSortRequested: function(name) { root.setSort(name) }
+                    }
+                    Item { Layout.preferredWidth: col.status }
+                }
+            }
+
+            // ── table body ─────────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true; Layout.fillHeight: true
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                clip: true
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    model: root.view
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Rectangle {
+                        width: ListView.view.width
+                        height: 34
+                        color: modelData.sessionId === root.focusedSessionId
+                               ? Qt.rgba(0.31, 0.55, 1.0, 0.16)
+                               : (root.checked[modelData.sessionId]
+                                  ? Qt.rgba(0.31, 0.55, 1.0, 0.07) : "transparent")
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.focusRow(modelData.sessionId)
+                        }
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 8
+                            spacing: 8
+
+                            Text {
+                                Layout.preferredWidth: col.chk
+                                text: root.checked[modelData.sessionId] ? "☑" : "☐"
+                                color: theme.textPrimary; font.pixelSize: 15
+                                horizontalAlignment: Text.AlignHCenter
+                                MouseArea {
+                                    anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                                    onClicked: function(mouse) {
+                                        root.toggleCheck(modelData.sessionId); mouse.accepted = true
+                                    }
+                                }
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.userLabel || "(unlabeled)"
+                                color: theme.textPrimary; font.pixelSize: 13
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.date
+                                text: modelData.dateTime || "-"
+                                color: theme.textSecondary; font.pixelSize: 13
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.config
+                                text: (modelData.configL || "—") + " / " + (modelData.configR || "—")
+                                color: theme.textSecondary; font.pixelSize: 13
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.dur
+                                text: root.formatDuration(modelData.durationSec)
+                                color: theme.textSecondary; font.pixelSize: 13
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.status
+                                text: modelData.interrupted ? "⚠" : "●"
+                                color: modelData.interrupted ? "#E6A23C" : "#3EC97A"
+                                font.pixelSize: 13
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+
+                    // Empty state.
+                    Text {
+                        anchors.centerIn: parent
+                        visible: root.view.length === 0
+                        text: root.scans.length === 0 ? "No scans yet."
+                                                      : "No scans match the filter."
+                        color: theme.textSecondary; font.pixelSize: 14
+                    }
+                }
+            }
+
+            // ── detail pane (focused row, read-only) ───────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 150
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                visible: root.focusedRow !== null
+
+                RowLayout {
+                    anchors.fill: parent; anchors.margins: 12; spacing: 16
+
+                    GridLayout {
+                        columns: 2; columnSpacing: 14; rowSpacing: 4
+                        Layout.preferredWidth: 320
+                        Layout.alignment: Qt.AlignTop
+                        Text { text: "Full label:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? root.focusedRow.label : ""; color: theme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
+                        Text { text: "Operator:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? (root.focusedRow.operator || "-") : ""; color: theme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Mask (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text {
+                            color: theme.textPrimary; font.pixelSize: 12
+                            text: root.focusedRow
+                                  ? ("0x" + (root.focusedRow.leftMask & 0xFF).toString(16).toUpperCase()
+                                     + " / 0x" + (root.focusedRow.rightMask & 0xFF).toString(16).toUpperCase())
+                                  : ""
+                        }
+                        Text { text: "Config (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? (root.focusedRow.configL + " / " + root.focusedRow.configR) : ""; color: theme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Samples:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text {
+                            color: theme.textPrimary; font.pixelSize: 12
+                            text: root.focusedSampleCount < 0 ? "…" : root.focusedSampleCount.toLocaleString()
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true; Layout.fillHeight: true; spacing: 4
+                        Text { text: "Notes (read-only):"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Rectangle {
+                            Layout.fillWidth: true; Layout.fillHeight: true
+                            radius: 4; color: theme.bgInput
+                            border.color: theme.borderSubtle; border.width: 1
+                            ScrollView {
+                                anchors.fill: parent; anchors.margins: 2
+                                TextArea {
+                                    readOnly: true; wrapMode: Text.Wrap; background: null
+                                    text: root.focusedRow ? (root.focusedRow.notes || "") : ""
+                                    color: theme.textPrimary; font.pixelSize: 12
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── actions ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true; spacing: 10
+
+                Text {
+                    text: root.checkedCount > 0 ? (root.checkedCount + " selected") : ""
+                    color: theme.textSecondary; font.pixelSize: 12
+                }
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Load in viewer →"
+                    Layout.preferredWidth: 140; Layout.preferredHeight: 34
+                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: parent.enabled ? theme.textSecondary : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        root.loadingPlot = true
+                        MotionInterface.loadPastScan(root.focusedRow.label)
+                    }
+                }
+                Button {
+                    text: "Export CSV"
+                    Layout.preferredWidth: 110; Layout.preferredHeight: 34
+                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: parent.enabled ? theme.textSecondary : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        exportDialog.selectedScanId = root.focusedRow.label
+                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                                    + "/" + root.focusedRow.label + "_export.csv"
+                        exportDialog.open()
+                    }
+                }
+                Button {
+                    text: "🔒 Delete" + (root.checkedCount > 0 ? " (" + root.checkedCount + ")" : "")
+                    Layout.preferredWidth: 120; Layout.preferredHeight: 34
+                    // Don't allow deleting while a scan is running (could be the
+                    // in-flight session).
+                    enabled: root.checkedCount > 0 && MotionInterface.state !== 4
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: parent.enabled ? "#E8786A" : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered && parent.enabled ? "#3A1714" : theme.bgInput
+                        border.color: parent.enabled ? "#C0392B" : theme.textTertiary; radius: 4
+                    }
+                    onClicked: root.requestDelete()
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+
+        // Busy overlay while "Load in viewer" is in flight.
+        Rectangle {
+            anchors.fill: parent; color: "#000"; opacity: 0.45
+            visible: root.loadingPlot; z: 9999; radius: 12
+            MouseArea { anchors.fill: parent }
+            Column {
+                anchors.centerIn: parent; spacing: 12
+                BusyIndicator { running: root.loadingPlot; width: 48; height: 48 }
+                Text { text: "Loading scan..."; color: theme.textPrimary; font.pixelSize: 14 }
+            }
+        }
+    }
+
+    // Reused developer-password prompt for delete confirmation.
+    PasswordPromptModal {
+        id: deletePrompt
+        title: "Confirm Delete"
+        description: "Enter the developer password to permanently delete the "
+                     + "selected scan(s) from the database. This cannot be undone."
+        confirmLabel: "Delete"
+        onAccepted: root.doDelete()
+    }
+
+    Dialogs.FileDialog {
+        id: exportDialog
+        title: "Export Scan CSV"
+        fileMode: Dialogs.FileDialog.SaveFile
+        nameFilters: ["CSV files (*.csv)", "All files (*)"]
+        property string selectedScanId: ""
+        onAccepted: {
+            var path = selectedFile.toString().replace("file:///", "")
+            var ok = MotionInterface.exportScanCsv(selectedScanId, path)
+            if (ok) MotionInterface.notify("Exported to " + path, "success")
+        }
+    }
+
+    Dialogs.MessageDialog { id: histErrDialog; title: "Error"; text: "" }
+
+    Connections {
+        target: MotionInterface
+        function onPastScanLoadFinished(label, ok) {
+            root.loadingPlot = false
+            if (ok) root.close()
+        }
+        function onDirectoryChanged() { if (root.visible) root.refresh() }
+        function onErrorOccurred(msg) {
+            root.loadingPlot = false
+            histErrDialog.text = msg || "Unknown error."
+            histErrDialog.visible = true
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create the sortable header-cell component**
+
+The header uses a small reusable cell. It takes its sort state via properties
+and reports clicks via a signal — a child `.qml` component has its own id
+scope and **cannot** see the `root` id defined in `HistoryModal.qml`, so all
+coupling goes through the public interface. Create `components/HistoryHeaderCell.qml`:
+
+```qml
+import QtQuick 6.0
+import QtQuick.Layouts 6.0
+
+// One clickable, sort-aware column header in the History table.
+Item {
+    id: cell
+    property string text: ""
+    property string sortName: ""
+    property string activeSort: ""   // the table's current sort key
+    property bool ascending: false
+    signal sortRequested(string name)
+
+    Layout.preferredHeight: 30
+
+    AppTheme { id: theme }
+
+    Row {
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 4
+        Text {
+            text: cell.text
+            color: theme.textSecondary
+            font.pixelSize: 12; font.weight: Font.DemiBold
+        }
+        Text {
+            visible: cell.activeSort === cell.sortName
+            text: cell.ascending ? "▲" : "▼"
+            color: theme.textSecondary; font.pixelSize: 9
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        onClicked: cell.sortRequested(cell.sortName)
+    }
+}
+```
+
+- [ ] **Step 3: Sanity-check the QML parses on launch**
+
+The Delete guard binds `MotionInterface.state !== 4` — confirmed valid: `state` is a `pyqtProperty(int, notify=stateChanged)` at `motion_connector.py:1055`, and `4 == RUNNING` per the state machine at `motion_connector.py:72`. No code change here; the parse check happens implicitly when the app launches in Step 5 (a QML syntax error aborts startup and prints the offending line to the console — watch for it).
+
+- [ ] **Step 4: Seed a scan DB for visual verification**
+
+The app needs a `scans.db` with sessions to show anything. Create one in the app's data directory (`dataDirectory` in `config/app_config.json`; default `C:\Users\ethan\Projects\scan_data`). Run:
+
+```bash
+python -c "
+from omotion.ScanDatabase import ScanDatabase
+import time
+db = ScanDatabase(db_path=r'C:\Users\ethan\Projects\scan_data\scans.db')
+def mk(label, dt, lm, rm, dur, notes):
+    sid = db.create_session(session_label=label, session_start=time.time(),
+        session_end=time.time()+dur, session_notes=notes,
+        session_meta={'scan_id':label.rsplit('_',1)[0],'subject_id':label.split('_',2)[2],
+            'operator':'ethan','duration_sec':dur,
+            'sdk_flags':{'reduced_mode':True,'left_camera_mask':lm,'right_camera_mask':rm}})
+    for i in range(50):
+        db.insert_session_data(session_id=sid,cam_id=0,side=0,timestamp_s=float(i),frame_id=i,bfi=1.0,bvi=2.0)
+mk('20260615_093100_Patient14', None, 0x5A, 0x5A, 15, 'Resting baseline. 00:08 subject moved.')
+mk('20260615_092000_Patient14', None, 0xC3, 0xC3, 5, 'Far config check.')
+mk('20260614_164000_BaselineA', None, 0x66, 0x66, 15, 'Middle row.')
+db.close(); print('seeded')
+"
+```
+
+Expected: `seeded`.
+
+- [ ] **Step 5: Launch the app and screenshot the History modal**
+
+Run `python main.py`, click the **History** sidebar panel, then capture the window (per the project's visual-check rule — PrintWindow flag 2). From a second terminal:
+
+```bash
+python -c "
+import win32gui, win32ui, win32con
+from ctypes import windll
+h = win32gui.FindWindow(None, 'OpenWater Bloodflow')
+l,t,r,b = win32gui.GetWindowRect(h); w,ht=r-l,b-t
+dc = win32gui.GetWindowDC(h); mdc = win32ui.CreateDCFromHandle(dc); sdc = mdc.CreateCompatibleDC()
+bmp = win32ui.CreateBitmap(); bmp.CreateCompatibleBitmap(mdc,w,ht); sdc.SelectObject(bmp)
+windll.user32.PrintWindow(h, sdc.GetSafeHdc(), 2)
+bmp.SaveBitmapFile(sdc, 'history_check.bmp'); print('saved history_check.bmp')
+"
+```
+
+Verify in `history_check.bmp`: three rows; columns User Label / Date-Time / Config (L/R, e.g. "Near / Near") / Duration ("0:15") / status dot; clicking a row fills the detail pane (label, operator, masks, config, samples ~50, notes); clicking a checkbox shows "N selected" and enables Delete; sorting by a header reorders rows; the search box filters. Confirm Load opens the viewer and Delete pops the password prompt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/HistoryModal.qml components/HistoryHeaderCell.qml
+git commit -m "feat: rework History into a sortable multiselect data table"
+```
+
+---
+
+## Task 4: Update the HIL History UI test
+
+`tests/test_history.py` is `@pytest.mark.dev` and drives the real UI with pyautogui/UIA. The old version keys off the ComboBox and the "View in plot →" button, both gone. **This task cannot be validated in this environment — it runs on the self-hosted hardware runner.** Make the edits, eyeball them for correctness, and flag for runner validation.
+
+**Files:**
+- Modify: `tests/test_history.py`
+
+- [ ] **Step 1: Replace the open-detection + seed-skip helpers**
+
+The seed fixture uses `selected_scan_text()` (ComboBox) to decide whether to skip, and `_is_history_open()` detects the modal via a ComboBox. The new modal has neither. Replace both with a text scan for the modal title.
+
+In `tests/test_history.py`, replace the `_is_history_open` function (lines ~246–255) with:
+
+```python
+def _history_text_present(needle: str) -> bool:
+    """True iff any UIA element under the app window shows ``needle``."""
+    try:
+        win = uia_window()
+        for elem in win.descendants():
+            try:
+                if needle.lower() in (elem.window_text() or "").lower():
+                    return True
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return False
+
+
+def _is_history_open() -> bool:
+    """The History modal is up iff its 'Scan History' title is visible."""
+    return _history_text_present("Scan History")
+```
+
+- [ ] **Step 2: Fix the seed fixture's skip probe**
+
+In `_seed_with_short_scan` (the `try` block ~lines 198–211), replace the `selected_scan_text()` skip check with a row-presence check. Change:
+
+```python
+        click_panel("History")
+        time.sleep(SLEEP)
+        if selected_scan_text():
+            log.info("Skipping seed scan — History already has entries")
+```
+
+to:
+
+```python
+        click_panel("History")
+        time.sleep(SLEEP)
+        # A populated table shows the column header; an empty one shows
+        # "No scans yet." Either way the modal is open here.
+        if _history_text_present("User Label") and not _history_text_present("No scans yet"):
+            log.info("Skipping seed scan — History already has entries")
+```
+
+- [ ] **Step 3: Rewrite `test_02` to assert a table row, not a ComboBox**
+
+Replace `test_02_latest_scan_listed` (lines ~283–302) with:
+
+```python
+    def test_02_latest_scan_listed(self, app):
+        _ensure_history_open()
+        # Poll up to 5 s for the table to populate (the seed scan was
+        # Middle/Middle, so its config cell reads "Middle / Middle").
+        deadline = time.time() + 5.0
+        found = False
+        while time.time() < deadline:
+            if _history_text_present("Middle") or not _history_text_present("No scans yet"):
+                found = True
+                break
+            time.sleep(0.3)
+        assert found, (
+            "History table is empty after 5 s — no scans found. Run a "
+            "scan first, or the History modal failed to open."
+        )
+```
+
+- [ ] **Step 4: Rewrite `test_03` to focus a row then Load**
+
+The Load button needs a focused row first. Replace `test_03_view_in_plot` (lines ~304–307) with:
+
+```python
+    def test_03_view_in_plot(self, app):
+        """Focus the first row, then 'Load in viewer →' loads it into the
+        embedded PlotViewer."""
+        # Click the first data row to focus it (just below the header).
+        win = uia_window()
+        rows = [e for e in win.descendants(control_type="Text")
+                if "Middle" in (e.window_text() or "")]
+        if rows:
+            click_element_center(rows[0], "first history row")
+            time.sleep(SLEEP)
+        click_by_name("Load in viewer →")
+        time.sleep(SLEEP)
+```
+
+- [ ] **Step 5: Verify no remaining references to the removed ComboBox helpers**
+
+Run: `python -c "s=open('tests/test_history.py',encoding='utf-8').read(); assert 'selected_scan_text' not in s, 'still references selected_scan_text'; assert 'View in plot' not in s, 'still references old button'; print('clean')"`
+Expected: `clean`. (`read_combobox_values` is still used by the seed `_select_sensor` flow for Scan Settings — that's a different ComboBox and stays.)
+
+- [ ] **Step 6: Byte-compile the test to catch syntax errors**
+
+Run: `python -m py_compile tests/test_history.py`
+Expected: no output (exit 0). Full execution requires the hardware runner — note that in the commit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_history.py
+git commit -m "test: update HIL History test for the new table UI (runner-validate)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the unit suite for the new slots: `python -m pytest tests/test_history_sessions.py -v` → all PASS.
+- [ ] Run the kept listing test to confirm no regression: `python -m pytest tests/test_scan_history_list.py -v` → all PASS.
+- [ ] Lint the touched Python: `python -m flake8 motion_connector.py tests/test_history_sessions.py` → no errors.
+- [ ] Confirm the visual check from Task 3 Step 5 looked correct (table, detail pane, multiselect, sort, delete prompt).
+- [ ] `tests/test_history.py` edited and byte-compiles; flagged for hardware-runner validation.
+
+## Spec coverage check
+
+- Modal container, DB-only source → Task 1/3. ✓
+- Columns User Label / Date-Time / Config (L/R) / Duration / status → Task 3 delegate. ✓
+- Sortable headers, search, config filter → Task 3 (`setSort`, `rebuildView`, toolbar). ✓
+- Multiselect + select-all → Task 3 (`checked`, `setAllChecked`). ✓
+- Read-only detail pane w/ notes + lazy sample count → Task 3 + `get_session_stats` (Task 2). ✓
+- Load (single, reuse `loadPastScan`) / Export (reuse `exportScanCsv`) → Task 3. ✓
+- Password-gated delete via `PasswordPromptModal` → `deleteScans` (Task 2) + Task 3. ✓
+- Delete disabled while RUNNING; interrupted rows block Load/Export → Task 3. ✓
+- Config name mapping unit-tested → Task 1 (`_config_name`). ✓
+- No SDK changes. ✓

--- a/docs/superpowers/plans/2026-06-15-replay-mode-awareness.md
+++ b/docs/superpowers/plans/2026-06-15-replay-mode-awareness.md
@@ -1,0 +1,369 @@
+# Replay Mode Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make past-scan replay render in the mode the scan was recorded in (Part A), and hide non-reduced scans from History while the app is in reduced mode (Part B).
+
+**Architecture:** A tri-state `reducedMode` indicator on `ScanDataSource` (derived from the loaded buffer layout on `PastScanSource`, `-1` on live), an `effectiveReduced` resolve in `PlotViewer.qml` that prefers the source's mode over the live config (mirrors the #175 mask resolve), and one filter condition in `HistoryModal.rebuildView()` keyed on the `reducedMode` field already present in each scan row.
+
+**Tech Stack:** Python 3.13, PyQt6, QML (QtQuick 6), pytest.
+
+**Spec:** [docs/superpowers/specs/2026-06-15-replay-mode-awareness-design.md](../specs/2026-06-15-replay-mode-awareness-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `data_sources.py` — add module helper `_derive_reduced_from_buffers()`, a `reducedMode` `pyqtProperty(int)` on `ScanDataSource` (backing field `self._reduced_mode`, default `-1`), and set it in `PastScanSource.__init__`.
+- **Modify** `tests/test_data_sources.py` — append unit tests next to the existing #175 mask tests (~line 668).
+- **Modify** `components/PlotViewer.qml` — add `effectiveReduced` computed property; swap the viewer's internal `reducedMode` reads over to it.
+- **Modify** `components/HistoryModal.qml` — add the reduced-mode filter in `rebuildView()` + re-filter on `appConfigChanged`.
+
+No connector changes, no `BloodFlow.qml` changes.
+
+---
+
+## Task 1: `data_sources.py` — tri-state `reducedMode` on the source
+
+**Files:**
+- Modify: `data_sources.py`
+- Test: `tests/test_data_sources.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_data_sources.py` immediately after `test_past_scan_source_masks_unknown_when_no_per_cam_streams` (~line 668):
+
+```python
+# ── Replay mode awareness — source reports its recorded reduced/dev mode ──
+# The viewer renders in the mode the scan was recorded in. reducedMode is a
+# tri-state: -1 unknown, 0 per-camera, 1 reduced — derived from the loaded
+# buffer cam_ids (reduced scans store only cam_id=-1; per-camera store 0..7).
+
+from data_sources import _derive_reduced_from_buffers
+
+
+def _one_sample_buffer():
+    buf = _CameraBuffer(max_capacity=None)
+    buf.append(t=0.0, v=1.0, frame_id=0)
+    return buf
+
+
+def test_derive_reduced_per_camera():
+    buffers = {("left", 0, "bfi"): _one_sample_buffer(),
+               ("right", 7, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 0
+
+
+def test_derive_reduced_side_average():
+    buffers = {("left", -1, "bfi"): _one_sample_buffer(),
+               ("right", -1, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 1
+
+
+def test_derive_reduced_empty_is_unknown():
+    assert _derive_reduced_from_buffers({}) == -1
+    # A buffer dict whose buffers hold no samples is also "unknown".
+    assert _derive_reduced_from_buffers({("left", -1, "bfi"): _CameraBuffer()}) == -1
+
+
+def test_past_scan_source_reduced_mode_for_side_average():
+    buffers = {}
+    for side in ("left", "right"):
+        buffers[(side, -1, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 1
+
+
+def test_past_scan_source_reduced_mode_for_per_camera():
+    buffers = {}
+    for cam_id in (0, 1, 6, 7):
+        buffers[("left", cam_id, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 0
+
+
+def test_live_scan_source_reduced_mode_unknown():
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.reducedMode == -1
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_data_sources.py -k "reduced_mode or derive_reduced" -v`
+Expected: FAIL — `ImportError: cannot import name '_derive_reduced_from_buffers'`.
+
+- [ ] **Step 3: Add the module helper**
+
+In `data_sources.py`, immediately after the `_derive_masks_from_buffers` function, add:
+
+```python
+def _derive_reduced_from_buffers(buffers) -> int:
+    """Tri-state recorded display mode from a loaded scan's buffer cam_ids:
+    -1 unknown, 0 per-camera, 1 reduced. Reduced-mode scans store only the
+    cam_id=-1 side average; per-camera (dev) scans store cam_id 0..7. Mirrors
+    _derive_masks_from_buffers — the viewer prefers this over the live config
+    so replay renders in the mode the scan was captured in."""
+    if buffers_are_empty(buffers):
+        return -1
+    if any(0 <= key[1] < 8 for key in buffers):
+        return 0
+    if any(key[1] == -1 for key in buffers):
+        return 1
+    return -1
+```
+
+- [ ] **Step 4: Add the backing field + property to `ScanDataSource`**
+
+In `data_sources.py`, in `ScanDataSource.__init__`, next to where `self._left_mask` / `self._right_mask` are initialized to `-1`, add:
+
+```python
+        # Recorded display mode, tri-state: -1 unknown / 0 per-camera / 1
+        # reduced. -1 for live sources (viewer follows the live config);
+        # PastScanSource derives the real value from its buffer layout.
+        self._reduced_mode: int = -1
+```
+
+Then add this property next to the `leftMask` / `rightMask` `pyqtProperty` definitions:
+
+```python
+    @pyqtProperty(int, constant=True)
+    def reducedMode(self) -> int:
+        """Recorded display mode this source represents: -1 unknown, 0
+        per-camera, 1 reduced. Exposed for QML (PlotViewer.effectiveReduced)
+        so a replayed scan renders in its own mode rather than the live config.
+        See ``leftMask`` for why this must be a pyqtProperty."""
+        return self._reduced_mode
+```
+
+- [ ] **Step 5: Set it in `PastScanSource.__init__`**
+
+In `data_sources.py`, in `PastScanSource.__init__`, immediately after the existing
+`self._left_mask, self._right_mask = _derive_masks_from_buffers(self.buffers)` line, add:
+
+```python
+        self._reduced_mode = _derive_reduced_from_buffers(self.buffers)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_data_sources.py -k "reduced_mode or derive_reduced" -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 7: Run the full data_sources suite (no regression) + lint**
+
+Run: `python -m pytest tests/test_data_sources.py -q`
+Expected: all pass.
+Run: `python -m flake8 data_sources.py tests/test_data_sources.py`
+Expected: no new errors on the added lines.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add data_sources.py tests/test_data_sources.py
+git commit -m "feat: PastScanSource reports its recorded reduced/dev mode"
+```
+
+---
+
+## Task 2: `PlotViewer.qml` — render in the scan's recorded mode
+
+QML isn't unit-tested; verify by launching against reduced and per-camera seed scans.
+
+**Files:**
+- Modify: `components/PlotViewer.qml`
+
+- [ ] **Step 1: Add the `effectiveReduced` resolve**
+
+In `components/PlotViewer.qml`, immediately after the `_effectiveRightMask` `readonly property`
+block (the #175 mask resolve, ~lines 168–174), add:
+
+```qml
+    // Replay adopts the loaded scan's recorded mode: when the source reports a
+    // known mode (reducedMode >= 0) use it, else fall back to the live-config
+    // `reducedMode` input. Mirrors _effectiveLeftMask/_effectiveRightMask (#175).
+    // Note: scanSource.reducedMode is an int tri-state (-1/0/1) from Python;
+    // viewer.reducedMode is the bool live-config input.
+    readonly property bool effectiveReduced:
+        (viewer.scanSource && viewer.scanSource.reducedMode !== undefined
+         && viewer.scanSource.reducedMode >= 0)
+            ? (viewer.scanSource.reducedMode === 1)
+            : viewer.reducedMode
+```
+
+- [ ] **Step 2: Swap the four `!viewer.reducedMode` reads**
+
+Replace all occurrences of `!viewer.reducedMode` with `!viewer.effectiveReduced` in
+`components/PlotViewer.qml` (5 sites: `showCellValues` at ~72, and the `visible: !viewer.reducedMode`
+toolbar/menu gates at ~1017, ~1096, ~1115, ~1131). None of these is the input-property declaration
+or the new `effectiveReduced` fallback (that fallback uses `viewer.reducedMode` *without* `!`), so a
+global `!viewer.reducedMode` → `!viewer.effectiveReduced` replacement is safe.
+
+Use Edit with `replace_all: true`, `old_string: "!viewer.reducedMode"`, `new_string: "!viewer.effectiveReduced"`.
+
+- [ ] **Step 3: Swap the three remaining (non-`!`) rendering reads**
+
+Three sites use `viewer.reducedMode` without a leading `!`. Edit each individually (do NOT touch the
+property declaration `property bool reducedMode: false` at ~line 68, nor the `effectiveReduced`
+fallback you just added):
+
+a) The active cell model (~line 221):
+```qml
+    readonly property var _activeCellModel: viewer.reducedMode
+        ? _reducedCellModel
+        : _devCellModel
+```
+→ change the first line to `readonly property var _activeCellModel: viewer.effectiveReduced`.
+
+b) The reduced side-readout footer `visible` (~line 649): `visible: viewer.reducedMode`
+→ `visible: viewer.effectiveReduced`.
+
+c) The cell grid columns (~line 674): `columns: viewer.reducedMode ? 1 : 4`
+→ `columns: viewer.effectiveReduced ? 1 : 4`.
+
+- [ ] **Step 4: Confirm all internal reads were swapped**
+
+Run: `python -c "s=open(r'components/PlotViewer.qml',encoding='utf-8').read(); print('viewer.reducedMode:', s.count('viewer.reducedMode')); print('effectiveReduced:', s.count('effectiveReduced'))"`
+Expected: `viewer.reducedMode` count is exactly **1** — the only remaining occurrence is the
+`effectiveReduced` fallback (`: viewer.reducedMode`). The property *declaration* is
+`property bool reducedMode` with no `viewer.` prefix, so it isn't counted. `effectiveReduced` count
+is **≥ 9** (its own declaration + the 8 swapped sites). If `viewer.reducedMode` > 1, a swap was
+missed — find and fix it.
+
+- [ ] **Step 5: Seed a per-camera (dev) scan alongside the reduced ones**
+
+The worktree already has a `scans.db` with reduced scans (`cam_id=-1`). Add one per-camera scan so
+you can verify both render paths. Run (adjust the path if `dataDirectory` is set):
+
+```bash
+python -c "
+from omotion.ScanDatabase import ScanDatabase
+import math, time
+db = ScanDatabase(db_path=r'scans.db')
+sid = db.create_session(session_label='20260613_101500_DevScan', session_start=time.time(),
+    session_end=time.time()+10, session_notes='Per-camera dev scan.',
+    session_meta={'scan_id':'20260613_101500','subject_id':'DevScan','operator':'ethan',
+        'duration_sec':10,'sdk_flags':{'reduced_mode':False,'left_camera_mask':0xC3,'right_camera_mask':0xC3}})
+rows=[]
+for i in range(400):
+    t=i/40.0
+    for side in (0,1):
+        for cam in (0,1,6,7):
+            rows.append(dict(session_id=sid,cam_id=cam,side=side,timestamp_s=t,frame_id=i,
+                             bfi=1.0+0.3*math.sin(t+cam),bvi=2.0+0.4*math.sin(t*0.8+cam),mean=120.0,contrast=0.05))
+db.insert_session_data_rows(rows); db.close(); print('seeded dev scan')
+"
+```
+
+- [ ] **Step 6: Launch in DEV mode and verify both render paths**
+
+Set `developerMode: true` and `reducedMode: false` in `config/app_config.json` (note the originals to
+restore). Launch with the conda interpreter (the background Bash `python` is not on PATH — exits 127):
+
+```
+Start-Process -FilePath "C:\Users\ethan\miniconda3\python.exe" -ArgumentList "main.py" -WorkingDirectory "<worktree>" -PassThru
+```
+
+Open History → load the **reduced** scan (e.g. `Patient14`): the plot must show the two big BFI/BVI
+**side panels** (reduced layout) with data. Then "Back to live" / load the **DevScan**: the plot must
+show the **per-camera grid** with traces. Screenshot the window (PrintWindow flag 2) and confirm.
+Check the newest `app-logs/ow-bloodflowapp-*.log` for zero QML errors. Restart the app to pick up QML
+edits (QML does not hot-reload).
+
+- [ ] **Step 7: Restore config and commit**
+
+Restore `developerMode` / `reducedMode` in `config/app_config.json` to their original values.
+```bash
+git add components/PlotViewer.qml
+git commit -m "feat: replay renders in the scan's recorded reduced/dev mode"
+```
+(Do not commit `scans.db` — it is gitignored.)
+
+---
+
+## Task 3: `HistoryModal.qml` — reduced mode hides non-reduced scans
+
+**Files:**
+- Modify: `components/HistoryModal.qml`
+
+- [ ] **Step 1: Add the filter condition in `rebuildView()`**
+
+In `components/HistoryModal.qml`, in `rebuildView()`, the filter currently reads:
+
+```qml
+        var q = (searchText || "").toLowerCase()
+        var cfg = configFilter
+        var arr = scans.filter(function(r) {
+            if (q.length > 0
+                && (r.userLabel || "").toLowerCase().indexOf(q) < 0
+                && (r.label || "").toLowerCase().indexOf(q) < 0)
+                return false
+            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
+                return false
+            return true
+        })
+```
+
+Insert an app-reduced read before the filter and an AND-condition inside it:
+
+```qml
+        var q = (searchText || "").toLowerCase()
+        var cfg = configFilter
+        // In reduced (clinical) mode, omit scans not shot in reduced mode —
+        // the reduced viewer can't render their per-camera data. Dev mode
+        // lists everything. A scan with no recorded mode counts as non-reduced.
+        var appReduced = MotionInterface.appConfig.reducedMode === true
+        var arr = scans.filter(function(r) {
+            if (appReduced && !r.reducedMode)
+                return false
+            if (q.length > 0
+                && (r.userLabel || "").toLowerCase().indexOf(q) < 0
+                && (r.label || "").toLowerCase().indexOf(q) < 0)
+                return false
+            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
+                return false
+            return true
+        })
+```
+
+- [ ] **Step 2: Re-filter when the app's reduced flag changes**
+
+In `components/HistoryModal.qml`, in the existing `Connections { target: MotionInterface ... }` block,
+add a handler so a runtime mode change while History is open re-applies the filter:
+
+```qml
+        function onAppConfigChanged() { if (root.visible) root.rebuildView() }
+```
+
+- [ ] **Step 3: Verify in both modes**
+
+With the reduced + dev seed scans from Task 2 present:
+- Launch with `reducedMode: true` → open History → the `DevScan` row must be **absent**; only the
+  reduced scans (Patient14 / BaselineA) appear.
+- Launch with `reducedMode: false` (dev) → open History → **all** scans appear, `DevScan` included.
+
+Screenshot each and confirm. Check the newest app log for zero QML errors. Restore
+`config/app_config.json` afterward.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/HistoryModal.qml
+git commit -m "feat: hide non-reduced scans from History while in reduced mode"
+```
+
+---
+
+## Final verification
+
+- [ ] `python -m pytest tests/test_data_sources.py -q` → all pass (new + existing).
+- [ ] `python -m pytest tests/test_history_sessions.py -q` → still pass (no regression).
+- [ ] `python -m flake8 data_sources.py tests/test_data_sources.py` → clean on new code.
+- [ ] Manual matrix confirmed: dev mode loads reduced→side-panels and dev→grid; reduced mode hides the dev scan from History; "Back to live" reverts the viewer to the config mode.
+- [ ] `config/app_config.json` restored to its original `developerMode` / `reducedMode` values.
+
+## Spec coverage check
+
+- Part A: source reports recorded mode (Task 1); viewer prefers it, reverts on Back-to-live (Task 2). ✓
+- Part B: reduced mode hides non-reduced scans, dev mode unfiltered (Task 3). ✓
+- Buffer-derived detection; viewer-only scope; no connector/BloodFlow/config-persistence changes. ✓
+- Unit tests for the derivation; manual matrix for the QML wiring. ✓

--- a/docs/superpowers/specs/2026-06-15-history-data-management-design.md
+++ b/docs/superpowers/specs/2026-06-15-history-data-management-design.md
@@ -1,0 +1,130 @@
+# History → Data Management Tool — Design
+
+**Date:** 2026-06-15
+**Status:** Approved for planning
+**Component:** `components/HistoryModal.qml`, `motion_connector.py`
+
+## Problem
+
+Today's History view ([HistoryModal.qml](../../../components/HistoryModal.qml)) is a single-select
+`ComboBox` picker plus a details pane. It works for "open one past scan" but is not a tool for
+*managing* a growing scan archive: you can't see all scans at a glance, can't sort or search,
+can't act on several at once, and can't delete anything.
+
+Rework it into a proper data-management tool: a sortable, searchable, multi-select **table** of
+scans with a detail pane and Load / Export / Delete actions.
+
+## Decisions (locked during brainstorming)
+
+| Question | Decision |
+|---|---|
+| Container | **Modal** — rebuild the existing `HistoryModal`, not a new page. Lowest-risk, fits `ModalManager`. |
+| List source | **DB `sessions` table only.** Drop the CSV-filename listing. Matches DB-as-system-of-record; CSVs are being phased out. Legacy pre-DB CSV-only scans (no session row) no longer appear. |
+| Delete scope | **DB session only** — `delete_session(id)` (CASCADE-deletes `session_data`). No file deletion. |
+| Delete auth | **Reuse the developer password** via the existing `PasswordPromptModal` + `checkDeveloperPassword()`. |
+| Notes | **Read-only** in the detail pane (viewable, not editable). |
+| "Time" column | **Duration** (`session_end − session_start`). |
+| Mode column | **Omitted.** |
+| Config column | Show **left / right** named configs, always both sides. |
+| Export CSV | **Kept** (existing `exportScanCsv`). |
+
+No SDK changes are required. Everything the table needs already exists in the scan DB:
+`ScanDBSink` writes `session_meta` at scan start with
+`sdk_flags.{left_camera_mask, right_camera_mask, reduced_mode}`, `duration_sec`, `operator`,
+`started_at_iso`, and `scan_id`/`subject_id`; `session_start`/`session_end` give real duration;
+`session_notes` holds notes. Empty/interrupted-before-any-data sessions are already pruned by
+`ScanDBSink.on_complete`.
+
+## UI
+
+A modal (same dimmed-backdrop + centered panel as today, slightly larger) containing:
+
+**Toolbar:** title · search field (filters by user label, case-insensitive substring) ·
+`Config ▾` filter (All + each named config) · Open Folder · Refresh · ✕.
+
+**Table** (header row + scrollable `ListView` of styled row delegates — matches the app's existing
+hand-styled control idiom; not `TableView`):
+
+| ☑ | User Label | Date / Time | Config (L / R) | Duration | status |
+|---|---|---|---|---|---|
+
+- Header checkbox = select-all / clear-all (respects the active search/config filter).
+- Per-row checkbox = multiselect membership.
+- Single-click anywhere on a row = **focus** it (highlights, fills the detail pane). Focus and
+  checkbox-membership are independent.
+- Clicking a column header sorts by it; click again to reverse. Default: **Date / Time descending.**
+- `status`: green dot = ok; amber ⚠ = interrupted (`session_end` is null).
+
+**Detail pane** (below the table, for the focused row): full label · operator · left/right mask
+(hex) · Config (L / R) · started-at · sample-row count · **read-only** Notes box (scrollable).
+Sample count is fetched lazily when a row is focused (keeps the list query cheap).
+
+**Actions** (bottom): "N selected" counter · `Load in viewer →` · `Export CSV` · `🔒 Delete (N)`.
+- **Load** — enabled when exactly one row is focused; calls the existing async
+  `loadPastScan(label)` with the busy overlay, closes on success (unchanged behavior).
+- **Export CSV** — acts on the focused row; existing `exportScanCsv(label, path)` + `FileDialog`.
+- **Delete (N)** — acts on all checked rows. Opens `PasswordPromptModal`; on `accepted()` calls
+  the new `deleteScans([sessionId…])`, then refreshes and clears the selection. Disabled while a
+  scan is RUNNING (don't delete the in-flight session).
+
+## Connector API (new)
+
+All read/delete use a short-lived `ScanDatabase(db_path)` handle (WAL allows concurrent
+read/write with a live scan). Best-effort: a missing/unreadable DB yields an empty list, never an
+exception into QML.
+
+- `get_scan_sessions() -> QVariantList[QVariantMap]` — one entry per `sessions` row, newest first.
+  Each map: `sessionId` (int DB id), `label`, `userLabel`, `operator`, `dateTime` (display string),
+  `timestamp` (raw `YYYYMMDD_HHMMSS` for sort), `durationSec` (float or −1 if open),
+  `leftMask`/`rightMask` (int), `reducedMode` (bool), `notes`, `interrupted` (bool,
+  `session_end is None`). Masks come from `session_meta.sdk_flags`; for older rows lacking meta,
+  fall back to deriving per-camera masks from `session_data` (returns −1/unknown for reduced-mode
+  rows that only stored the cam_id=−1 average). The list query does **not** count rows.
+- `get_session_stats(sessionId: int) -> QVariantMap` — `{ "sampleCount": int }`. Called on focus so
+  the per-row `COUNT(*)` cost is paid once per selection, not once per listed scan.
+- `deleteScans(sessionIds: list[int]) -> int` — `delete_session()` per id; returns the count
+  deleted. The password gate lives in QML (`PasswordPromptModal`); the slot itself is unguarded
+  glue. Logs each deletion.
+
+`loadPastScan` and `exportScanCsv` are reused unchanged. `get_scan_list` / `get_scan_details`
+stay (still used by `loadPastScan` and existing tests).
+
+## Config-name mapping
+
+Masks → names mirror `CameraSelectionModal`'s pattern table:
+`0x00→None, 0x5A→Near, 0x66→Middle, 0xC3→Far, 0x99→Outer, 0x0F→Left, 0xF0→Right, 0x42→Third Row,
+0xFF→All`; anything else → `0xNN` hex; unknown (−1) → `—`. Column renders `"{left} / {right}"`.
+Mapping lives in a new `components/ScanConfigNames.js` (`.pragma library`) imported by
+`HistoryModal`; `CameraSelectionModal` is left untouched for now.
+
+## Components & tidiness
+
+- Rewrite `HistoryModal.qml` around the table. Reuse `PasswordPromptModal` (instantiated inside,
+  like `DeveloperUnlockModal`), the busy overlay, the `friendlyDate`/`formatMasks` helpers, and the
+  `MotionInterface` `Connections` block (`onPastScanLoadFinished`, `onDirectoryChanged`,
+  `onErrorOccurred`).
+- New `components/ScanConfigNames.js` for the mask→name mapping.
+- New connector slots grouped next to `get_scan_list` (~line 1384). Keep them small and DB-only;
+  do not grow the existing 4031-line file with table-rendering logic — that stays in QML.
+
+## Error handling
+
+- Empty archive → table shows an "No scans yet" empty state; actions disabled.
+- DB read failure → empty list + a logged warning (current best-effort pattern).
+- Delete of an already-removed id → `delete_session` returns False; counted as not-deleted, no error.
+- Interrupted rows (`⚠`) → Load/Export disabled (no replayable data), Delete still allowed.
+
+## Testing
+
+- Connector unit tests (no hardware): `get_scan_sessions` shape + sort + mask/config derivation
+  from `session_meta` and from `session_data` fallback; `deleteScans` removes rows and cascades;
+  `get_session_stats` count. Build a temp `ScanDatabase`, insert sessions/data, assert.
+- Update the existing UI tests that drive the old `ComboBox` History
+  (`tests/test_history.py`, and `tests/test_scan_history_list.py` if it touches the modal) to the
+  new table interaction.
+
+## Out of scope
+
+- Deleting on-disk CSV/raw/telemetry files (DB-only delete by decision).
+- Editing notes from History (read-only by decision).
+- A full-page History route, renaming labels, bulk export, date-range filtering.

--- a/docs/superpowers/specs/2026-06-15-replay-mode-awareness-design.md
+++ b/docs/superpowers/specs/2026-06-15-replay-mode-awareness-design.md
@@ -1,0 +1,133 @@
+# Replay Mode Awareness — Design
+
+**Date:** 2026-06-15
+**Status:** Approved for planning
+**Components:** `data_sources.py`, `components/PlotViewer.qml`, `components/HistoryModal.qml`
+**Rides on:** the History data-management branch (`claude/determined-kalam-a1d23d`, PR #194)
+
+## Problem
+
+The plot viewer's reduced-vs-per-camera **display mode** follows the live app config
+(`reducedMode`), not the mode a loaded past scan was *recorded* in. A reduced-mode scan stores
+its data under `cam_id = -1` (the side average); a per-camera/dev scan stores `cam_id = 0..7`. So
+loading a reduced scan while the app is in dev mode (or vice-versa) renders a blank/empty plot —
+the viewer queries cells that have no data.
+
+This is the same class of mismatch that [#175](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/pull/190)
+fixed for camera *masks* (replay uses the scan's own config, not the live selection); it was
+simply never extended to the reduced/dev mode itself.
+
+Two complementary fixes:
+
+- **A. The viewer adopts the loaded scan's recorded mode** (both directions), reverting to the
+  live config on "Back to live".
+- **B. In reduced mode, History hides scans not shot in reduced mode** — so a clinician in the
+  reduced clinical view never sees or loads an engineering/dev scan they can't render.
+
+Together they cover every case: reduced app shows only reduced scans (always renderable);
+dev app shows everything, and a reduced scan loaded in dev mode renders correctly via A.
+
+## Part A — Viewer adopts the loaded scan's recorded mode
+
+### Decisions
+
+- **Scope: plot viewer only.** Loading a scan changes only how the plot area renders. The sidebar,
+  settings access, and `BloodFlow.qml` page layout stay on the live config. (User decision.)
+- **Temporary.** The effective mode is tied to the active scan source, so it reverts to the live
+  config automatically when the viewer returns to the live source ("Back to live").
+- **Detection source: the loaded buffer layout**, not `session_meta`. What the viewer can actually
+  render is determined by which `cam_id`s are present; deriving from the buffers guarantees the
+  render mode matches renderable data (and is self-consistent with how #175 derives masks). For
+  well-formed scans this is identical to `session_meta.sdk_flags.reduced_mode`.
+
+### `data_sources.py`
+
+Add a tri-state indicator on `ScanDataSource`, exposed exactly like `leftMask`/`rightMask`:
+
+- New `pyqtProperty(int, constant=True) reducedMode` backed by `self._reduced_mode`, default `-1`.
+  Values: `-1` unknown, `0` per-camera, `1` reduced.
+- `LiveScanSource` leaves it `-1` (unknown → viewer follows the live config; no behavior change).
+- `PastScanSource.__init__` sets `self._reduced_mode` from its loaded buffers, alongside the
+  existing `_derive_masks_from_buffers` call, via a new module helper:
+
+  ```python
+  def _derive_reduced_from_buffers(buffers) -> int:
+      """-1 unknown / 0 per-camera / 1 reduced, from which cam_ids a loaded
+      scan carries. Reduced scans store only the cam_id=-1 side average;
+      per-camera scans store cam_id 0..7. Mirrors _derive_masks_from_buffers."""
+      if buffers_are_empty(buffers):
+          return -1
+      if any(0 <= key[1] < 8 for key in buffers):
+          return 0
+      if any(key[1] == -1 for key in buffers):
+          return 1
+      return -1
+  ```
+
+### `components/PlotViewer.qml`
+
+- Add `readonly property bool effectiveReduced` resolving the source's mode with a fallback,
+  mirroring the `_effectiveLeftMask` resolve at lines 168–174:
+
+  ```qml
+  readonly property bool effectiveReduced:
+      (viewer.scanSource && viewer.scanSource.reducedMode !== undefined
+       && viewer.scanSource.reducedMode >= 0)
+          ? (viewer.scanSource.reducedMode === 1)
+          : viewer.reducedMode
+  ```
+
+- Swap the viewer's **internal rendering/visibility** reads of `viewer.reducedMode` over to
+  `viewer.effectiveReduced`. Known sites (verify exhaustively during implementation):
+  `showCellValues` (72), `_activeCellModel` (221), the reduced side-readout footer `visible` (649),
+  the cell grid `columns` (674), and the `!reducedMode`-gated toolbar/menu items (1017, 1096, 1115,
+  1131). Leave the external **input** property `reducedMode` (68) and its `BloodFlow.qml` binding
+  untouched — it remains the live-config fallback.
+
+No connector and no `BloodFlow.qml` changes. Masks already follow the source (#175); with
+`effectiveReduced` driving the cell model, replay now fully self-describes its layout.
+
+## Part B — Reduced mode hides non-reduced scans in History
+
+### Decision
+
+One-directional: **when the app is in reduced mode, the History table omits any scan whose recorded
+mode is not reduced.** Dev mode lists everything (reduced scans included, rendered correctly by
+Part A). A legacy scan with no recorded mode is treated as non-reduced, so it is hidden in reduced
+mode — the conservative choice for the clinical view. (User-confirmed.)
+
+### `components/HistoryModal.qml`
+
+The row map from `get_scan_sessions()` already carries `reducedMode`
+(`_session_to_row` reads `session_meta.sdk_flags.reduced_mode`), so no connector change.
+
+In `rebuildView()`, add one AND-condition to the existing filter chain (search + Config dropdown):
+when the app is in reduced mode, drop rows where `reducedMode` is falsy. The app's reduced flag is
+read from `MotionInterface.appConfig.reducedMode` (the same source `BloodFlow.qml` uses), reactive
+via `appConfigChanged`. The existing empty-state ("No scans match the filter.") covers the case
+where the filter removes everything.
+
+## Error handling
+
+- Unknown source mode (`-1`, e.g. a live source or an empty past scan) → viewer falls back to the
+  live config, i.e. today's behavior. No blank-plot regression for empty scans (already guarded by
+  `buffers_are_empty` in the load path).
+- Part A and Part B both key off the scan's recorded mode; for well-formed scans the buffer-derived
+  value (Part A) and `session_meta.reduced_mode` (Part B) agree. A malformed scan where they
+  disagree is a pre-existing data defect, not introduced here.
+
+## Testing
+
+- **Unit (`tests/test_data_sources.py`):** `PastScanSource(preloaded_buffers=…).reducedMode` returns
+  `1` for cam_id=-1-only buffers, `0` for per-camera buffers, `-1` for empty; and
+  `_derive_reduced_from_buffers` directly for the three cases.
+- **Manual:** launch against two seed DBs (one reduced `cam_id=-1` scan, one per-camera `cam_id=0..7`
+  scan) and confirm: (1) in dev mode, loading the reduced scan renders the reduced panels and
+  loading the per-camera scan renders the grid; (2) "Back to live" reverts to the config mode;
+  (3) in reduced mode, the dev scan is absent from the History list.
+
+## Out of scope
+
+- Hiding reduced scans while in dev mode (only the reduced-mode direction was requested).
+- Switching any UI outside the plot viewer (sidebar/settings/page layout stay on live config).
+- Persisting any mode change to `app_config.json`.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1668,6 +1668,64 @@ class MotionConnector(QObject):
         rows.sort(key=lambda r: r["timestamp"], reverse=True)
         return rows
 
+    @pyqtSlot(int, result="QVariantMap")
+    def get_session_stats(self, session_id: int):
+        """Lazily fetch heavier per-scan stats (row count) when a History
+        row is focused, so the list query itself stays cheap."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return {"sampleCount": 0}
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                row = next(
+                    db._connection().execute(
+                        "SELECT COUNT(*) FROM session_data"
+                        " WHERE session_id = ?",
+                        (int(session_id),),
+                    ),
+                    None,
+                )
+                return {"sampleCount": int(row[0]) if row else 0}
+            finally:
+                db.close()
+        except Exception:
+            logger.warning(
+                "get_session_stats failed for %s", session_id,
+                exc_info=True)
+            return {"sampleCount": 0}
+
+    @pyqtSlot("QVariantList", result=int)
+    def deleteScans(self, session_ids):
+        """Delete the given scan-DB sessions (CASCADE removes their
+        session_data). Returns the count actually deleted. The developer-
+        password gate is enforced in QML before this is called."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return 0
+        deleted = 0
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for sid in session_ids:
+                    try:
+                        if db.delete_session(int(sid)):
+                            deleted += 1
+                            logger.info(
+                                "deleteScans: removed session %s", sid)
+                    except Exception:
+                        logger.warning(
+                            "deleteScans: failed to delete %s", sid,
+                            exc_info=True)
+            finally:
+                db.close()
+        except Exception:
+            logger.warning(
+                "deleteScans: could not open scan DB", exc_info=True)
+        return deleted
+
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):
         return self._directory

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1651,7 +1651,14 @@ class MotionConnector(QObject):
             db = ScanDatabase(db_path)
             try:
                 for s in db.iter_sessions():
-                    rows.append(self._session_to_row(s))
+                    # Per-row guard: one malformed session must not blank the
+                    # whole History view — skip it and keep the rest.
+                    try:
+                        rows.append(self._session_to_row(s))
+                    except Exception:
+                        logger.warning(
+                            "get_scan_sessions: skipping malformed session %s",
+                            s.get("id"), exc_info=True)
             finally:
                 db.close()
         except Exception:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -76,6 +76,23 @@ def developer_password_matches(pw) -> bool:
     return isinstance(pw, str) and pw == _DEVELOPER_PASSWORD
 
 
+# Camera-mask → human config name, mirroring CameraSelectionModal's
+# pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
+# reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.
+_CONFIG_NAMES = {
+    0x00: "None", 0x5A: "Near", 0x66: "Middle", 0xC3: "Far",
+    0x99: "Outer", 0x0F: "Left", 0xF0: "Right", 0x42: "Third Row",
+    0xFF: "All",
+}
+
+
+def _config_name(mask) -> str:
+    if mask is None or mask < 0:
+        return "—"
+    m = int(mask) & 0xFF
+    return _CONFIG_NAMES.get(m, f"0x{m:02X}")
+
+
 logger = logging.getLogger("openmotion.bloodflow-app.connector")
 
 # Define system states
@@ -1557,6 +1574,92 @@ class MotionConnector(QObject):
             "notes": notes,
             "hasData": bool(has_db_rows or corrected or left or right),
         }
+
+    @staticmethod
+    def _friendly_ts(ts: str) -> str:
+        """'YYYYMMDD_HHMMSS' -> 'YYYY-MM-DD HH:MM:SS'; pass through."""
+        if not ts or len(ts) != 15:
+            return ts or "-"
+        return (f"{ts[0:4]}-{ts[4:6]}-{ts[6:8]} "
+                f"{ts[9:11]}:{ts[11:13]}:{ts[13:15]}")
+
+    def _session_to_row(self, s: dict) -> dict:
+        """Flatten one ScanDatabase session dict into the QVariantMap the
+        History table consumes. Masks/operator come from session_meta
+        (written by ScanDBSink); duration from session_start/end."""
+        label = (s.get("session_label") or "").strip()
+        meta = s.get("session_meta")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except Exception:
+                meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        flags = meta.get("sdk_flags") or {}
+
+        left_mask = flags.get("left_camera_mask", -1)
+        right_mask = flags.get("right_camera_mask", -1)
+        if left_mask is None:
+            left_mask = -1
+        if right_mask is None:
+            right_mask = -1
+
+        user_label = meta.get("subject_id") or ""
+        timestamp = ""
+        m = re.match(r"^(\d{8}_\d{6})_?(.*)$", label)
+        if m:
+            timestamp = m.group(1)
+            if not user_label:
+                user_label = m.group(2)
+
+        start = s.get("session_start")
+        end = s.get("session_end")
+        if start is not None and end is not None:
+            duration = float(end) - float(start)
+        else:
+            duration = -1.0
+
+        return {
+            "sessionId": int(s.get("id")),
+            "label": label,
+            "userLabel": user_label,
+            "operator": meta.get("operator") or "",
+            "timestamp": timestamp or label,
+            "dateTime": self._friendly_ts(timestamp),
+            "durationSec": duration,
+            "leftMask": int(left_mask),
+            "rightMask": int(right_mask),
+            "configL": _config_name(left_mask),
+            "configR": _config_name(right_mask),
+            "reducedMode": bool(flags.get("reduced_mode", False)),
+            "notes": s.get("session_notes") or "",
+            "interrupted": end is None,
+        }
+
+    @pyqtSlot(result="QVariantList")
+    def get_scan_sessions(self):
+        """Return one row per scan-DB session, newest first, for the
+        History table. DB-only — does not list CSV-derived scans.
+        Best-effort: a missing/unreadable DB yields []."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return []
+        rows = []
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for s in db.iter_sessions():
+                    rows.append(self._session_to_row(s))
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("get_scan_sessions: could not read scan DB",
+                           exc_info=True)
+            return []
+        rows.sort(key=lambda r: r["timestamp"], reverse=True)
+        return rows
 
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1679,6 +1679,9 @@ class MotionConnector(QObject):
             from omotion.ScanDatabase import ScanDatabase
             db = ScanDatabase(db_path)
             try:
+                # Raw COUNT via the connection — ScanDatabase exposes no
+                # public row-count API; get_scan_details reaches for
+                # _connection() the same way for its EXISTS probe.
                 row = next(
                     db._connection().execute(
                         "SELECT COUNT(*) FROM session_data"

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -668,6 +668,60 @@ def test_past_scan_source_masks_unknown_when_no_per_cam_streams():
     assert src.rightMask == -1
 
 
+# ── Replay mode awareness — source reports its recorded reduced/dev mode ──
+# The viewer renders in the mode the scan was recorded in. reducedMode is a
+# tri-state: -1 unknown, 0 per-camera, 1 reduced — derived from the loaded
+# buffer cam_ids (reduced scans store only cam_id=-1; per-camera store 0..7).
+
+from data_sources import _derive_reduced_from_buffers
+
+
+def _one_sample_buffer():
+    buf = _CameraBuffer(max_capacity=None)
+    buf.append(t=0.0, v=1.0, frame_id=0)
+    return buf
+
+
+def test_derive_reduced_per_camera():
+    buffers = {("left", 0, "bfi"): _one_sample_buffer(),
+               ("right", 7, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 0
+
+
+def test_derive_reduced_side_average():
+    buffers = {("left", -1, "bfi"): _one_sample_buffer(),
+               ("right", -1, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 1
+
+
+def test_derive_reduced_empty_is_unknown():
+    assert _derive_reduced_from_buffers({}) == -1
+    # A buffer dict whose buffers hold no samples is also "unknown".
+    empty_buf = {("left", -1, "bfi"): _CameraBuffer()}
+    assert _derive_reduced_from_buffers(empty_buf) == -1
+
+
+def test_past_scan_source_reduced_mode_for_side_average():
+    buffers = {}
+    for side in ("left", "right"):
+        buffers[(side, -1, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 1
+
+
+def test_past_scan_source_reduced_mode_for_per_camera():
+    buffers = {}
+    for cam_id in (0, 1, 6, 7):
+        buffers[("left", cam_id, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 0
+
+
+def test_live_scan_source_reduced_mode_unknown():
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.reducedMode == -1
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # currentScanSource holder pattern — verified via a parallel mini-class
 # (MotionConnector uses the same pattern; see motion_connector.py)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -27,7 +27,6 @@ from hil_helpers import (
     click_element_center,
     click_panel,
     force_app_config_value,
-    selected_scan_text,
     write_app_config_value,
 )
 
@@ -198,7 +197,13 @@ def _seed_with_short_scan(app):
     try:
         click_panel("History")
         time.sleep(SLEEP)
-        if selected_scan_text():
+        # A populated table shows the column header; an empty one shows
+        # "No scans yet." Either way the modal is open here.
+        has_data = (
+            _history_text_present("User Label")
+            and not _history_text_present("No scans yet")
+        )
+        if has_data:
             log.info("Skipping seed scan — History already has entries")
             require_focus()
             pyautogui.press("escape")
@@ -243,16 +248,24 @@ def _seed_with_short_scan(app):
     yield
 
 
-def _is_history_open() -> bool:
-    """True iff the History modal appears to be on top — detected via
-    the presence of any ComboBox in the UIA tree (the scan picker is
-    the only ComboBox the bloodflow page exposes when no other modal
-    is up)."""
+def _history_text_present(needle: str) -> bool:
+    """True iff any UIA element under the app window shows ``needle``."""
     try:
         win = uia_window()
-        return bool(win.descendants(control_type="ComboBox"))
+        for elem in win.descendants():
+            try:
+                if needle.lower() in (elem.window_text() or "").lower():
+                    return True
+            except Exception:
+                continue
     except Exception:
-        return False
+        pass
+    return False
+
+
+def _is_history_open() -> bool:
+    """The History modal is up iff its 'Scan History' title is visible."""
+    return _history_text_present("Scan History")
 
 
 def _ensure_history_open() -> None:
@@ -281,35 +294,39 @@ class TestHistory:
         _ensure_history_open()
 
     def test_02_latest_scan_listed(self, app):
-        # Defensive: re-ensure the modal is up before reading. The
-        # seed fixture's close-with-escape doesn't actually fire
-        # (HistoryModal has no Keys handler), so we can't trust the
-        # state coming into this test.
         _ensure_history_open()
-        # Poll for up to 5 s — the ComboBox can take a moment to
-        # populate on a slow runner.
+        # Poll up to 5 s for the table to populate (the seed scan was
+        # Middle/Middle, so its config cell reads "Middle / Middle").
         deadline = time.time() + 5.0
-        scan_text = ""
+        found = False
         while time.time() < deadline:
-            scan_text = selected_scan_text()
-            if scan_text:
+            no_data = _history_text_present("No scans yet")
+            if _history_text_present("Middle") or not no_data:
+                found = True
                 break
             time.sleep(0.3)
-        assert len(scan_text) > 0, (
-            "ComboBox is empty after 5 s -- no scans found. Run a "
+        assert found, (
+            "History table is empty after 5 s — no scans found. Run a "
             "scan first, or the History modal failed to open."
         )
-        log.info(f"  Scan ComboBox text: '{scan_text}'")
 
     def test_03_view_in_plot(self, app):
-        """'View in plot →' loads the scan into the embedded PlotViewer."""
-        click_by_name("View in plot →")
+        """Focus the first row, then 'Load in viewer →' loads it into the
+        embedded PlotViewer."""
+        # Click the first data row to focus it (just below the header).
+        win = uia_window()
+        rows = [e for e in win.descendants(control_type="Text")
+                if "Middle" in (e.window_text() or "")]
+        if rows:
+            click_element_center(rows[0], "first history row")
+            time.sleep(SLEEP)
+        click_by_name("Load in viewer →")
         time.sleep(SLEEP)
 
     def test_04_history_closed_by_view(self, app):
         """The button closes the History modal itself after loading."""
         assert not _is_history_open(), (
-            "History modal still open after 'View in plot →' — expected "
+            "History modal still open after 'Load in viewer →' — expected "
             "it to close itself after loading the scan."
         )
 

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -1,0 +1,85 @@
+"""History data-management connector slots — DB-only, no hardware."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector, _config_name
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _make_session(db_path, label, start, end, left_mask, right_mask,
+                  reduced=True, notes=None, subject=None, operator="ethan"):
+    # Default the subject_id to the label's trailing user-label segment so
+    # rows carry distinct userLabels (matches how scans are really named).
+    if subject is None:
+        parts = label.split("_", 2)
+        subject = parts[2] if len(parts) > 2 else ""
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(
+        session_label=label, session_start=start, session_end=end,
+        session_notes=notes,
+        session_meta={
+            "scan_id": label.rsplit("_", 1)[0], "subject_id": subject,
+            "operator": operator, "duration_sec": (end - start) if end else 0,
+            "sdk_flags": {
+                "reduced_mode": reduced,
+                "left_camera_mask": left_mask,
+                "right_camera_mask": right_mask,
+            },
+        },
+    )
+    db.close()
+    return sid
+
+
+def test_config_name_known_and_unknown():
+    assert _config_name(0x5A) == "Near"
+    assert _config_name(0xC3) == "Far"
+    assert _config_name(0x00) == "None"
+    assert _config_name(0x12) == "0x12"   # unmapped -> hex
+    assert _config_name(-1) == "—"        # unknown
+
+
+def test_get_scan_sessions_rows_and_sort(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _make_session(db_path, "20260612_093100_subjB", 200.0, 215.0, 0x5A, 0x66)
+    c = _connector(tmp_path, db_path)
+
+    rows = c.get_scan_sessions()
+    assert [r["userLabel"] for r in rows] == ["subjB", "subjA"]  # newest first
+    top = rows[0]
+    assert top["configL"] == "Near" and top["configR"] == "Middle"
+    assert top["durationSec"] == 15.0
+    assert top["leftMask"] == 0x5A and top["rightMask"] == 0x66
+    assert top["interrupted"] is False
+    assert top["dateTime"] == "2026-06-12 09:31:00"
+
+
+def test_get_scan_sessions_interrupted_open_session(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_100000_subjC", 300.0, None, 0xFF, 0xFF)
+    c = _connector(tmp_path, db_path)
+    row = c.get_scan_sessions()[0]
+    assert row["interrupted"] is True
+    assert row["durationSec"] == -1.0
+
+
+def test_get_scan_sessions_empty_without_db(tmp_path):
+    c = _connector(tmp_path, None)
+    assert c.get_scan_sessions() == []

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -110,3 +110,47 @@ def test_get_scan_sessions_interrupted_open_session(tmp_path):
 def test_get_scan_sessions_empty_without_db(tmp_path):
     c = _connector(tmp_path, None)
     assert c.get_scan_sessions() == []
+
+
+def _insert_rows(db_path, session_id, n):
+    db = ScanDatabase(db_path=db_path)
+    for i in range(n):
+        db.insert_session_data(
+            session_id=session_id, cam_id=0, side=0,
+            timestamp_s=float(i), frame_id=i, bfi=1.0, bvi=2.0,
+        )
+    db.close()
+
+
+def test_get_session_stats_counts_rows(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sid = _make_session(
+        db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _insert_rows(db_path, sid, 7)
+    c = _connector(tmp_path, db_path)
+    assert c.get_session_stats(sid)["sampleCount"] == 7
+
+
+def test_delete_scans_removes_session_and_cascades(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    keep = _make_session(
+        db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    drop = _make_session(
+        db_path, "20260612_093000_drop", 200.0, 205.0, 0x5A, 0x5A)
+    _insert_rows(db_path, drop, 5)
+    c = _connector(tmp_path, db_path)
+
+    removed = c.deleteScans([drop])
+    assert removed == 1
+    remaining = [r["sessionId"] for r in c.get_scan_sessions()]
+    assert remaining == [keep]
+    # session_data cascade-deleted with the session
+    assert c.get_session_stats(drop)["sampleCount"] == 0
+
+
+def test_delete_scans_empty_list_is_noop(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    c = _connector(tmp_path, db_path)
+    assert c.deleteScans([]) == 0
+    assert len(c.get_scan_sessions()) == 1

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -154,3 +154,10 @@ def test_delete_scans_empty_list_is_noop(tmp_path):
     c = _connector(tmp_path, db_path)
     assert c.deleteScans([]) == 0
     assert len(c.get_scan_sessions()) == 1
+
+
+def test_stats_and_delete_without_db_are_safe(tmp_path):
+    """No scan DB configured → both slots no-op rather than raise."""
+    c = _connector(tmp_path, None)
+    assert c.get_session_stats(1) == {"sampleCount": 0}
+    assert c.deleteScans([1, 2]) == 0

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -53,6 +53,33 @@ def test_config_name_known_and_unknown():
     assert _config_name(0x00) == "None"
     assert _config_name(0x12) == "0x12"   # unmapped -> hex
     assert _config_name(-1) == "—"        # unknown
+    assert _config_name(None) == "—"      # missing
+
+
+def test_get_scan_sessions_skips_malformed_row_keeps_rest(tmp_path):
+    """One unparseable session must not blank the whole History view."""
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    c = _connector(tmp_path, db_path)
+
+    real = MotionConnector._session_to_row
+
+    def flaky(self, s):
+        if s.get("session_label", "").endswith("boom"):
+            raise ValueError("malformed row")
+        return real(self, s)
+
+    db = ScanDatabase(db_path=db_path)
+    db.create_session(session_label="20260612_093000_boom",
+                      session_start=200.0, session_end=205.0,
+                      session_notes=None, session_meta={})
+    db.close()
+
+    c._session_to_row = flaky.__get__(c, MotionConnector)
+    rows = c.get_scan_sessions()
+    labels = [r["label"] for r in rows]
+    assert "20260612_092000_subjA" in labels
+    assert "20260612_093000_boom" not in labels
 
 
 def test_get_scan_sessions_rows_and_sort(tmp_path):


### PR DESCRIPTION
## Summary

Reworks the History view from a single-select ComboBox picker into a proper data-management table, driven entirely by the scan database (`sessions` table) — no CSV-filename listing.

- **Sortable, searchable, multiselect table** — columns: User Label · Date / Time · Config (left / right, e.g. `Near / Far`) · Duration · status (ok / ⚠ interrupted). Clickable headers sort; default Date/Time descending. Search filters by label; a Config dropdown filters by configuration.
- **Read-only detail pane** for the focused row: full label, operator, L/R masks, config, lazily-fetched sample-row count, and notes.
- **Actions** — `Load in viewer →` (reuses the async `loadPastScan`), `Export CSV` (reuses `exportScanCsv`), and a password-gated `🔒 Delete (N)` acting on all checked rows. Delete opens the existing `PasswordPromptModal` (developer password), then calls a new `deleteScans()` → `delete_session()` (CASCADE removes `session_data`). Delete is disabled while a scan is RUNNING; interrupted rows block Load/Export.

### Implementation

- **No SDK changes.** Config (incl. reduced-mode), operator, and duration all come from `session_meta` (`sdk_flags.left/right_camera_mask`, `reduced_mode`) + `session_start`/`session_end`, which `ScanDBSink` already writes.
- New connector slots in `motion_connector.py` (kept small, DB-only): `get_scan_sessions()`, `get_session_stats()`, `deleteScans()`, plus a unit-testable `_config_name()` mask→name helper. Table rendering lives entirely in QML.
- `components/HistoryModal.qml` rewritten around a header + `ListView` table; new `components/HistoryHeaderCell.qml` for sort-aware headers (decoupled via properties + a `sortRequested` signal). Root contract preserved, so `BloodFlow.qml` / `ModalManager` are untouched.
- Spec: `docs/superpowers/specs/2026-06-15-history-data-management-design.md`; plan: `docs/superpowers/plans/2026-06-15-history-data-management.md`.

## Test Plan

- [x] New connector unit tests (`tests/test_history_sessions.py`, 9 tests): session-row shape + sort, config/mask derivation, interrupted/open sessions, missing-DB safety, malformed-row skip, sample-count, and cascade delete. **All pass.**
- [x] No regression in the kept `tests/test_scan_history_list.py` (4 tests pass).
- [x] flake8 clean on new code; QML loads with zero errors on app boot (verified via log + screenshot — table renders with correct config decoding).
- [ ] `tests/test_history.py` (HIL, `@pytest.mark.dev`) updated to the new table UI; byte-compiles, **requires the self-hosted hardware runner to validate end-to-end**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)