### PR TITLE
feat: critical-error codes + dismissible modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,17 @@ Edit `config/app_config.json` to customize behavior:
 | `bviMin` / `bviMax` | `4.0` / `8.0` | Manual BVI plot bounds (when autoscale is off) |
 | `meanMin` / `meanMax` | `0` / `200` | Manual mean plot bounds |
 | `contrastMin` / `contrastMax` | `0.0` / `0.7` | Manual contrast plot bounds |
+| `support_email` | `support@openwater.health` | Destination for the critical-error modal's **Send Bug Report** button |
+| `bug_report_smtp` | _(absent)_ | Optional `{host, port, username, password, from_addr, use_tls}` block. When set, bug reports are emailed automatically with the session log attached; otherwise the app opens your mail client for manual send |
 
 Most of these are also editable from the in-app **Settings** panel and persisted automatically.
+
+## Critical Errors
+
+Showstopper conditions (e.g. the sensor's boot-time I2C self-check failing) raise
+a dismissible modal carrying a stable error code such as `E-101`. See
+[docs/ERROR_CODES.md](docs/ERROR_CODES.md) for the full catalog and recommended
+actions.
 
 ## Antivirus Note (Windows)
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Edit `config/app_config.json` to customize behavior:
 | `contrastMin` / `contrastMax` | `0.0` / `0.7` | Manual contrast plot bounds |
 | `support_email` | `support@openwater.health` | Destination for the critical-error modal's **Send Bug Report** button |
 | `bug_report_smtp` | _(absent)_ | Optional `{host, port, username, password, from_addr, use_tls}` block. When set, bug reports are emailed automatically with the session log attached; otherwise the app opens your mail client for manual send |
-| `connectionTimeoutSec` | `30` | Startup connection watchdog grace period before flagging missing devices (E-104/E-106); `0` disables it |
-| `requireConsole` | `true` | Watchdog raises E-104 if no console connected at startup |
-| `minSensors` | `1` | Watchdog raises E-106 if fewer than this many sensors connected at startup |
+| `connectionTimeoutSec` | `30` | Startup connection watchdog grace period before warning about missing devices (E-104/E-106, yellow toast); `0` disables it |
+| `requireConsole` | `true` | Watchdog warns (E-104) if no console connected at startup |
+| `minSensors` | `1` | Watchdog warns (E-106) if fewer than this many sensors connected at startup |
 
 Most of these are also editable from the in-app **Settings** panel and persisted automatically.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Edit `config/app_config.json` to customize behavior:
 | `contrastMin` / `contrastMax` | `0.0` / `0.7` | Manual contrast plot bounds |
 | `support_email` | `support@openwater.health` | Destination for the critical-error modal's **Send Bug Report** button |
 | `bug_report_smtp` | _(absent)_ | Optional `{host, port, username, password, from_addr, use_tls}` block. When set, bug reports are emailed automatically with the session log attached; otherwise the app opens your mail client for manual send |
+| `connectionTimeoutSec` | `30` | Startup connection watchdog grace period before flagging missing devices (E-104/E-106); `0` disables it |
+| `requireConsole` | `true` | Watchdog raises E-104 if no console connected at startup |
+| `minSensors` | `1` | Watchdog raises E-106 if fewer than this many sensors connected at startup |
 
 Most of these are also editable from the in-app **Settings** panel and persisted automatically.
 

--- a/bug_report.py
+++ b/bug_report.py
@@ -1,0 +1,99 @@
+"""Bug-report assembly and delivery for the critical-error modal.
+
+Split into pure helpers (report text, config check, mailto URL — unit-tested)
+and thin I/O wrappers (SMTP send, reveal-in-Explorer — side-effecting, exercised
+manually). The connector orchestrates: build the text, then either send via SMTP
+(if fully configured) or fall back to opening the user's mail client.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from email.message import EmailMessage
+from urllib.parse import urlencode
+
+logger = logging.getLogger(__name__)
+
+_SMTP_REQUIRED_FIELDS = ("host", "port", "username", "password", "from_addr")
+
+
+# --- pure helpers -----------------------------------------------------------
+def build_report_text(
+    *,
+    code: str,
+    title: str,
+    message: str,
+    timestamp: str,
+    app_version: str,
+    device_info: str,
+    log_path: str,
+) -> str:
+    """Human-readable report body included in the email / clipboard."""
+    return (
+        "OpenWater BloodFlow — Critical Error Report\n"
+        "-------------------------------------------\n"
+        f"Code:       {code}\n"
+        f"Title:      {title}\n"
+        f"Message:    {message}\n"
+        f"Time:       {timestamp}\n"
+        f"App version: {app_version}\n"
+        f"Devices:    {device_info}\n"
+        f"Log file:   {log_path}\n"
+        "\n"
+        "Please attach the log file above if it is not already attached.\n"
+    )
+
+
+def smtp_config_complete(cfg: dict | None) -> bool:
+    """True iff every required SMTP field is present and non-empty."""
+    if not cfg:
+        return False
+    return all(str(cfg.get(f, "")).strip() for f in _SMTP_REQUIRED_FIELDS)
+
+
+def build_mailto_url(address: str, *, subject: str, body: str) -> str:
+    """Build a ``mailto:`` URL with URL-encoded subject and body."""
+    query = urlencode({"subject": subject, "body": body})
+    return f"mailto:{address}?{query}"
+
+
+# --- I/O wrappers (side-effecting; not unit-tested) -------------------------
+def send_via_smtp(cfg: dict, *, to_addr: str, subject: str, body: str,
+                  log_path: str | None) -> None:
+    """Send the report via SMTP with the log attached. Raises on failure."""
+    import smtplib
+
+    msg = EmailMessage()
+    msg["From"] = cfg["from_addr"]
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    if log_path and os.path.isfile(log_path):
+        with open(log_path, "rb") as fh:
+            msg.add_attachment(
+                fh.read(), maintype="text", subtype="plain",
+                filename=os.path.basename(log_path),
+            )
+
+    with smtplib.SMTP(cfg["host"], int(cfg["port"]), timeout=30) as srv:
+        if cfg.get("use_tls", True):
+            srv.starttls()
+        srv.login(cfg["username"], cfg["password"])
+        srv.send_message(msg)
+
+
+def reveal_in_file_manager(path: str) -> None:
+    """Open the OS file manager with ``path`` selected. Best-effort."""
+    try:
+        if sys.platform.startswith("win"):
+            subprocess.Popen(["explorer", "/select,", os.path.normpath(path)])
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", "-R", path])
+        else:
+            subprocess.Popen(["xdg-open", os.path.dirname(path) or "."])
+    except Exception as exc:  # pragma: no cover - environment dependent
+        logger.warning("Could not reveal log file %s: %s", path, exc)

--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -1,0 +1,298 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import OpenMotion 1.0
+
+/*  CriticalErrorModal — blocking, dismissible alert for showstopper
+ *  conditions carrying a stable error code (see error_codes.py /
+ *  docs/ERROR_CODES.md).
+ *
+ *  Host once, top-level, above everything else:
+ *
+ *      CriticalErrorModal { id: criticalErrorModal; anchors.fill: parent; z: 100000 }
+ *
+ *  It listens to MotionInterface.criticalErrorRaised and shows itself. If
+ *  several fire close together they are queued and shown one at a time.
+ *  Dismissible via the Dismiss button, the backdrop, or Esc.
+ */
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 100000
+
+    AppTheme { id: theme }
+
+    // Current error fields (bound into the panel).
+    property string code: ""
+    property string title: ""
+    property string message: ""
+    property string suggestedAction: ""
+    property string detail: ""
+
+    // Pending errors waiting their turn.
+    property var _queue: []
+    property bool _detailExpanded: false
+
+    function _enqueue(code, title, message, action, detail) {
+        var q = root._queue.slice()
+        q.push({code: code, title: title, message: message,
+                action: action, detail: detail})
+        root._queue = q
+        if (!root.visible)
+            root._showNext()
+    }
+
+    function _showNext() {
+        if (root._queue.length === 0) {
+            root.visible = false
+            return
+        }
+        var q = root._queue.slice()
+        var e = q.shift()
+        root._queue = q
+        root.code = e.code
+        root.title = e.title
+        root.message = e.message
+        root.suggestedAction = e.action
+        root.detail = e.detail
+        root._detailExpanded = false
+        root.visible = true
+        root.forceActiveFocus()
+    }
+
+    function dismiss() {
+        root._showNext()  // advances to the next queued error, or hides
+    }
+
+    function _reportText() {
+        return "Code: " + root.code
+            + "\nTitle: " + root.title
+            + "\nMessage: " + root.message
+            + (root.detail ? "\nDetail: " + root.detail : "")
+    }
+
+    Connections {
+        target: MotionInterface
+        function onCriticalErrorRaised(code, title, message, action, detail) {
+            root._enqueue(code, title, message, action, detail)
+        }
+    }
+
+    // Backdrop — click outside dismisses.
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000C0"
+        MouseArea { anchors.fill: parent; onClicked: root.dismiss() }
+    }
+
+    // Panel
+    Rectangle {
+        width: 460
+        height: contentCol.implicitHeight + headerBar.height + 16 + 20
+        radius: 14
+        color: theme.bgContainer
+        border.color: theme.accentRed
+        border.width: 1
+        anchors.centerIn: parent
+
+        // Absorb clicks so they don't reach the backdrop.
+        MouseArea { anchors.fill: parent }
+
+        // Red header bar with code badge.
+        Rectangle {
+            id: headerBar
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 44
+            radius: 14
+            color: theme.accentRed
+            // square off the bottom corners so only the top is rounded
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: parent.radius
+                color: theme.accentRed
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                spacing: 10
+
+                Rectangle {
+                    Layout.preferredHeight: 24
+                    Layout.preferredWidth: codeText.implicitWidth + 16
+                    radius: 4
+                    color: "#FFFFFF"
+                    Text {
+                        id: codeText
+                        anchors.centerIn: parent
+                        text: root.code
+                        color: theme.accentRed
+                        font.pixelSize: 13
+                        font.weight: Font.Bold
+                        font.family: "Consolas, monospace"
+                    }
+                }
+
+                Text {
+                    text: "Critical Error"
+                    color: "#FFFFFF"
+                    font.pixelSize: 15
+                    font.weight: Font.DemiBold
+                    Layout.fillWidth: true
+                }
+
+                Text {
+                    visible: root._queue.length > 0
+                    text: root._queue.length + " more"
+                    color: "#FFFFFFCC"
+                    font.pixelSize: 12
+                }
+            }
+        }
+
+        ColumnLayout {
+            id: contentCol
+            anchors.top: headerBar.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.topMargin: 16
+            width: parent.width - 40
+            spacing: 12
+
+            Text {
+                text: root.title
+                color: theme.textPrimary
+                font.pixelSize: 17
+                font.weight: Font.DemiBold
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            Text {
+                text: root.message
+                color: theme.textSecondary
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            // Suggested action callout.
+            Rectangle {
+                visible: root.suggestedAction !== ""
+                Layout.fillWidth: true
+                radius: 6
+                color: theme.bgInput
+                Layout.preferredHeight: actionRow.implicitHeight + 16
+                RowLayout {
+                    id: actionRow
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    spacing: 8
+                    Text {
+                        text: "→"
+                        color: theme.accentBlue
+                        font.pixelSize: 14
+                        font.weight: Font.Bold
+                    }
+                    Text {
+                        text: root.suggestedAction
+                        color: theme.textPrimary
+                        font.pixelSize: 13
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                }
+            }
+
+            // Collapsible technical detail.
+            Text {
+                visible: root.detail !== ""
+                text: (root._detailExpanded ? "▼ " : "▶ ") + "Details"
+                color: theme.textTertiary
+                font.pixelSize: 12
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root._detailExpanded = !root._detailExpanded
+                }
+            }
+            Text {
+                visible: root.detail !== "" && root._detailExpanded
+                text: root.detail
+                color: theme.textTertiary
+                font.pixelSize: 12
+                font.family: "Consolas, monospace"
+                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                Layout.fillWidth: true
+            }
+
+            // Buttons
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                spacing: 10
+
+                Button {
+                    text: "Copy details"
+                    Layout.preferredHeight: 32
+                    onClicked: MotionInterface.copyToClipboard(root._reportText())
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSoft; border.width: 1
+                    }
+                }
+
+                Button {
+                    text: "Send Bug Report to Openwater"
+                    Layout.preferredHeight: 32
+                    onClicked: MotionInterface.sendBugReport(root.code)
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSubtle; border.width: 1
+                    }
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Dismiss"
+                    Layout.preferredHeight: 32
+                    onClicked: root.dismiss()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Qt.lighter(theme.accentRed, 1.1) : theme.accentRed
+                        radius: 4
+                    }
+                }
+            }
+        }
+    }
+
+    Keys.onReleased: function(event) {
+        if (event.key === Qt.Key_Escape) { root.dismiss(); event.accepted = true }
+    }
+}

--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -88,7 +88,7 @@ Item {
 
     // Panel
     Rectangle {
-        width: 460
+        width: 520
         height: contentCol.implicitHeight + headerBar.height + 16 + 20
         radius: 14
         color: theme.bgContainer
@@ -159,9 +159,11 @@ Item {
         ColumnLayout {
             id: contentCol
             anchors.top: headerBar.bottom
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.left: parent.left
+            anchors.right: parent.right
             anchors.topMargin: 16
-            width: parent.width - 40
+            anchors.leftMargin: 20
+            anchors.rightMargin: 20
             spacing: 12
 
             Text {

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -60,5 +60,6 @@
   "histoThrottle": false,
   "histoCmp": true,
   "commVerbose": false,
-  "verboseCommandHandling": false
+  "verboseCommandHandling": false,
+  "support_email": "support@openwater.health"
 }

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -61,5 +61,8 @@
   "histoCmp": true,
   "commVerbose": false,
   "verboseCommandHandling": false,
-  "support_email": "support@openwater.health"
+  "support_email": "support@openwater.health",
+  "connectionTimeoutSec": 30,
+  "requireConsole": true,
+  "minSensors": 1
 }

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -39,12 +39,27 @@ The laser may not operate correctly until this is resolved.
 **What to do:** Power-cycle the console and reconnect. If it persists, send a bug
 report — the console firmware or config may need attention.
 
+### E-104 — Console not detected
+No console was detected within the expected time after the app started (the
+startup *connection watchdog*). The system cannot run a scan without the console.
+
+**What to do:** Check the console USB cable and power, then reconnect. Power-cycle
+the console if it does not appear.
+
 ### E-105 — Camera power-on failed
 The sensor could not power on its cameras during initialization, so camera
 identities could not be read.
 
 **What to do:** Power-cycle the sensor and reconnect. If only some cameras are
 affected, the camera board may need service.
+
+### E-106 — Sensor not detected
+Fewer sensor modules were detected than required within the expected time after
+the app started (the startup *connection watchdog*). At least one sensor is
+required to scan.
+
+**What to do:** Check the sensor USB cable and power, then reconnect. Try a
+different USB port if it does not appear.
 
 ## E-2xx — Laser safety
 
@@ -78,6 +93,22 @@ finishing.
 
 **What to do:** Wait a few seconds for the previous scan to finish, then try
 again. Reconnect if the system stays busy.
+
+## Startup connection watchdog
+
+E-104 and E-106 are raised by a one-shot check armed at app launch. If the
+expected devices haven't enumerated within `connectionTimeoutSec` (default 30 s),
+the missing ones are flagged. Tunable in
+[`config/app_config.json`](../config/app_config.json):
+
+- `connectionTimeoutSec` (default `30`) — grace period before the check runs;
+  `0` disables the watchdog.
+- `requireConsole` (default `true`) — raise E-104 if no console connected.
+- `minSensors` (default `1`) — raise E-106 if fewer than this many sensors
+  connected.
+
+Disconnects that happen *after* startup are handled by the normal connection
+status UI, not by this watchdog.
 
 ## Sending a bug report
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -14,6 +14,10 @@ this document is generated from that registry. They are grouped by subsystem:
 When reporting a problem, quote the code — it tells support exactly which check
 failed.
 
+Not every coded condition is critical: the **startup connection watchdog**
+(E-104 / E-106) is a non-blocking *warning* shown as a yellow toast, not the
+modal — see [Startup warnings](#startup-warnings-connection-watchdog) below.
+
 ## E-1xx — Startup / initialization
 
 ### E-101 — Sensor self-check failed
@@ -39,27 +43,12 @@ The laser may not operate correctly until this is resolved.
 **What to do:** Power-cycle the console and reconnect. If it persists, send a bug
 report — the console firmware or config may need attention.
 
-### E-104 — Console not detected
-No console was detected within the expected time after the app started (the
-startup *connection watchdog*). The system cannot run a scan without the console.
-
-**What to do:** Check the console USB cable and power, then reconnect. Power-cycle
-the console if it does not appear.
-
 ### E-105 — Camera power-on failed
 The sensor could not power on its cameras during initialization, so camera
 identities could not be read.
 
 **What to do:** Power-cycle the sensor and reconnect. If only some cameras are
 affected, the camera board may need service.
-
-### E-106 — Sensor not detected
-Fewer sensor modules were detected than required within the expected time after
-the app started (the startup *connection watchdog*). At least one sensor is
-required to scan.
-
-**What to do:** Check the sensor USB cable and power, then reconnect. Try a
-different USB port if it does not appear.
 
 ## E-2xx — Laser safety
 
@@ -94,17 +83,29 @@ finishing.
 **What to do:** Wait a few seconds for the previous scan to finish, then try
 again. Reconnect if the system stays busy.
 
-## Startup connection watchdog
+## Startup warnings (connection watchdog)
 
-E-104 and E-106 are raised by a one-shot check armed at app launch. If the
-expected devices haven't enumerated within `connectionTimeoutSec` (default 30 s),
-the missing ones are flagged. Tunable in
-[`config/app_config.json`](../config/app_config.json):
+A one-shot check armed at app launch flags expected devices that never showed
+up. Unlike the codes above it is **non-blocking**: it shows a **yellow warning
+toast** in the bottom-right, not the critical modal, because the fix is usually
+just "plug it in and reconnect". If the expected devices haven't enumerated
+within `connectionTimeoutSec` (default 30 s) after launch:
+
+- **E-104 — Console not detected** → `"Console not detected. Check the console
+  USB cable and power, then reconnect."`
+- **E-106 — Sensor not detected** → `"Sensor not detected. Check the sensor USB
+  cable and power, then reconnect."`
+- **Both missing** → a single consolidated toast: `"System not found. Check that
+  the console and sensor are connected and powered on."`
+
+The codes E-104/E-106 still appear in the app log for support traceability.
+
+Tunable in [`config/app_config.json`](../config/app_config.json):
 
 - `connectionTimeoutSec` (default `30`) — grace period before the check runs;
   `0` disables the watchdog.
-- `requireConsole` (default `true`) — raise E-104 if no console connected.
-- `minSensors` (default `1`) — raise E-106 if fewer than this many sensors
+- `requireConsole` (default `true`) — warn (E-104) if no console connected.
+- `minSensors` (default `1`) — warn (E-106) if fewer than this many sensors
   connected.
 
 Disconnects that happen *after* startup are handled by the normal connection

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,0 +1,95 @@
+# Critical Error Codes
+
+When the BloodFlow app hits a showstopper condition it raises a **critical-error
+modal** carrying a stable code (e.g. `E-101`). The modal is dismissible and
+offers **Copy details** and **Send Bug Report to Openwater**.
+
+Codes are the single source of truth in [`error_codes.py`](../error_codes.py);
+this document is generated from that registry. They are grouped by subsystem:
+
+- **E-1xx** — startup / initialization
+- **E-2xx** — laser safety
+- **E-3xx** — scan / capture
+
+When reporting a problem, quote the code — it tells support exactly which check
+failed.
+
+## E-1xx — Startup / initialization
+
+### E-101 — Sensor self-check failed
+One or more of the sensor's internal I2C devices (the I2C mux, the IMU, a
+camera, or an FPGA) did not respond during the firmware's power-on self-check.
+The system cannot scan reliably in this state.
+
+**What to do:** Power-cycle the sensor and reconnect. If it persists, the sensor
+hardware needs service — send a bug report.
+
+### E-102 — Sensor self-check unreadable
+The sensor connected but did not return its power-on self-check result, so its
+internal device health is unknown (typically older firmware, or the status
+command was rejected).
+
+**What to do:** Power-cycle the sensor and reconnect. If it persists, update the
+sensor firmware or send a bug report.
+
+### E-103 — Console initialization failed
+The console connected but its laser-power configuration could not be applied.
+The laser may not operate correctly until this is resolved.
+
+**What to do:** Power-cycle the console and reconnect. If it persists, send a bug
+report — the console firmware or config may need attention.
+
+### E-105 — Camera power-on failed
+The sensor could not power on its cameras during initialization, so camera
+identities could not be read.
+
+**What to do:** Power-cycle the sensor and reconnect. If only some cameras are
+affected, the camera board may need service.
+
+## E-2xx — Laser safety
+
+### E-201 — Laser safety monitor unresponsive
+The laser-safety monitor stopped reporting a known-good state for longer than
+the allowed transient window, so laser safety cannot be confirmed. The laser was
+shut off as a precaution.
+
+**What to do:** Power-cycle the system and reconnect. Do not scan until this
+clears — send a bug report if it persists; the safety I2C link may be failing.
+
+### E-202 — Laser safety trip
+The laser-safety monitor tripped during a scan and the laser was shut off. The
+scan was stopped.
+
+**What to do:** Remove any obstruction, let the system settle, and start a new
+scan. If it trips repeatedly, stop and send a bug report.
+
+## E-3xx — Scan / capture
+
+### E-301 — Scan aborted before start
+A scan was requested but a precondition check failed, so the scan was aborted
+before the laser fired.
+
+**What to do:** Resolve the reported precondition (connection, safety, or
+configuration) and start the scan again.
+
+### E-302 — Scan could not start
+The system refused to start a new scan, usually because a previous scan is still
+finishing.
+
+**What to do:** Wait a few seconds for the previous scan to finish, then try
+again. Reconnect if the system stays busy.
+
+## Sending a bug report
+
+The **Send Bug Report to Openwater** button packages the current session log plus
+the error context for support.
+
+- By default it opens your mail client with a pre-filled message to
+  `support@openwater.health`, copies the report to your clipboard, and reveals
+  the session log file so you can attach it before sending.
+- If an SMTP relay is configured (`bug_report_smtp` in
+  [`config/app_config.json`](../config/app_config.json)), the report is sent
+  automatically with the log attached — no manual step.
+
+The support address is configurable via the `support_email` key in
+`config/app_config.json`.

--- a/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
+++ b/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
@@ -49,9 +49,9 @@ their existing toast/inline handling).
 | E-101 | Sensor I2C self-check: expected device(s) missing at boot (mux / IMU / camera / FPGA) | `_check_sensor_i2c_health` (reads `MotionSensor.i2c_health`) |
 | E-102 | I2C health unreadable — firmware returned no snapshot | `_check_sensor_i2c_health` (`i2c_health is None`) |
 | E-103 | Console init failed — laser-power params didn't apply at connect | `_on_handle_state_changed_impl` console branch |
-| E-104 | Console not detected within startup timeout | connection watchdog (`_check_connection_watchdog`) |
+| E-104 | Console not detected within startup timeout | connection watchdog — **warning toast, not modal** |
 | E-105 | Camera power-on failed during init | `_run_sensor_init` |
-| E-106 | Fewer sensors than required within startup timeout | connection watchdog (`_check_connection_watchdog`) |
+| E-106 | Fewer sensors than required within startup timeout | connection watchdog — **warning toast, not modal** |
 | E-201 | Laser safety monitor unresponsive beyond transient window | safety_known streak block (issue #119) |
 | E-202 | Laser safety trip during scan | `_on_safety_trip_during_capture` |
 | E-301 | Capture aborted before laser fired (precondition fail) | `startCapture` abort (with reason) |
@@ -66,10 +66,17 @@ failed", which has a clean site. E-203 was merged into E-201; E-303 was dropped
 CONNECTED/DISCONNECTED (it retries enumeration internally, with no
 "failed attempt" event), E-104/E-106 are driven by a one-shot timer armed at
 startup. After `connectionTimeoutSec` (default 30 s) it checks the cached
-connection state and raises E-104 if the console is required but absent, and
-E-106 if fewer than `minSensors` (default 1) sensors connected. Config:
-`connectionTimeoutSec` / `requireConsole` / `minSensors`. Post-startup
-disconnects remain the job of the existing connection-status UI.
+connection state. Config: `connectionTimeoutSec` / `requireConsole` /
+`minSensors`. Post-startup disconnects remain the job of the existing
+connection-status UI.
+
+**Severity (updated):** E-104/E-106 are **non-blocking warnings**, not the
+critical modal — a missing system at startup is a "plug it in" situation. They
+surface as a single yellow toast (bottom-right, `tag="connection-watchdog"`,
+sticky); when both are missing it collapses to `"System not found"`. So they are
+**not** in the `error_codes.py` modal registry — `_check_connection_watchdog`
+calls `notify(..., "warning", ...)` directly and logs the codes for support. The
+modal registry holds 8 codes (E-101/102/103/105, E-201/202, E-301/302).
 
 ## Modal — `components/CriticalErrorModal.qml`
 

--- a/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
+++ b/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
@@ -46,20 +46,23 @@ their existing toast/inline handling).
 
 | Code | Condition | Source site |
 |---|---|---|
-| E-101 | Sensor I2C bus check failed — expected device(s) missing at boot (mux / IMU / camera / FPGA) | `MotionSensor.is_i2c_healthy()` false after connect |
-| E-102 | I2C health unreadable — firmware returned no snapshot | `MotionSensor.i2c_health is None` |
-| E-103 | Sensor failed to connect / not detected (on a failed connect attempt) | connection handler |
-| E-104 | Console failed to connect / not detected (on a failed connect attempt) | connection handler |
+| E-101 | Sensor I2C self-check: expected device(s) missing at boot (mux / IMU / camera / FPGA) | `_check_sensor_i2c_health` (reads `MotionSensor.i2c_health`) |
+| E-102 | I2C health unreadable — firmware returned no snapshot | `_check_sensor_i2c_health` (`i2c_health is None`) |
+| E-103 | Console init failed — laser-power params didn't apply at connect | `_on_handle_state_changed_impl` console branch |
 | E-105 | Camera power-on failed during init | `_run_sensor_init` |
-| E-201 | Laser safety chip unresponsive at startup | safety read at connect |
-| E-202 | Laser safety trip during scan | `safetyTripDuringCaptureRequested` |
-| E-203 | Laser safety state unknown beyond transient threshold | safety_known streak (issue #119) |
-| E-301 | Capture aborted before laser fired (precondition fail) | `startCapture` abort |
-| E-302 | SDK refused to spawn a new scan | `startCapture` |
-| E-303 | Capture / pipeline failed | `captureFinished(ok=False)` |
+| E-201 | Laser safety monitor unresponsive beyond transient window | safety_known streak block (issue #119) |
+| E-202 | Laser safety trip during scan | `_on_safety_trip_during_capture` |
+| E-301 | Capture aborted before laser fired (precondition fail) | `startCapture` abort (with reason) |
+| E-302 | SDK refused to spawn a new scan | `startCapture` (no reason) |
 
-E-103/E-104 fire only on a *failed connect attempt*, not on routine
-unplug/disconnect (those keep the existing connection-status UI).
+**Reshaped from the original proposal so every documented code has a real
+trigger.** Dropped: E-104 (console "not detected" — connection is
+CONNECTED/DISCONNECTED only; no failed-attempt event without a new timeout
+watchdog), E-203 (merged into E-201), E-303 (capture is fail-soft —
+`captureFinished` always emits success). E-103 was repurposed from "sensor not
+detected" to "console init failed", which does have a clean site. A
+connection-timeout watchdog for true enumeration failures (E-104-style) is a
+possible follow-up.
 
 ## Modal — `components/CriticalErrorModal.qml`
 

--- a/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
+++ b/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
@@ -1,0 +1,112 @@
+# Critical-Error Codes + Modal — Design
+
+Date: 2026-06-15
+Branch: `feature/critical-error-codes-modal` (off `next-next`)
+
+## Goal
+
+Surface critical/showstopper conditions (e.g. the boot-time I2C check failing) to
+the clinician as a dismissible modal carrying a stable **error code**, and publish
+the authoritative list of codes in the docs.
+
+Today these conditions are only written to the app log; nothing blocks or alerts
+the user in the UI. The app already has a toast path (`MotionInterface.notify`)
+and a generic `errorOccurred(str)` signal, but neither is coded, blocking, or
+self-documenting.
+
+## Scope
+
+In scope (categories chosen by product owner):
+
+- **E-1xx** Startup / initialization failures (I2C check, connect, camera power).
+- **E-2xx** Laser-safety showstoppers.
+- **E-3xx** Scan / capture aborts.
+
+Out of scope: calibration failures, contact-quality soft warnings (these keep
+their existing toast/inline handling).
+
+## Architecture
+
+`motion_connector.py` is ~4031 lines; CLAUDE.md warns against growing it. So:
+
+- **New module `error_codes.py`** — frozen registry of codes. Each entry:
+  `code`, `category`, `title`, `message`, `suggested_action`. Plus a
+  `CriticalError` dataclass and `lookup(code) -> CriticalError`. Pure, no Qt,
+  unit-testable.
+- **Connector additions (thin):**
+  - `criticalErrorRaised = pyqtSignal(str, str, str, str)  # code, title, message, detail`
+  - `_raise_critical(self, code: str, detail: str = "")` — looks up the registry,
+    logs, and emits the signal. Emitted via `Qt.QueuedConnection` semantics so
+    worker-thread call sites (USB I/O, scanner) are safe.
+  - `@pyqtSlot(str) sendBugReport(code)` — see Bug report.
+- Existing failure sites add a `self._raise_critical(...)` call. The failure
+  paths' own behavior is unchanged; this is an additive surfacing layer.
+
+## Catalog (authoritative list → `docs/ERROR_CODES.md`)
+
+| Code | Condition | Source site |
+|---|---|---|
+| E-101 | Sensor I2C bus check failed — expected device(s) missing at boot (mux / IMU / camera / FPGA) | `MotionSensor.is_i2c_healthy()` false after connect |
+| E-102 | I2C health unreadable — firmware returned no snapshot | `MotionSensor.i2c_health is None` |
+| E-103 | Sensor failed to connect / not detected (on a failed connect attempt) | connection handler |
+| E-104 | Console failed to connect / not detected (on a failed connect attempt) | connection handler |
+| E-105 | Camera power-on failed during init | `_run_sensor_init` |
+| E-201 | Laser safety chip unresponsive at startup | safety read at connect |
+| E-202 | Laser safety trip during scan | `safetyTripDuringCaptureRequested` |
+| E-203 | Laser safety state unknown beyond transient threshold | safety_known streak (issue #119) |
+| E-301 | Capture aborted before laser fired (precondition fail) | `startCapture` abort |
+| E-302 | SDK refused to spawn a new scan | `startCapture` |
+| E-303 | Capture / pipeline failed | `captureFinished(ok=False)` |
+
+E-103/E-104 fire only on a *failed connect attempt*, not on routine
+unplug/disconnect (those keep the existing connection-status UI).
+
+## Modal — `components/CriticalErrorModal.qml`
+
+- Style matches `PasswordPromptModal`. Hosted top-level in `main.qml` so it
+  overlays every page. Connected to `MotionInterface.criticalErrorRaised`.
+- Dismissible: backdrop click, Dismiss button, Esc.
+- Content: red header with **code badge** (`E-101`), title, message,
+  suggested-action line, collapsible detail block.
+- **Queue**: if several fire, show one at a time; show a "N more" affordance.
+- Buttons: **Copy details**, **Send Bug Report to Openwater**, **Dismiss**.
+
+## Bug report (hybrid — works today, upgrades cleanly)
+
+No Openwater backend / mail relay exists today, and embedding SMTP credentials in
+a clinical desktop app is undesirable. So:
+
+- **Default (zero infra):** `sendBugReport(code)` builds a report (code, message,
+  timestamp, app version, device IDs), reveals the current session log in
+  Explorer (`explorer /select,<logpath>`), copies the prefilled report to the
+  clipboard, and opens the default mail client via
+  `mailto:support@openwater.health?subject=...&body=...`. The user attaches the
+  highlighted log and sends. (Desktop apps cannot silently attach a file to an
+  arbitrary mail client — this is the honest limitation.)
+- **Upgrade (opt-in, true one-click):** if an optional `bug_report_smtp` block is
+  present and complete in `app_config.json`, send directly via `smtplib` on a
+  background thread with the log **attached automatically**; emit a result toast.
+  Absent by default → fallback above.
+
+Config additions:
+- `support_email` (default `"support@openwater.health"`).
+- optional `bug_report_smtp: { host, port, username, password, use_tls, from_addr }`.
+
+The connector must expose the **current session log path**. `main.py` sets up the
+timestamped per-launch log; we surface its path to the connector for the report.
+
+## Testing
+
+- Unit (`@pytest.mark.unit`, mock the seam — no app launch, per repo rule):
+  - registry completeness: every catalog code resolves; no dup codes.
+  - `_raise_critical` emits the correct 4-tuple payload for a known code.
+  - bug-report builder: produces expected report text; selects SMTP vs mailto
+    fallback based on config presence.
+- QML modal: visual screenshot check (PrintWindow flag 2) after layout — boot-log
+  grep won't catch geometry bugs.
+
+## Non-goals / YAGNI
+
+- No retry/auto-recovery from the modal (dismiss only + bug report).
+- No new backend service.
+- No reworking of the existing toast/`errorOccurred` paths.

--- a/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
+++ b/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
@@ -49,20 +49,27 @@ their existing toast/inline handling).
 | E-101 | Sensor I2C self-check: expected device(s) missing at boot (mux / IMU / camera / FPGA) | `_check_sensor_i2c_health` (reads `MotionSensor.i2c_health`) |
 | E-102 | I2C health unreadable — firmware returned no snapshot | `_check_sensor_i2c_health` (`i2c_health is None`) |
 | E-103 | Console init failed — laser-power params didn't apply at connect | `_on_handle_state_changed_impl` console branch |
+| E-104 | Console not detected within startup timeout | connection watchdog (`_check_connection_watchdog`) |
 | E-105 | Camera power-on failed during init | `_run_sensor_init` |
+| E-106 | Fewer sensors than required within startup timeout | connection watchdog (`_check_connection_watchdog`) |
 | E-201 | Laser safety monitor unresponsive beyond transient window | safety_known streak block (issue #119) |
 | E-202 | Laser safety trip during scan | `_on_safety_trip_during_capture` |
 | E-301 | Capture aborted before laser fired (precondition fail) | `startCapture` abort (with reason) |
 | E-302 | SDK refused to spawn a new scan | `startCapture` (no reason) |
 
 **Reshaped from the original proposal so every documented code has a real
-trigger.** Dropped: E-104 (console "not detected" — connection is
-CONNECTED/DISCONNECTED only; no failed-attempt event without a new timeout
-watchdog), E-203 (merged into E-201), E-303 (capture is fail-soft —
-`captureFinished` always emits success). E-103 was repurposed from "sensor not
-detected" to "console init failed", which does have a clean site. A
-connection-timeout watchdog for true enumeration failures (E-104-style) is a
-possible follow-up.
+trigger.** E-103 was repurposed from "sensor not detected" to "console init
+failed", which has a clean site. E-203 was merged into E-201; E-303 was dropped
+(capture is fail-soft — `captureFinished` always emits success).
+
+**Connection watchdog (added):** because the SDK exposes only
+CONNECTED/DISCONNECTED (it retries enumeration internally, with no
+"failed attempt" event), E-104/E-106 are driven by a one-shot timer armed at
+startup. After `connectionTimeoutSec` (default 30 s) it checks the cached
+connection state and raises E-104 if the console is required but absent, and
+E-106 if fewer than `minSensors` (default 1) sensors connected. Config:
+`connectionTimeoutSec` / `requireConsole` / `minSensors`. Post-startup
+disconnects remain the job of the existing connection-status UI.
 
 ## Modal — `components/CriticalErrorModal.qml`
 

--- a/error_codes.py
+++ b/error_codes.py
@@ -70,12 +70,28 @@ _STARTUP = [
         "report — the console firmware or config may need attention.",
     ),
     _e(
+        "E-104", "startup",
+        "Console not detected",
+        "No console was detected within the expected time after the app "
+        "started. The system cannot run a scan without the console.",
+        "Check the console USB cable and power, then reconnect. Power-cycle "
+        "the console if it does not appear.",
+    ),
+    _e(
         "E-105", "startup",
         "Camera power-on failed",
         "The sensor could not power on its cameras during initialization, so "
         "camera identities could not be read.",
         "Power-cycle the sensor and reconnect. If only some cameras are "
         "affected, the camera board may need service.",
+    ),
+    _e(
+        "E-106", "startup",
+        "Sensor not detected",
+        "Fewer sensor modules were detected than required within the expected "
+        "time after the app started. At least one sensor is required to scan.",
+        "Check the sensor USB cable and power, then reconnect. Try a different "
+        "USB port if it does not appear.",
     ),
 ]
 

--- a/error_codes.py
+++ b/error_codes.py
@@ -1,0 +1,146 @@
+"""Critical-error code catalog for the BloodFlow app.
+
+Single source of truth for the showstopper conditions surfaced to the user
+through the critical-error modal. Pure data — no Qt, no hardware — so it stays
+unit-testable and importable from anywhere.
+
+Codes are grouped by subsystem:
+
+    E-1xx  startup / initialization
+    E-2xx  laser safety
+    E-3xx  scan / capture
+
+The human-readable catalog lives in ``docs/ERROR_CODES.md`` and is generated
+from this registry; keep the two in sync.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CriticalError:
+    """One showstopper condition.
+
+    Attributes:
+        code: stable identifier, e.g. ``"E-101"``.
+        category: ``"startup"`` | ``"safety"`` | ``"scan"``.
+        title: short headline shown in the modal.
+        message: one or two sentences describing what happened.
+        suggested_action: what the operator should try.
+    """
+
+    code: str
+    category: str
+    title: str
+    message: str
+    suggested_action: str
+
+
+def _e(code, category, title, message, suggested_action) -> CriticalError:
+    return CriticalError(code, category, title, message, suggested_action)
+
+
+# --- E-1xx: startup / initialization ----------------------------------------
+_STARTUP = [
+    _e(
+        "E-101", "startup",
+        "Sensor self-check failed",
+        "The sensor reported that one or more internal devices (I2C mux, IMU, "
+        "a camera, or an FPGA) did not respond during its power-on self-check. "
+        "The system cannot scan reliably in this state.",
+        "Power-cycle the sensor and reconnect. If it persists, the sensor "
+        "hardware needs service — send a bug report.",
+    ),
+    _e(
+        "E-102", "startup",
+        "Sensor self-check unreadable",
+        "The sensor connected but did not return its power-on self-check "
+        "result, so its internal device health is unknown.",
+        "Power-cycle the sensor and reconnect. If it persists, update the "
+        "sensor firmware or send a bug report.",
+    ),
+    _e(
+        "E-103", "startup",
+        "Console initialization failed",
+        "The console connected but its laser-power configuration could not be "
+        "applied. The laser may not operate correctly until this is resolved.",
+        "Power-cycle the console and reconnect. If it persists, send a bug "
+        "report — the console firmware or config may need attention.",
+    ),
+    _e(
+        "E-105", "startup",
+        "Camera power-on failed",
+        "The sensor could not power on its cameras during initialization, so "
+        "camera identities could not be read.",
+        "Power-cycle the sensor and reconnect. If only some cameras are "
+        "affected, the camera board may need service.",
+    ),
+]
+
+# --- E-2xx: laser safety -----------------------------------------------------
+_SAFETY = [
+    _e(
+        "E-201", "safety",
+        "Laser safety monitor unresponsive",
+        "The laser-safety monitor stopped reporting a known-good state for "
+        "longer than the allowed transient window, so laser safety cannot be "
+        "confirmed. The laser was shut off as a precaution.",
+        "Power-cycle the system and reconnect. Do not scan until this clears "
+        "— send a bug report if it persists; the safety I2C link may be "
+        "failing.",
+    ),
+    _e(
+        "E-202", "safety",
+        "Laser safety trip",
+        "The laser-safety monitor tripped during a scan and the laser was shut "
+        "off. The scan was stopped.",
+        "Remove any obstruction, let the system settle, and start a new scan. "
+        "If it trips repeatedly, stop and send a bug report.",
+    ),
+]
+
+# --- E-3xx: scan / capture ---------------------------------------------------
+_SCAN = [
+    _e(
+        "E-301", "scan",
+        "Scan aborted before start",
+        "A scan was requested but a precondition check failed, so the scan was "
+        "aborted before the laser fired.",
+        "Resolve the reported precondition (connection, safety, or "
+        "configuration) and start the scan again.",
+    ),
+    _e(
+        "E-302", "scan",
+        "Scan could not start",
+        "The system refused to start a new scan, usually because a previous "
+        "scan is still finishing.",
+        "Wait a few seconds for the previous scan to finish, then try again. "
+        "Reconnect if the system stays busy.",
+    ),
+]
+
+
+ERROR_CODES: dict[str, CriticalError] = {
+    err.code: err for err in (*_STARTUP, *_SAFETY, *_SCAN)
+}
+
+
+def lookup(code: str) -> CriticalError:
+    """Return the catalog entry for ``code``.
+
+    Never raises: an unknown code yields a generic entry that preserves the
+    code, so the modal can always show *something* even for a code that
+    predates this build.
+    """
+    err = ERROR_CODES.get(code)
+    if err is not None:
+        return err
+    return CriticalError(
+        code=code,
+        category="startup",
+        title="Critical error",
+        message="A critical error occurred.",
+        suggested_action="Send a bug report with the session log attached.",
+    )

--- a/error_codes.py
+++ b/error_codes.py
@@ -70,14 +70,6 @@ _STARTUP = [
         "report — the console firmware or config may need attention.",
     ),
     _e(
-        "E-104", "startup",
-        "Console not detected",
-        "No console was detected within the expected time after the app "
-        "started. The system cannot run a scan without the console.",
-        "Check the console USB cable and power, then reconnect. Power-cycle "
-        "the console if it does not appear.",
-    ),
-    _e(
         "E-105", "startup",
         "Camera power-on failed",
         "The sensor could not power on its cameras during initialization, so "
@@ -85,15 +77,13 @@ _STARTUP = [
         "Power-cycle the sensor and reconnect. If only some cameras are "
         "affected, the camera board may need service.",
     ),
-    _e(
-        "E-106", "startup",
-        "Sensor not detected",
-        "Fewer sensor modules were detected than required within the expected "
-        "time after the app started. At least one sensor is required to scan.",
-        "Check the sensor USB cable and power, then reconnect. Try a different "
-        "USB port if it does not appear.",
-    ),
 ]
+
+# Note: E-104 (console not detected) and E-106 (sensor not detected) are NOT in
+# this critical-modal registry. The startup connection watchdog surfaces them as
+# a non-blocking yellow warning toast instead (see
+# MotionConnector._check_connection_watchdog). They remain documented in
+# docs/ERROR_CODES.md under "Startup warnings".
 
 # --- E-2xx: laser safety -----------------------------------------------------
 _SAFETY = [

--- a/main.py
+++ b/main.py
@@ -140,6 +140,13 @@ def _load_app_config() -> dict:
         # painted. Gated on `developerMode && showProfiling` so clinical
         # users never see it.
         "showProfiling": False,
+        # Critical-error bug report (see error_codes.py / CriticalErrorModal).
+        "support_email": "support@openwater.health",
+        "bug_report_smtp": None,
+        # Startup connection watchdog (E-104/E-106).
+        "connectionTimeoutSec": 30,
+        "requireConsole": True,
+        "minSensors": 1,
     }
     config_path = resource_path("config", "app_config.json")
     if not config_path.exists():

--- a/main.py
+++ b/main.py
@@ -272,7 +272,10 @@ def main():
 
     engine = QQmlApplicationEngine()
 
-    connector = MotionConnector(motion_interface, app_config=app_config, data_dir=_data_dir)
+    connector = MotionConnector(
+        motion_interface, app_config=app_config, data_dir=_data_dir,
+        app_version=APP_VERSION, log_path=logfile_path,
+    )
     qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", connector)
     engine.rootContext().setContextProperty("appVersion", APP_VERSION)
 

--- a/main.qml
+++ b/main.qml
@@ -204,4 +204,12 @@ ApplicationWindow {
     TestResultsWindow {
         id: testResultsWindow
     }
+
+    // Critical-error modal — top-level so it overlays every page and toast.
+    // Listens to MotionInterface.criticalErrorRaised; see docs/ERROR_CODES.md.
+    CriticalErrorModal {
+        id: criticalErrorModal
+        anchors.fill: parent
+        z: 100000
+    }
 }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -683,6 +683,12 @@ class MotionConnector(QObject):
         self._support_email = cfg.get("support_email", "support@openwater.health")
         self._bug_report_smtp = cfg.get("bug_report_smtp")
 
+        # Connection watchdog (E-104/E-106): one-shot check armed at startup
+        # that flags expected devices that never enumerated. 0 disables it.
+        self._connection_timeout_sec = float(cfg.get("connectionTimeoutSec", 30))
+        self._require_console = bool(cfg.get("requireConsole", True))
+        self._min_sensors = int(cfg.get("minSensors", 1))
+
         self._interface = interface
         self._scan_workflow = self._interface.scan_workflow
 
@@ -891,6 +897,11 @@ class MotionConnector(QObject):
 
         self._interface.console.telemetry.add_listener(self._on_telemetry_update)
 
+        # Arm the startup connection watchdog (E-104/E-106). The timer starts
+        # once the Qt event loop runs — by which point motion_interface.start()
+        # has had its window to enumerate already-attached devices.
+        self._arm_connection_watchdog()
+
     def set_ft_thresholds(
         self,
         min_mean_per_camera=None,
@@ -1024,6 +1035,36 @@ class MotionConnector(QObject):
                 self._raise_critical("E-101", detail=f"{side} sensor: {missing}")
         except Exception:
             logger.exception("I2C health check failed for %s sensor", side)
+
+    def _arm_connection_watchdog(self) -> None:
+        """Schedule the one-shot startup connection check (E-104/E-106)."""
+        if self._connection_timeout_sec > 0:
+            QTimer.singleShot(
+                int(self._connection_timeout_sec * 1000),
+                self._check_connection_watchdog,
+            )
+
+    def _check_connection_watchdog(self) -> None:
+        """Flag devices that never connected within the startup timeout.
+
+        One-shot: reads the current cached connection state. If the console
+        and/or the required number of sensors still haven't enumerated, raise
+        the matching critical error. Disconnects that happen *after* startup
+        are handled by the normal connection-status UI, not here.
+        """
+        try:
+            if self._require_console and not self._consoleConnected:
+                self._raise_critical("E-104")
+            n_sensors = (int(bool(self._leftSensorConnected))
+                         + int(bool(self._rightSensorConnected)))
+            if n_sensors < self._min_sensors:
+                self._raise_critical(
+                    "E-106",
+                    detail=f"{n_sensors} of {self._min_sensors} "
+                           f"required sensor(s) detected",
+                )
+        except Exception:
+            logger.exception("connection watchdog check failed")
 
     @staticmethod
     def _i2c_missing_devices(health: dict) -> str:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1045,24 +1045,43 @@ class MotionConnector(QObject):
             )
 
     def _check_connection_watchdog(self) -> None:
-        """Flag devices that never connected within the startup timeout.
+        """Warn about devices that never connected within the startup timeout.
 
-        One-shot: reads the current cached connection state. If the console
-        and/or the required number of sensors still haven't enumerated, raise
-        the matching critical error. Disconnects that happen *after* startup
-        are handled by the normal connection-status UI, not here.
+        One-shot: reads the current cached connection state. A missing console
+        (E-104) and/or too few sensors (E-106) are non-blocking — they surface
+        as a single yellow warning toast (bottom-right), not the critical
+        modal, since the fix is usually just "plug it in". If *both* are
+        missing the toast collapses to a plain "System not found". Disconnects
+        that happen *after* startup are handled by the connection-status UI.
         """
         try:
-            if self._require_console and not self._consoleConnected:
-                self._raise_critical("E-104")
+            console_missing = self._require_console and not self._consoleConnected
             n_sensors = (int(bool(self._leftSensorConnected))
                          + int(bool(self._rightSensorConnected)))
-            if n_sensors < self._min_sensors:
-                self._raise_critical(
-                    "E-106",
-                    detail=f"{n_sensors} of {self._min_sensors} "
-                           f"required sensor(s) detected",
-                )
+            sensors_missing = n_sensors < self._min_sensors
+            if not console_missing and not sensors_missing:
+                return
+
+            if console_missing and sensors_missing:
+                logger.warning(
+                    "Connection watchdog: console and sensors missing "
+                    "(E-104/E-106: %d of %d sensors)", n_sensors, self._min_sensors)
+                msg = ("System not found. Check that the console and sensor "
+                       "are connected and powered on.")
+            elif console_missing:
+                logger.warning("Connection watchdog: console not detected (E-104)")
+                msg = ("Console not detected. Check the console USB cable and "
+                       "power, then reconnect.")
+            else:
+                logger.warning(
+                    "Connection watchdog: sensor not detected "
+                    "(E-106: %d of %d)", n_sensors, self._min_sensors)
+                msg = ("Sensor not detected. Check the sensor USB cable and "
+                       "power, then reconnect.")
+            # Sticky, single (tagged) yellow toast — the user must act, but it
+            # never blocks the UI like the critical modal.
+            self.notify(msg, "warning", duration_ms=0, dismissible=True,
+                        tag="connection-watchdog")
         except Exception:
             logger.exception("connection watchdog check failed")
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -38,6 +38,8 @@ from processing.visualize_bloodflow import VisualizeBloodflow
 from motion_config import (
     load_tec_params,
 )
+import error_codes
+import bug_report
 from nan_gap_tracker import NanGapTracker, gap_note_line
 from utils.resource_path import resource_path
 from data_sources import (
@@ -566,6 +568,10 @@ class MotionConnector(QObject):
     gyroscopeSensorUpdated = pyqtSignal(float, float, float)  # (x, y, z)
     rgbStateReceived = pyqtSignal(int, str)  # (state, state_text)
     errorOccurred = pyqtSignal(str)
+    # Critical/showstopper conditions surfaced to the user as a blocking,
+    # dismissible modal with a stable error code (see error_codes.py).
+    # Payload: (code, title, message, suggestedAction, detail).
+    criticalErrorRaised = pyqtSignal(str, str, str, str, str)
     notificationRequested = pyqtSignal('QVariant')  # toast notification payload dict
     notificationDismissByIdRequested = pyqtSignal(int)   # dismiss the toast with this id
     notificationDismissByTagRequested = pyqtSignal(str)  # dismiss the toast with this tag
@@ -661,12 +667,21 @@ class MotionConnector(QObject):
         config_dir="config",
         parent=None,
         log_level=logging.INFO,
+        app_version="",
+        log_path="",
     ):
         super().__init__(parent)
         cfg = app_config or {}
 
         # Store the full config dict — exposed to QML as appConfig property
         self._app_config = dict(cfg)
+
+        # Bug-report context (see sendBugReport). app_version + log_path come
+        # from main.py; support_email / bug_report_smtp from app config.
+        self._app_version = app_version
+        self._log_path = log_path
+        self._support_email = cfg.get("support_email", "support@openwater.health")
+        self._bug_report_smtp = cfg.get("bug_report_smtp")
 
         self._interface = interface
         self._scan_workflow = self._interface.scan_workflow
@@ -953,6 +968,11 @@ class MotionConnector(QObject):
 
         self.getFanControlStatus(side)
 
+        # Surface the firmware's boot-time I2C self-check (E-101/E-102) — the
+        # canonical "I2C check at the beginning". Best-effort: never blocks
+        # init, just raises the modal if the sensor reports trouble.
+        self._check_sensor_i2c_health(side)
+
         # Power on all cameras, fill the ID cache (serial numbers, connection info), then power off
         try:
             sensor = getattr(self._interface, side, None) if self._interface else None
@@ -972,6 +992,7 @@ class MotionConnector(QObject):
                             "Could not power on cameras on %s sensor for ID cache fill",
                             side,
                         )
+                        self._raise_critical("E-105", detail=f"{side} sensor")
                         refresh_cache()  # try anyway in case some cameras are already on
                 elif refresh_cache:
                     refresh_cache()  # fallback: fill cache without power cycle (may get zeros for off cameras)
@@ -983,6 +1004,42 @@ class MotionConnector(QObject):
         self._read_and_log_camera_uids(side)
 
         self.connectionStatusChanged.emit()
+
+    def _check_sensor_i2c_health(self, side: str) -> None:
+        """Raise E-101/E-102 if a sensor's boot-time I2C self-check is bad.
+
+        Reads the firmware's cached snapshot (no disruptive rescan). Never
+        raises out — it's a best-effort surfacing layer over the SDK's
+        ``MotionSensor.i2c_health``.
+        """
+        try:
+            sensor = getattr(self._interface, side, None) if self._interface else None
+            if sensor is None or not sensor.is_connected():
+                return
+            health = getattr(sensor, "i2c_health", None)
+            if health is None:
+                self._raise_critical("E-102", detail=f"{side} sensor")
+            elif not health.get("all_present", False):
+                missing = self._i2c_missing_devices(health)
+                self._raise_critical("E-101", detail=f"{side} sensor: {missing}")
+        except Exception:
+            logger.exception("I2C health check failed for %s sensor", side)
+
+    @staticmethod
+    def _i2c_missing_devices(health: dict) -> str:
+        """Human-readable summary of which I2C devices didn't respond."""
+        parts = []
+        if not health.get("mux", True):
+            parts.append("mux")
+        if not health.get("imu", True):
+            parts.append("imu")
+        cams = [i for i, ok in enumerate(health.get("cameras", [])) if not ok]
+        if cams:
+            parts.append("cameras " + ",".join(str(i) for i in cams))
+        fpgas = [i for i, ok in enumerate(health.get("fpgas", [])) if not ok]
+        if fpgas:
+            parts.append("fpgas " + ",".join(str(i) for i in fpgas))
+        return "; ".join(parts) or "unknown device"
 
     # --- GETTERS/SETTERS FOR Qt PROPERTIES ---
     def getUserLabel(self) -> str:
@@ -1211,6 +1268,8 @@ class MotionConnector(QObject):
                         logger.info("Laser power params applied from config")
                     else:
                         logger.error("Failed to apply laser power params from config")
+                        self._raise_critical(
+                            "E-103", detail="laser power params not applied")
                 except Exception as e:
                     logger.warning(
                         f"Console connect-time setup interrupted "
@@ -2669,12 +2728,14 @@ class MotionConnector(QObject):
                 logger.warning("startCapture aborted: %s", reason)
                 self.captureLog.emit(f"Scan aborted: {reason}")
                 self.errorOccurred.emit(reason)
+                self._raise_critical("E-301", detail=reason)
             else:
                 logger.warning(
                     "startCapture aborted: SDK refused to spawn a new scan "
                     "(usually a previous worker thread that didn't exit cleanly)."
                 )
                 self.captureLog.emit("Capture already running.")
+                self._raise_critical("E-302")
         return bool(started)
 
     def _log_scan_image_stats(self, left_csv: str, right_csv: str) -> None:
@@ -2852,6 +2913,7 @@ class MotionConnector(QObject):
         self.captureLog.emit(
             "Laser safety system tripped. Scan will be cancelled in 5 seconds."
         )
+        self._raise_critical("E-202")
         QTimer.singleShot(5000, self.stopCapture)
 
     @pyqtSlot(result=QVariant)
@@ -2949,6 +3011,7 @@ class MotionConnector(QObject):
                     logger.error(f"Laser safety failure: {fault_detail}")
                     self.safetyFailure = True
                     self._fire_safety_notification(fault_detail)
+                    self._raise_critical("E-201", detail=fault_detail)
                     self.stopTrigger()
                     self._laserOn = False
                     self.laserStateChanged.emit()
@@ -3839,6 +3902,87 @@ class MotionConnector(QObject):
         cb = QGuiApplication.clipboard()
         if cb is not None:
             cb.setText(text)
+
+    # --- CRITICAL ERROR SURFACING -----------------------------------------
+    def _raise_critical(self, code: str, detail: str = "") -> None:
+        """Surface a showstopper to the user via the critical-error modal.
+
+        Looks ``code`` up in :mod:`error_codes`, logs it, and emits
+        ``criticalErrorRaised``. Safe to call from worker threads — the QML
+        side connects with a queued connection. Never raises.
+        """
+        try:
+            err = error_codes.lookup(code)
+            logger.error("CRITICAL %s — %s%s", code, err.title,
+                         f" ({detail})" if detail else "")
+            self.criticalErrorRaised.emit(
+                code, err.title, err.message, err.suggested_action, detail)
+        except Exception:
+            logger.exception("Failed to raise critical error %s", code)
+
+    def _device_info_str(self) -> str:
+        """Best-effort one-line device identity for bug reports."""
+        try:
+            console, left, right = self._interface.is_device_connected()
+            return f"console={'yes' if console else 'no'} " \
+                   f"left={'yes' if left else 'no'} " \
+                   f"right={'yes' if right else 'no'}"
+        except Exception:
+            return "unknown"
+
+    @pyqtSlot(str)
+    def sendBugReport(self, code: str) -> None:
+        """Send the current session log + error context to Openwater support.
+
+        If a complete ``bug_report_smtp`` block is configured the email is sent
+        directly (with the log attached) on a background thread. Otherwise we
+        fall back to opening the user's mail client and revealing the log file
+        so they can attach it manually.
+        """
+        err = error_codes.lookup(code)
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        subject = f"BloodFlow Bug Report — {code} {err.title}"
+        body = bug_report.build_report_text(
+            code=code, title=err.title, message=err.message,
+            timestamp=timestamp, app_version=self._app_version or "unknown",
+            device_info=self._device_info_str(),
+            log_path=self._log_path or "(no log file)",
+        )
+        if bug_report.smtp_config_complete(self._bug_report_smtp):
+            self._send_bug_report_smtp(subject, body)
+        else:
+            self._send_bug_report_fallback(subject, body)
+
+    def _send_bug_report_smtp(self, subject: str, body: str) -> None:
+        """Send the report via SMTP on a daemon thread; toast the result."""
+        def _worker():
+            try:
+                bug_report.send_via_smtp(
+                    self._bug_report_smtp, to_addr=self._support_email,
+                    subject=subject, body=body, log_path=self._log_path or None,
+                )
+                self.notify("Bug report sent to Openwater.", "success")
+            except Exception as exc:
+                logger.exception("SMTP bug report failed")
+                self.notify(f"Could not send bug report: {exc}", "error")
+                # Fall back so the user can still get the report out.
+                self._send_bug_report_fallback(subject, body)
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _send_bug_report_fallback(self, subject: str, body: str) -> None:
+        """Open the mail client, copy the report, and reveal the log file."""
+        import webbrowser
+        self.copyToClipboard(body)
+        if self._log_path:
+            bug_report.reveal_in_file_manager(self._log_path)
+        try:
+            webbrowser.open(bug_report.build_mailto_url(
+                self._support_email, subject=subject, body=body))
+        except Exception:
+            logger.exception("Could not open mail client for bug report")
+        self.notify(
+            "Bug report copied to clipboard. Attach the highlighted log "
+            "file and send the email to Openwater.", "info", 8000, True)
 
     def connect_signals(self):
         """Subscribe to per-handle state changes on the SDK interface."""

--- a/tests/test_app_config_defaults.py
+++ b/tests/test_app_config_defaults.py
@@ -69,6 +69,33 @@ def test_unknown_keys_are_dropped(tmp_path, monkeypatch):
     assert "autoConfigureOnStartup" not in cfg
 
 
+def test_critical_error_config_keys_preserved(tmp_path, monkeypatch):
+    """Bug-report + connection-watchdog keys must survive the whitelist.
+
+    `_load_app_config` drops any key not present in the in-code defaults, so
+    these keys must be registered there or they silently never reach the
+    connector (e.g. `bug_report_smtp` could never enable SMTP send).
+    """
+    config_path = tmp_path / "app_config.json"
+    config_path.write_text(
+        json.dumps({
+            "support_email": "x@y.z",
+            "bug_report_smtp": {"host": "h"},
+            "connectionTimeoutSec": 12,
+            "requireConsole": True,
+            "minSensors": 2,
+        }),
+        encoding="utf-8",
+    )
+    _patch_config_path(monkeypatch, config_path)
+    cfg = app_main._load_app_config()
+    assert cfg["support_email"] == "x@y.z"
+    assert cfg["bug_report_smtp"] == {"host": "h"}
+    assert cfg["connectionTimeoutSec"] == 12
+    assert cfg["minSensors"] == 2
+    assert cfg["requireConsole"] is True
+
+
 def test_auto_configure_flag_is_gone():
     """Tombstone for issue #154: the startup auto-flash flag must not
     come back — not in the in-code defaults, not in the shipped config,

--- a/tests/test_bug_report.py
+++ b/tests/test_bug_report.py
@@ -1,0 +1,64 @@
+"""Bug-report builder — pure helpers, no I/O (no SMTP, no shell, no Qt)."""
+
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+import bug_report
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_report_text_includes_code_and_context():
+    text = bug_report.build_report_text(
+        code="E-101",
+        title="Sensor self-check failed",
+        message="One or more devices did not respond.",
+        timestamp="2026-06-15 23:00:00",
+        app_version="1.2.3",
+        device_info="left=ABC123 console=XYZ",
+        log_path=r"C:\scan_data\app-logs\ow.log",
+    )
+    assert "E-101" in text
+    assert "Sensor self-check failed" in text
+    assert "One or more devices did not respond." in text
+    assert "2026-06-15 23:00:00" in text
+    assert "1.2.3" in text
+    assert "ABC123" in text
+    assert r"C:\scan_data\app-logs\ow.log" in text
+
+
+def test_smtp_config_complete_true_when_all_fields_present():
+    cfg = {
+        "host": "smtp.example.com",
+        "port": 587,
+        "username": "u",
+        "password": "p",
+        "from_addr": "app@example.com",
+    }
+    assert bug_report.smtp_config_complete(cfg) is True
+
+
+@pytest.mark.parametrize("cfg", [
+    None,
+    {},
+    {"host": "smtp.example.com"},  # missing the rest
+    {"host": "", "port": 587, "username": "u", "password": "p",
+     "from_addr": "a@b.c"},  # empty host
+])
+def test_smtp_config_incomplete_returns_false(cfg):
+    assert bug_report.smtp_config_complete(cfg) is False
+
+
+def test_build_mailto_url_encodes_subject_and_body():
+    url = bug_report.build_mailto_url(
+        "support@openwater.health",
+        subject="BloodFlow Bug Report — E-101",
+        body="line one\nline two & more",
+    )
+    split = urlsplit(url)
+    assert split.scheme == "mailto"
+    assert split.path == "support@openwater.health"
+    q = parse_qs(split.query)
+    assert q["subject"] == ["BloodFlow Bug Report — E-101"]
+    assert q["body"] == ["line one\nline two & more"]

--- a/tests/test_critical_error_signal.py
+++ b/tests/test_critical_error_signal.py
@@ -25,10 +25,6 @@ def _connector(tmp_path, app_config=None, connected=(True, True, True)):
     )
 
 
-def _codes(received):
-    return [r[0] for r in received]
-
-
 _FULL_SMTP = {
     "host": "smtp.example.com", "port": 587, "username": "u",
     "password": "p", "from_addr": "app@example.com",
@@ -114,55 +110,79 @@ def test_i2c_health_none_raises_e102(tmp_path):
     assert received[0][0] == "E-102"
 
 
-def test_watchdog_all_connected_raises_nothing(tmp_path):
+def _notifs(conn):
+    """Capture toast payloads emitted via notificationRequested."""
+    out = []
+    conn.notificationRequested.connect(lambda p: out.append(p))
+    return out
+
+
+def test_watchdog_all_connected_no_notification(tmp_path):
     conn = _connector(tmp_path, connected=(True, True, True))
-    received = []
-    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+    notifs = _notifs(conn)
 
     conn._check_connection_watchdog()
 
-    assert received == []
+    assert notifs == []
 
 
-def test_watchdog_no_console_raises_e104(tmp_path):
-    conn = _connector(tmp_path, connected=(False, True, False))
-    received = []
-    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
-
-    conn._check_connection_watchdog()
-
-    assert _codes(received) == ["E-104"]
-
-
-def test_watchdog_no_sensor_raises_e106(tmp_path):
-    conn = _connector(tmp_path, connected=(True, False, False))
-    received = []
-    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
-
-    conn._check_connection_watchdog()
-
-    assert _codes(received) == ["E-106"]
-
-
-def test_watchdog_nothing_connected_raises_both(tmp_path):
+def test_watchdog_is_a_warning_not_a_critical_modal(tmp_path):
+    """E-104/E-106 are downgraded: a yellow warning toast, never the modal."""
     conn = _connector(tmp_path, connected=(False, False, False))
-    received = []
-    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+    crit = []
+    conn.criticalErrorRaised.connect(lambda *a: crit.append(a))
+    notifs = _notifs(conn)
 
     conn._check_connection_watchdog()
 
-    assert set(_codes(received)) == {"E-104", "E-106"}
+    assert crit == []
+    assert all(n["type"] == "warning" for n in notifs)
+
+
+def test_watchdog_both_missing_shows_single_system_not_found(tmp_path):
+    conn = _connector(tmp_path, connected=(False, False, False))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "System not found" in notifs[0]["text"]
+
+
+def test_watchdog_console_only_missing_warns(tmp_path):
+    conn = _connector(tmp_path, connected=(False, True, False))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "Console" in notifs[0]["text"]
+    assert "System not found" not in notifs[0]["text"]
+
+
+def test_watchdog_sensor_only_missing_warns(tmp_path):
+    conn = _connector(tmp_path, connected=(True, False, False))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "Sensor" in notifs[0]["text"]
 
 
 def test_watchdog_respects_min_sensors_config(tmp_path):
     conn = _connector(tmp_path, app_config={"minSensors": 2},
                       connected=(True, True, False))  # only one sensor
-    received = []
-    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+    notifs = _notifs(conn)
 
     conn._check_connection_watchdog()
 
-    assert _codes(received) == ["E-106"]
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "Sensor" in notifs[0]["text"]
 
 
 def test_send_bug_report_selects_smtp_when_configured(tmp_path, monkeypatch):

--- a/tests/test_critical_error_signal.py
+++ b/tests/test_critical_error_signal.py
@@ -1,0 +1,136 @@
+"""Connector glue for critical errors: signal payload + bug-report routing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import error_codes
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, app_config=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    cfg = {"developerMode": False}
+    if app_config:
+        cfg.update(app_config)
+    return MotionConnector(
+        interface=iface, app_config=cfg,
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+_FULL_SMTP = {
+    "host": "smtp.example.com", "port": 587, "username": "u",
+    "password": "p", "from_addr": "app@example.com",
+}
+
+
+def test_raise_critical_emits_registry_payload(tmp_path):
+    conn = _connector(tmp_path)
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._raise_critical("E-101", detail="mux missing")
+
+    assert len(received) == 1
+    code, title, message, action, detail = received[0]
+    entry = error_codes.lookup("E-101")
+    assert code == "E-101"
+    assert title == entry.title
+    assert message == entry.message
+    assert action == entry.suggested_action
+    assert detail == "mux missing"
+
+
+def test_raise_critical_unknown_code_still_emits(tmp_path):
+    conn = _connector(tmp_path)
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._raise_critical("E-777")
+
+    assert len(received) == 1
+    assert received[0][0] == "E-777"
+    assert received[0][1]  # generic title, non-empty
+
+
+def _healthy():
+    return {"mux": True, "imu": True, "cameras": [True] * 8,
+            "fpgas": [True] * 8, "all_present": True}
+
+
+def test_i2c_health_all_present_raises_nothing(tmp_path):
+    conn = _connector(tmp_path)
+    conn._interface.left.is_connected.return_value = True
+    conn._interface.left.i2c_health = _healthy()
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_sensor_i2c_health("left")
+
+    assert received == []
+
+
+def test_i2c_health_missing_device_raises_e101_with_detail(tmp_path):
+    conn = _connector(tmp_path)
+    conn._interface.left.is_connected.return_value = True
+    snap = _healthy()
+    snap["cameras"] = [True, True, False, True, True, True, True, True]
+    snap["imu"] = False
+    snap["all_present"] = False
+    conn._interface.left.i2c_health = snap
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_sensor_i2c_health("left")
+
+    assert len(received) == 1
+    code, _title, _msg, _action, detail = received[0]
+    assert code == "E-101"
+    assert "imu" in detail
+    assert "2" in detail  # camera index 2 missing
+
+
+def test_i2c_health_none_raises_e102(tmp_path):
+    conn = _connector(tmp_path)
+    conn._interface.left.is_connected.return_value = True
+    conn._interface.left.i2c_health = None
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_sensor_i2c_health("left")
+
+    assert len(received) == 1
+    assert received[0][0] == "E-102"
+
+
+def test_send_bug_report_selects_smtp_when_configured(tmp_path, monkeypatch):
+    conn = _connector(tmp_path, app_config={"bug_report_smtp": _FULL_SMTP})
+    chosen = []
+    monkeypatch.setattr(conn, "_send_bug_report_smtp",
+                        lambda *a, **k: chosen.append("smtp"))
+    monkeypatch.setattr(conn, "_send_bug_report_fallback",
+                        lambda *a, **k: chosen.append("fallback"))
+
+    conn.sendBugReport("E-101")
+
+    assert chosen == ["smtp"]
+
+
+def test_send_bug_report_falls_back_without_smtp(tmp_path, monkeypatch):
+    conn = _connector(tmp_path)  # no bug_report_smtp configured
+    chosen = []
+    monkeypatch.setattr(conn, "_send_bug_report_smtp",
+                        lambda *a, **k: chosen.append("smtp"))
+    monkeypatch.setattr(conn, "_send_bug_report_fallback",
+                        lambda *a, **k: chosen.append("fallback"))
+
+    conn.sendBugReport("E-101")
+
+    assert chosen == ["fallback"]

--- a/tests/test_critical_error_signal.py
+++ b/tests/test_critical_error_signal.py
@@ -10,9 +10,9 @@ from motion_connector import MotionConnector
 pytestmark = pytest.mark.unit
 
 
-def _connector(tmp_path, app_config=None):
+def _connector(tmp_path, app_config=None, connected=(True, True, True)):
     iface = MagicMock()
-    iface.is_device_connected.return_value = (True, True, True)
+    iface.is_device_connected.return_value = connected
     iface.scan_workflow.running = False
     iface.scan_workflow.config_running = False
     iface.scan_db_path = None
@@ -23,6 +23,10 @@ def _connector(tmp_path, app_config=None):
         interface=iface, app_config=cfg,
         data_dir=str(tmp_path), config_dir="config",
     )
+
+
+def _codes(received):
+    return [r[0] for r in received]
 
 
 _FULL_SMTP = {
@@ -108,6 +112,57 @@ def test_i2c_health_none_raises_e102(tmp_path):
 
     assert len(received) == 1
     assert received[0][0] == "E-102"
+
+
+def test_watchdog_all_connected_raises_nothing(tmp_path):
+    conn = _connector(tmp_path, connected=(True, True, True))
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_connection_watchdog()
+
+    assert received == []
+
+
+def test_watchdog_no_console_raises_e104(tmp_path):
+    conn = _connector(tmp_path, connected=(False, True, False))
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_connection_watchdog()
+
+    assert _codes(received) == ["E-104"]
+
+
+def test_watchdog_no_sensor_raises_e106(tmp_path):
+    conn = _connector(tmp_path, connected=(True, False, False))
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_connection_watchdog()
+
+    assert _codes(received) == ["E-106"]
+
+
+def test_watchdog_nothing_connected_raises_both(tmp_path):
+    conn = _connector(tmp_path, connected=(False, False, False))
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_connection_watchdog()
+
+    assert set(_codes(received)) == {"E-104", "E-106"}
+
+
+def test_watchdog_respects_min_sensors_config(tmp_path):
+    conn = _connector(tmp_path, app_config={"minSensors": 2},
+                      connected=(True, True, False))  # only one sensor
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_connection_watchdog()
+
+    assert _codes(received) == ["E-106"]
 
 
 def test_send_bug_report_selects_smtp_when_configured(tmp_path, monkeypatch):

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -48,8 +48,10 @@ def test_lookup_unknown_code_returns_generic_fallback():
 
 def test_expected_catalog_codes_present():
     expected = {
-        "E-101", "E-102", "E-103", "E-104", "E-105", "E-106",
+        "E-101", "E-102", "E-103", "E-105",
         "E-201", "E-202",
         "E-301", "E-302",
     }
+    # E-104/E-106 are intentionally absent: the connection watchdog surfaces
+    # them as warning toasts, not via this critical-modal registry.
     assert expected == set(error_codes.ERROR_CODES.keys())

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -1,0 +1,55 @@
+"""Critical-error code registry — pure data, no hardware or Qt."""
+
+import pytest
+
+import error_codes
+
+pytestmark = pytest.mark.unit
+
+
+def test_lookup_known_code_returns_entry():
+    err = error_codes.lookup("E-101")
+    assert err.code == "E-101"
+    assert err.category == "startup"
+    assert err.title  # non-empty
+    assert err.message
+    assert err.suggested_action
+
+
+def test_registry_entries_are_complete_and_unique():
+    codes = list(error_codes.ERROR_CODES.keys())
+    assert codes, "registry is empty"
+    assert len(codes) == len(set(codes)), "duplicate codes"
+    for code, err in error_codes.ERROR_CODES.items():
+        assert err.code == code, f"key/value code mismatch for {code}"
+        assert err.title.strip()
+        assert err.message.strip()
+        assert err.suggested_action.strip()
+        assert err.category in {"startup", "safety", "scan"}
+
+
+def test_category_matches_code_prefix():
+    prefix_to_category = {"E-1": "startup", "E-2": "safety", "E-3": "scan"}
+    for code, err in error_codes.ERROR_CODES.items():
+        prefix = code[:3]
+        assert prefix in prefix_to_category, f"unexpected prefix for {code}"
+        assert err.category == prefix_to_category[prefix], (
+            f"{code} category {err.category!r} != {prefix_to_category[prefix]!r}"
+        )
+
+
+def test_lookup_unknown_code_returns_generic_fallback():
+    err = error_codes.lookup("E-999")
+    # Never raise inside an error path — return a usable generic entry.
+    assert err.code == "E-999"
+    assert err.title.strip()
+    assert err.message.strip()
+
+
+def test_expected_catalog_codes_present():
+    expected = {
+        "E-101", "E-102", "E-103", "E-105",
+        "E-201", "E-202",
+        "E-301", "E-302",
+    }
+    assert expected == set(error_codes.ERROR_CODES.keys())

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -48,7 +48,7 @@ def test_lookup_unknown_code_returns_generic_fallback():
 
 def test_expected_catalog_codes_present():
     expected = {
-        "E-101", "E-102", "E-103", "E-105",
+        "E-101", "E-102", "E-103", "E-104", "E-105", "E-106",
         "E-201", "E-202",
         "E-301", "E-302",
     }


### PR DESCRIPTION
## What

Surfaces showstopper conditions to the clinician as a **blocking, dismissible critical-error modal** carrying a stable code, publishes the code list in the docs, and adds a non-blocking **startup connection watchdog**. Previously these conditions were only written to the app log.

Design spec: `docs/superpowers/specs/2026-06-15-critical-error-codes-design.md`.

## Critical-error modal (8 codes → `docs/ERROR_CODES.md`)

Single source of truth in `error_codes.py`; every code is wired to a real trigger. The modal (`components/CriticalErrorModal.qml`, top-level in `main.qml`) queues multiple errors, shows a code badge + suggested action + collapsible detail, and is dismissible (button / backdrop / Esc).

| Startup (E-1xx) | Safety (E-2xx) | Scan (E-3xx) |
|---|---|---|
| E-101 sensor I2C self-check failed | E-201 safety monitor unresponsive | E-301 scan aborted before start |
| E-102 self-check unreadable | E-202 safety trip during scan | E-302 scan could not start |
| E-103 console init failed | | |
| E-105 camera power-on failed | | |

`_raise_critical()` is an additive surfacing layer — **no behavior change** to the underlying failure paths.

## Startup connection watchdog → warning toast (E-104 / E-106)

A one-shot check armed at launch flags expected devices that never enumerated (the SDK only exposes CONNECTED/DISCONNECTED, so this is the only way to catch "never showed up"). A missing system at startup is a "plug it in" situation, **not** a showstopper, so it shows a **yellow warning toast** (bottom-right), not the modal:

- console missing → "Console not detected…"
- sensors missing → "Sensor not detected…"
- **both missing → "System not found…"** (single consolidated toast)

Config: `connectionTimeoutSec` (30), `requireConsole` (true), `minSensors` (1).

## Bug report

The modal's **Send Bug Report to Openwater** button packages the session log + context to `support@openwater.health`. Default opens the mail client and reveals the log for manual attach (zero infra); set the optional `bug_report_smtp` config block for automatic SMTP send with the log attached.

## Config additions (`config/app_config.json`)

`support_email`, optional `bug_report_smtp`, `connectionTimeoutSec`, `requireConsole`, `minSensors` — all registered in `main.py`'s `_load_app_config` defaults (a whitelist; unregistered keys are silently dropped).

## Testing

- **30+ unit tests**: registry integrity, bug-report routing (SMTP vs mailto), I2C-health decoding, critical-signal payload, connection-watchdog warning toasts, and config-key preservation. Full suite green; flake8 clean.
- Modal layout and the warning toast both verified by full-size headless render.
- Launched on real hardware: QML loads clean, no false positives; the "System not found" toast fired correctly when hardware was absent at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)