### PR TITLE
feat: audit log + password-gated Logs viewer (CSV export + debug-log bundle)

### DIFF
--- a/audit_log.py
+++ b/audit_log.py
@@ -1,0 +1,202 @@
+"""Append-only, machine-readable audit log stored in scans.db.
+
+A small, self-contained logger used primarily by auditors. Writes one
+row per event to a ``logs`` table in the same SQLite file the SDK's
+ScanDatabase uses (scans.db). Owns its own long-lived connection so it
+can append alongside ScanDatabase's on-demand handles.
+
+Fail-soft by contract: construction with a missing path, or any DB
+error, degrades the instance to a no-op — a failed audit write must
+never crash or block the app.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import logging
+import platform
+import socket
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openmotion.bloodflow-app.audit")
+
+# ── Event-type constants ────────────────────────────────────────────────
+EV_SYSTEM_STARTUP = "system_startup"
+EV_SYSTEM_INFO = "system_info"
+EV_SYSTEM_SHUTDOWN = "system_shutdown"
+EV_DEVICE_CONNECTED = "device_connected"
+EV_DEVICE_DISCONNECTED = "device_disconnected"
+EV_DEVICE_STATS = "device_stats"
+EV_SCAN_STARTED = "scan_started"
+EV_SCAN_ENDED = "scan_ended"
+EV_CALIBRATION_STARTED = "calibration_started"
+EV_CALIBRATION_ENDED = "calibration_ended"
+EV_SETTINGS_CHANGED = "settings_changed"
+EV_SCAN_VIEWED = "scan_viewed"
+EV_SCAN_DELETED = "scan_deleted"
+EV_AUDIT_LOG_VIEWED = "audit_log_viewed"
+EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+
+# CSV export column order.
+_CSV_FIELDS = ["ts_iso", "ts_epoch", "event_type", "details"]
+
+
+def gather_host_info() -> Dict[str, Any]:
+    """Collect host/system facts for the ``system_info`` event. Best-effort
+    — any probe that fails is simply omitted."""
+    info: Dict[str, Any] = {}
+    try:
+        info["hostname"] = socket.gethostname()
+        info["platform"] = platform.platform()
+        info["system"] = f"{platform.system()} {platform.release()}".strip()
+        info["arch"] = platform.machine()
+        info["processor"] = platform.processor()
+        info["python"] = platform.python_version()
+    except Exception:
+        logger.warning("gather_host_info: core probe failed", exc_info=True)
+    try:
+        if platform.system() == "Windows":
+            import ctypes
+
+            class _MEMSTATUSEX(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            mem = _MEMSTATUSEX()
+            mem.dwLength = ctypes.sizeof(_MEMSTATUSEX)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(mem))
+            info["ram_gb"] = round(mem.ullTotalPhys / (1024 ** 3), 2)
+    except Exception:
+        pass
+    return info
+
+
+class AuditLog:
+    """Append-only audit-event store backed by the ``logs`` table in
+    scans.db. Thread-safe (single connection + write lock). No-op when
+    constructed without a usable path."""
+
+    def __init__(self, db_path: Optional[str | Path]) -> None:
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        if not db_path:
+            logger.info(
+                "AuditLog: no db_path — audit logging disabled (no-op)."
+            )
+            return
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._conn = conn
+            self._init_schema()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to open %s — disabling audit logging.",
+                db_path, exc_info=True,
+            )
+            self._conn = None
+
+    def _init_schema(self) -> None:
+        assert self._conn is not None
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS logs (
+                id          INTEGER PRIMARY KEY,
+                ts_epoch    REAL NOT NULL,
+                ts_iso      TEXT NOT NULL,
+                event_type  TEXT NOT NULL,
+                details     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
+            """
+        )
+        self._conn.commit()
+
+    @property
+    def enabled(self) -> bool:
+        return self._conn is not None
+
+    def log(
+        self, event_type: str, details: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Append one event. ``details`` (if truthy) is stored as compact,
+        deterministic JSON. Never raises."""
+        if self._conn is None:
+            return
+        ts_epoch = time.time()
+        ts_iso = datetime.datetime.fromtimestamp(ts_epoch).isoformat(
+            timespec="seconds"
+        )
+        details_json = (
+            json.dumps(
+                details, separators=(",", ":"), sort_keys=True, default=str
+            )
+            if details else None
+        )
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO logs (ts_epoch, ts_iso, event_type, details)"
+                    " VALUES (?, ?, ?, ?)",
+                    (ts_epoch, ts_iso, str(event_type), details_json),
+                )
+                self._conn.commit()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to write %s event", event_type, exc_info=True
+            )
+
+    def query(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` rows, newest first, as plain dicts."""
+        if self._conn is None:
+            return []
+        try:
+            with self._lock:
+                cur = self._conn.execute(
+                    "SELECT id, ts_epoch, ts_iso, event_type, details"
+                    " FROM logs ORDER BY id DESC LIMIT ?",
+                    (int(limit),),
+                )
+                cols = [c[0] for c in cur.description]
+                return [dict(zip(cols, row)) for row in cur.fetchall()]
+        except Exception:
+            logger.warning("AuditLog: query failed", exc_info=True)
+            return []
+
+    def export_csv(self, dest_path: str | Path) -> int:
+        """Write the full log (oldest first) to ``dest_path`` as CSV.
+        Returns the number of data rows written."""
+        if self._conn is None:
+            return 0
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT ts_iso, ts_epoch, event_type, details"
+                " FROM logs ORDER BY id ASC"
+            ).fetchall()
+        with open(dest_path, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(_CSV_FIELDS)
+            w.writerows(rows)
+        return len(rows)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None

--- a/audit_log.py
+++ b/audit_log.py
@@ -42,6 +42,7 @@ EV_SCAN_VIEWED = "scan_viewed"
 EV_SCAN_DELETED = "scan_deleted"
 EV_AUDIT_LOG_VIEWED = "audit_log_viewed"
 EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+EV_DEBUG_BUNDLE_CREATED = "debug_bundle_created"
 
 # CSV export column order.
 _CSV_FIELDS = ["ts_iso", "ts_epoch", "event_type", "details"]

--- a/audit_log.py
+++ b/audit_log.py
@@ -179,6 +179,20 @@ class AuditLog:
             logger.warning("AuditLog: query failed", exc_info=True)
             return []
 
+    def count(self) -> int:
+        """Total number of log rows (0 when disabled / on error)."""
+        try:
+            with self._lock:
+                if self._conn is None:
+                    return 0
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM logs"
+                ).fetchone()
+                return int(row[0]) if row else 0
+        except Exception:
+            logger.warning("AuditLog: count failed", exc_info=True)
+            return 0
+
     def export_csv(self, dest_path: str | Path) -> int:
         """Write the full log (oldest first) to ``dest_path`` as CSV.
         Returns the number of data rows written (0 on any failure)."""

--- a/audit_log.py
+++ b/audit_log.py
@@ -126,7 +126,6 @@ class AuditLog:
             CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
             """
         )
-        self._conn.commit()
 
     @property
     def enabled(self) -> bool:
@@ -135,22 +134,23 @@ class AuditLog:
     def log(
         self, event_type: str, details: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Append one event. ``details`` (if truthy) is stored as compact,
+        """Append one event. ``details`` (if not None) is stored as compact,
         deterministic JSON. Never raises."""
-        if self._conn is None:
-            return
         ts_epoch = time.time()
-        ts_iso = datetime.datetime.fromtimestamp(ts_epoch).isoformat(
-            timespec="seconds"
+        ts_iso = (
+            datetime.datetime.fromtimestamp(ts_epoch)
+            .astimezone()
+            .isoformat(timespec="seconds")
         )
         details_json = (
-            json.dumps(
-                details, separators=(",", ":"), sort_keys=True, default=str
-            )
-            if details else None
+            json.dumps(details, separators=(",", ":"), sort_keys=True,
+                       default=str)
+            if details is not None else None
         )
         try:
             with self._lock:
+                if self._conn is None:
+                    return
                 self._conn.execute(
                     "INSERT INTO logs (ts_epoch, ts_iso, event_type, details)"
                     " VALUES (?, ?, ?, ?)",
@@ -164,10 +164,10 @@ class AuditLog:
 
     def query(self, limit: int = 500) -> List[Dict[str, Any]]:
         """Return up to ``limit`` rows, newest first, as plain dicts."""
-        if self._conn is None:
-            return []
         try:
             with self._lock:
+                if self._conn is None:
+                    return []
                 cur = self._conn.execute(
                     "SELECT id, ts_epoch, ts_iso, event_type, details"
                     " FROM logs ORDER BY id DESC LIMIT ?",
@@ -181,18 +181,28 @@ class AuditLog:
 
     def export_csv(self, dest_path: str | Path) -> int:
         """Write the full log (oldest first) to ``dest_path`` as CSV.
-        Returns the number of data rows written."""
-        if self._conn is None:
-            return 0
+        Returns the number of data rows written (0 on any failure)."""
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT ts_iso, ts_epoch, event_type, details"
-                " FROM logs ORDER BY id ASC"
-            ).fetchall()
-        with open(dest_path, "w", newline="", encoding="utf-8") as f:
-            w = csv.writer(f)
-            w.writerow(_CSV_FIELDS)
-            w.writerows(rows)
+            if self._conn is None:
+                return 0
+            try:
+                rows = self._conn.execute(
+                    "SELECT ts_iso, ts_epoch, event_type, details"
+                    " FROM logs ORDER BY id ASC"
+                ).fetchall()
+            except Exception:
+                logger.warning("AuditLog: export_csv query failed",
+                               exc_info=True)
+                return 0
+        try:
+            with open(dest_path, "w", newline="", encoding="utf-8") as f:
+                w = csv.writer(f)
+                w.writerow(_CSV_FIELDS)
+                w.writerows(rows)
+        except OSError:
+            logger.warning("AuditLog: export_csv write to %s failed",
+                           dest_path, exc_info=True)
+            return 0
         return len(rows)
 
     def close(self) -> None:

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -202,11 +202,19 @@ Item {
         nameFilters: ["CSV files (*.csv)", "All files (*)"]
         onAccepted: {
             var path = selectedFile.toString().replace("file:///", "")
-            var ok = MotionInterface.exportAuditLogCsv(path)
-            if (ok) {
-                MotionInterface.notify("Audit log exported to " + ok, "success")
+            // exportAuditLogCsv returns the written path ("" on failure).
+            var dest = MotionInterface.exportAuditLogCsv(path)
+            if (dest) {
+                MotionInterface.notify("Audit log exported to " + dest, "success")
                 root.refresh()   // pick up the audit_log_exported entry
             }
         }
+    }
+
+    // Refresh if the data directory (and therefore the scan DB) changes
+    // while the viewer is open — mirrors HistoryModal's behavior.
+    Connections {
+        target: MotionInterface
+        function onDirectoryChanged() { if (root.visible) root.refresh() }
     }
 }

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -1,0 +1,212 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import QtQuick.Dialogs as Dialogs
+import OpenMotion 1.0
+
+// Audit-log viewer. Lists machine-readable audit entries (newest first)
+// and exports them as CSV. Opened from the password gate in SettingsModal.
+// Governed by ModalManager (see HistoryModal.qml for the modal contract).
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 9998
+
+    AppTheme { id: theme }
+
+    readonly property string label: "Audit Log"
+    property var entries: []
+
+    function open() {
+        // Record the view first, then load (so the view event is included).
+        MotionInterface.recordAuditLogViewed()
+        refresh()
+        root.visible = true
+    }
+    function close() { root.visible = false }
+
+    function refresh() {
+        try { entries = MotionInterface.auditLogEntries(500) || [] }
+        catch (e) { entries = [] }
+    }
+
+    QtObject {
+        id: col
+        readonly property int time: 160
+        readonly property int event: 170
+    }
+
+    // ── backdrop ───────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000AA"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    Rectangle {
+        width: Math.min(parent.width - 60, 980)
+        height: Math.min(parent.height - 60, 700)
+        radius: 12
+        color: theme.bgContainer
+        border.color: theme.borderSubtle
+        border.width: 2
+        anchors.centerIn: parent
+
+        MouseArea { anchors.fill: parent }   // absorb clicks
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 18
+            spacing: 12
+
+            // ── toolbar ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                Text {
+                    text: root.label
+                    font.pixelSize: 20; font.weight: Font.Bold
+                    color: theme.textPrimary
+                }
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Export CSV"
+                    Layout.preferredWidth: 110; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                                    + "/audit_log.csv"
+                        exportDialog.open()
+                    }
+                }
+                Button {
+                    text: "Refresh"
+                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: root.refresh()
+                }
+                Rectangle {
+                    width: 28; height: 28; radius: 14
+                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
+                    border.color: theme.borderHover; border.width: 1
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    MouseArea {
+                        id: xArea; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor; onClicked: root.close()
+                    }
+                }
+            }
+
+            // ── table header ───────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                color: theme.bgCardAlt; radius: 4
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                    spacing: 8
+                    Text { text: "Time"; Layout.preferredWidth: col.time
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Event"; Layout.preferredWidth: col.event
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Details"; Layout.fillWidth: true
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                }
+            }
+
+            // ── table body ─────────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true; Layout.fillHeight: true
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                clip: true
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    model: root.entries
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Rectangle {
+                        width: ListView.view.width
+                        height: 30
+                        color: index % 2 === 0 ? "transparent" : Qt.rgba(1, 1, 1, 0.02)
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 8
+                            spacing: 8
+                            Text {
+                                Layout.preferredWidth: col.time
+                                text: modelData.ts_iso || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.event
+                                text: modelData.event_type || ""
+                                color: theme.textPrimary; font.pixelSize: 12
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.details || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+
+                    Text {
+                        anchors.centerIn: parent
+                        visible: root.entries.length === 0
+                        text: "No audit entries yet."
+                        color: theme.textSecondary; font.pixelSize: 14
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+
+    Dialogs.FileDialog {
+        id: exportDialog
+        title: "Export Audit Log CSV"
+        fileMode: Dialogs.FileDialog.SaveFile
+        nameFilters: ["CSV files (*.csv)", "All files (*)"]
+        onAccepted: {
+            var path = selectedFile.toString().replace("file:///", "")
+            var ok = MotionInterface.exportAuditLogCsv(path)
+            if (ok) {
+                MotionInterface.notify("Audit log exported to " + ok, "success")
+                root.refresh()   // pick up the audit_log_exported entry
+            }
+        }
+    }
+}

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -73,6 +73,27 @@ Item {
                 Item { Layout.fillWidth: true }
 
                 Button {
+                    text: "Send Debug Logs"
+                    Layout.preferredWidth: 140; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    // Connector builds the zip, reveals it, and toasts the
+                    // support address; refresh so the debug_bundle_created
+                    // entry shows up in the list.
+                    onClicked: {
+                        MotionInterface.prepareDebugLogBundle()
+                        root.refresh()
+                    }
+                }
+
+                Button {
                     text: "Export CSV"
                     Layout.preferredWidth: 110; Layout.preferredHeight: 32
                     hoverEnabled: true

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -73,27 +73,6 @@ Item {
                 Item { Layout.fillWidth: true }
 
                 Button {
-                    text: "Send Debug Logs"
-                    Layout.preferredWidth: 140; Layout.preferredHeight: 32
-                    hoverEnabled: true
-                    contentItem: Text {
-                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
-                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
-                    }
-                    background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
-                    }
-                    // Connector builds the zip, reveals it, and toasts the
-                    // support address; refresh so the debug_bundle_created
-                    // entry shows up in the list.
-                    onClicked: {
-                        MotionInterface.prepareDebugLogBundle()
-                        root.refresh()
-                    }
-                }
-
-                Button {
                     text: "Export CSV"
                     Layout.preferredWidth: 110; Layout.preferredHeight: 32
                     hoverEnabled: true

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -63,6 +63,19 @@ Item {
         )
     }
 
+    // Emitted when the user enters the correct password for the audit log.
+    // BloodFlow.qml opens the (ModalManager-governed) LogsModal in response.
+    signal logsRequested()
+
+    // Password gate for the audit Logs viewer.
+    PasswordPromptModal {
+        id: logsPasswordModal
+        title: "Audit Log"
+        description: "Enter the password to view the audit log."
+        confirmLabel: "View Logs"
+        onAccepted: root.logsRequested()
+    }
+
     // ── Lifecycle ───────────────────────────────────────────────────────────
     function _loadFromConfig() {
         var cfg = MotionInterface.appConfig
@@ -753,6 +766,30 @@ Item {
                                 }
                             }
                         }
+                    }
+                }
+
+                // ── Audit Log ────────────────────────────────────────────────
+                SectionCard {
+                    title: "Audit Log"
+
+                    FieldRow {
+                        label: "Logs"
+                        ActionButton {
+                            text: "View Logs"
+                            Layout.preferredWidth: 130
+                            onClicked: logsPasswordModal.open()
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    Text {
+                        text: "Password-protected, machine-readable record of system "
+                              + "events for auditors. Open the viewer to browse entries "
+                              + "or export them as CSV."
+                        color: root.colTextMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
                     }
                 }
 

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -780,12 +780,20 @@ Item {
                             Layout.preferredWidth: 130
                             onClicked: logsPasswordModal.open()
                         }
+                        ActionButton {
+                            text: "Send Debug Logs"
+                            Layout.preferredWidth: 150
+                            // Direct action — zips the last 48h of app logs,
+                            // reveals the file, and toasts the support address.
+                            onClicked: MotionInterface.prepareDebugLogBundle()
+                        }
                         Item { Layout.fillWidth: true }
                     }
                     Text {
                         text: "Password-protected, machine-readable record of system "
                               + "events for auditors. Open the viewer to browse entries "
-                              + "or export them as CSV."
+                              + "or export them as CSV. Send Debug Logs zips the last "
+                              + "48 hours of app logs to email to support@openwater.cc."
                         color: root.colTextMuted
                         font.pixelSize: 11
                         wrapMode: Text.WordWrap

--- a/debug_bundle.py
+++ b/debug_bundle.py
@@ -1,0 +1,112 @@
+"""Build a zip bundle of recent app logs for emailing to support.
+
+Collects the last N hours of app log files plus app_config.json and a
+generated system_info.txt into a single zip. Pure file logic -- no Qt, no
+hardware -- so it is unit-testable against a temp directory.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from audit_log import gather_host_info
+
+logger = logging.getLogger("openmotion.bloodflow-app.debug-bundle")
+
+WINDOW_HOURS = 48
+
+
+def _system_info_text(
+    now_epoch: float, extra_info: Optional[Dict[str, Any]]
+) -> str:
+    """Render host info (+ caller-supplied extras) as sorted key: value
+    lines, with a leading local-time 'generated' stamp."""
+    info = gather_host_info()
+    if extra_info:
+        info.update(extra_info)
+    generated = (
+        datetime.datetime.fromtimestamp(now_epoch)
+        .astimezone()
+        .isoformat(timespec="seconds")
+    )
+    lines = [f"generated: {generated}"]
+    lines += [f"{k}: {info[k]}" for k in sorted(info)]
+    return "\n".join(lines) + "\n"
+
+
+def build_debug_bundle(
+    data_dir: str | Path,
+    dest_dir: str | Path,
+    now_epoch: float,
+    *,
+    window_hours: int = WINDOW_HOURS,
+    config_path: str | Path | None = None,
+    extra_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Zip recent app logs + config + system info into dest_dir.
+
+    Includes <data_dir>/app-logs/*.log with mtime within window_hours,
+    the app_config.json at config_path (default <data_dir>/app_config.json)
+    if present, and a generated system_info.txt. Returns
+    {"path", "file_count", "log_count", "bytes"}.
+    """
+    data_dir = Path(data_dir)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    cutoff = now_epoch - window_hours * 3600
+    log_dir = data_dir / "app-logs"
+    recent_logs = []
+    if log_dir.is_dir():
+        for p in sorted(log_dir.glob("*.log")):
+            try:
+                if p.stat().st_mtime >= cutoff:
+                    recent_logs.append(p)
+            except OSError:
+                logger.warning(
+                    "debug_bundle: stat failed for %s", p, exc_info=True
+                )
+
+    if config_path is None:
+        config_path = data_dir / "app_config.json"
+    config_path = Path(config_path)
+
+    stamp = datetime.datetime.fromtimestamp(now_epoch).strftime(
+        "%Y%m%d_%H%M%S"
+    )
+    dest = dest_dir / f"debug-bundle-{stamp}.zip"
+
+    file_count = 0
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in recent_logs:
+            try:
+                zf.write(p, arcname=f"app-logs/{p.name}")
+                file_count += 1
+            except OSError:
+                logger.warning(
+                    "debug_bundle: could not add %s", p, exc_info=True
+                )
+        if config_path.is_file():
+            try:
+                zf.write(config_path, arcname=config_path.name)
+                file_count += 1
+            except OSError:
+                logger.warning(
+                    "debug_bundle: could not add config %s", config_path,
+                    exc_info=True,
+                )
+        zf.writestr(
+            "system_info.txt", _system_info_text(now_epoch, extra_info)
+        )
+        file_count += 1
+
+    return {
+        "path": str(dest),
+        "file_count": file_count,
+        "log_count": len(recent_logs),
+        "bytes": dest.stat().st_size,
+    }

--- a/debug_bundle.py
+++ b/debug_bundle.py
@@ -52,7 +52,12 @@ def build_debug_bundle(
     Includes <data_dir>/app-logs/*.log with mtime within window_hours,
     the app_config.json at config_path (default <data_dir>/app_config.json)
     if present, and a generated system_info.txt. Returns
-    {"path", "file_count", "log_count", "bytes"}.
+    {"path", "file_count", "log_count", "bytes"} where:
+      - log_count  = log files that matched the time window.
+      - file_count = entries actually written into the zip (logs + config
+        if present + system_info). May be < log_count + 1 if a matched log
+        fails to add (skipped fail-soft).
+      - bytes      = size of the written zip on disk.
     """
     data_dir = Path(data_dir)
     dest_dir = Path(dest_dir)

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -23,7 +23,7 @@ The viewer lists entries **newest first**, with three columns:
 
 | Column | Meaning |
 |---|---|
-| **Time** | Local timestamp the event was recorded (ISO-8601, e.g. `2026-06-15T09:14:02`). |
+| **Time** | Local timestamp the event was recorded (ISO-8601 with UTC offset, e.g. `2026-06-15T09:14:02-07:00`). |
 | **Event** | The event type (see the table below). |
 | **Details** | A compact JSON object with event-specific fields. |
 
@@ -86,7 +86,7 @@ Schema:
 |---|---|---|
 | `id` | INTEGER | Auto-incrementing primary key (also the insertion order). |
 | `ts_epoch` | REAL | Event time as a Unix timestamp (seconds since 1970-01-01 UTC). |
-| `ts_iso` | TEXT | Event time as a local ISO-8601 string, e.g. `2026-06-15T09:14:02`. |
+| `ts_iso` | TEXT | Event time as a local ISO-8601 string with UTC offset (unambiguous across DST), e.g. `2026-06-15T09:14:02-07:00`. |
 | `event_type` | TEXT | One of the event types in the table above. |
 | `details` | TEXT | Compact JSON object, or empty when the event has no payload. |
 
@@ -110,8 +110,8 @@ archiving), with one header row and one row per event:
 
 ```
 ts_iso,ts_epoch,event_type,details
-2026-06-15T09:14:02,1750000442.12,system_startup,"{""app_version"":""1.2.3"",""data_dir"":""C:\\…"",""sdk_version"":""…""}"
-2026-06-15T09:14:02,1750000442.13,system_info,"{""arch"":""AMD64"",""hostname"":""LAB-PC-01"",…}"
+2026-06-15T09:14:02-07:00,1750000442.12,system_startup,"{""app_version"":""1.2.3"",""data_dir"":""C:\\…"",""sdk_version"":""…""}"
+2026-06-15T09:14:02-07:00,1750000442.13,system_info,"{""arch"":""AMD64"",""hostname"":""LAB-PC-01"",…}"
 ```
 
 The `details` column holds the raw JSON for each event, quoted per standard

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -88,7 +88,7 @@ Schema:
 | `ts_epoch` | REAL | Event time as a Unix timestamp (seconds since 1970-01-01 UTC). |
 | `ts_iso` | TEXT | Event time as a local ISO-8601 string with UTC offset (unambiguous across DST), e.g. `2026-06-15T09:14:02-07:00`. |
 | `event_type` | TEXT | One of the event types in the table above. |
-| `details` | TEXT | Compact JSON object, or empty when the event has no payload. |
+| `details` | TEXT | Compact JSON object, or `NULL` when the event has no payload. |
 
 Because it's plain SQLite, auditors can also query the table directly with
 any SQLite tool, for example:

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -54,6 +54,7 @@ plus a small JSON `details` payload. The app records the following events:
 | `scan_deleted` | One or more scans are deleted. | `session_ids`, `count` |
 | `audit_log_viewed` | The audit log itself is opened. | `entry_count` |
 | `audit_log_exported` | The audit log is exported to CSV. | `dest`, `row_count` |
+| `debug_bundle_created` | The "Send Debug Logs" button is used. | `dest`, `file_count`, `log_count`, `bytes`, `window_hours` |
 
 Notes for auditors:
 
@@ -101,6 +102,18 @@ LIMIT 50;
 ```
 
 ---
+
+## Sending debug logs to Openwater
+
+The **Send Debug Logs** button (top of the audit-log viewer) packages the
+app's diagnostic logs for support. It writes a zip to
+`<dataDirectory>/app-logs/debug-bundles/debug-bundle-<timestamp>.zip`
+containing the app log files from the last 48 hours, `app_config.json`,
+and a `system_info.txt` (app/SDK version + host details). The file
+explorer opens with the zip selected, and a message shows the path —
+**email that zip to support@openwater.cc**. No data is sent
+automatically, and the bundle contains no scan data or patient
+information.
 
 ## Exporting to CSV
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,0 +1,141 @@
+# Audit Log — User & Auditor Guide
+
+The OpenWater Bloodflow app keeps an **audit log**: a machine-readable,
+append-only record of significant system events. It exists primarily for
+**auditors** who need to reconstruct what the system and its operators did,
+and when. This guide explains how to open it, what it records, and how to
+read or export it.
+
+---
+
+## Opening the audit log
+
+1. Open **Settings** (gear icon).
+2. Scroll to the **Audit Log** section and click **View Logs**.
+3. Enter the access password when prompted.
+
+> The password is the same one used for other protected actions in the app
+> (e.g. starting a calibration or deleting scans). Ask your system
+> administrator if you don't have it. The audit log is read-only from the
+> UI — there is no way to edit or delete individual entries through the app.
+
+The viewer lists entries **newest first**, with three columns:
+
+| Column | Meaning |
+|---|---|
+| **Time** | Local timestamp the event was recorded (ISO-8601, e.g. `2026-06-15T09:14:02`). |
+| **Event** | The event type (see the table below). |
+| **Details** | A compact JSON object with event-specific fields. |
+
+Use **Refresh** to reload, and **Export CSV** to save the full log to a file
+(see [Exporting](#exporting-to-csv)).
+
+---
+
+## What gets recorded
+
+Each entry is intentionally **minimal and structured** — a short event type
+plus a small JSON `details` payload. The app records the following events:
+
+| Event type | When it happens | Key details |
+|---|---|---|
+| `system_startup` | The app launches. | `app_version`, `sdk_version`, `data_dir` |
+| `system_info` | At launch, right after startup. | `hostname`, `platform`, `system`, `arch`, `processor`, `python`, `ram_gb` |
+| `system_shutdown` | The app closes cleanly. | `clean` |
+| `device_connected` | The console or a sensor connects. | `device` (`console`/`left`/`right`), `reason` |
+| `device_disconnected` | The console or a sensor disconnects. | `device`, `reason` |
+| `device_stats` | When a device connects, once its IDs are readable. | `device`, `hardware_id`, `firmware_version` |
+| `scan_started` | A scan begins. | `label`, `left_mask`, `right_mask` |
+| `scan_ended` | A scan finishes or is stopped. | `label`, `session_label`, `duration_s`, `outcome` |
+| `calibration_started` | A calibration begins. | `target` (`both`/`left`/`right`) |
+| `calibration_ended` | A calibration finishes. | `target`, `outcome` (`passed`/`failed`/`aborted`), `reason` |
+| `settings_changed` | A setting is changed and saved. | `changes` — only the keys that actually changed, each as `{ "old": …, "new": … }` |
+| `scan_viewed` | A past scan is opened in the viewer. | `label` |
+| `scan_deleted` | One or more scans are deleted. | `session_ids`, `count` |
+| `audit_log_viewed` | The audit log itself is opened. | `entry_count` |
+| `audit_log_exported` | The audit log is exported to CSV. | `dest`, `row_count` |
+
+Notes for auditors:
+
+- **The audit log audits itself.** Opening the viewer and exporting it are
+  both recorded (`audit_log_viewed`, `audit_log_exported`), so access to the
+  audit data leaves its own trail.
+- **System statistics** are split across two events: host/OS facts at launch
+  (`system_info`) and per-device hardware/firmware IDs on connect
+  (`device_stats`).
+- **Settings changes record a diff**, not the full configuration — only the
+  keys whose values changed, with their old and new values. A save that
+  changes nothing produces no entry.
+- Some payloads use a stable scan **label** (e.g. `ow3SW4HD`) and/or a
+  **session label** (e.g. `20260610_163915_ow3SW4HD`) as the identifier,
+  consistent with how scans are named elsewhere in the app and in the scan
+  database.
+
+---
+
+## Where the data lives
+
+Audit entries are stored in a table named **`logs`** inside the app's scan
+database, `scans.db`, which lives in your configured **data directory** (the
+same folder as your scan CSVs and the scan history). The table is
+append-only; the app never updates or removes rows.
+
+Schema:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INTEGER | Auto-incrementing primary key (also the insertion order). |
+| `ts_epoch` | REAL | Event time as a Unix timestamp (seconds since 1970-01-01 UTC). |
+| `ts_iso` | TEXT | Event time as a local ISO-8601 string, e.g. `2026-06-15T09:14:02`. |
+| `event_type` | TEXT | One of the event types in the table above. |
+| `details` | TEXT | Compact JSON object, or empty when the event has no payload. |
+
+Because it's plain SQLite, auditors can also query the table directly with
+any SQLite tool, for example:
+
+```sql
+SELECT ts_iso, event_type, details
+FROM logs
+ORDER BY id DESC
+LIMIT 50;
+```
+
+---
+
+## Exporting to CSV
+
+In the audit-log viewer, click **Export CSV** and choose a destination. The
+exported file is UTF-8 and ordered **oldest first** (stable for diffing and
+archiving), with one header row and one row per event:
+
+```
+ts_iso,ts_epoch,event_type,details
+2026-06-15T09:14:02,1750000442.12,system_startup,"{""app_version"":""1.2.3"",""data_dir"":""C:\\…"",""sdk_version"":""…""}"
+2026-06-15T09:14:02,1750000442.13,system_info,"{""arch"":""AMD64"",""hostname"":""LAB-PC-01"",…}"
+```
+
+The `details` column holds the raw JSON for each event, quoted per standard
+CSV rules. Every common spreadsheet and data tool can read this directly;
+the JSON keys within `details` are sorted alphabetically so the format is
+deterministic.
+
+---
+
+## Frequently asked
+
+**Can entries be edited or removed?**
+Not through the app. The log is append-only and the viewer is read-only.
+
+**Does deleting a scan remove its audit entries?**
+No. Deleting scans removes the scan data, but the `scan_deleted` event (and
+all earlier `scan_started` / `scan_viewed` entries for that scan) remain in
+the audit log.
+
+**What if the data directory is unavailable at startup?**
+Audit logging fails safe: if the database can't be opened, the app keeps
+running normally and simply records nothing — a failed audit write never
+interrupts a scan or crashes the app.
+
+**Is patient/subject data stored in the log?**
+The log records scan **labels** and masks, not histogram data or computed
+BFI/BVI values. Treat labels according to your site's data-handling policy.

--- a/docs/superpowers/plans/2026-06-15-audit-log.md
+++ b/docs/superpowers/plans/2026-06-15-audit-log.md
@@ -1,0 +1,1544 @@
+# Audit Log Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a machine-readable, append-only audit log to the bloodflow app's `scans.db`, surfaced through a password-gated **Logs** button in Settings with CSV export.
+
+**Architecture:** A standalone `audit_log.py` module (`AuditLog` class) owns a long-lived sqlite3 connection to `scans.db`, lazily creates a `logs` table, and exposes `log()/query()/export_csv()`. `MotionConnector` holds one `AuditLog` instance and calls `self._audit.log(...)` at thin instrumentation sites. A new `LogsModal.qml` (reached via a password gate in `SettingsModal.qml`) lists entries and exports CSV.
+
+**Tech Stack:** Python 3.13, PyQt6, sqlite3 (stdlib), pytest. QML 6.
+
+**Design spec:** [docs/superpowers/specs/2026-06-15-audit-log-design.md](../specs/2026-06-15-audit-log-design.md)
+
+---
+
+## File Structure
+
+- **Create** `audit_log.py` — `AuditLog` class + event-type constants + `gather_host_info()`. One responsibility: the audit logging store.
+- **Create** `tests/test_audit_log.py` — unit tests for the module.
+- **Create** `tests/test_audit_connector.py` — unit tests for connector-level instrumentation.
+- **Create** `components/LogsModal.qml` — the log viewer modal (modeled on `HistoryModal.qml`).
+- **Modify** `motion_connector.py` — construct `AuditLog`, add QML slots, add instrumentation call sites.
+- **Modify** `components/SettingsModal.qml` — Audit Log section + password gate + `logsRequested()` signal.
+- **Modify** `pages/BloodFlow.qml` — add `LogsModal` instance, register it in `ModalManager`, wire `onLogsRequested`.
+
+All call sites are thin one-liners; the existing `motion_connector.py` (4031 lines) gains a small slot block and ~8 single-line log calls.
+
+---
+
+## Task 1: AuditLog module
+
+**Files:**
+- Create: `audit_log.py`
+- Test: `tests/test_audit_log.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_audit_log.py`:
+
+```python
+"""Unit tests for the append-only audit log (audit_log.py)."""
+import csv
+import json
+import sqlite3
+import threading
+
+import pytest
+
+from audit_log import AuditLog, gather_host_info, EV_SYSTEM_STARTUP
+
+pytestmark = pytest.mark.unit
+
+
+def test_log_creates_table_and_inserts_row(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log(EV_SYSTEM_STARTUP, {"app_version": "1.2.3"})
+    a.close()
+
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        "SELECT event_type, details FROM logs"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == EV_SYSTEM_STARTUP
+    assert json.loads(rows[0][1]) == {"app_version": "1.2.3"}
+
+
+def test_reopen_is_idempotent(tmp_path):
+    db = str(tmp_path / "scans.db")
+    AuditLog(db).close()
+    a = AuditLog(db)          # second open must not raise on CREATE
+    a.log("system_info", None)
+    a.close()
+
+
+def test_none_details_stored_as_null(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log("system_shutdown", None)
+    a.close()
+    conn = sqlite3.connect(db)
+    val = conn.execute("SELECT details FROM logs").fetchone()[0]
+    conn.close()
+    assert val is None
+
+
+def test_query_is_newest_first_and_honors_limit(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for i in range(5):
+        a.log("scan_started", {"n": i})
+    out = a.query(limit=3)
+    a.close()
+    assert len(out) == 3
+    # newest (n=4) first
+    assert json.loads(out[0]["details"])["n"] == 4
+
+
+def test_export_csv_roundtrips(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"label": "owABC"})
+    a.log("scan_ended", {"label": "owABC"})
+    dest = tmp_path / "audit.csv"
+    n = a.export_csv(str(dest))
+    a.close()
+    assert n == 2
+    with open(dest, newline="", encoding="utf-8") as f:
+        reader = list(csv.DictReader(f))
+    assert reader[0]["event_type"] == "scan_started"   # oldest first
+    assert json.loads(reader[0]["details"])["label"] == "owABC"
+
+
+def test_no_path_is_silent_noop(tmp_path):
+    a = AuditLog(None)
+    assert a.enabled is False
+    a.log("scan_started", {"x": 1})          # must not raise
+    assert a.query() == []
+    assert a.export_csv(str(tmp_path / "x.csv")) == 0
+    a.close()
+
+
+def test_concurrent_writes_all_land(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+
+    def worker():
+        for _ in range(20):
+            a.log("scan_started", {"t": 1})
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(a.query(limit=1000)) == 60
+    a.close()
+
+
+def test_gather_host_info_has_core_fields():
+    info = gather_host_info()
+    assert "hostname" in info
+    assert "platform" in info
+    assert "python" in info
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_audit_log.py -p no:cacheprovider -q`
+Expected: FAIL at import — `ModuleNotFoundError: No module named 'audit_log'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `audit_log.py`:
+
+```python
+"""Append-only, machine-readable audit log stored in scans.db.
+
+A small, self-contained logger used primarily by auditors. Writes one
+row per event to a ``logs`` table in the same SQLite file the SDK's
+ScanDatabase uses (scans.db). Owns its own long-lived connection so it
+can append alongside ScanDatabase's on-demand handles.
+
+Fail-soft by contract: construction with a missing path, or any DB
+error, degrades the instance to a no-op — a failed audit write must
+never crash or block the app.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import logging
+import platform
+import socket
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openmotion.bloodflow-app.audit")
+
+# ── Event-type constants ────────────────────────────────────────────────
+EV_SYSTEM_STARTUP = "system_startup"
+EV_SYSTEM_INFO = "system_info"
+EV_SYSTEM_SHUTDOWN = "system_shutdown"
+EV_DEVICE_CONNECTED = "device_connected"
+EV_DEVICE_DISCONNECTED = "device_disconnected"
+EV_DEVICE_STATS = "device_stats"
+EV_SCAN_STARTED = "scan_started"
+EV_SCAN_ENDED = "scan_ended"
+EV_CALIBRATION_STARTED = "calibration_started"
+EV_CALIBRATION_ENDED = "calibration_ended"
+EV_SETTINGS_CHANGED = "settings_changed"
+EV_SCAN_VIEWED = "scan_viewed"
+EV_SCAN_DELETED = "scan_deleted"
+EV_AUDIT_LOG_VIEWED = "audit_log_viewed"
+EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+
+# CSV export column order.
+_CSV_FIELDS = ["ts_iso", "ts_epoch", "event_type", "details"]
+
+
+def gather_host_info() -> Dict[str, Any]:
+    """Collect host/system facts for the ``system_info`` event. Best-effort
+    — any probe that fails is simply omitted."""
+    info: Dict[str, Any] = {}
+    try:
+        info["hostname"] = socket.gethostname()
+        info["platform"] = platform.platform()
+        info["system"] = f"{platform.system()} {platform.release()}".strip()
+        info["arch"] = platform.machine()
+        info["processor"] = platform.processor()
+        info["python"] = platform.python_version()
+    except Exception:
+        logger.warning("gather_host_info: core probe failed", exc_info=True)
+    try:
+        if platform.system() == "Windows":
+            import ctypes
+
+            class _MEMSTATUSEX(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            mem = _MEMSTATUSEX()
+            mem.dwLength = ctypes.sizeof(_MEMSTATUSEX)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(mem))
+            info["ram_gb"] = round(mem.ullTotalPhys / (1024 ** 3), 2)
+    except Exception:
+        pass
+    return info
+
+
+class AuditLog:
+    """Append-only audit-event store backed by the ``logs`` table in
+    scans.db. Thread-safe (single connection + write lock). No-op when
+    constructed without a usable path."""
+
+    def __init__(self, db_path: Optional[str | Path]) -> None:
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        if not db_path:
+            logger.info("AuditLog: no db_path — audit logging disabled (no-op).")
+            return
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._conn = conn
+            self._init_schema()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to open %s — disabling audit logging.",
+                db_path, exc_info=True,
+            )
+            self._conn = None
+
+    def _init_schema(self) -> None:
+        assert self._conn is not None
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS logs (
+                id          INTEGER PRIMARY KEY,
+                ts_epoch    REAL NOT NULL,
+                ts_iso      TEXT NOT NULL,
+                event_type  TEXT NOT NULL,
+                details     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
+            """
+        )
+        self._conn.commit()
+
+    @property
+    def enabled(self) -> bool:
+        return self._conn is not None
+
+    def log(self, event_type: str, details: Optional[Dict[str, Any]] = None) -> None:
+        """Append one event. ``details`` (if truthy) is stored as compact,
+        deterministic JSON. Never raises."""
+        if self._conn is None:
+            return
+        ts_epoch = time.time()
+        ts_iso = datetime.datetime.fromtimestamp(ts_epoch).isoformat(
+            timespec="seconds"
+        )
+        details_json = (
+            json.dumps(details, separators=(",", ":"), sort_keys=True, default=str)
+            if details else None
+        )
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO logs (ts_epoch, ts_iso, event_type, details)"
+                    " VALUES (?, ?, ?, ?)",
+                    (ts_epoch, ts_iso, str(event_type), details_json),
+                )
+                self._conn.commit()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to write %s event", event_type, exc_info=True
+            )
+
+    def query(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` rows, newest first, as plain dicts."""
+        if self._conn is None:
+            return []
+        try:
+            with self._lock:
+                cur = self._conn.execute(
+                    "SELECT id, ts_epoch, ts_iso, event_type, details"
+                    " FROM logs ORDER BY id DESC LIMIT ?",
+                    (int(limit),),
+                )
+                cols = [c[0] for c in cur.description]
+                return [dict(zip(cols, row)) for row in cur.fetchall()]
+        except Exception:
+            logger.warning("AuditLog: query failed", exc_info=True)
+            return []
+
+    def export_csv(self, dest_path: str | Path) -> int:
+        """Write the full log (oldest first) to ``dest_path`` as CSV.
+        Returns the number of data rows written."""
+        if self._conn is None:
+            return 0
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT ts_iso, ts_epoch, event_type, details"
+                " FROM logs ORDER BY id ASC"
+            ).fetchall()
+        with open(dest_path, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(_CSV_FIELDS)
+            w.writerows(rows)
+        return len(rows)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_log.py -p no:cacheprovider -q`
+Expected: PASS (8 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `python -m flake8 audit_log.py tests/test_audit_log.py`
+Expected: no output (clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add audit_log.py tests/test_audit_log.py
+git commit -m "feat: add append-only AuditLog store (audit_log.py)"
+```
+
+---
+
+## Task 2: Wire AuditLog into the connector (startup, system_info, shutdown)
+
+**Files:**
+- Modify: `motion_connector.py` (`__init__` ~line 829; `shutdown` ~line 1338)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_audit_connector.py`:
+
+```python
+"""Unit tests for audit-log instrumentation in MotionConnector."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None, app_config=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface,
+        app_config=app_config or {"developerMode": False},
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+
+
+def _types(c):
+    return [e["event_type"] for e in c.auditLogEntries()]
+
+
+def test_construct_logs_startup_and_system_info(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    t = _types(c)
+    assert "system_startup" in t
+    assert "system_info" in t
+
+
+def test_shutdown_logs_system_shutdown(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.shutdown()
+    assert "system_shutdown" in _types(c)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_construct_logs_startup_and_system_info -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: 'MotionConnector' object has no attribute 'auditLogEntries'` (slots added in Task 3) **or** `system_startup` not present. Either failure is acceptable for this step; both events are wired here and the slot in Task 3.
+
+> NOTE: This test depends on `auditLogEntries()` from Task 3. If executing strictly task-by-task, run this test at the end of Task 3. The implementation edits below (constructing `self._audit` + logging) belong to Task 2.
+
+- [ ] **Step 3: Construct AuditLog in `__init__`**
+
+In `motion_connector.py`, find this line in `__init__` (~line 829):
+
+```python
+        self._directory = resolved_dir
+```
+
+Insert immediately after it:
+
+```python
+
+        # ── Audit log: append-only, machine-readable event record in
+        #    scans.db, surfaced via the password-gated Logs modal. See
+        #    audit_log.py. No-op if the interface has no scan_db_path.
+        from audit_log import AuditLog, gather_host_info
+        self._audit = AuditLog(getattr(self._interface, "scan_db_path", None))
+        try:
+            from version import get_version as _get_app_version
+            _app_version = _get_app_version()
+        except Exception:
+            _app_version = ""
+        try:
+            _sdk_version = self._interface.get_sdk_version()
+            _sdk_version = _sdk_version if isinstance(_sdk_version, str) else ""
+        except Exception:
+            _sdk_version = ""
+        self._audit.log("system_startup", {
+            "app_version": _app_version,
+            "sdk_version": _sdk_version,
+            "data_dir": self._directory,
+        })
+        self._audit.log("system_info", gather_host_info())
+```
+
+- [ ] **Step 4: Log shutdown + close in `shutdown()`**
+
+Find `shutdown` (~line 1338):
+
+```python
+        logger.info("Shutting down MotionConnector...")
+        self.stopCapture()
+        logger.info("MotionConnector shutdown complete.")
+```
+
+Replace with:
+
+```python
+        logger.info("Shutting down MotionConnector...")
+        self.stopCapture()
+        try:
+            self._audit.log("system_shutdown", {"clean": True})
+            self._audit.close()
+        except Exception:
+            logger.warning("audit shutdown log failed", exc_info=True)
+        logger.info("MotionConnector shutdown complete.")
+```
+
+- [ ] **Step 5: (defer test run to end of Task 3)**
+
+`auditLogEntries()` does not exist yet. Proceed to Task 3, then run:
+Run: `python -m pytest tests/test_audit_connector.py -k "startup or shutdown" -p no:cacheprovider -q`
+Expected (after Task 3): PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: log system startup/info/shutdown to audit log"
+```
+
+---
+
+## Task 3: QML-facing slots (entries, record-viewed, export)
+
+**Files:**
+- Modify: `motion_connector.py` (add slots after `deleteScans`, ~line 1730)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_record_viewed_and_entries(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.recordAuditLogViewed()
+    assert "audit_log_viewed" in _types(c)
+
+
+def test_export_csv_writes_file_and_logs_export(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit.csv")
+    out = c.exportAuditLogCsv(dest)
+    assert out == dest
+    assert os.path.exists(dest)
+    assert "audit_log_exported" in _types(c)
+
+
+def test_export_csv_strips_file_url(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit2.csv")
+    out = c.exportAuditLogCsv("file:///" + dest.replace("\\", "/"))
+    assert os.path.exists(out)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_record_viewed_and_entries -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: ... has no attribute 'recordAuditLogViewed'`.
+
+- [ ] **Step 3: Add the slots**
+
+In `motion_connector.py`, find the end of `deleteScans` (the method starting ~line 1703). It ends with a block returning `deleted`. Locate the final `return deleted` of `deleteScans` and insert the following three slots immediately after that method (before the next `@pyqtSlot`/method):
+
+```python
+    # ── Audit log (QML-facing) ───────────────────────────────────────────
+    @pyqtSlot(result="QVariantList")
+    @pyqtSlot(int, result="QVariantList")
+    def auditLogEntries(self, limit: int = 500):
+        """Audit-log rows (newest first) for the Logs modal. Pure read —
+        does not itself log, so refreshing never double-logs."""
+        try:
+            return self._audit.query(int(limit))
+        except Exception:
+            logger.warning("auditLogEntries failed", exc_info=True)
+            return []
+
+    @pyqtSlot()
+    def recordAuditLogViewed(self):
+        """Record that the audit log was opened. Called once from
+        LogsModal.open()."""
+        try:
+            n = len(self._audit.query())
+        except Exception:
+            n = 0
+        self._audit.log("audit_log_viewed", {"entry_count": n})
+
+    @pyqtSlot(str, result=str)
+    def exportAuditLogCsv(self, dest_path: str) -> str:
+        """Export the full audit log to CSV. Accepts a plain path or a
+        file:// URL. Records an ``audit_log_exported`` event. Returns the
+        written path, or '' on failure."""
+        if not dest_path:
+            return ""
+        path = dest_path.replace("file:///", "").replace("file://", "")
+        try:
+            n = self._audit.export_csv(path)
+            self._audit.log("audit_log_exported", {"dest": path, "row_count": n})
+            logger.info("exportAuditLogCsv: wrote %d rows -> %s", n, path)
+            return path
+        except Exception:
+            logger.exception("exportAuditLogCsv failed for %r", path)
+            self.errorOccurred.emit("Audit log export failed.")
+            return ""
+```
+
+- [ ] **Step 4: Run Task 2 + Task 3 tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -p no:cacheprovider -q`
+Expected: PASS (all current tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `python -m flake8 motion_connector.py tests/test_audit_connector.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: add audit-log QML slots (entries, record-viewed, export)"
+```
+
+---
+
+## Task 4: Connect / disconnect + device_stats instrumentation
+
+**Files:**
+- Modify: `motion_connector.py` (`_on_handle_state_changed_impl` ~line 1215; add `_log_device_stats` helper)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_disconnect_logs_device_disconnected(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "left"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.CONNECTED, ConnectionState.DISCONNECTED,
+        "unplugged",
+    )
+    t = _types(c)
+    assert "device_disconnected" in t
+
+
+def test_connect_logs_device_connected_and_stats(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "console"
+    handle.get_hardware_id.return_value = "DEADBEEF"
+    handle.get_version.return_value = "1.0.0"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.DISCONNECTED, ConnectionState.CONNECTED,
+        "found",
+    )
+    t = _types(c)
+    assert "device_connected" in t
+    assert "device_stats" in t
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_disconnect_logs_device_disconnected -p no:cacheprovider -q`
+Expected: FAIL — `assert 'device_disconnected' in [...]` (event not logged yet).
+
+- [ ] **Step 3: Add the device-stats helper**
+
+In `motion_connector.py`, immediately before `def update_state(self):` (~line 1252), add:
+
+```python
+    def _log_device_stats(self, name: str) -> None:
+        """Best-effort audit of a device's hardware + firmware IDs on
+        connect. Missing values are logged as empty strings."""
+        handle = getattr(self._interface, name, None)
+        hwid = ""
+        fw = ""
+        try:
+            if handle is not None and hasattr(handle, "get_hardware_id"):
+                hwid = str(handle.get_hardware_id() or "")
+        except Exception:
+            pass
+        try:
+            if handle is not None and hasattr(handle, "get_version"):
+                fw = str(handle.get_version() or "")
+        except Exception:
+            pass
+        self._audit.log("device_stats", {
+            "device": name, "hardware_id": hwid, "firmware_version": fw,
+        })
+```
+
+- [ ] **Step 4: Instrument the connect/disconnect emit block**
+
+Find this block in `_on_handle_state_changed_impl` (~line 1215):
+
+```python
+        if is_now_connected:
+            logger.info("Handle %s -> CONNECTED (%s)", name, reason)
+            self.signalConnected.emit(name, "")
+        elif is_now_lost:
+            logger.info(
+                "Handle %s -> DISCONNECTED (%s) and state is %s",
+                name, reason, self._state,
+            )
+            self.signalDisconnected.emit(name, "")
+```
+
+Replace with:
+
+```python
+        if is_now_connected:
+            logger.info("Handle %s -> CONNECTED (%s)", name, reason)
+            self.signalConnected.emit(name, "")
+            self._audit.log("device_connected",
+                            {"device": name, "reason": str(reason)})
+            self._log_device_stats(name)
+        elif is_now_lost:
+            logger.info(
+                "Handle %s -> DISCONNECTED (%s) and state is %s",
+                name, reason, self._state,
+            )
+            self.signalDisconnected.emit(name, "")
+            self._audit.log("device_disconnected",
+                            {"device": name, "reason": str(reason)})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k "device or connect" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit device connect/disconnect + hw/fw stats"
+```
+
+---
+
+## Task 5: Calibration instrumentation (started / ended)
+
+**Files:**
+- Modify: `motion_connector.py` (`runCalibration` ~line 3724; `_on_calibration_complete` ~line 3982)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_run_calibration_logs_started(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._interface.start_calibration.return_value = True
+    c.runCalibration("left")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_started"]
+    assert ev
+    assert json.loads(ev[0]["details"])["target"] == "left"
+
+
+def test_calibration_complete_logs_ended(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._calibration_t0 = None
+    result = MagicMock()
+    result.canceled = False
+    result.ok = True
+    result.passed = True
+    result.csv_path = "cal.csv"
+    c._on_calibration_complete(result)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_ended"]
+    assert ev
+    assert json.loads(ev[0]["details"])["outcome"] == "passed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_run_calibration_logs_started -p no:cacheprovider -q`
+Expected: FAIL — no `calibration_started` event.
+
+- [ ] **Step 3: Instrument `runCalibration`**
+
+In `runCalibration`, find (~line 3721):
+
+```python
+        self._calibration_status = "running"
+        self.calibrationStateChanged.emit()
+        self.captureLog.emit("Calibration: starting…")
+        self._calibration_t0 = time.monotonic()
+```
+
+Replace with:
+
+```python
+        self._calibration_status = "running"
+        self._calibration_target = target
+        self.calibrationStateChanged.emit()
+        self.captureLog.emit("Calibration: starting…")
+        self._calibration_t0 = time.monotonic()
+        self._audit.log("calibration_started", {"target": target})
+```
+
+- [ ] **Step 4: Instrument `_on_calibration_complete`**
+
+In `_on_calibration_complete`, find the tail (~line 3979):
+
+```python
+        logger.info(
+            "=== Calibration ended: %s after %.1fs ===",
+            self._calibration_status, elapsed_s,
+        )
+        self.calibrationStateChanged.emit()
+```
+
+Replace with:
+
+```python
+        logger.info(
+            "=== Calibration ended: %s after %.1fs ===",
+            self._calibration_status, elapsed_s,
+        )
+        self._audit.log("calibration_ended", {
+            "target": getattr(self, "_calibration_target", None),
+            "outcome": self._calibration_status,
+            "reason": self._calibration_failure_reason or None,
+        })
+        self.calibrationStateChanged.emit()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k calibration -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit calibration start/end"
+```
+
+---
+
+## Task 6: Settings-changed instrumentation
+
+**Files:**
+- Modify: `motion_connector.py` (`setConfig` ~line 1785; `saveConfigs` ~line 1793)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_set_config_logs_settings_changed(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None      # don't touch the real config file
+    c.setConfig("plotWindowSec", 30)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[0]["details"])
+    assert d["changes"]["plotWindowSec"]["new"] == 30
+
+
+def test_save_configs_logs_only_changed_keys(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None
+    c._app_config["plotWindowSec"] = 15
+    c.saveConfigs({"plotWindowSec": 15, "bfiMax": 12.0})
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[-1]["details"])["changes"]
+    assert "bfiMax" in d            # changed
+    assert "plotWindowSec" not in d  # unchanged -> omitted
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_set_config_logs_settings_changed -p no:cacheprovider -q`
+Expected: FAIL — no `settings_changed` event.
+
+- [ ] **Step 3: Instrument `setConfig`**
+
+Find `setConfig` (~line 1785):
+
+```python
+    @pyqtSlot(str, 'QVariant')
+    def setConfig(self, key: str, value):
+        """Update a single config key, persist to disk, and notify QML."""
+        self._app_config[key] = value
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config set: {key} = {value!r}")
+```
+
+Replace with:
+
+```python
+    @pyqtSlot(str, 'QVariant')
+    def setConfig(self, key: str, value):
+        """Update a single config key, persist to disk, and notify QML."""
+        old = self._app_config.get(key)
+        self._app_config[key] = value
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config set: {key} = {value!r}")
+        if old != value:
+            self._audit.log("settings_changed",
+                            {"changes": {key: {"old": old, "new": value}}})
+```
+
+- [ ] **Step 4: Instrument `saveConfigs`**
+
+Find `saveConfigs` (~line 1793):
+
+```python
+    @pyqtSlot('QVariantMap')
+    def saveConfigs(self, configs: dict):
+        """Update multiple config keys at once, persist to disk, and notify QML."""
+        self._app_config.update(configs)
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
+```
+
+Replace with:
+
+```python
+    @pyqtSlot('QVariantMap')
+    def saveConfigs(self, configs: dict):
+        """Update multiple config keys at once, persist to disk, and notify QML."""
+        changes = {}
+        for k, v in configs.items():
+            old = self._app_config.get(k)
+            if old != v:
+                changes[k] = {"old": old, "new": v}
+        self._app_config.update(configs)
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
+        if changes:
+            self._audit.log("settings_changed", {"changes": changes})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k "config" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit settings changes (changed keys only)"
+```
+
+---
+
+## Task 7: Scan view + delete instrumentation
+
+**Files:**
+- Modify: `motion_connector.py` (`deleteScans` ~line 1703; `loadPastScan` ~line 1923)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_delete_scans_logs_scan_deleted(tmp_path):
+    from omotion.ScanDatabase import ScanDatabase
+    db_path = str(tmp_path / "scans.db")
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label="L1", session_start=1.0,
+                            session_meta={})
+    db.close()
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.deleteScans([sid])
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_deleted"]
+    assert ev
+    assert json.loads(ev[0]["details"])["count"] == 1
+
+
+def test_load_past_scan_logs_scan_viewed(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.loadPastScan("20260101_000000_owABC")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_viewed"]
+    assert ev
+    assert json.loads(ev[0]["details"])["label"] == "20260101_000000_owABC"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_delete_scans_logs_scan_deleted -p no:cacheprovider -q`
+Expected: FAIL — no `scan_deleted` event.
+
+- [ ] **Step 3: Instrument `deleteScans`**
+
+In `deleteScans`, find the final return (~line 1730, the method's last line). It looks like:
+
+```python
+        return deleted
+```
+
+Immediately before that `return deleted`, insert:
+
+```python
+        self._audit.log("scan_deleted", {
+            "session_ids": [int(s) for s in session_ids],
+            "count": deleted,
+        })
+```
+
+(There is exactly one `return deleted` in `deleteScans` — anchor on it within that method.)
+
+- [ ] **Step 4: Instrument `loadPastScan`**
+
+In `loadPastScan`, find this block (~line 1923):
+
+```python
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            logger.warning(
+                "loadPastScan: scan_db_path unavailable on interface"
+            )
+            self.pastScanLoadFinished.emit(session_label, False)
+            return
+```
+
+Immediately after that block (before the `# Per-cam corrected CSV` comment), insert:
+
+```python
+        self._audit.log("scan_viewed", {"label": session_label})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k "delete or past_scan" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit scan view + delete"
+```
+
+---
+
+## Task 8: Scan start / end instrumentation (manual-verified)
+
+**Files:**
+- Modify: `motion_connector.py` (`startCapture` ~line 2231; nested `_on_pipeline_complete` ~line 2375)
+
+> **No unit test:** `scan_started` lives deep inside `startCapture` (after the live-source/laser kickoff path) and `scan_ended` lives inside the nested `_on_pipeline_complete` closure, which only runs when the SDK scan pipeline completes. Neither is callable in isolation without a full hardware scan, so these two events are verified manually in Task 10 (run a scan, inspect the `logs` table). This is a deliberate coverage gap, not an oversight.
+
+- [ ] **Step 1: Instrument `scan_started`**
+
+In `startCapture`, find (~line 2230):
+
+```python
+        self._capture_running = True
+        self._capture_start_time = time.time()
+```
+
+Insert immediately after:
+
+```python
+        self._audit.log("scan_started", {
+            "label": subject_id,
+            "left_mask": int(left_camera_mask),
+            "right_mask": int(right_camera_mask),
+            "session_id": None,
+        })
+```
+
+- [ ] **Step 2: Instrument `scan_ended`**
+
+In the nested `_on_pipeline_complete` closure, find (~line 2372):
+
+```python
+            self._capture_left_path = ""
+            self._capture_right_path = ""
+            self._capture_running = False
+            self._safety_cancel_scheduled = False
+            self._capture_thread = None
+            self.captureFinished.emit(True, "", "", "")
+```
+
+Replace with:
+
+```python
+            self._capture_left_path = ""
+            self._capture_right_path = ""
+            self._capture_running = False
+            self._safety_cancel_scheduled = False
+            self._capture_thread = None
+            try:
+                _outcome_kind = outcome.kind
+            except Exception:
+                _outcome_kind = None
+            try:
+                _dur = (time.time() - self._capture_start_time
+                        if self._capture_start_time else None)
+            except Exception:
+                _dur = None
+            self._audit.log("scan_ended", {
+                "label": subject_id,
+                "session_label": session_label or None,
+                "duration_s": round(_dur, 1) if _dur is not None else None,
+                "outcome": _outcome_kind,
+            })
+            self.captureFinished.emit(True, "", "", "")
+```
+
+(`subject_id` is the `startCapture` argument captured by the closure; `session_label` is assigned ~line 2342 in the same closure; `outcome` is assigned ~line 2351 and guarded above in case classification raised.)
+
+- [ ] **Step 3: Verify import + lint (no unit test here)**
+
+Run: `python -c "import motion_connector"`
+Expected: no error.
+Run: `python -m flake8 motion_connector.py`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add motion_connector.py
+git commit -m "feat: audit scan start/end"
+```
+
+---
+
+## Task 9: LogsModal + Settings button + BloodFlow wiring
+
+**Files:**
+- Create: `components/LogsModal.qml`
+- Modify: `components/SettingsModal.qml` (add signal + password modal + Audit Log card)
+- Modify: `pages/BloodFlow.qml` (add `LogsModal`, register in `ModalManager`, wire `onLogsRequested`)
+
+> **No automated test:** QML is not unit-tested in this repo (no hot reload; HIL tests require hardware). Verified visually in Task 10.
+
+- [ ] **Step 1: Create `components/LogsModal.qml`**
+
+```qml
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import QtQuick.Dialogs as Dialogs
+import OpenMotion 1.0
+
+// Audit-log viewer. Lists machine-readable audit entries (newest first)
+// and exports them as CSV. Opened from the password gate in SettingsModal.
+// Governed by ModalManager (see HistoryModal.qml for the modal contract).
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 9998
+
+    AppTheme { id: theme }
+
+    readonly property string label: "Audit Log"
+    property var entries: []
+
+    function open() {
+        // Record the view first, then load (so the view event is included).
+        MotionInterface.recordAuditLogViewed()
+        refresh()
+        root.visible = true
+    }
+    function close() { root.visible = false }
+
+    function refresh() {
+        try { entries = MotionInterface.auditLogEntries(500) || [] }
+        catch (e) { entries = [] }
+    }
+
+    QtObject {
+        id: col
+        readonly property int time: 160
+        readonly property int event: 170
+    }
+
+    // ── backdrop ───────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000AA"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    Rectangle {
+        width: Math.min(parent.width - 60, 980)
+        height: Math.min(parent.height - 60, 700)
+        radius: 12
+        color: theme.bgContainer
+        border.color: theme.borderSubtle
+        border.width: 2
+        anchors.centerIn: parent
+
+        MouseArea { anchors.fill: parent }   // absorb clicks
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 18
+            spacing: 12
+
+            // ── toolbar ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                Text {
+                    text: root.label
+                    font.pixelSize: 20; font.weight: Font.Bold
+                    color: theme.textPrimary
+                }
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Export CSV"
+                    Layout.preferredWidth: 110; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                                    + "/audit_log.csv"
+                        exportDialog.open()
+                    }
+                }
+                Button {
+                    text: "Refresh"
+                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: root.refresh()
+                }
+                Rectangle {
+                    width: 28; height: 28; radius: 14
+                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
+                    border.color: theme.borderHover; border.width: 1
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    MouseArea {
+                        id: xArea; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor; onClicked: root.close()
+                    }
+                }
+            }
+
+            // ── table header ───────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                color: theme.bgCardAlt; radius: 4
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                    spacing: 8
+                    Text { text: "Time"; Layout.preferredWidth: col.time
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Event"; Layout.preferredWidth: col.event
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Details"; Layout.fillWidth: true
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                }
+            }
+
+            // ── table body ─────────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true; Layout.fillHeight: true
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                clip: true
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    model: root.entries
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Rectangle {
+                        width: ListView.view.width
+                        height: 30
+                        color: index % 2 === 0 ? "transparent" : Qt.rgba(1, 1, 1, 0.02)
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 8
+                            spacing: 8
+                            Text {
+                                Layout.preferredWidth: col.time
+                                text: modelData.ts_iso || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.event
+                                text: modelData.event_type || ""
+                                color: theme.textPrimary; font.pixelSize: 12
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.details || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+
+                    Text {
+                        anchors.centerIn: parent
+                        visible: root.entries.length === 0
+                        text: "No audit entries yet."
+                        color: theme.textSecondary; font.pixelSize: 14
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+
+    Dialogs.FileDialog {
+        id: exportDialog
+        title: "Export Audit Log CSV"
+        fileMode: Dialogs.FileDialog.SaveFile
+        nameFilters: ["CSV files (*.csv)", "All files (*)"]
+        onAccepted: {
+            var path = selectedFile.toString().replace("file:///", "")
+            var ok = MotionInterface.exportAuditLogCsv(path)
+            if (ok) {
+                MotionInterface.notify("Audit log exported to " + ok, "success")
+                root.refresh()   // pick up the audit_log_exported entry
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the signal + password modal + Audit Log card to `SettingsModal.qml`**
+
+In `components/SettingsModal.qml`, find the existing calibration password modal (~line 56):
+
+```qml
+    // Password gate for the Calibrate action.
+    PasswordPromptModal {
+        id: calibrationPasswordModal
+        title: "Calibration"
+        description: "Enter the password to start calibration."
+        confirmLabel: "Calibrate"
+        onAccepted: MotionInterface.runCalibration(
+            calibrationTargetCombo.currentText.toLowerCase()
+        )
+    }
+```
+
+Immediately after that block, add:
+
+```qml
+    // Emitted when the user enters the correct password for the audit log.
+    // BloodFlow.qml opens the (ModalManager-governed) LogsModal in response.
+    signal logsRequested()
+
+    // Password gate for the audit Logs viewer.
+    PasswordPromptModal {
+        id: logsPasswordModal
+        title: "Audit Log"
+        description: "Enter the password to view the audit log."
+        confirmLabel: "View Logs"
+        onAccepted: root.logsRequested()
+    }
+```
+
+Then find the end of the **Appearance** `SectionCard` (the closing `}` right before the `// ── Developer ──` comment, ~line 757) and insert a new card between Appearance and Developer:
+
+```qml
+                // ── Audit Log ────────────────────────────────────────────────
+                SectionCard {
+                    title: "Audit Log"
+
+                    FieldRow {
+                        label: "Logs"
+                        ActionButton {
+                            text: "View Logs"
+                            Layout.preferredWidth: 130
+                            onClicked: logsPasswordModal.open()
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    Text {
+                        text: "Password-protected, machine-readable record of system "
+                              + "events for auditors. Open the viewer to browse entries "
+                              + "or export them as CSV."
+                        color: root.colTextMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                }
+```
+
+- [ ] **Step 3: Add `LogsModal` + wiring to `BloodFlow.qml`**
+
+In `pages/BloodFlow.qml`, find the `SettingsModal` block (~line 333):
+
+```qml
+    SettingsModal {
+        id: settingsModal
+    }
+```
+
+Replace with:
+
+```qml
+    SettingsModal {
+        id: settingsModal
+        // Audit Log: the password gate lives in SettingsModal; on success
+        // close Settings and open the ModalManager-governed LogsModal.
+        onLogsRequested: {
+            settingsModal.close()
+            modalManager.toggle(logsModal)
+        }
+    }
+
+    LogsModal {
+        id: logsModal
+    }
+```
+
+Then find the `ModalManager` modals list (~line 231):
+
+```qml
+        modals: [scanSettingsModal, notesModal, historyModal,
+                 settingsModal, contactQualityModal]
+```
+
+Replace with:
+
+```qml
+        modals: [scanSettingsModal, notesModal, historyModal,
+                 settingsModal, contactQualityModal, logsModal]
+```
+
+- [ ] **Step 4: Smoke-check QML parses**
+
+Run: `python -c "import main"`
+Expected: no error (imports only; does not launch the app).
+
+> Full visual verification happens in Task 10.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/LogsModal.qml components/SettingsModal.qml pages/BloodFlow.qml
+git commit -m "feat: add password-gated Logs modal with CSV export"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit-test set for this feature**
+
+Run: `python -m pytest tests/test_audit_log.py tests/test_audit_connector.py tests/test_developer_password.py -p no:cacheprovider -q`
+Expected: all PASS.
+
+- [ ] **Step 2: Lint everything touched**
+
+Run: `python -m flake8 audit_log.py motion_connector.py tests/test_audit_log.py tests/test_audit_connector.py`
+Expected: clean.
+
+- [ ] **Step 3: Visual + behavioral check (hardware-optional)**
+
+Launch the app from source (see memory: use the conda python, not background Bash; `dataDirectory` null → DB lands in cwd):
+
+```
+python main.py
+```
+
+Verify:
+1. Open **Settings** → an **Audit Log** card with a **View Logs** button is visible (even with `developerMode: false`).
+2. Click **View Logs** → password prompt appears. Wrong password → "Incorrect password". Correct password (`OpenwaterHealth`) → LogsModal opens.
+3. The list already contains `system_startup` and `system_info` rows (newest first), plus an `audit_log_viewed` row for opening it.
+4. Change a setting (e.g. time window) and reopen the log → a `settings_changed` row appears with the changed key.
+5. Click **Export CSV**, save, and open the file → header `ts_iso,ts_epoch,event_type,details` with one row per event.
+6. (If hardware attached) connect/disconnect a device, run a scan, run a calibration → `device_connected`/`device_stats`, `scan_started`/`scan_ended`, `calibration_started`/`calibration_ended` rows appear. This is the verification path for the Task 8 scan events that have no unit test.
+
+Inspect the table directly if needed:
+
+```
+python -c "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); [print(r) for r in c.execute('SELECT ts_iso,event_type,details FROM logs ORDER BY id DESC LIMIT 20')]" <dataDirectory>\scans.db
+```
+
+- [ ] **Step 4: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "test: verify audit-log feature end to end"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- system_startup/info/shutdown → Task 2 ✓
+- device connect/disconnect + hw/fw stats → Task 4 ✓
+- scan start/end → Task 8 ✓
+- calibration start/end → Task 5 ✓
+- settings changes (diff) → Task 6 ✓
+- scan view + delete → Task 7 ✓
+- audit_log_viewed + exported → Tasks 3 (slots) + 9 (UI) ✓
+- typed-event + JSON details schema, app-side `logs` table in scans.db, fail-soft, thread-safe → Task 1 ✓
+- password-gated Logs button (reused developer password) + CSV export → Task 9 ✓
+
+**Placeholder scan:** none (all steps contain concrete code/commands).
+
+**Type/name consistency:** `self._audit` (AuditLog), `auditLogEntries`/`recordAuditLogViewed`/`exportAuditLogCsv` slots, `logsRequested()` signal, `logsModal` id, event-type strings, and CSV field order are consistent across Tasks 1, 3, 9.
+
+**Known coverage gap (intentional, not silent):** Task 8 (`scan_started`/`scan_ended`) has no unit test — both sites are unreachable without a full hardware scan; verified manually in Task 10 Step 3.6.

--- a/docs/superpowers/plans/2026-06-16-debug-log-bundle.md
+++ b/docs/superpowers/plans/2026-06-16-debug-log-bundle.md
@@ -1,0 +1,573 @@
+# Debug Log Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Send Debug Logs to Openwater" button to the LogsModal that zips the last 48h of app logs (+ config + system info), reveals the zip in the file explorer, and tells the user to email it to support@openwater.cc.
+
+**Architecture:** A pure `debug_bundle.py` module (`build_debug_bundle`) does the file-gathering/zipping (unit-testable against a temp dir). A thin `prepareDebugLogBundle()` connector slot calls it, reveals the file, toasts, and records an audit event. One QML button wires it up.
+
+**Tech Stack:** Python 3.13, PyQt6, stdlib `zipfile`/`glob`/`subprocess`, pytest. QML 6.
+
+**Design spec:** [docs/superpowers/specs/2026-06-16-debug-log-bundle-design.md](../specs/2026-06-16-debug-log-bundle-design.md)
+
+---
+
+## File Structure
+
+- **Create** `debug_bundle.py` — `build_debug_bundle(...)` + `WINDOW_HOURS`. Pure file logic, no Qt.
+- **Create** `tests/test_debug_bundle.py` — unit tests for the module.
+- **Modify** `audit_log.py` — add `EV_DEBUG_BUNDLE_CREATED` constant.
+- **Modify** `motion_connector.py` — add `prepareDebugLogBundle()` slot + `_reveal_in_explorer()` helper.
+- **Modify** `tests/test_audit_connector.py` — slot test.
+- **Modify** `components/LogsModal.qml` — "Send Debug Logs" toolbar button.
+- **Modify** `docs/audit-log.md` — document the button + the new event.
+
+---
+
+## Task 1: debug_bundle module
+
+**Files:**
+- Create: `debug_bundle.py`
+- Test: `tests/test_debug_bundle.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_debug_bundle.py`:
+
+```python
+"""Unit tests for the debug-log bundle builder (debug_bundle.py)."""
+import os
+import zipfile
+
+import pytest
+
+from debug_bundle import build_debug_bundle, WINDOW_HOURS
+
+pytestmark = pytest.mark.unit
+
+_NOW = 1_750_000_000.0  # fixed epoch for deterministic tests
+
+
+def _write(path, text="x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_window_hours_default_is_48():
+    assert WINDOW_HOURS == 48
+
+
+def test_includes_recent_logs_excludes_old(tmp_path):
+    data = tmp_path / "data"
+    logs = data / "app-logs"
+    for name in ("ow-bloodflowapp-A.log", "ow-bloodflowapp-B.log"):
+        _write(logs / name, "log")
+        os.utime(logs / name, (_NOW - 3600, _NOW - 3600))   # 1h ago
+    old = logs / "ow-bloodflowapp-OLD.log"
+    _write(old, "old")
+    os.utime(old, (_NOW - 49 * 3600, _NOW - 49 * 3600))     # 49h ago
+    _write(data / "app_config.json", '{"k":1}')
+
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert "app-logs/ow-bloodflowapp-A.log" in names
+    assert "app-logs/ow-bloodflowapp-B.log" in names
+    assert "app-logs/ow-bloodflowapp-OLD.log" not in names
+    assert "app_config.json" in names
+    assert "system_info.txt" in names
+    assert meta["log_count"] == 2
+    assert meta["bytes"] == os.path.getsize(meta["path"])
+    base = os.path.basename(meta["path"])
+    assert base.startswith("debug-bundle-") and base.endswith(".zip")
+
+
+def test_empty_window_still_writes_system_info(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert names == ["system_info.txt"]   # no logs, no config present
+    assert meta["log_count"] == 0
+    assert meta["file_count"] == 1
+
+
+def test_system_info_contains_versions_and_host(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+    txt = zipfile.ZipFile(meta["path"]).read("system_info.txt").decode("utf-8")
+    assert "app_version: 1.2.3" in txt
+    assert "sdk_version: 9.9" in txt
+    assert "hostname:" in txt
+    assert "generated:" in txt
+
+
+def test_explicit_config_path_is_used(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    cfg = tmp_path / "elsewhere" / "app_config.json"
+    _write(cfg, '{"x":2}')
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW, config_path=str(cfg),
+    )
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert "app_config.json" in names
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_debug_bundle.py -p no:cacheprovider -q`
+Expected: FAIL at import — `ModuleNotFoundError: No module named 'debug_bundle'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `debug_bundle.py`:
+
+```python
+"""Build a zip bundle of recent app logs for emailing to support.
+
+Collects the last N hours of app log files plus app_config.json and a
+generated system_info.txt into a single zip. Pure file logic — no Qt, no
+hardware — so it is unit-testable against a temp directory.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from audit_log import gather_host_info
+
+logger = logging.getLogger("openmotion.bloodflow-app.debug-bundle")
+
+WINDOW_HOURS = 48
+
+
+def _system_info_text(now_epoch: float, extra_info: Optional[Dict[str, Any]]) -> str:
+    """Render host info (+ caller-supplied extras) as sorted key: value
+    lines, with a leading local-time 'generated' stamp."""
+    info = gather_host_info()
+    if extra_info:
+        info.update(extra_info)
+    generated = (
+        datetime.datetime.fromtimestamp(now_epoch)
+        .astimezone()
+        .isoformat(timespec="seconds")
+    )
+    lines = [f"generated: {generated}"]
+    lines += [f"{k}: {info[k]}" for k in sorted(info)]
+    return "\n".join(lines) + "\n"
+
+
+def build_debug_bundle(
+    data_dir: str | Path,
+    dest_dir: str | Path,
+    now_epoch: float,
+    *,
+    window_hours: int = WINDOW_HOURS,
+    config_path: str | Path | None = None,
+    extra_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Zip recent app logs + config + system info into dest_dir.
+
+    Includes <data_dir>/app-logs/*.log with mtime within window_hours,
+    the app_config.json at config_path (default <data_dir>/app_config.json)
+    if present, and a generated system_info.txt. Returns
+    {"path", "file_count", "log_count", "bytes"}.
+    """
+    data_dir = Path(data_dir)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    cutoff = now_epoch - window_hours * 3600
+    log_dir = data_dir / "app-logs"
+    recent_logs = []
+    if log_dir.is_dir():
+        for p in sorted(log_dir.glob("*.log")):
+            try:
+                if p.stat().st_mtime >= cutoff:
+                    recent_logs.append(p)
+            except OSError:
+                logger.warning("debug_bundle: stat failed for %s", p, exc_info=True)
+
+    if config_path is None:
+        config_path = data_dir / "app_config.json"
+    config_path = Path(config_path)
+
+    stamp = datetime.datetime.fromtimestamp(now_epoch).strftime("%Y%m%d_%H%M%S")
+    dest = dest_dir / f"debug-bundle-{stamp}.zip"
+
+    file_count = 0
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in recent_logs:
+            try:
+                zf.write(p, arcname=f"app-logs/{p.name}")
+                file_count += 1
+            except OSError:
+                logger.warning("debug_bundle: could not add %s", p, exc_info=True)
+        if config_path.is_file():
+            try:
+                zf.write(config_path, arcname=config_path.name)
+                file_count += 1
+            except OSError:
+                logger.warning(
+                    "debug_bundle: could not add config %s", config_path,
+                    exc_info=True,
+                )
+        zf.writestr("system_info.txt", _system_info_text(now_epoch, extra_info))
+        file_count += 1
+
+    return {
+        "path": str(dest),
+        "file_count": file_count,
+        "log_count": len(recent_logs),
+        "bytes": dest.stat().st_size,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_debug_bundle.py -p no:cacheprovider -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `python -m flake8 debug_bundle.py tests/test_debug_bundle.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add debug_bundle.py tests/test_debug_bundle.py
+git commit -m "feat: add debug_bundle module (zip recent app logs)"
+```
+(Commit message must end with the trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`)
+
+---
+
+## Task 2: Connector slot + reveal helper + event constant
+
+**Files:**
+- Modify: `audit_log.py` (event-type constants block)
+- Modify: `motion_connector.py` (add slot + helper after `exportAuditLogCsv`)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
+    import os
+    import zipfile
+    db = str(tmp_path / "scans.db")
+    logs = tmp_path / "app-logs"
+    logs.mkdir()
+    (logs / "ow-bloodflowapp-x.log").write_text("hello", encoding="utf-8")
+    c = _connector(tmp_path, scan_db_path=db)
+    # Don't spawn a real file-explorer process during the test.
+    c._reveal_in_explorer = lambda p: None
+    path = c.prepareDebugLogBundle()
+    assert path and os.path.exists(path)
+    assert path.endswith(".zip")
+    names = zipfile.ZipFile(path).namelist()
+    assert any(n.startswith("app-logs/") for n in names)
+    assert "system_info.txt" in names
+    assert "debug_bundle_created" in _types(c)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_prepare_debug_bundle_creates_zip_and_logs -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: 'MotionConnector' object has no attribute 'prepareDebugLogBundle'`.
+
+- [ ] **Step 3: Add the event constant**
+
+In `audit_log.py`, find:
+
+```python
+EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+```
+
+Insert immediately after it:
+
+```python
+EV_DEBUG_BUNDLE_CREATED = "debug_bundle_created"
+```
+
+- [ ] **Step 4: Add the slot + helper to the connector**
+
+In `motion_connector.py`, find the end of `exportAuditLogCsv` (it returns `""` on failure / the path on success — the method directly above is the audit-log block added earlier). Immediately after the end of `exportAuditLogCsv`, insert:
+
+```python
+    @pyqtSlot(result=str)
+    def prepareDebugLogBundle(self) -> str:
+        """Zip the last 48h of app logs (+ config + system info) into
+        app-logs/debug-bundles/, reveal it in the file explorer, and toast
+        the support address. Returns the zip path, or '' on failure."""
+        try:
+            from debug_bundle import build_debug_bundle, WINDOW_HOURS
+            try:
+                from version import get_version as _gv
+                app_version = _gv()
+            except Exception:
+                app_version = ""
+            try:
+                sdk_version = self._interface.get_sdk_version()
+                sdk_version = sdk_version if isinstance(sdk_version, str) else ""
+            except Exception:
+                sdk_version = ""
+            dest_dir = os.path.join(self._directory, "app-logs", "debug-bundles")
+            meta = build_debug_bundle(
+                self._directory,
+                dest_dir,
+                time.time(),
+                config_path=resource_path("config", "app_config.json"),
+                extra_info={"app_version": app_version, "sdk_version": sdk_version},
+            )
+        except Exception:
+            logger.exception("prepareDebugLogBundle: failed to build bundle")
+            self.errorOccurred.emit("Could not create the debug log bundle.")
+            return ""
+
+        path = meta["path"]
+        self._reveal_in_explorer(path)
+        from audit_log import EV_DEBUG_BUNDLE_CREATED
+        self._audit.log(EV_DEBUG_BUNDLE_CREATED, {
+            "dest": path,
+            "file_count": meta["file_count"],
+            "log_count": meta["log_count"],
+            "bytes": meta["bytes"],
+            "window_hours": WINDOW_HOURS,
+        })
+        self.notify(
+            "Debug logs saved to " + path
+            + ". Please email this file to support@openwater.cc.",
+            "success", 0, True, "debug-bundle",
+        )
+        return path
+
+    def _reveal_in_explorer(self, path: str) -> None:
+        """Best-effort: open the OS file browser with the file selected.
+        Never raises — a failed reveal must not lose the bundle."""
+        try:
+            import subprocess
+            import sys
+            if sys.platform.startswith("win"):
+                subprocess.Popen(["explorer", "/select,", os.path.normpath(path)])
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", "-R", path])
+            else:
+                subprocess.Popen(["xdg-open", os.path.dirname(path)])
+        except Exception:
+            logger.warning(
+                "could not reveal %s in file explorer", path, exc_info=True
+            )
+```
+
+(`os`, `time`, `resource_path`, `logger`, `pyqtSlot`, and the `errorOccurred`/`notify` members all already exist in this module — do not re-import or redefine them.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k debug_bundle -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint**
+
+Run: `python -m flake8 audit_log.py tests/test_audit_connector.py`
+Expected: clean (the test file must be clean; `motion_connector.py` has pre-existing violations — confirm the slot's added lines introduce none by checking the violation count is unchanged: `python -m flake8 motion_connector.py | wc -l` before/after should both be the same baseline).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add audit_log.py motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: prepareDebugLogBundle connector slot + reveal + audit event"
+```
+(Trailer required.)
+
+---
+
+## Task 3: LogsModal "Send Debug Logs" button
+
+**Files:**
+- Modify: `components/LogsModal.qml` (toolbar)
+
+> **No automated test:** QML is not unit-tested in this repo. Verified by `python -c "import main"` and visually in Task 4.
+
+- [ ] **Step 1: Add the button**
+
+In `components/LogsModal.qml`, find the toolbar spacer immediately before the Export CSV button:
+
+```qml
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Export CSV"
+```
+
+Replace with (inserts the new button between the spacer and Export CSV):
+
+```qml
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Send Debug Logs"
+                    Layout.preferredWidth: 140; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    // Connector builds the zip, reveals it, and toasts the
+                    // support address; refresh so the debug_bundle_created
+                    // entry shows up in the list.
+                    onClicked: {
+                        MotionInterface.prepareDebugLogBundle()
+                        root.refresh()
+                    }
+                }
+
+                Button {
+                    text: "Export CSV"
+```
+
+- [ ] **Step 2: Verify QML parses + balance**
+
+Run: `python -c "import main; print('import ok')"`
+Expected: `import ok` (no traceback).
+Run: `python -c "s=open('components/LogsModal.qml',encoding='utf-8').read(); print('braces',s.count('{')-s.count('}'),'parens',s.count('(')-s.count(')'),'brackets',s.count('[')-s.count(']'))"`
+Expected: `braces 0 parens 0 brackets 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/LogsModal.qml
+git commit -m "feat: add Send Debug Logs button to LogsModal"
+```
+(Trailer required.)
+
+---
+
+## Task 4: Docs + verification
+
+**Files:**
+- Modify: `docs/audit-log.md`
+
+- [ ] **Step 1: Document the button + event**
+
+In `docs/audit-log.md`, find the event-types table row:
+
+```
+| `audit_log_exported` | The audit log is exported to CSV. | `dest`, `row_count` |
+```
+
+Insert immediately after it:
+
+```
+| `debug_bundle_created` | The "Send Debug Logs" button is used. | `dest`, `file_count`, `log_count`, `bytes`, `window_hours` |
+```
+
+Then find the `## Exporting to CSV` heading and insert this new section immediately before it:
+
+```markdown
+## Sending debug logs to Openwater
+
+The **Send Debug Logs** button (top of the audit-log viewer) packages the
+app's diagnostic logs for support. It writes a zip to
+`<dataDirectory>/app-logs/debug-bundles/debug-bundle-<timestamp>.zip`
+containing the app log files from the last 48 hours, `app_config.json`,
+and a `system_info.txt` (app/SDK version + host details). The file
+explorer opens with the zip selected, and a message shows the path —
+**email that zip to support@openwater.cc**. No data is sent automatically,
+and the bundle contains no scan data or patient information.
+
+```
+
+- [ ] **Step 2: Run the feature's full test set**
+
+Run: `python -m pytest tests/test_debug_bundle.py tests/test_audit_connector.py tests/test_audit_log.py -p no:cacheprovider -q`
+Expected: all PASS.
+
+- [ ] **Step 3: Lint touched Python**
+
+Run: `python -m flake8 debug_bundle.py tests/test_debug_bundle.py tests/test_audit_connector.py`
+Expected: clean.
+
+- [ ] **Step 4: End-to-end smoke (no hardware)**
+
+Run this script to confirm the slot produces a real zip with the expected members:
+
+```bash
+python - <<'PY'
+import sys, os, tempfile, zipfile
+sys.path.insert(0, os.getcwd())
+from unittest.mock import MagicMock
+from PyQt6.QtCore import QCoreApplication
+app = QCoreApplication(sys.argv)
+from motion_connector import MotionConnector
+d = tempfile.mkdtemp()
+os.makedirs(os.path.join(d, "app-logs"))
+open(os.path.join(d, "app-logs", "ow-bloodflowapp-demo.log"), "w").write("demo log\n")
+iface = MagicMock()
+iface.is_device_connected.return_value = (False, False, False)
+iface.scan_workflow.running = False
+iface.scan_workflow.config_running = False
+iface.scan_db_path = os.path.join(d, "scans.db")
+iface.get_sdk_version.return_value = "1.5.8"
+c = MotionConnector(interface=iface, app_config={"developerMode": False},
+                    data_dir=d, config_dir="config")
+c._reveal_in_explorer = lambda p: None
+path = c.prepareDebugLogBundle()
+print("bundle:", path)
+print("members:", zipfile.ZipFile(path).namelist())
+PY
+```
+Expected: prints a `debug-bundle-*.zip` path under `app-logs/debug-bundles/` whose members include `app-logs/ow-bloodflowapp-demo.log` and `system_info.txt`.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add docs/audit-log.md
+git commit -m "docs: document Send Debug Logs button + debug_bundle_created event"
+```
+(Trailer required.)
+
+- [ ] **Step 6: Manual/visual check (controller does this after execution)**
+
+Launch `python main.py`, open Settings → Audit Log → View Logs (password `OpenwaterHealth`), click **Send Debug Logs**: confirm the file explorer opens with the zip selected, a success toast shows the path + support@openwater.cc, and a `debug_bundle_created` row appears after the list refreshes.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Zip last 48h of `app-logs/*.log` → Task 1 (`build_debug_bundle`, mtime filter) ✓
+- Include `app_config.json` + `system_info.txt` (host + app/SDK version) → Task 1 ✓
+- Output to `app-logs/debug-bundles/debug-bundle-<ts>.zip` → Task 2 (`dest_dir`) ✓
+- Reveal in explorer (Windows `/select`, best-effort) → Task 2 (`_reveal_in_explorer`) ✓
+- Toast with support@openwater.cc (sticky) → Task 2 ✓
+- `debug_bundle_created` audit event with `{dest,file_count,log_count,bytes,window_hours}` → Task 2 ✓
+- Fail-soft (build/reveal never crash) → Task 2 (try/except around build; `_reveal_in_explorer` never raises) ✓
+- Button in LogsModal → Task 3 ✓
+- Pure-module unit tests + connector slot test → Tasks 1, 2 ✓
+- Docs → Task 4 ✓
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type/name consistency:** `build_debug_bundle(data_dir, dest_dir, now_epoch, *, window_hours, config_path, extra_info)` and its return keys (`path`/`file_count`/`log_count`/`bytes`) are used identically in Tasks 1, 2, and 4. `prepareDebugLogBundle`, `_reveal_in_explorer`, `EV_DEBUG_BUNDLE_CREATED`, and the `debug_bundle_created` string are consistent across tasks.
+
+**Known limitation (intentional):** the QML button (Task 3) and the reveal/toast side effects have no automated test (QML isn't unit-tested here; the reveal spawns an OS process) — verified via import smoke + the Task 4 end-to-end script + the Task 4 Step 6 manual check.

--- a/docs/superpowers/specs/2026-06-15-audit-log-design.md
+++ b/docs/superpowers/specs/2026-06-15-audit-log-design.md
@@ -1,0 +1,203 @@
+# Audit Log — Design
+
+**Date:** 2026-06-15
+**Status:** Approved (design); pending spec review
+**Branch base:** `next-next`
+
+## Goal
+
+Add a machine-readable, append-only audit log to the bloodflow app's
+SQLite database (`scans.db`). Entries are intended primarily for
+**auditors**: minimal, structured, and exportable. The log is reached
+through a password-gated **Logs** button in the Settings panel, which
+opens a modal that lists entries and can export them as CSV.
+
+## Decisions (locked)
+
+- **Password gate:** reuse the existing developer password
+  (`_DEVELOPER_PASSWORD` / `MotionInterface.checkDeveloperPassword`,
+  motion_connector.py:71) — same mechanism as the Calibrate gate.
+- **Entry shape:** minimal fixed core columns + a JSON `details` blob
+  (typed-event + JSON details).
+- **Table location:** app-side, in the same `scans.db` file. No SDK
+  (`openmotion-sdk`) edits.
+
+## Architecture
+
+A new standalone module **`audit_log.py`** with an `AuditLog` class.
+
+- Owns its own `sqlite3` connection to `scan_db_path`
+  (`check_same_thread=False`), lazily creates the `logs` table, and
+  exposes a small API: `log(event_type, details=None)`, `query(limit)`,
+  `export_csv(dest_path)`, `close()`.
+- The connector (`MotionConnector`) holds a single `AuditLog` instance,
+  constructed in `__init__` from
+  `getattr(self._interface, "scan_db_path", None)`. Call sites are thin
+  one-liners (`self._audit.log("scan_started", {...})`).
+- Rationale: keeps the already-oversized `motion_connector.py` (4031
+  lines) from growing materially, mirrors the `motion_config.py`
+  extraction precedent, and makes the logger unit-testable against a
+  tmp DB with no app launch / no hardware.
+
+### Concurrency
+
+Audit events fire from multiple threads — the SDK connection-monitor
+thread (`_on_handle_state_changed_impl`), scan-worker threads
+(scan end), and the Qt UI thread (settings, view, delete). Therefore:
+
+- `sqlite3.connect(path, check_same_thread=False)`.
+- A `threading.Lock` guarding every write.
+- `PRAGMA journal_mode=WAL`, `PRAGMA busy_timeout=5000` — coexists with
+  the SDK's `ScanDatabase`, which also opens WAL connections to the same
+  file on demand.
+
+### Fail-soft
+
+`AuditLog` must never crash or block the app. If `scan_db_path` is
+`None` (e.g. headless/unit context) or the connection/insert raises,
+the instance degrades to a no-op and logs a single warning via the
+standard `logging` logger. A failed audit write never propagates.
+
+## Schema
+
+Created by `AuditLog._init_schema()` (idempotent, `IF NOT EXISTS`):
+
+```sql
+CREATE TABLE IF NOT EXISTS logs (
+    id          INTEGER PRIMARY KEY,
+    ts_epoch    REAL NOT NULL,   -- time.time()
+    ts_iso      TEXT NOT NULL,   -- ISO-8601 local time, sortable
+    event_type  TEXT NOT NULL,   -- one of the event-type constants below
+    details     TEXT             -- compact JSON object; NULL when no payload
+);
+
+CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
+```
+
+`details` is `json.dumps(obj, separators=(",", ":"), sort_keys=True)` —
+compact and deterministic. Stored as `NULL` when there is no payload.
+
+## Event types & instrumentation points
+
+Event-type strings are module-level constants in `audit_log.py`.
+
+| event_type | Fired at (file:line anchor) | `details` |
+|---|---|---|
+| `system_startup` | `MotionConnector.__init__` | `app_version`, `sdk_version`, `data_dir` |
+| `system_info` | `__init__`, immediately after `system_startup` | `hostname`, `platform`, `system`, `arch`, `processor`, `python`, `ram_gb` (host info, mirrors SDK `log_system_info`) |
+| `system_shutdown` | `MotionConnector.shutdown()` (called from `main.py` `handle_exit`, :294) | `clean: true` |
+| `device_connected` | `_on_handle_state_changed_impl` (motion_connector.py:1137) | `device` (`console`/`left`/`right`), `reason` |
+| `device_disconnected` | `_on_handle_state_changed_impl` | `device`, `reason` |
+| `device_stats` | on connect, once IDs are readable (same handler) | `device`, `hardware_id`, `firmware_version` |
+| `scan_started` | `startCapture` (motion_connector.py:2183) | `label`, `left_mask`, `right_mask`, `session_id` (`null` if not yet assigned — `ScanDBSink` may create the session row after this point; `scan_ended` carries the authoritative id) |
+| `scan_ended` | `stopCapture` (motion_connector.py:1320) / scan-complete | `session_id`, `duration_s`, `outcome` |
+| `calibration_started` | `runCalibration` (motion_connector.py:3645, status→running at :3721) | `target` (`both`/`left`/`right`) |
+| `calibration_ended` | `_on_calibration_complete` (motion_connector.py:3935) | `target`, `outcome` (`passed`/`failed`/`aborted`), `reason` |
+| `settings_changed` | `setConfig` (:1785) and `saveConfigs` (:1793) | changed keys only, as `{key: {old, new}}` (diff computed before the update is applied) |
+| `scan_viewed` | `loadPastScan` (motion_connector.py:1923) | `session_id`, `label` |
+| `scan_deleted` | `deleteScans` (motion_connector.py:1703) | `session_ids`, `count` |
+| `audit_log_viewed` | LogsModal opened (connector slot called from QML on open) | `entry_count` |
+| `audit_log_exported` | `exportAuditLogCsv` (connector slot) | `dest`, `row_count` |
+
+Notes:
+- `device_stats` reads `get_hardware_id()` and `get_version()` off the
+  console/sensor handle (SDK: `MotionConsole.get_hardware_id` :556,
+  `MotionSensor.get_hardware_id` :451, `*.get_version`). Best-effort:
+  missing values logged as empty strings.
+- `settings_changed` only records keys whose value actually changed, so
+  a no-op save produces no entry (or an entry with an empty diff —
+  implementation may skip empty diffs entirely).
+- `audit_log_viewed` / `audit_log_exported` make audit-data access
+  itself auditable, per the requirement to log viewing.
+
+## UI
+
+### Settings — Logs button
+
+In `components/SettingsModal.qml`, add an **"Audit Log"** `SectionCard`
+containing a **Logs** `ActionButton`. The card is **not** gated on
+`developerMode` (auditors are not developers). On click it opens a
+`PasswordPromptModal` (reused; title "Audit Log", description "Enter the
+password to view the audit log."); `onAccepted` opens the LogsModal.
+
+### LogsModal
+
+New `components/LogsModal.qml`, modeled on `HistoryModal.qml`:
+
+- Standard modal shell (backdrop, title bar with ✕, ESC-to-close,
+  click-outside-to-close) consistent with existing modals.
+- Exposes `readonly property string label: "Audit Log"`, `visible`, and
+  `function open()` / `function close()` so `ModalManager` governs it.
+- A scrollable, newest-first table with columns **Time** (`ts_iso`),
+  **Event** (`event_type`), **Details** (the JSON string, elided/wrapped).
+  Rows come from `MotionInterface.auditLogEntries(limit)`.
+- `open()` calls a connector slot to (a) record the `audit_log_viewed`
+  event and (b) load entries.
+- An **Export CSV** button using `QtQuick.Dialogs` `FileDialog`
+  (default folder = `MotionInterface.directory`), wired to
+  `MotionInterface.exportAuditLogCsv(destPath)`.
+
+Register `logsModal` in `BloodFlow.qml`'s `ModalManager { modals: [...] }`
+list.
+
+### Connector slots (QML-facing)
+
+Added to `MotionConnector`:
+
+- `@pyqtSlot(int, result="QVariantList") auditLogEntries(limit=500)` —
+  pure read: returns rows as `{id, ts_iso, ts_epoch, event_type,
+  details}` dicts, newest first. Does **not** log (so re-querying/
+  refreshing the table never double-logs).
+- `@pyqtSlot() recordAuditLogViewed()` — records the single
+  `audit_log_viewed` event. Called exactly once from `LogsModal.open()`,
+  separately from `auditLogEntries()`.
+- `@pyqtSlot(str, result=str) exportAuditLogCsv(dest_path)` — writes the
+  full log to CSV (columns: `ts_iso, ts_epoch, event_type, details`),
+  records `audit_log_exported`, returns the written path (or "" on
+  failure). Accepts a `file://` URL or plain path (normalize like the
+  existing `FolderDialog` handlers in SettingsModal).
+
+## CSV export format
+
+Header row, then one row per entry, ordered oldest→newest (stable for
+diffing):
+
+```
+ts_iso,ts_epoch,event_type,details
+2026-06-15T09:14:02,1750000442.12,system_startup,"{""app_version"":""1.2.3"",...}"
+```
+
+`details` is the raw JSON string, quoted per `csv` module rules. UTF-8,
+`newline=""` (matches the existing FT-CSV writer at
+motion_connector.py:2593).
+
+## Testing
+
+`tests/test_audit_log.py`, all `@pytest.mark.unit` (no app launch, no
+hardware — conftest autouse fixtures short-circuit on `unit`):
+
+- Table is created on first use; `IF NOT EXISTS` is idempotent on reopen.
+- `log()` inserts a row with epoch + ISO timestamps and round-trips the
+  JSON `details`.
+- `log()` with `details=None` stores SQL `NULL`.
+- `query(limit)` returns newest-first and honors the limit.
+- `export_csv()` writes the expected header and quoting; round-trips
+  through `csv.DictReader`.
+- `AuditLog(None)` (no path) is a silent no-op: `log()`/`query()`/
+  `export_csv()` don't raise, `query()` returns `[]`.
+- Concurrent writes from two threads don't raise and both land (lock).
+
+Optional connector-level unit test: constructing `MotionConnector` with
+a tmp `scan_db_path` produces `system_startup` + `system_info` rows.
+
+The existing `tests/test_developer_password.py` already covers the
+password check being reused here.
+
+## Out of scope / YAGNI
+
+- No log rotation / retention policy (append-only; auditors keep the
+  file). Revisit only if table size becomes a real problem.
+- No in-app filtering/search UI beyond newest-first listing (CSV export
+  covers downstream analysis).
+- No SDK changes.
+- No new config flags.

--- a/docs/superpowers/specs/2026-06-16-debug-log-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-16-debug-log-bundle-design.md
@@ -1,0 +1,185 @@
+# Debug Log Bundle — Design
+
+**Date:** 2026-06-16
+**Status:** Approved (design); pending spec review
+**Branch:** `claude/dreamy-borg-0c01f8` (builds on the audit-log feature)
+
+## Goal
+
+Add a **"Send Debug Logs to Openwater"** button to the audit-log viewer
+(`LogsModal`). It zips the last 48 hours of app logs (plus minimal
+diagnostic context), reveals the zip in the file explorer, and tells the
+user to email it to **support@openwater.cc**. No mail client is launched
+and nothing is auto-sent (a `mailto:` link cannot attach a file, and
+true one-click send would require new SMTP/HTTP infrastructure that is
+out of scope).
+
+## Decisions (locked)
+
+- **Behavior:** zip → reveal in file explorer → toast with the support
+  address. No mail-client launch, no auto-send.
+- **Bundle contents:** `app-logs/*.log` modified in the last 48h, plus
+  `app_config.json` and a generated `system_info.txt`. No `scans.db`,
+  no scan CSVs, no patient/subject data.
+- **Recipient shown in the toast:** `support@openwater.cc`.
+
+## Architecture
+
+A new standalone module **`debug_bundle.py`** with a pure function, plus
+a thin connector slot and one QML button.
+
+- `build_debug_bundle(data_dir, dest_dir, now_epoch, window_hours=48)
+  -> dict` — walks `<data_dir>/app-logs/*.log`, keeps files whose mtime
+  is `>= now_epoch - window_hours*3600`, adds `<data_dir>/app_config.json`
+  (if present) and a generated `system_info.txt`, writes a zip into
+  `dest_dir`, and returns metadata
+  `{"path", "file_count", "log_count", "bytes"}`. `now_epoch` is a
+  parameter so tests are deterministic (the connector passes
+  `time.time()`).
+- The connector slot `prepareDebugLogBundle()` calls the builder, reveals
+  the file, shows a toast, and records an audit event.
+- Rationale: file-gathering/zipping logic is unit-testable against a tmp
+  directory with no app launch; the 4031-line `motion_connector.py`
+  stays lean (one thin slot). Mirrors the `audit_log.py` precedent.
+
+### `system_info.txt`
+
+Reuses `audit_log.gather_host_info()` and adds app + SDK version. Plain
+key/value text lines, e.g.:
+
+```
+app_version: 1.2.0-dev.4
+sdk_version: 1.5.8
+generated: 2026-06-16T10:30:00-07:00
+hostname: LAB-PC-01
+platform: Windows-11-10.0.26200-SP0
+...
+```
+
+The builder owns host probing (`gather_host_info()`) and the `generated`
+timestamp (derived from `now_epoch`). The connector supplies the app/SDK
+versions via `extra_info` (it can't probe them from the pure module).
+The builder merges `extra_info` over the host info and writes the
+combined key/value lines to `system_info.txt`.
+
+## Module API (`debug_bundle.py`)
+
+```python
+WINDOW_HOURS = 48
+
+def build_debug_bundle(
+    data_dir: str | Path,
+    dest_dir: str | Path,
+    now_epoch: float,
+    *,
+    window_hours: int = WINDOW_HOURS,
+    config_path: str | Path | None = None,
+    extra_info: dict | None = None,
+) -> dict:
+    """Zip recent app logs + config + system info into dest_dir.
+
+    Returns {"path": str, "file_count": int, "log_count": int,
+             "bytes": int}. Creates dest_dir if needed. The zip name is
+    debug-bundle-<YYYYMMDD_HHMMSS>.zip derived from now_epoch (local).
+    """
+```
+
+- `config_path`: path to `app_config.json`. Defaults to
+  `<data_dir>/app_config.json` when `None`. The connector passes the
+  real location (`resource_path("config", "app_config.json")`), since
+  the config does **not** live under the data directory. Included at the
+  zip root if the path exists; silently skipped if not.
+- `extra_info`: version info (`app_version`, `sdk_version`) merged into
+  `system_info.txt`. Not a path carrier.
+
+Behavior details:
+- Source logs: `<data_dir>/app-logs/*.log` with
+  `mtime >= now_epoch - window_hours*3600`. Stored in the zip under
+  `app-logs/<filename>`.
+- `app_config.json`: include the file at `config_path` (default
+  `<data_dir>/app_config.json`) at the zip root, if it exists.
+- `system_info.txt`: written at the zip root from `gather_host_info()`
+  merged with `extra_info` (app_version, sdk_version) and a `generated`
+  local-ISO-8601 timestamp from `now_epoch`.
+- Output filename: `debug-bundle-<YYYYMMDD_HHMMSS>.zip` (timestamp from
+  `now_epoch`, local time).
+- Returns metadata; never partially writes — builds into the named file
+  and closes it. Best-effort per-file: a log that can't be read is
+  skipped (logged), not fatal.
+
+## Connector slot (`motion_connector.py`)
+
+```python
+@pyqtSlot(result=str)
+def prepareDebugLogBundle(self) -> str:
+    """Zip the last 48h of app logs (+ config + system info) into
+    app-logs/debug-bundles/, reveal it in the file explorer, and toast
+    the support address. Returns the zip path, or '' on failure."""
+```
+
+- `dest_dir = <self._directory>/app-logs/debug-bundles`.
+- `extra_info = {"app_version": get_version(), "sdk_version":
+  self._interface.get_sdk_version()}` (each guarded; "" on failure),
+  and `config_path = resource_path("config", "app_config.json")`.
+- On success: reveal the file (Windows: `subprocess.run(["explorer",
+  "/select,", path])`; other OS: `QDesktopServices.openUrl` on the
+  folder — best-effort, wrapped in try/except), then
+  `self.notify("Debug logs saved to <path>. Please email this file to
+  support@openwater.cc.", "success", 0, True, "debug-bundle")` (sticky
+  so the path stays readable), and
+  `self._audit.log("debug_bundle_created", {...})`.
+- On failure: log the exception, `self.errorOccurred.emit(...)` and/or a
+  warning toast, return "".
+
+## UI (`components/LogsModal.qml`)
+
+Add a button **"Send Debug Logs"** in the toolbar, before "Export CSV"
+(same button styling as the existing toolbar buttons). `onClicked:
+MotionInterface.prepareDebugLogBundle()`. The connector handles the
+reveal + toast, so the button has no further logic. A short helper text
+or tooltip is not required (the toast explains what happened).
+
+## Audit integration
+
+New event **`debug_bundle_created`**, `details:
+{"dest", "file_count", "log_count", "bytes", "window_hours"}`. Added as
+an event-type constant in `audit_log.py` (`EV_DEBUG_BUNDLE_CREATED`) for
+consistency; it appears in the same Logs viewer.
+
+## Error handling
+
+Fail-soft throughout. Zipping failure → error toast, return "", no
+crash. Reveal failure → still toast the path. Missing `app_config.json`
+or zero recent logs → still produce a valid zip (with whatever exists +
+`system_info.txt`); the metadata reflects the actual counts.
+
+## Testing
+
+`tests/test_debug_bundle.py` (`@pytest.mark.unit`):
+- Create a tmp `data_dir/app-logs` with three `*.log` files; backdate one
+  past 48h via `os.utime`. Add a tmp `app_config.json`. Call
+  `build_debug_bundle(data_dir, dest, now_epoch=<fixed>)`.
+- Assert the resulting zip (via `zipfile.ZipFile.namelist()`) contains
+  the two recent logs under `app-logs/`, `app_config.json`, and
+  `system_info.txt`; excludes the aged log.
+- Assert returned metadata: `log_count == 2`, `file_count`,
+  `bytes == os.path.getsize(path)`, `path` ends with the expected name.
+- `system_info.txt` contains `app_version` / `sdk_version` keys from
+  `extra_info`.
+- Empty case: no recent logs → zip still contains `system_info.txt`
+  (and config if present), `log_count == 0`, no exception.
+
+Connector-level (`tests/test_audit_connector.py`, `@pytest.mark.unit`):
+- `prepareDebugLogBundle()` returns a path that exists under
+  `app-logs/debug-bundles/`, and a `debug_bundle_created` audit event is
+  recorded. (Reveal/notify side effects are best-effort and not
+  asserted; the slot must not raise when `explorer` is unavailable.)
+
+## Out of scope / YAGNI
+
+- No SMTP/HTTP auto-send; no mail-client launch.
+- No retention/cleanup of old bundles (they're small; revisit only if
+  this becomes a problem).
+- No configurable window in the UI (fixed 48h; the constant is the one
+  tuning point).
+- No inclusion of `scans.db` or scan CSVs.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -671,6 +671,14 @@ class MotionConnector(QObject):
         self._interface = interface
         self._scan_workflow = self._interface.scan_workflow
 
+        # Audit log constructed early — before connect_signals() — so the
+        # connect/disconnect handler and other instrumentation can call
+        # self._audit.log(...) safely. No-op if there's no scan_db_path.
+        # The system_startup / system_info events are logged later, once
+        # self._directory is resolved.
+        from audit_log import AuditLog
+        self._audit = AuditLog(getattr(self._interface, "scan_db_path", None))
+
         # Unpack operational settings from config
         self._force_laser_fail            = bool(cfg.get("forceLaserFail", False))
         self._camera_temp_alert_threshold_c = float(cfg.get("cameraTempAlertThresholdC", 105.0))
@@ -828,11 +836,10 @@ class MotionConnector(QObject):
         os.makedirs(resolved_dir, exist_ok=True)
         self._directory = resolved_dir
 
-        # ── Audit log: append-only, machine-readable event record in
-        #    scans.db, surfaced via the password-gated Logs modal. See
-        #    audit_log.py. No-op if the interface has no scan_db_path.
-        from audit_log import AuditLog, gather_host_info
-        self._audit = AuditLog(getattr(self._interface, "scan_db_path", None))
+        # ── Audit log startup events (the AuditLog itself was constructed
+        #    earlier, before connect_signals). Logged here now that
+        #    self._directory is resolved.
+        from audit_log import gather_host_info
         try:
             from version import get_version as _get_app_version
             _app_version = _get_app_version()
@@ -1775,7 +1782,7 @@ class MotionConnector(QObject):
         """Record that the audit log was opened. Called once from
         LogsModal.open()."""
         try:
-            n = len(self._audit.query())
+            n = self._audit.count()
         except Exception:
             n = 0
         self._audit.log("audit_log_viewed", {"entry_count": n})

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -3822,9 +3822,11 @@ class MotionConnector(QObject):
         )
 
         self._calibration_status = "running"
+        self._calibration_target = target
         self.calibrationStateChanged.emit()
         self.captureLog.emit("Calibration: starting…")
         self._calibration_t0 = time.monotonic()
+        self._audit.log("calibration_started", {"target": target})
         logger.info(
             "=== Calibration started: target=%s left=0x%02X right=0x%02X "
             "scan_duration=%ss ===",
@@ -4083,6 +4085,11 @@ class MotionConnector(QObject):
             "=== Calibration ended: %s after %.1fs ===",
             self._calibration_status, elapsed_s,
         )
+        self._audit.log("calibration_ended", {
+            "target": getattr(self, "_calibration_target", None),
+            "outcome": self._calibration_status,
+            "reason": self._calibration_failure_reason or None,
+        })
         self.calibrationStateChanged.emit()
 
     @property

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1895,7 +1895,8 @@ class MotionConnector(QObject):
         self.notify(
             "Debug logs saved to " + path
             + ". Please email this file to support@openwater.cc.",
-            "success", 0, True, "debug-bundle",
+            type_="success", duration_ms=0, dismissible=True,
+            tag="debug-bundle",
         )
         return path
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2348,6 +2348,12 @@ class MotionConnector(QObject):
         self.scanNotesChanged.emit()
         self._capture_running = True
         self._capture_start_time = time.time()
+        self._audit.log("scan_started", {
+            "label": subject_id,
+            "left_mask": int(left_camera_mask),
+            "right_mask": int(right_camera_mask),
+            "session_id": None,
+        })
         # Per-scan monotonic zero for plot timestamps. sample.timestamp_s comes
         # from each sensor's firmware clock, which resets on sensor reboot — so
         # after a mid-scan unplug/replug, the two sides' clocks diverge and the
@@ -2491,6 +2497,21 @@ class MotionConnector(QObject):
             self._capture_running = False
             self._safety_cancel_scheduled = False
             self._capture_thread = None
+            try:
+                _outcome_kind = outcome.kind
+            except Exception:
+                _outcome_kind = None
+            try:
+                _dur = (time.time() - self._capture_start_time
+                        if self._capture_start_time else None)
+            except Exception:
+                _dur = None
+            self._audit.log("scan_ended", {
+                "label": subject_id,
+                "session_label": session_label or None,
+                "duration_s": round(_dur, 1) if _dur is not None else None,
+                "outcome": _outcome_kind,
+            })
             self.captureFinished.emit(True, "", "", "")
             self.scanNotesReady.emit()
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1246,12 +1246,17 @@ class MotionConnector(QObject):
         if is_now_connected:
             logger.info("Handle %s -> CONNECTED (%s)", name, reason)
             self.signalConnected.emit(name, "")
+            self._audit.log("device_connected",
+                            {"device": name, "reason": str(reason)})
+            self._log_device_stats(name)
         elif is_now_lost:
             logger.info(
                 "Handle %s -> DISCONNECTED (%s) and state is %s",
                 name, reason, self._state,
             )
             self.signalDisconnected.emit(name, "")
+            self._audit.log("device_disconnected",
+                            {"device": name, "reason": str(reason)})
             # Abort an in-flight FPGA flash / sensor-configure pipeline.
             # The SDK does not subscribe to disconnect events for the
             # configure-cameras flow (only start_scan does), so without
@@ -1279,6 +1284,26 @@ class MotionConnector(QObject):
         if is_now_connected or is_now_lost:
             self.connectionStatusChanged.emit()
             self.update_state()
+
+    def _log_device_stats(self, name: str) -> None:
+        """Best-effort audit of a device's hardware + firmware IDs on
+        connect. Missing values are logged as empty strings."""
+        handle = getattr(self._interface, name, None)
+        hwid = ""
+        fw = ""
+        try:
+            if handle is not None and hasattr(handle, "get_hardware_id"):
+                hwid = str(handle.get_hardware_id() or "")
+        except Exception:
+            pass
+        try:
+            if handle is not None and hasattr(handle, "get_version"):
+                fw = str(handle.get_version() or "")
+        except Exception:
+            pass
+        self._audit.log("device_stats", {
+            "device": name, "hardware_id": hwid, "firmware_version": fw,
+        })
 
     def update_state(self):
         """Update system state based on connection and configuration."""

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -795,6 +795,7 @@ class MotionConnector(QObject):
         )
         self._calibration_status = ""  # "", "running", "passed", "failed", "aborted"
         self._calibration_failure_reason = ""  # populated only on FAIL in dev mode
+        self._calibration_target = None  # last runCalibration() target
         self._test_scan_status = ""              # "", "running", "done", "aborted", "failed"
         self._test_scan_failure_reason = ""
         self._test_scan_rows: list[dict] = []
@@ -1788,8 +1789,16 @@ class MotionConnector(QObject):
         except Exception:
             logger.warning(
                 "deleteScans: could not open scan DB", exc_info=True)
+        # Tolerate non-int ids the same way the delete loop above does —
+        # this comprehension runs outside AuditLog.log's fail-soft wrapper.
+        _ids = []
+        for s in session_ids:
+            try:
+                _ids.append(int(s))
+            except (TypeError, ValueError):
+                pass
         self._audit.log("scan_deleted", {
-            "session_ids": [int(s) for s in session_ids],
+            "session_ids": _ids,
             "count": deleted,
         })
         return deleted
@@ -2352,7 +2361,6 @@ class MotionConnector(QObject):
             "label": subject_id,
             "left_mask": int(left_camera_mask),
             "right_mask": int(right_camera_mask),
-            "session_id": None,
         })
         # Per-scan monotonic zero for plot timestamps. sample.timestamp_s comes
         # from each sensor's firmware clock, which resets on sensor reboot — so
@@ -4123,7 +4131,7 @@ class MotionConnector(QObject):
             self._calibration_status, elapsed_s,
         )
         self._audit.log("calibration_ended", {
-            "target": getattr(self, "_calibration_target", None),
+            "target": self._calibration_target,
             "outcome": self._calibration_status,
             "reason": self._calibration_failure_reason or None,
         })

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -827,6 +827,28 @@ class MotionConnector(QObject):
 
         os.makedirs(resolved_dir, exist_ok=True)
         self._directory = resolved_dir
+
+        # ── Audit log: append-only, machine-readable event record in
+        #    scans.db, surfaced via the password-gated Logs modal. See
+        #    audit_log.py. No-op if the interface has no scan_db_path.
+        from audit_log import AuditLog, gather_host_info
+        self._audit = AuditLog(getattr(self._interface, "scan_db_path", None))
+        try:
+            from version import get_version as _get_app_version
+            _app_version = _get_app_version()
+        except Exception:
+            _app_version = ""
+        try:
+            _sdk_version = self._interface.get_sdk_version()
+            _sdk_version = _sdk_version if isinstance(_sdk_version, str) else ""
+        except Exception:
+            _sdk_version = ""
+        self._audit.log("system_startup", {
+            "app_version": _app_version,
+            "sdk_version": _sdk_version,
+            "data_dir": self._directory,
+        })
+        self._audit.log("system_info", gather_host_info())
         logger.info(f"[Connector] Directory initialized to: {self._directory}")
 
         self._user_label = self.generate_user_label()
@@ -1341,6 +1363,11 @@ class MotionConnector(QObject):
         teardown) right after this returns."""
         logger.info("Shutting down MotionConnector...")
         self.stopCapture()
+        try:
+            self._audit.log("system_shutdown", {"clean": True})
+            self._audit.close()
+        except Exception:
+            logger.warning("audit shutdown log failed", exc_info=True)
         logger.info("MotionConnector shutdown complete.")
 
     # --- SCAN MANAGEMENT METHODS ---

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -840,7 +840,9 @@ class MotionConnector(QObject):
             _app_version = ""
         try:
             _sdk_version = self._interface.get_sdk_version()
-            _sdk_version = _sdk_version if isinstance(_sdk_version, str) else ""
+            _sdk_version = (
+                _sdk_version if isinstance(_sdk_version, str) else ""
+            )
         except Exception:
             _sdk_version = ""
         self._audit.log("system_startup", {
@@ -1365,7 +1367,6 @@ class MotionConnector(QObject):
         self.stopCapture()
         try:
             self._audit.log("system_shutdown", {"clean": True})
-            self._audit.close()
         except Exception:
             logger.warning("audit shutdown log failed", exc_info=True)
         logger.info("MotionConnector shutdown complete.")
@@ -1755,6 +1756,48 @@ class MotionConnector(QObject):
             logger.warning(
                 "deleteScans: could not open scan DB", exc_info=True)
         return deleted
+
+    # ── Audit log (QML-facing) ───────────────────────────────────────────
+    @pyqtSlot(result="QVariantList")
+    @pyqtSlot(int, result="QVariantList")
+    def auditLogEntries(self, limit: int = 500):
+        """Audit-log rows (newest first) for the Logs modal. Pure read —
+        does not itself log, so refreshing never double-logs."""
+        try:
+            return self._audit.query(int(limit))
+        except Exception:
+            logger.warning("auditLogEntries failed", exc_info=True)
+            return []
+
+    @pyqtSlot()
+    def recordAuditLogViewed(self):
+        """Record that the audit log was opened. Called once from
+        LogsModal.open()."""
+        try:
+            n = len(self._audit.query())
+        except Exception:
+            n = 0
+        self._audit.log("audit_log_viewed", {"entry_count": n})
+
+    @pyqtSlot(str, result=str)
+    def exportAuditLogCsv(self, dest_path: str) -> str:
+        """Export the full audit log to CSV. Accepts a plain path or a
+        file:// URL. Records an ``audit_log_exported`` event. Returns the
+        written path, or '' on failure."""
+        if not dest_path:
+            return ""
+        path = dest_path.replace("file:///", "").replace("file://", "")
+        try:
+            n = self._audit.export_csv(path)
+            self._audit.log(
+                "audit_log_exported", {"dest": path, "row_count": n}
+            )
+            logger.info("exportAuditLogCsv: wrote %d rows -> %s", n, path)
+            return path
+        except Exception:
+            logger.exception("exportAuditLogCsv failed for %r", path)
+            self.errorOccurred.emit("Audit log export failed.")
+            return ""
 
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1887,18 +1887,29 @@ class MotionConnector(QObject):
     @pyqtSlot(str, 'QVariant')
     def setConfig(self, key: str, value):
         """Update a single config key, persist to disk, and notify QML."""
+        old = self._app_config.get(key)
         self._app_config[key] = value
         self._save_app_config()
         self.appConfigChanged.emit()
         logger.debug(f"[Connector] Config set: {key} = {value!r}")
+        if old != value:
+            self._audit.log("settings_changed",
+                            {"changes": {key: {"old": old, "new": value}}})
 
     @pyqtSlot('QVariantMap')
     def saveConfigs(self, configs: dict):
         """Update multiple config keys at once, persist to disk, and notify QML."""
+        changes = {}
+        for k, v in configs.items():
+            old = self._app_config.get(k)
+            if old != v:
+                changes[k] = {"old": old, "new": v}
         self._app_config.update(configs)
         self._save_app_config()
         self.appConfigChanged.emit()
         logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
+        if changes:
+            self._audit.log("settings_changed", {"changes": changes})
 
     @pyqtSlot(bool)
     def setWriteRawCsv(self, enabled: bool) -> None:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1845,6 +1845,79 @@ class MotionConnector(QObject):
             self.errorOccurred.emit("Audit log export failed.")
             return ""
 
+    @pyqtSlot(result=str)
+    def prepareDebugLogBundle(self) -> str:
+        """Zip the last 48h of app logs (+ config + system info) into
+        app-logs/debug-bundles/, reveal it in the file explorer, and toast
+        the support address. Returns the zip path, or '' on failure."""
+        try:
+            from debug_bundle import build_debug_bundle, WINDOW_HOURS
+            try:
+                from version import get_version as _gv
+                app_version = _gv()
+            except Exception:
+                app_version = ""
+            try:
+                sdk_version = self._interface.get_sdk_version()
+                sdk_version = (
+                    sdk_version if isinstance(sdk_version, str) else ""
+                )
+            except Exception:
+                sdk_version = ""
+            dest_dir = os.path.join(
+                self._directory, "app-logs", "debug-bundles"
+            )
+            meta = build_debug_bundle(
+                self._directory,
+                dest_dir,
+                time.time(),
+                config_path=resource_path("config", "app_config.json"),
+                extra_info={
+                    "app_version": app_version,
+                    "sdk_version": sdk_version,
+                },
+            )
+        except Exception:
+            logger.exception("prepareDebugLogBundle: failed to build bundle")
+            self.errorOccurred.emit("Could not create the debug log bundle.")
+            return ""
+
+        path = meta["path"]
+        self._reveal_in_explorer(path)
+        from audit_log import EV_DEBUG_BUNDLE_CREATED
+        self._audit.log(EV_DEBUG_BUNDLE_CREATED, {
+            "dest": path,
+            "file_count": meta["file_count"],
+            "log_count": meta["log_count"],
+            "bytes": meta["bytes"],
+            "window_hours": WINDOW_HOURS,
+        })
+        self.notify(
+            "Debug logs saved to " + path
+            + ". Please email this file to support@openwater.cc.",
+            "success", 0, True, "debug-bundle",
+        )
+        return path
+
+    def _reveal_in_explorer(self, path: str) -> None:
+        """Best-effort: open the OS file browser with the file selected.
+        Never raises — a failed reveal must not lose the bundle."""
+        try:
+            import subprocess
+            import sys
+            if sys.platform.startswith("win"):
+                subprocess.Popen(
+                    ["explorer", "/select,", os.path.normpath(path)]
+                )
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", "-R", path])
+            else:
+                subprocess.Popen(["xdg-open", os.path.dirname(path)])
+        except Exception:
+            logger.warning(
+                "could not reveal %s in file explorer", path, exc_info=True
+            )
+
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):
         return self._directory

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1367,6 +1367,7 @@ class MotionConnector(QObject):
         self.stopCapture()
         try:
             self._audit.log("system_shutdown", {"clean": True})
+            self._audit.close()
         except Exception:
             logger.warning("audit shutdown log failed", exc_info=True)
         logger.info("MotionConnector shutdown complete.")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1788,6 +1788,10 @@ class MotionConnector(QObject):
         except Exception:
             logger.warning(
                 "deleteScans: could not open scan DB", exc_info=True)
+        self._audit.log("scan_deleted", {
+            "session_ids": [int(s) for s in session_ids],
+            "count": deleted,
+        })
         return deleted
 
     # ── Audit log (QML-facing) ───────────────────────────────────────────
@@ -2041,6 +2045,7 @@ class MotionConnector(QObject):
             )
             self.pastScanLoadFinished.emit(session_label, False)
             return
+        self._audit.log("scan_viewed", {"label": session_label})
         # Per-cam corrected CSV ({scan_id}.csv, 82-col wide format)
         # is the only source of per-cam BFI/BVI/mean/contrast for
         # past replay — the DB's session_data only holds side-

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -229,7 +229,7 @@ Rectangle {
     ModalManager {
         id: modalManager
         modals: [scanSettingsModal, notesModal, historyModal,
-                 settingsModal, contactQualityModal]
+                 settingsModal, contactQualityModal, logsModal]
     }
 
     // Data viewer — fills remaining space to the right of ButtonPanel.
@@ -332,6 +332,16 @@ Rectangle {
 
     SettingsModal {
         id: settingsModal
+        // Audit Log: the password gate lives in SettingsModal; on success
+        // close Settings and open the ModalManager-governed LogsModal.
+        onLogsRequested: {
+            settingsModal.close()
+            modalManager.toggle(logsModal)
+        }
+    }
+
+    LogsModal {
+        id: logsModal
     }
 
     ContactQualityModal {

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -333,7 +333,9 @@ Rectangle {
     SettingsModal {
         id: settingsModal
         // Audit Log: the password gate lives in SettingsModal; on success
-        // close Settings and open the ModalManager-governed LogsModal.
+        // close Settings first so toggle() sees current === null and goes
+        // straight to logsModal.open() (no redundant close), then open the
+        // ModalManager-governed LogsModal.
         onLogsRequested: {
             settingsModal.close()
             modalManager.toggle(logsModal)

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -1,5 +1,4 @@
 """Unit tests for audit-log instrumentation in MotionConnector."""
-import json
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -198,3 +198,23 @@ def test_load_past_scan_logs_scan_viewed(tmp_path):
           if e["event_type"] == "scan_viewed"]
     assert ev
     assert json.loads(ev[0]["details"])["label"] == "20260101_000000_owABC"
+
+
+def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
+    import os
+    import zipfile
+    db = str(tmp_path / "scans.db")
+    logs = tmp_path / "app-logs"
+    logs.mkdir()
+    (logs / "ow-bloodflowapp-x.log").write_text("hello", encoding="utf-8")
+    c = _connector(tmp_path, scan_db_path=db)
+    # Don't spawn a real file-explorer process during the test.
+    c._reveal_in_explorer = lambda p: None
+    path = c.prepareDebugLogBundle()
+    assert path and os.path.exists(path)
+    assert path.endswith(".zip")
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+    assert any(n.startswith("app-logs/") for n in names)
+    assert "system_info.txt" in names
+    assert "debug_bundle_created" in _types(c)

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -138,3 +138,27 @@ def test_calibration_complete_logs_ended(tmp_path):
           if e["event_type"] == "calibration_ended"]
     assert ev
     assert json.loads(ev[0]["details"])["outcome"] == "passed"
+
+
+def test_set_config_logs_settings_changed(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None      # don't touch the real config
+    c.setConfig("plotWindowSec", 30)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[0]["details"])
+    assert d["changes"]["plotWindowSec"]["new"] == 30
+
+
+def test_save_configs_logs_only_changed_keys(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None
+    c._app_config["plotWindowSec"] = 15
+    c.saveConfigs({"plotWindowSec": 15, "bfiMax": 12.0})
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[-1]["details"])["changes"]
+    assert "bfiMax" in d
+    assert "plotWindowSec" not in d

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -111,3 +111,30 @@ def test_connect_logs_device_connected_and_stats(tmp_path):
     t = _types(c)
     assert "device_connected" in t
     assert "device_stats" in t
+
+
+def test_run_calibration_logs_started(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._interface.start_calibration.return_value = True
+    c.runCalibration("left")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_started"]
+    assert ev
+    assert json.loads(ev[0]["details"])["target"] == "left"
+
+
+def test_calibration_complete_logs_ended(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._calibration_t0 = None
+    result = MagicMock()
+    result.canceled = False
+    result.ok = True
+    result.passed = True
+    result.csv_path = "cal.csv"
+    c._on_calibration_complete(result)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_ended"]
+    assert ev
+    assert json.loads(ev[0]["details"])["outcome"] == "passed"

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -1,4 +1,5 @@
 """Unit tests for audit-log instrumentation in MotionConnector."""
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -82,3 +83,31 @@ def test_no_db_path_noop(tmp_path):
     dest = str(tmp_path / "out.csv")
     c.exportAuditLogCsv(dest)      # no raise; nothing written when disabled
     assert not os.path.exists(dest)
+
+
+def test_disconnect_logs_device_disconnected(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "left"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.CONNECTED, ConnectionState.DISCONNECTED,
+        "unplugged",
+    )
+    assert "device_disconnected" in _types(c)
+
+
+def test_connect_logs_device_connected_and_stats(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "console"
+    handle.get_hardware_id.return_value = "DEADBEEF"
+    handle.get_version.return_value = "1.0.0"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.DISCONNECTED, ConnectionState.CONNECTED,
+        "found",
+    )
+    t = _types(c)
+    assert "device_connected" in t
+    assert "device_stats" in t

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -35,9 +35,16 @@ def test_construct_logs_startup_and_system_info(tmp_path):
 
 
 def test_shutdown_logs_system_shutdown(tmp_path):
-    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    # shutdown() also closes the audit handle, so read the committed
+    # rows straight from the DB file rather than via the live connector.
+    import sqlite3
+    db = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db)
     c.shutdown()
-    assert "system_shutdown" in _types(c)
+    conn = sqlite3.connect(db)
+    types = [r[0] for r in conn.execute("SELECT event_type FROM logs")]
+    conn.close()
+    assert "system_shutdown" in types
 
 
 def test_record_viewed_and_entries(tmp_path):

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -104,6 +104,11 @@ def test_connect_logs_device_connected_and_stats(tmp_path):
     handle.name = "console"
     handle.get_hardware_id.return_value = "DEADBEEF"
     handle.get_version.return_value = "1.0.0"
+    # _log_device_stats resolves the handle via getattr(self._interface,
+    # name) — in production that IS the same object the callback receives.
+    # Wire the mock interface so the test exercises that real resolution
+    # and can assert the captured IDs.
+    c._interface.console = handle
     c._on_handle_state_changed_impl(
         handle, ConnectionState.DISCONNECTED, ConnectionState.CONNECTED,
         "found",
@@ -111,6 +116,12 @@ def test_connect_logs_device_connected_and_stats(tmp_path):
     t = _types(c)
     assert "device_connected" in t
     assert "device_stats" in t
+    stats = [e for e in c.auditLogEntries()
+             if e["event_type"] == "device_stats"]
+    assert stats
+    d = json.loads(stats[0]["details"])
+    assert d["hardware_id"] == "DEADBEEF"
+    assert d["firmware_version"] == "1.0.0"
 
 
 def test_run_calibration_logs_started(tmp_path):

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -1,0 +1,65 @@
+"""Unit tests for audit-log instrumentation in MotionConnector."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None, app_config=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface,
+        app_config=app_config or {"developerMode": False},
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+
+
+def _types(c):
+    return [e["event_type"] for e in c.auditLogEntries()]
+
+
+def test_construct_logs_startup_and_system_info(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    t = _types(c)
+    assert "system_startup" in t
+    assert "system_info" in t
+
+
+def test_shutdown_logs_system_shutdown(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.shutdown()
+    assert "system_shutdown" in _types(c)
+
+
+def test_record_viewed_and_entries(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.recordAuditLogViewed()
+    assert "audit_log_viewed" in _types(c)
+
+
+def test_export_csv_writes_file_and_logs_export(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit.csv")
+    out = c.exportAuditLogCsv(dest)
+    assert out == dest
+    assert os.path.exists(dest)
+    assert "audit_log_exported" in _types(c)
+
+
+def test_export_csv_strips_file_url(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit2.csv")
+    out = c.exportAuditLogCsv("file:///" + dest.replace("\\", "/"))
+    assert os.path.exists(out)

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -218,3 +218,18 @@ def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
     assert any(n.startswith("app-logs/") for n in names)
     assert "system_info.txt" in names
     assert "debug_bundle_created" in _types(c)
+
+
+def test_prepare_debug_bundle_failure_returns_empty(tmp_path, monkeypatch):
+    # If the bundle build raises, the slot must return "" and NOT log a
+    # debug_bundle_created event (fail-soft, mirrors the other slots).
+    import debug_bundle
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._reveal_in_explorer = lambda p: None
+
+    def boom(*a, **k):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(debug_bundle, "build_debug_bundle", boom)
+    assert c.prepareDebugLogBundle() == ""
+    assert "debug_bundle_created" not in _types(c)

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -162,3 +162,28 @@ def test_save_configs_logs_only_changed_keys(tmp_path):
     d = json.loads(ev[-1]["details"])["changes"]
     assert "bfiMax" in d
     assert "plotWindowSec" not in d
+
+
+def test_delete_scans_logs_scan_deleted(tmp_path):
+    from omotion.ScanDatabase import ScanDatabase
+    db_path = str(tmp_path / "scans.db")
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label="L1", session_start=1.0,
+                            session_meta={})
+    db.close()
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.deleteScans([sid])
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_deleted"]
+    assert ev
+    assert json.loads(ev[0]["details"])["count"] == 1
+
+
+def test_load_past_scan_logs_scan_viewed(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.loadPastScan("20260101_000000_owABC")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_viewed"]
+    assert ev
+    assert json.loads(ev[0]["details"])["label"] == "20260101_000000_owABC"

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -68,4 +68,17 @@ def test_export_csv_strips_file_url(tmp_path):
     c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
     dest = str(tmp_path / "audit2.csv")
     out = c.exportAuditLogCsv("file:///" + dest.replace("\\", "/"))
+    assert out                     # returned path must be non-empty
     assert os.path.exists(out)
+
+
+def test_no_db_path_noop(tmp_path):
+    # With no scan_db_path the audit log is a no-op; the connector must
+    # still construct and the slots must return gracefully (no raise).
+    import os
+    c = _connector(tmp_path, scan_db_path=None)
+    assert c.auditLogEntries() == []
+    c.recordAuditLogViewed()       # must not raise
+    dest = str(tmp_path / "out.csv")
+    c.exportAuditLogCsv(dest)      # no raise; nothing written when disabled
+    assert not os.path.exists(dest)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,103 @@
+"""Unit tests for the append-only audit log (audit_log.py)."""
+import csv
+import json
+import sqlite3
+import threading
+
+import pytest
+
+from audit_log import AuditLog, gather_host_info, EV_SYSTEM_STARTUP
+
+pytestmark = pytest.mark.unit
+
+
+def test_log_creates_table_and_inserts_row(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log(EV_SYSTEM_STARTUP, {"app_version": "1.2.3"})
+    a.close()
+
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        "SELECT event_type, details FROM logs"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == EV_SYSTEM_STARTUP
+    assert json.loads(rows[0][1]) == {"app_version": "1.2.3"}
+
+
+def test_reopen_is_idempotent(tmp_path):
+    db = str(tmp_path / "scans.db")
+    AuditLog(db).close()
+    a = AuditLog(db)          # second open must not raise on CREATE
+    a.log("system_info", None)
+    a.close()
+
+
+def test_none_details_stored_as_null(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log("system_shutdown", None)
+    a.close()
+    conn = sqlite3.connect(db)
+    val = conn.execute("SELECT details FROM logs").fetchone()[0]
+    conn.close()
+    assert val is None
+
+
+def test_query_is_newest_first_and_honors_limit(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for i in range(5):
+        a.log("scan_started", {"n": i})
+    out = a.query(limit=3)
+    a.close()
+    assert len(out) == 3
+    # newest (n=4) first
+    assert json.loads(out[0]["details"])["n"] == 4
+
+
+def test_export_csv_roundtrips(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"label": "owABC"})
+    a.log("scan_ended", {"label": "owABC"})
+    dest = tmp_path / "audit.csv"
+    n = a.export_csv(str(dest))
+    a.close()
+    assert n == 2
+    with open(dest, newline="", encoding="utf-8") as f:
+        reader = list(csv.DictReader(f))
+    assert reader[0]["event_type"] == "scan_started"   # oldest first
+    assert json.loads(reader[0]["details"])["label"] == "owABC"
+
+
+def test_no_path_is_silent_noop(tmp_path):
+    a = AuditLog(None)
+    assert a.enabled is False
+    a.log("scan_started", {"x": 1})          # must not raise
+    assert a.query() == []
+    assert a.export_csv(str(tmp_path / "x.csv")) == 0
+    a.close()
+
+
+def test_concurrent_writes_all_land(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+
+    def worker():
+        for _ in range(20):
+            a.log("scan_started", {"t": 1})
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(a.query(limit=1000)) == 60
+    a.close()
+
+
+def test_gather_host_info_has_core_fields():
+    info = gather_host_info()
+    assert "hostname" in info
+    assert "platform" in info
+    assert "python" in info

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -32,6 +32,7 @@ def test_reopen_is_idempotent(tmp_path):
     AuditLog(db).close()
     a = AuditLog(db)          # second open must not raise on CREATE
     a.log("system_info", None)
+    assert len(a.query()) == 1
     a.close()
 
 
@@ -101,3 +102,25 @@ def test_gather_host_info_has_core_fields():
     assert "hostname" in info
     assert "platform" in info
     assert "python" in info
+
+
+def test_log_and_query_after_close_do_not_raise(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"x": 1})
+    a.close()
+    # After close the instance must stay fail-soft.
+    a.log("scan_started", {"x": 2})   # must not raise
+    assert a.query() == []
+    assert a.export_csv(str(tmp_path / "after_close.csv")) == 0
+
+
+def test_empty_dict_details_is_serialized_not_null(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log("scan_ended", {})
+    a.close()
+    import sqlite3 as _sql
+    conn = _sql.connect(db)
+    val = conn.execute("SELECT details FROM logs").fetchone()[0]
+    conn.close()
+    assert val == "{}"

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -97,6 +97,15 @@ def test_concurrent_writes_all_land(tmp_path):
     a.close()
 
 
+def test_count_returns_total_rows(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for _ in range(7):
+        a.log("scan_started", {"x": 1})
+    assert a.count() == 7
+    a.close()
+    assert a.count() == 0          # no-op after close
+
+
 def test_gather_host_info_has_core_fields():
     info = gather_host_info()
     assert "hostname" in info

--- a/tests/test_debug_bundle.py
+++ b/tests/test_debug_bundle.py
@@ -36,7 +36,8 @@ def test_includes_recent_logs_excludes_old(tmp_path):
         extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
     )
 
-    names = zipfile.ZipFile(meta["path"]).namelist()
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
     assert "app-logs/ow-bloodflowapp-A.log" in names
     assert "app-logs/ow-bloodflowapp-B.log" in names
     assert "app-logs/ow-bloodflowapp-OLD.log" not in names
@@ -52,7 +53,8 @@ def test_empty_window_still_writes_system_info(tmp_path):
     data = tmp_path / "data"
     (data / "app-logs").mkdir(parents=True)
     meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
-    names = zipfile.ZipFile(meta["path"]).namelist()
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
     assert names == ["system_info.txt"]   # no logs, no config present
     assert meta["log_count"] == 0
     assert meta["file_count"] == 1
@@ -65,7 +67,8 @@ def test_system_info_contains_versions_and_host(tmp_path):
         str(data), str(tmp_path / "out"), now_epoch=_NOW,
         extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
     )
-    txt = zipfile.ZipFile(meta["path"]).read("system_info.txt").decode("utf-8")
+    with zipfile.ZipFile(meta["path"]) as zf:
+        txt = zf.read("system_info.txt").decode("utf-8")
     assert "app_version: 1.2.3" in txt
     assert "sdk_version: 9.9" in txt
     assert "hostname:" in txt
@@ -80,5 +83,47 @@ def test_explicit_config_path_is_used(tmp_path):
     meta = build_debug_bundle(
         str(data), str(tmp_path / "out"), now_epoch=_NOW, config_path=str(cfg),
     )
-    names = zipfile.ZipFile(meta["path"]).namelist()
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
     assert "app_config.json" in names
+
+
+def test_missing_app_logs_dir_still_produces_zip(tmp_path):
+    # No app-logs/ directory at all — must still produce a valid zip
+    # containing just system_info.txt, no exception.
+    data = tmp_path / "data"
+    data.mkdir()
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert names == ["system_info.txt"]
+    assert meta["log_count"] == 0
+
+
+def test_unreadable_log_is_skipped_not_fatal(tmp_path, monkeypatch):
+    # A log that passes the mtime filter but fails zf.write must be
+    # skipped (counted in log_count, absent from the zip) rather than
+    # aborting the bundle.
+    data = tmp_path / "data"
+    logs = data / "app-logs"
+    _write(logs / "ow-bloodflowapp-good.log", "ok")
+    os.utime(logs / "ow-bloodflowapp-good.log", (_NOW - 3600, _NOW - 3600))
+    _write(logs / "ow-bloodflowapp-bad.log", "bad")
+    os.utime(logs / "ow-bloodflowapp-bad.log", (_NOW - 3600, _NOW - 3600))
+
+    real_write = zipfile.ZipFile.write
+
+    def flaky_write(self, filename, arcname=None, *a, **k):
+        if str(filename).endswith("ow-bloodflowapp-bad.log"):
+            raise OSError("simulated read failure")
+        return real_write(self, filename, arcname, *a, **k)
+
+    monkeypatch.setattr(zipfile.ZipFile, "write", flaky_write)
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert "app-logs/ow-bloodflowapp-good.log" in names
+    assert "app-logs/ow-bloodflowapp-bad.log" not in names
+    assert "system_info.txt" in names
+    assert meta["log_count"] == 2          # both matched the window
+    assert meta["file_count"] == 2         # good log + system_info only

--- a/tests/test_debug_bundle.py
+++ b/tests/test_debug_bundle.py
@@ -1,0 +1,84 @@
+"""Unit tests for the debug-log bundle builder (debug_bundle.py)."""
+import os
+import zipfile
+
+import pytest
+
+from debug_bundle import build_debug_bundle, WINDOW_HOURS
+
+pytestmark = pytest.mark.unit
+
+_NOW = 1_750_000_000.0  # fixed epoch for deterministic tests
+
+
+def _write(path, text="x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_window_hours_default_is_48():
+    assert WINDOW_HOURS == 48
+
+
+def test_includes_recent_logs_excludes_old(tmp_path):
+    data = tmp_path / "data"
+    logs = data / "app-logs"
+    for name in ("ow-bloodflowapp-A.log", "ow-bloodflowapp-B.log"):
+        _write(logs / name, "log")
+        os.utime(logs / name, (_NOW - 3600, _NOW - 3600))   # 1h ago
+    old = logs / "ow-bloodflowapp-OLD.log"
+    _write(old, "old")
+    os.utime(old, (_NOW - 49 * 3600, _NOW - 49 * 3600))     # 49h ago
+    _write(data / "app_config.json", '{"k":1}')
+
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert "app-logs/ow-bloodflowapp-A.log" in names
+    assert "app-logs/ow-bloodflowapp-B.log" in names
+    assert "app-logs/ow-bloodflowapp-OLD.log" not in names
+    assert "app_config.json" in names
+    assert "system_info.txt" in names
+    assert meta["log_count"] == 2
+    assert meta["bytes"] == os.path.getsize(meta["path"])
+    base = os.path.basename(meta["path"])
+    assert base.startswith("debug-bundle-") and base.endswith(".zip")
+
+
+def test_empty_window_still_writes_system_info(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert names == ["system_info.txt"]   # no logs, no config present
+    assert meta["log_count"] == 0
+    assert meta["file_count"] == 1
+
+
+def test_system_info_contains_versions_and_host(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+    txt = zipfile.ZipFile(meta["path"]).read("system_info.txt").decode("utf-8")
+    assert "app_version: 1.2.3" in txt
+    assert "sdk_version: 9.9" in txt
+    assert "hostname:" in txt
+    assert "generated:" in txt
+
+
+def test_explicit_config_path_is_used(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    cfg = tmp_path / "elsewhere" / "app_config.json"
+    _write(cfg, '{"x":2}')
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW, config_path=str(cfg),
+    )
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert "app_config.json" in names


### PR DESCRIPTION
## Summary

Adds an append-only, machine-readable **audit log** to the app's `scans.db` (for auditors), surfaced through a password-gated **Logs** viewer in Settings, plus two actions in that viewer: **Export CSV** and **Send Debug Logs**.

### Audit log (issue #186)
- **`audit_log.py`** — `AuditLog` store: own long-lived sqlite3 connection to `scans.db`, lazily-created `logs` table (`id, ts_epoch, ts_iso, event_type, details`), thread-safe (lock + WAL + busy_timeout), fail-soft (no-op on missing path / any error). `ts_iso` is local ISO-8601 with UTC offset; `details` is compact deterministic JSON.
- **`motion_connector.py`** — constructs `AuditLog` early in `__init__`; QML slots `auditLogEntries` / `recordAuditLogViewed` / `exportAuditLogCsv`; instrumentation for: startup/shutdown, system info, device connect/disconnect + hw/fw stats, scan start/end, calibration start/end, settings changes (changed-keys diff), scan view, and scan delete.
- **`components/LogsModal.qml`** (new) + **`SettingsModal.qml`** (Audit Log card + password gate, reusing the developer password) + **`pages/BloodFlow.qml`** (registers the modal in ModalManager).

### Debug-log bundle
- **`debug_bundle.py`** (new) — pure `build_debug_bundle(...)`: zips `app-logs/*.log` from the last 48h + `app_config.json` + a generated `system_info.txt` into `app-logs/debug-bundles/debug-bundle-<ts>.zip`. No scan data / patient info.
- **`prepareDebugLogBundle()`** connector slot — builds the zip, reveals it in the OS file explorer, toasts the support address (support@openwater.cc), and records a `debug_bundle_created` audit event. Fail-soft.
- **"Send Debug Logs"** button in the Logs viewer toolbar.

### Docs
- User/auditor guide: `docs/audit-log.md`. Design specs + implementation plans under `docs/superpowers/`.

Built test-first, task-by-task, with per-task spec + code-quality review and a final holistic review for each feature.

## Test Plan

- [x] `python -m pytest tests/test_audit_log.py tests/test_audit_connector.py tests/test_debug_bundle.py tests/test_developer_password.py` — all green
- [x] Full hardware-free suite: `python -m pytest tests/ -m unit` → **248 passed**
- [x] `python -m flake8` on all new/changed files — clean (no new violations in `motion_connector.py`)
- [x] `python -c "import main"` — QML loads
- [x] **Live, real hardware (2026-06-16):** verified `system_startup`/`system_info`, `device_connected`/`device_stats` (real hw/fw IDs), `scan_started`/`scan_ended`, `settings_changed`, `audit_log_viewed`, `system_shutdown` all fire with correct payloads
- [x] End-to-end debug-bundle smoke: zip written under `app-logs/debug-bundles/` with members `app-logs/*.log`, `app_config.json`, `system_info.txt`
- [ ] **Manual:** Settings → Audit Log → View Logs (password) → browse, **Export CSV**, **Send Debug Logs** (confirm explorer opens with the zip selected + toast)
- [ ] **Manual (hardware):** `calibration_*`, `scan_viewed`/`scan_deleted`, `audit_log_exported`, `debug_bundle_created` rows

Full test instructions for the audit log are on issue #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)