### PR TITLE
fix: report configured scan duration in session notes (#201)

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -389,12 +389,29 @@ class _TriggerStateSink:
             c._trigger_state = "ON"
             if c._trigger_on_mono is None:
                 c._trigger_on_mono = time.monotonic()
+                c._trigger_on_ts = payload.timestamp_s
             c.triggerStateChanged.emit()
         elif payload.state == "OFF":
             c._trigger_state = "OFF"
             if c._trigger_on_mono is not None:
-                c._trigger_cumulative_s += time.monotonic() - c._trigger_on_mono
+                # Prefer the SDK-stamped, scan-relative timestamps: the OFF
+                # event can sit queued behind histogram batches in the runner's
+                # diagnostics channel and be consumed ~1 s after it was emitted,
+                # which inflates a receive-time measurement (a 16:00 scan shows
+                # as 16:01 — issue #201). Fall back to host receive-time only
+                # if the timestamps are unusable (e.g. the SDK's t0-None path
+                # emits 0.0 for both edges, giving a non-positive delta).
+                ts_delta = (
+                    payload.timestamp_s - c._trigger_on_ts
+                    if c._trigger_on_ts is not None
+                    else 0.0
+                )
+                if ts_delta > 0:
+                    c._trigger_cumulative_s += ts_delta
+                else:
+                    c._trigger_cumulative_s += time.monotonic() - c._trigger_on_mono
                 c._trigger_on_mono = None
+                c._trigger_on_ts = None
             c.triggerStateChanged.emit()
 
     def on_complete(self) -> None:
@@ -684,6 +701,11 @@ class MotionConnector(QObject):
         # _on_dropout_check / _scan_elapsed_str can read them off the instance.
         self._trigger_cumulative_s: float = 0.0
         self._trigger_on_mono: float | None = None
+        # Scan-relative timestamp (from the SDK's TriggerStateEvent) of the
+        # current ON edge. Preferred over _trigger_on_mono for the final
+        # duration measurement because it is immune to host-side event-queue
+        # latency — see _TriggerStateSink (issue #201).
+        self._trigger_on_ts: float | None = None
         self._sensor_debug_logging        = bool(cfg.get("sensorDebugLogging", False))
         self._camera_fake_data            = bool(cfg.get("cameraFakeData", False))
         self._histo_throttle              = bool(cfg.get("histoThrottle", False))
@@ -2115,6 +2137,7 @@ class MotionConnector(QObject):
         # Reset trigger ON-time mirrors so _scan_elapsed_str starts from zero.
         self._trigger_cumulative_s = 0.0
         self._trigger_on_mono = None
+        self._trigger_on_ts = None
 
         # _CompletionSink calls this from its on_complete() method once the
         # ScanRunner finishes.

--- a/tests/test_trigger_duration.py
+++ b/tests/test_trigger_duration.py
@@ -1,0 +1,85 @@
+"""Trigger-ON duration measurement (issue #201).
+
+The scan-notes "duration" line must reflect the laser-on time the firmware
+actually ran, derived from the SDK's scan-relative TriggerStateEvent
+``timestamp_s`` — NOT the host's event-receive wall-clock. The OFF event can
+sit queued behind histogram batches in the runner's diagnostics channel and be
+consumed ~1 s after it was emitted; measuring receive-time inflated a 960 s
+(16:00) scan to 16:01.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector, _TriggerStateSink
+from omotion.pipeline.batch import TriggerStateEvent
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _reset_trigger_state(c):
+    c._trigger_cumulative_s = 0.0
+    c._trigger_on_mono = None
+    c._trigger_on_ts = None
+
+
+# NOTE: these are intentionally module-level functions, not grouped in a
+# class. The conftest's pytest_runtest_setup hook xfails every test after the
+# first failure *within a class*, which would mask independent failures here.
+
+
+def test_cumulative_uses_event_timestamp_delta(tmp_path):
+    """A 960 s laser-on interval emitted at scan-relative ts 2.0 → 962.2
+    must measure as 960.2 s regardless of how long the host took to
+    consume the OFF event."""
+    c = _connector(tmp_path)
+    _reset_trigger_state(c)
+    sink = _TriggerStateSink(c)
+
+    # ON emitted 2.0 s into the scan (post-setup), OFF at 962.2 s.
+    sink.consume("diagnostics", TriggerStateEvent(state="ON", timestamp_s=2.0))
+    sink.consume("diagnostics", TriggerStateEvent(state="OFF", timestamp_s=962.2))
+
+    assert c._trigger_cumulative_s == pytest.approx(960.2, abs=1e-6)
+
+
+def test_formatted_duration_floors_to_configured(tmp_path):
+    """A 960 s scan that overshoots by the guard's poll granularity must
+    still display 00:16:00, not 00:16:01 (issue #201)."""
+    c = _connector(tmp_path)
+    _reset_trigger_state(c)
+    sink = _TriggerStateSink(c)
+
+    sink.consume("diagnostics", TriggerStateEvent(state="ON", timestamp_s=0.0))
+    sink.consume("diagnostics", TriggerStateEvent(state="OFF", timestamp_s=960.2))
+
+    assert c._scan_elapsed_str() == "00:16:00"
+
+
+def test_falls_back_to_monotonic_when_timestamps_unavailable(tmp_path):
+    """If the SDK could not stamp the events (both ts 0.0 — the t0-None
+    fallback), the measurement must not silently collapse to a negative or
+    garbage value; it falls back to host receive-time."""
+    c = _connector(tmp_path)
+    _reset_trigger_state(c)
+    sink = _TriggerStateSink(c)
+
+    sink.consume("diagnostics", TriggerStateEvent(state="ON", timestamp_s=0.0))
+    # No usable timestamp delta -> receive-time delta (≈0 in this fast test)
+    # is used; it must be non-negative, never a negative/garbage value.
+    sink.consume("diagnostics", TriggerStateEvent(state="OFF", timestamp_s=0.0))
+
+    assert c._trigger_cumulative_s >= 0.0


### PR DESCRIPTION
Fixes #201.

## Problem
Session notes displayed the scan duration one second longer than configured — a 960 s (16:00) scan showed as `00:16:01`. Confirmed from the issue's attached log: `duration=960s` → `Full scan ended: completed — duration 00:16:01`.

## Root cause
The notes "duration" line is built in `_TriggerStateSink` (`motion_connector.py`), which measured the laser-on interval using the connector's own `time.monotonic()` at the moment each `TriggerStateEvent` was **consumed**. The trigger-OFF event is dispatched on the runner's diagnostics channel and sits queued behind buffered histogram batches, so it's consumed ~1 s after it was actually emitted. That inflated the measured interval to 961 s; `int()` truncation then rendered `16:01`.

The SDK already stamps every `TriggerStateEvent` with an authoritative scan-relative `timestamp_s` (anchored to the scan's monotonic t0 at emission) — the connector was ignoring it, even though the event's own docstring says sinks should use it for trigger-ON time.

## Fix
Measure the cumulative trigger-ON duration from `payload.timestamp_s` (immune to host event-queue latency), falling back to receive-time monotonic only when the timestamps are unusable (e.g. the SDK's t0-None path emits 0.0 for both edges). The guard's poll granularity overshoot (~0.2 s) now floors cleanly to the configured 16:00.

## Testing
- New `tests/test_trigger_duration.py` — written test-first (failed on the old receive-time code, passes now).
- Full unit suite green: `pytest -m unit` → 202 passed.

Note: the SDK trigger-emit code this relies on is identical on `next` and `next-next`.