### PR TITLE
fix: make Scan History dropdown scroll when the list is long (#199)

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -183,6 +183,16 @@ Item {
                     Layout.preferredHeight: 36
                     model: scans
                     font.pixelSize: 13
+                    // Largest the dropdown popup may grow: the space between
+                    // the bottom of the field and the bottom of the modal,
+                    // less a small margin. Caps a long scan list so it stays
+                    // on-screen and the inner ListView scrolls instead of
+                    // running off the bottom of the window (issue #199).
+                    // Floored at ~3 rows so it's never uselessly small.
+                    readonly property real maxPopupHeight: {
+                        var below = root.height - mapToItem(root, 0, height).y - 12
+                        return Math.max(below, 96)
+                    }
                     contentItem: Text {
                         leftPadding: 10
                         text: scanPicker.displayText
@@ -222,12 +232,20 @@ Item {
                     popup: Popup {
                         y: scanPicker.height
                         width: scanPicker.width
-                        implicitHeight: contentItem.implicitHeight + 2
+                        // Cap the height so the popup never extends past the
+                        // bottom of the window; the ListView then overflows
+                        // and becomes scrollable (issue #199).
+                        height: Math.min(contentItem.implicitHeight + 2,
+                                         scanPicker.maxPopupHeight)
                         padding: 1
                         contentItem: ListView {
                             clip: true
                             implicitHeight: contentHeight
                             model: scanPicker.delegateModel
+                            // Keep the keyboard-highlighted row scrolled into
+                            // view so arrow-key navigation is visible — you can
+                            // tell which scan is selected (issue #199).
+                            currentIndex: scanPicker.highlightedIndex
                             ScrollIndicator.vertical: ScrollIndicator {}
                         }
                         background: Rectangle {


### PR DESCRIPTION
Fixes #199.

## Problem
In the Scan History modal, once the scan-picker dropdown filled to the bottom of the window you could not scroll or see the highlighted item. Arrow keys changed the selection but the highlight moved off-screen so you couldn't tell which scan you were choosing.

## Root cause
The ComboBox `popup` in `components/HistoryModal.qml` bound `implicitHeight` to its full content height with no cap:

```qml
implicitHeight: contentItem.implicitHeight + 2
```

With many scans the popup grows past the bottom of the window. Because the popup is *exactly* as tall as its content, the inner `ListView` never overflows, so the `ScrollIndicator` never engages and there's nothing to scroll. Keyboard navigation also wasn't tracked into view.

## Fix
- Cap the popup height to the space available within the modal (`maxPopupHeight`), so the `ListView` overflows and becomes scrollable (mouse wheel + ScrollIndicator).
- Bind `ListView.currentIndex` to `highlightedIndex` (the standard Qt ComboBox-popup pattern) so arrow-key navigation keeps the highlighted row visible.

## Testing
QML has no unit-test harness here and the app has no hardware-free launch mode, so this was verified at the binding level: a standalone harness using the identical popup structure resolves `maxPopupHeight` to 392 px for a 480 px window while 60 rows of content would be 1920 px — so the popup binding caps at 392 and the content overflows (scrollable). **A quick visual check on real hardware is still worthwhile** (open History with a long scan list; confirm the dropdown scrolls and arrow keys track the highlight).