### PR TITLE
Rebase next-next onto next (History rework, audit log, error codes, CQ, plot break)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,20 @@ Edit `config/app_config.json` to customize behavior:
 | `bviMin` / `bviMax` | `4.0` / `8.0` | Manual BVI plot bounds (when autoscale is off) |
 | `meanMin` / `meanMax` | `0` / `200` | Manual mean plot bounds |
 | `contrastMin` / `contrastMax` | `0.0` / `0.7` | Manual contrast plot bounds |
+| `support_email` | `support@openwater.health` | Destination for the critical-error modal's **Send Bug Report** button |
+| `bug_report_smtp` | _(absent)_ | Optional `{host, port, username, password, from_addr, use_tls}` block. When set, bug reports are emailed automatically with the session log attached; otherwise the app opens your mail client for manual send |
+| `connectionTimeoutSec` | `30` | Startup connection watchdog grace period before warning about missing devices (E-104/E-106, yellow toast); `0` disables it |
+| `requireConsole` | `true` | Watchdog warns (E-104) if no console connected at startup |
+| `minSensors` | `1` | Watchdog warns (E-106) if fewer than this many sensors connected at startup |
 
 Most of these are also editable from the in-app **Settings** panel and persisted automatically.
+
+## Critical Errors
+
+Showstopper conditions (e.g. the sensor's boot-time I2C self-check failing) raise
+a dismissible modal carrying a stable error code such as `E-101`. See
+[docs/ERROR_CODES.md](docs/ERROR_CODES.md) for the full catalog and recommended
+actions.
 
 ## Antivirus Note (Windows)
 

--- a/audit_log.py
+++ b/audit_log.py
@@ -1,0 +1,227 @@
+"""Append-only, machine-readable audit log stored in scans.db.
+
+A small, self-contained logger used primarily by auditors. Writes one
+row per event to a ``logs`` table in the same SQLite file the SDK's
+ScanDatabase uses (scans.db). Owns its own long-lived connection so it
+can append alongside ScanDatabase's on-demand handles.
+
+Fail-soft by contract: construction with a missing path, or any DB
+error, degrades the instance to a no-op — a failed audit write must
+never crash or block the app.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import logging
+import platform
+import socket
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openmotion.bloodflow-app.audit")
+
+# ── Event-type constants ────────────────────────────────────────────────
+EV_SYSTEM_STARTUP = "system_startup"
+EV_SYSTEM_INFO = "system_info"
+EV_SYSTEM_SHUTDOWN = "system_shutdown"
+EV_DEVICE_CONNECTED = "device_connected"
+EV_DEVICE_DISCONNECTED = "device_disconnected"
+EV_DEVICE_STATS = "device_stats"
+EV_SCAN_STARTED = "scan_started"
+EV_SCAN_ENDED = "scan_ended"
+EV_CALIBRATION_STARTED = "calibration_started"
+EV_CALIBRATION_ENDED = "calibration_ended"
+EV_SETTINGS_CHANGED = "settings_changed"
+EV_SCAN_VIEWED = "scan_viewed"
+EV_SCAN_DELETED = "scan_deleted"
+EV_AUDIT_LOG_VIEWED = "audit_log_viewed"
+EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+EV_DEBUG_BUNDLE_CREATED = "debug_bundle_created"
+
+# CSV export column order.
+_CSV_FIELDS = ["ts_iso", "ts_epoch", "event_type", "details"]
+
+
+def gather_host_info() -> Dict[str, Any]:
+    """Collect host/system facts for the ``system_info`` event. Best-effort
+    — any probe that fails is simply omitted."""
+    info: Dict[str, Any] = {}
+    try:
+        info["hostname"] = socket.gethostname()
+        info["platform"] = platform.platform()
+        info["system"] = f"{platform.system()} {platform.release()}".strip()
+        info["arch"] = platform.machine()
+        info["processor"] = platform.processor()
+        info["python"] = platform.python_version()
+    except Exception:
+        logger.warning("gather_host_info: core probe failed", exc_info=True)
+    try:
+        if platform.system() == "Windows":
+            import ctypes
+
+            class _MEMSTATUSEX(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            mem = _MEMSTATUSEX()
+            mem.dwLength = ctypes.sizeof(_MEMSTATUSEX)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(mem))
+            info["ram_gb"] = round(mem.ullTotalPhys / (1024 ** 3), 2)
+    except Exception:
+        pass
+    return info
+
+
+class AuditLog:
+    """Append-only audit-event store backed by the ``logs`` table in
+    scans.db. Thread-safe (single connection + write lock). No-op when
+    constructed without a usable path."""
+
+    def __init__(self, db_path: Optional[str | Path]) -> None:
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        if not db_path:
+            logger.info(
+                "AuditLog: no db_path — audit logging disabled (no-op)."
+            )
+            return
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._conn = conn
+            self._init_schema()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to open %s — disabling audit logging.",
+                db_path, exc_info=True,
+            )
+            self._conn = None
+
+    def _init_schema(self) -> None:
+        assert self._conn is not None
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS logs (
+                id          INTEGER PRIMARY KEY,
+                ts_epoch    REAL NOT NULL,
+                ts_iso      TEXT NOT NULL,
+                event_type  TEXT NOT NULL,
+                details     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
+            """
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self._conn is not None
+
+    def log(
+        self, event_type: str, details: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Append one event. ``details`` (if not None) is stored as compact,
+        deterministic JSON. Never raises."""
+        ts_epoch = time.time()
+        ts_iso = (
+            datetime.datetime.fromtimestamp(ts_epoch)
+            .astimezone()
+            .isoformat(timespec="seconds")
+        )
+        details_json = (
+            json.dumps(details, separators=(",", ":"), sort_keys=True,
+                       default=str)
+            if details is not None else None
+        )
+        try:
+            with self._lock:
+                if self._conn is None:
+                    return
+                self._conn.execute(
+                    "INSERT INTO logs (ts_epoch, ts_iso, event_type, details)"
+                    " VALUES (?, ?, ?, ?)",
+                    (ts_epoch, ts_iso, str(event_type), details_json),
+                )
+                self._conn.commit()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to write %s event", event_type, exc_info=True
+            )
+
+    def query(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` rows, newest first, as plain dicts."""
+        try:
+            with self._lock:
+                if self._conn is None:
+                    return []
+                cur = self._conn.execute(
+                    "SELECT id, ts_epoch, ts_iso, event_type, details"
+                    " FROM logs ORDER BY id DESC LIMIT ?",
+                    (int(limit),),
+                )
+                cols = [c[0] for c in cur.description]
+                return [dict(zip(cols, row)) for row in cur.fetchall()]
+        except Exception:
+            logger.warning("AuditLog: query failed", exc_info=True)
+            return []
+
+    def count(self) -> int:
+        """Total number of log rows (0 when disabled / on error)."""
+        try:
+            with self._lock:
+                if self._conn is None:
+                    return 0
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM logs"
+                ).fetchone()
+                return int(row[0]) if row else 0
+        except Exception:
+            logger.warning("AuditLog: count failed", exc_info=True)
+            return 0
+
+    def export_csv(self, dest_path: str | Path) -> int:
+        """Write the full log (oldest first) to ``dest_path`` as CSV.
+        Returns the number of data rows written (0 on any failure)."""
+        with self._lock:
+            if self._conn is None:
+                return 0
+            try:
+                rows = self._conn.execute(
+                    "SELECT ts_iso, ts_epoch, event_type, details"
+                    " FROM logs ORDER BY id ASC"
+                ).fetchall()
+            except Exception:
+                logger.warning("AuditLog: export_csv query failed",
+                               exc_info=True)
+                return 0
+        try:
+            with open(dest_path, "w", newline="", encoding="utf-8") as f:
+                w = csv.writer(f)
+                w.writerow(_CSV_FIELDS)
+                w.writerows(rows)
+        except OSError:
+            logger.warning("AuditLog: export_csv write to %s failed",
+                           dest_path, exc_info=True)
+            return 0
+        return len(rows)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None

--- a/bug_report.py
+++ b/bug_report.py
@@ -1,0 +1,99 @@
+"""Bug-report assembly and delivery for the critical-error modal.
+
+Split into pure helpers (report text, config check, mailto URL — unit-tested)
+and thin I/O wrappers (SMTP send, reveal-in-Explorer — side-effecting, exercised
+manually). The connector orchestrates: build the text, then either send via SMTP
+(if fully configured) or fall back to opening the user's mail client.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from email.message import EmailMessage
+from urllib.parse import urlencode
+
+logger = logging.getLogger(__name__)
+
+_SMTP_REQUIRED_FIELDS = ("host", "port", "username", "password", "from_addr")
+
+
+# --- pure helpers -----------------------------------------------------------
+def build_report_text(
+    *,
+    code: str,
+    title: str,
+    message: str,
+    timestamp: str,
+    app_version: str,
+    device_info: str,
+    log_path: str,
+) -> str:
+    """Human-readable report body included in the email / clipboard."""
+    return (
+        "OpenWater BloodFlow — Critical Error Report\n"
+        "-------------------------------------------\n"
+        f"Code:       {code}\n"
+        f"Title:      {title}\n"
+        f"Message:    {message}\n"
+        f"Time:       {timestamp}\n"
+        f"App version: {app_version}\n"
+        f"Devices:    {device_info}\n"
+        f"Log file:   {log_path}\n"
+        "\n"
+        "Please attach the log file above if it is not already attached.\n"
+    )
+
+
+def smtp_config_complete(cfg: dict | None) -> bool:
+    """True iff every required SMTP field is present and non-empty."""
+    if not cfg:
+        return False
+    return all(str(cfg.get(f, "")).strip() for f in _SMTP_REQUIRED_FIELDS)
+
+
+def build_mailto_url(address: str, *, subject: str, body: str) -> str:
+    """Build a ``mailto:`` URL with URL-encoded subject and body."""
+    query = urlencode({"subject": subject, "body": body})
+    return f"mailto:{address}?{query}"
+
+
+# --- I/O wrappers (side-effecting; not unit-tested) -------------------------
+def send_via_smtp(cfg: dict, *, to_addr: str, subject: str, body: str,
+                  log_path: str | None) -> None:
+    """Send the report via SMTP with the log attached. Raises on failure."""
+    import smtplib
+
+    msg = EmailMessage()
+    msg["From"] = cfg["from_addr"]
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    if log_path and os.path.isfile(log_path):
+        with open(log_path, "rb") as fh:
+            msg.add_attachment(
+                fh.read(), maintype="text", subtype="plain",
+                filename=os.path.basename(log_path),
+            )
+
+    with smtplib.SMTP(cfg["host"], int(cfg["port"]), timeout=30) as srv:
+        if cfg.get("use_tls", True):
+            srv.starttls()
+        srv.login(cfg["username"], cfg["password"])
+        srv.send_message(msg)
+
+
+def reveal_in_file_manager(path: str) -> None:
+    """Open the OS file manager with ``path`` selected. Best-effort."""
+    try:
+        if sys.platform.startswith("win"):
+            subprocess.Popen(["explorer", "/select,", os.path.normpath(path)])
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", "-R", path])
+        else:
+            subprocess.Popen(["xdg-open", os.path.dirname(path) or "."])
+    except Exception as exc:  # pragma: no cover - environment dependent
+        logger.warning("Could not reveal log file %s: %s", path, exc)

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -13,10 +13,7 @@ import OpenMotion 1.0
  *
  *  API:
  *      open() / close()
- *      reset(forLiveScan, durationEstimate)
- *                                -> enter "checking" state; durationEstimate
- *                                   (seconds, optional) drives the elapsed
- *                                   counter shown under the spinner
+ *      reset(forLiveScan)        -> enter "checking" state
  *      showOk()                  -> enter "ok" state
  *      showError(msg)            -> enter "error" state with message
  *      addWarning(cameraLabel, typeKey, typeText, value)
@@ -73,12 +70,6 @@ Item {
     property int rightMask: 0xFF
     property string errorText: ""
 
-    // Elapsed-time tracking for the "checking" state. ``durationEstimate``
-    // is purely cosmetic (shown as "~Ns"); the real completion signal comes
-    // from contactQualityCheckFinished.
-    property int durationEstimate: 0
-    property int elapsedMs: 0
-
     // Each entry: { camera, typeKey, typeText, value }
     property var entries: []
 
@@ -91,30 +82,24 @@ Item {
 
     // ── public API ───────────────────────────────────────────────────────
     function open()  { root.visible = true; panel.forceActiveFocus() }
-    function close() { root.visible = false; elapsedTimer.stop() }
+    function close() { root.visible = false }
 
-    function reset(forLiveScan, durationEstimateArg) {
+    function reset(forLiveScan) {
         liveScan = !!forLiveScan
         liveScanDismissable = !liveScan
         clearHoldoffTimer.stop()
         entries = []
         errorText = ""
         state_ = "checking"
-        durationEstimate = (durationEstimateArg !== undefined && durationEstimateArg !== null)
-                           ? Math.max(0, durationEstimateArg | 0) : 0
-        elapsedMs = 0
-        elapsedTimer.restart()
         if (!visible) open()
     }
 
     function showOk() {
-        elapsedTimer.stop()
         state_ = "ok"
         if (!visible) open()
     }
 
     function showError(msg) {
-        elapsedTimer.stop()
         errorText = msg || "Hardware error"
         state_ = "error"
         if (!visible) open()
@@ -132,7 +117,6 @@ Item {
                     value: value
                 }
                 entries = upd
-                elapsedTimer.stop()
                 state_ = "warnings"
                 liveScanDismissable = false
                 clearHoldoffTimer.stop()
@@ -148,7 +132,6 @@ Item {
             value: value
         })
         entries = copy
-        elapsedTimer.stop()
         state_ = "warnings"
         liveScanDismissable = false
         clearHoldoffTimer.stop()
@@ -231,19 +214,6 @@ Item {
         return ((mask >> bit) & 1) === 1
     }
 
-    // Ticks every 500 ms while in "checking" state to update the elapsed
-    // label. Stopped on every exit path (close / showOk / showError /
-    // addWarning) so it never leaks past the check.
-    Timer {
-        id: elapsedTimer
-        interval: 500
-        repeat: true
-        onTriggered: {
-            if (root.state_ !== "checking") { stop(); return }
-            root.elapsedMs += interval
-        }
-    }
-
     // Continue becomes available only after contact quality stays clear
     // for clearHoldoffMs continuously during a live warning state.
     Timer {
@@ -306,37 +276,14 @@ Item {
                 text: root.label
             }
 
-            // Spinner for "checking" state
+            // Spinner for "checking" state. No countdown / status text:
+            // camera programming now happens once at startup, so both the
+            // old "Configuring sensor modules…" and "x / Ns" phases collapse
+            // into a single indeterminate spinner.
             BusyIndicator {
                 visible: root.state_ === "checking"
                 running: visible
                 Layout.alignment: Qt.AlignHCenter
-            }
-
-            // Elapsed / expected-duration counter under the spinner. Only
-            // shown while actively checking; hidden in ok/warnings/error.
-            Text {
-                visible: root.state_ === "checking"
-                Layout.alignment: Qt.AlignHCenter
-                horizontalAlignment: Text.AlignHCenter
-                color: theme.textSecondary
-                font.pixelSize: 13
-                text: {
-                    var secs = Math.floor(root.elapsedMs / 1000)
-                    if (root.durationEstimate > 0)
-                        return "Checking contact quality… (" + secs + "s / ~" + root.durationEstimate + "s)"
-                    return "Configuring sensor modules. Please wait up to 2 minutes (" + secs + " / 120sec)"
-                }
-            }
-
-            Text {
-                visible: root.state_ === "checking" && root.durationEstimate === 0
-                Layout.alignment: Qt.AlignHCenter
-                horizontalAlignment: Text.AlignHCenter
-                color: theme.textSecondary
-                font.pixelSize: 12
-                font.italic: true
-                text: "This initialization is performed once per session at startup."
             }
 
             // OK message

--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -1,0 +1,300 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import OpenMotion 1.0
+
+/*  CriticalErrorModal — blocking, dismissible alert for showstopper
+ *  conditions carrying a stable error code (see error_codes.py /
+ *  docs/ERROR_CODES.md).
+ *
+ *  Host once, top-level, above everything else:
+ *
+ *      CriticalErrorModal { id: criticalErrorModal; anchors.fill: parent; z: 100000 }
+ *
+ *  It listens to MotionInterface.criticalErrorRaised and shows itself. If
+ *  several fire close together they are queued and shown one at a time.
+ *  Dismissible via the Dismiss button, the backdrop, or Esc.
+ */
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 100000
+
+    AppTheme { id: theme }
+
+    // Current error fields (bound into the panel).
+    property string code: ""
+    property string title: ""
+    property string message: ""
+    property string suggestedAction: ""
+    property string detail: ""
+
+    // Pending errors waiting their turn.
+    property var _queue: []
+    property bool _detailExpanded: false
+
+    function _enqueue(code, title, message, action, detail) {
+        var q = root._queue.slice()
+        q.push({code: code, title: title, message: message,
+                action: action, detail: detail})
+        root._queue = q
+        if (!root.visible)
+            root._showNext()
+    }
+
+    function _showNext() {
+        if (root._queue.length === 0) {
+            root.visible = false
+            return
+        }
+        var q = root._queue.slice()
+        var e = q.shift()
+        root._queue = q
+        root.code = e.code
+        root.title = e.title
+        root.message = e.message
+        root.suggestedAction = e.action
+        root.detail = e.detail
+        root._detailExpanded = false
+        root.visible = true
+        root.forceActiveFocus()
+    }
+
+    function dismiss() {
+        root._showNext()  // advances to the next queued error, or hides
+    }
+
+    function _reportText() {
+        return "Code: " + root.code
+            + "\nTitle: " + root.title
+            + "\nMessage: " + root.message
+            + (root.detail ? "\nDetail: " + root.detail : "")
+    }
+
+    Connections {
+        target: MotionInterface
+        function onCriticalErrorRaised(code, title, message, action, detail) {
+            root._enqueue(code, title, message, action, detail)
+        }
+    }
+
+    // Backdrop — click outside dismisses.
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000C0"
+        MouseArea { anchors.fill: parent; onClicked: root.dismiss() }
+    }
+
+    // Panel
+    Rectangle {
+        width: 520
+        height: contentCol.implicitHeight + headerBar.height + 16 + 20
+        radius: 14
+        color: theme.bgContainer
+        border.color: theme.accentRed
+        border.width: 1
+        anchors.centerIn: parent
+
+        // Absorb clicks so they don't reach the backdrop.
+        MouseArea { anchors.fill: parent }
+
+        // Red header bar with code badge.
+        Rectangle {
+            id: headerBar
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 44
+            radius: 14
+            color: theme.accentRed
+            // square off the bottom corners so only the top is rounded
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: parent.radius
+                color: theme.accentRed
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                spacing: 10
+
+                Rectangle {
+                    Layout.preferredHeight: 24
+                    Layout.preferredWidth: codeText.implicitWidth + 16
+                    radius: 4
+                    color: "#FFFFFF"
+                    Text {
+                        id: codeText
+                        anchors.centerIn: parent
+                        text: root.code
+                        color: theme.accentRed
+                        font.pixelSize: 13
+                        font.weight: Font.Bold
+                        font.family: "Consolas, monospace"
+                    }
+                }
+
+                Text {
+                    text: "Critical Error"
+                    color: "#FFFFFF"
+                    font.pixelSize: 15
+                    font.weight: Font.DemiBold
+                    Layout.fillWidth: true
+                }
+
+                Text {
+                    visible: root._queue.length > 0
+                    text: root._queue.length + " more"
+                    color: "#FFFFFFCC"
+                    font.pixelSize: 12
+                }
+            }
+        }
+
+        ColumnLayout {
+            id: contentCol
+            anchors.top: headerBar.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.topMargin: 16
+            anchors.leftMargin: 20
+            anchors.rightMargin: 20
+            spacing: 12
+
+            Text {
+                text: root.title
+                color: theme.textPrimary
+                font.pixelSize: 17
+                font.weight: Font.DemiBold
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            Text {
+                text: root.message
+                color: theme.textSecondary
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            // Suggested action callout.
+            Rectangle {
+                visible: root.suggestedAction !== ""
+                Layout.fillWidth: true
+                radius: 6
+                color: theme.bgInput
+                Layout.preferredHeight: actionRow.implicitHeight + 16
+                RowLayout {
+                    id: actionRow
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    spacing: 8
+                    Text {
+                        text: "→"
+                        color: theme.accentBlue
+                        font.pixelSize: 14
+                        font.weight: Font.Bold
+                    }
+                    Text {
+                        text: root.suggestedAction
+                        color: theme.textPrimary
+                        font.pixelSize: 13
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                }
+            }
+
+            // Collapsible technical detail.
+            Text {
+                visible: root.detail !== ""
+                text: (root._detailExpanded ? "▼ " : "▶ ") + "Details"
+                color: theme.textTertiary
+                font.pixelSize: 12
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root._detailExpanded = !root._detailExpanded
+                }
+            }
+            Text {
+                visible: root.detail !== "" && root._detailExpanded
+                text: root.detail
+                color: theme.textTertiary
+                font.pixelSize: 12
+                font.family: "Consolas, monospace"
+                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                Layout.fillWidth: true
+            }
+
+            // Buttons
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                spacing: 10
+
+                Button {
+                    text: "Copy details"
+                    Layout.preferredHeight: 32
+                    onClicked: MotionInterface.copyToClipboard(root._reportText())
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSoft; border.width: 1
+                    }
+                }
+
+                Button {
+                    text: "Send Bug Report to Openwater"
+                    Layout.preferredHeight: 32
+                    onClicked: MotionInterface.sendBugReport(root.code)
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: theme.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        radius: 4
+                        border.color: theme.borderSubtle; border.width: 1
+                    }
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Dismiss"
+                    Layout.preferredHeight: 32
+                    onClicked: root.dismiss()
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? Qt.lighter(theme.accentRed, 1.1) : theme.accentRed
+                        radius: 4
+                    }
+                }
+            }
+        }
+    }
+
+    Keys.onReleased: function(event) {
+        if (event.key === Qt.Key_Escape) { root.dismiss(); event.accepted = true }
+    }
+}

--- a/components/HistoryHeaderCell.qml
+++ b/components/HistoryHeaderCell.qml
@@ -1,0 +1,37 @@
+import QtQuick 6.0
+import QtQuick.Layouts 6.0
+
+// One clickable, sort-aware column header in the History table.
+Item {
+    id: cell
+    property string text: ""
+    property string sortName: ""
+    property string activeSort: ""   // the table's current sort key
+    property bool ascending: false
+    signal sortRequested(string name)
+
+    Layout.preferredHeight: 30
+
+    AppTheme { id: theme }
+
+    Row {
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 4
+        Text {
+            text: cell.text
+            color: theme.textSecondary
+            font.pixelSize: 12; font.weight: Font.DemiBold
+        }
+        Text {
+            visible: cell.activeSort === cell.sortName
+            text: cell.ascending ? "▲" : "▼"
+            color: theme.textSecondary; font.pixelSize: 9
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        onClicked: cell.sortRequested(cell.sortName)
+    }
+}

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -29,7 +29,6 @@ Item {
     property int focusedSampleCount: -1
     // Toolbar filters / sort.
     property string searchText: ""
-    property string configFilter: "All"
     property string sortKey: "timestamp"
     property bool sortAsc: false
     // Async "Load in viewer" busy state (issue #152 pattern).
@@ -54,7 +53,6 @@ Item {
 
     function rebuildView() {
         var q = (searchText || "").toLowerCase()
-        var cfg = configFilter
         // In reduced (clinical) mode, omit scans not shot in reduced mode —
         // the reduced viewer can't render their per-camera data. Dev mode
         // lists everything. A scan with no recorded mode counts as non-reduced.
@@ -65,8 +63,6 @@ Item {
             if (q.length > 0
                 && (r.userLabel || "").toLowerCase().indexOf(q) < 0
                 && (r.label || "").toLowerCase().indexOf(q) < 0)
-                return false
-            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
                 return false
             return true
         })
@@ -143,9 +139,8 @@ Item {
         return "0x" + (m & 0xFF).toString(16).toUpperCase()
     }
 
-    // Re-filter whenever the search/config filter changes.
+    // Re-filter whenever the search text changes.
     onSearchTextChanged: rebuildView()
-    onConfigFilterChanged: rebuildView()
 
     // ── backdrop ───────────────────────────────────────────────────
     Rectangle {
@@ -165,7 +160,7 @@ Item {
     }
 
     Rectangle {
-        width: Math.min(parent.width - 60, 960)
+        width: Math.min(parent.width - 60, 1040)
         height: Math.min(parent.height - 60, 680)
         radius: 12
         color: theme.bgContainer
@@ -184,84 +179,35 @@ Item {
             // ── toolbar ────────────────────────────────────────────
             RowLayout {
                 Layout.fillWidth: true
-                spacing: 10
+                spacing: 12
 
                 Text {
                     text: root.label
                     font.pixelSize: 20; font.weight: Font.Bold
                     color: theme.textPrimary
                 }
-                Item { Layout.preferredWidth: 8 }
+                Item { Layout.fillWidth: true }
 
                 TextField {
                     id: searchField
-                    Layout.preferredWidth: 200
-                    Layout.preferredHeight: 32
+                    Layout.preferredWidth: 240
+                    Layout.preferredHeight: 34
                     placeholderText: "Search label…"
                     color: theme.textPrimary
                     placeholderTextColor: theme.textSecondary
                     font.pixelSize: 13
-                    leftPadding: 10; rightPadding: 10
+                    leftPadding: 12; rightPadding: 12
                     verticalAlignment: TextInput.AlignVCenter
                     background: Rectangle {
-                        color: theme.bgInput; radius: 4
+                        color: theme.bgInput; radius: 6
                         border.color: searchField.activeFocus ? theme.accentBlue : theme.borderSubtle
                         border.width: 1
                     }
                     onTextChanged: root.searchText = text
                 }
 
-                ComboBox {
-                    id: configBox
-                    Layout.preferredWidth: 130
-                    Layout.preferredHeight: 32
-                    model: ["All", "Near", "Middle", "Far", "Outer",
-                            "Left", "Right", "Third Row", "None"]
-                    font.pixelSize: 13
-                    contentItem: Text {
-                        leftPadding: 10; text: configBox.displayText
-                        font: configBox.font; color: theme.textPrimary
-                        verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
-                    }
-                    background: Rectangle {
-                        color: theme.bgInput; radius: 4
-                        border.color: theme.borderSubtle; border.width: 1
-                    }
-                    onCurrentTextChanged: root.configFilter = currentText
-                }
-
-                Item { Layout.fillWidth: true }
-
-                Button {
-                    text: "Open Folder"
-                    Layout.preferredWidth: 100; Layout.preferredHeight: 32
-                    hoverEnabled: true
-                    contentItem: Text {
-                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
-                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
-                    }
-                    background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
-                    }
-                    onClicked: Qt.openUrlExternally("file:///" + MotionInterface.directory)
-                }
-                Button {
-                    text: "Refresh"
-                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
-                    hoverEnabled: true
-                    contentItem: Text {
-                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
-                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
-                    }
-                    background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
-                    }
-                    onClicked: root.refresh()
-                }
                 Rectangle {
-                    width: 28; height: 28; radius: 14
+                    width: 30; height: 30; radius: 15
                     color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
                     border.color: theme.borderHover; border.width: 1
                     Behavior on color { ColorAnimation { duration: 120 } }
@@ -414,22 +360,27 @@ Item {
             // ── detail pane (focused row, read-only) ───────────────
             Rectangle {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 150
+                Layout.preferredHeight: 230
                 radius: 6; color: theme.bgCardAlt
                 border.color: theme.borderSubtle; border.width: 1
                 visible: root.focusedRow !== null
 
-                RowLayout {
-                    anchors.fill: parent; anchors.margins: 12; spacing: 16
+                // Stacked: a compact metadata strip on top, then the notes box
+                // spanning the full pane width below (much wider than the old
+                // side-by-side layout).
+                ColumnLayout {
+                    anchors.fill: parent; anchors.margins: 14; spacing: 10
 
                     GridLayout {
-                        columns: 2; columnSpacing: 14; rowSpacing: 4
-                        Layout.preferredWidth: 320
-                        Layout.alignment: Qt.AlignTop
+                        Layout.fillWidth: true
+                        columns: 6; columnSpacing: 12; rowSpacing: 6
                         Text { text: "Full label:"; color: theme.textSecondary; font.pixelSize: 12 }
                         Text { text: root.focusedRow ? root.focusedRow.label : ""; color: theme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
                         Text { text: "Operator:"; color: theme.textSecondary; font.pixelSize: 12 }
                         Text { text: root.focusedRow ? (root.focusedRow.operator || "-") : ""; color: theme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Samples:"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedSampleCount < 0 ? "…" : root.focusedSampleCount.toLocaleString(); color: theme.textPrimary; font.pixelSize: 12; Layout.preferredWidth: 70 }
+
                         Text { text: "Mask (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
                         Text {
                             color: theme.textPrimary; font.pixelSize: 12
@@ -440,27 +391,19 @@ Item {
                         }
                         Text { text: "Config (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
                         Text { text: root.focusedRow ? (root.focusedRow.configL + " / " + root.focusedRow.configR) : ""; color: theme.textPrimary; font.pixelSize: 12 }
-                        Text { text: "Samples:"; color: theme.textSecondary; font.pixelSize: 12 }
-                        Text {
-                            color: theme.textPrimary; font.pixelSize: 12
-                            text: root.focusedSampleCount < 0 ? "…" : root.focusedSampleCount.toLocaleString()
-                        }
                     }
 
-                    ColumnLayout {
-                        Layout.fillWidth: true; Layout.fillHeight: true; spacing: 4
-                        Text { text: "Notes (read-only):"; color: theme.textSecondary; font.pixelSize: 12 }
-                        Rectangle {
-                            Layout.fillWidth: true; Layout.fillHeight: true
-                            radius: 4; color: theme.bgInput
-                            border.color: theme.borderSubtle; border.width: 1
-                            ScrollView {
-                                anchors.fill: parent; anchors.margins: 2
-                                TextArea {
-                                    readOnly: true; wrapMode: Text.Wrap; background: null
-                                    text: root.focusedRow ? (root.focusedRow.notes || "") : ""
-                                    color: theme.textPrimary; font.pixelSize: 12
-                                }
+                    Text { text: "Notes (read-only):"; color: theme.textSecondary; font.pixelSize: 12 }
+                    Rectangle {
+                        Layout.fillWidth: true; Layout.fillHeight: true
+                        radius: 4; color: theme.bgInput
+                        border.color: theme.borderSubtle; border.width: 1
+                        ScrollView {
+                            anchors.fill: parent; anchors.margins: 2
+                            TextArea {
+                                readOnly: true; wrapMode: Text.Wrap; background: null
+                                text: root.focusedRow ? (root.focusedRow.notes || "") : ""
+                                color: theme.textPrimary; font.pixelSize: 12
                             }
                         }
                     }
@@ -468,47 +411,52 @@ Item {
             }
 
             // ── actions ────────────────────────────────────────────
+            // Destructive Delete sits apart on the left; primary actions
+            // (Export, then the emphasized Load) group on the right.
             RowLayout {
                 Layout.fillWidth: true; spacing: 10
 
-                Text {
-                    text: root.checkedCount > 0 ? (root.checkedCount + " selected") : ""
-                    color: theme.textSecondary; font.pixelSize: 12
+                Button {
+                    id: deleteBtn
+                    text: "🗑  Delete" + (root.checkedCount > 0 ? "  (" + root.checkedCount + ")" : "")
+                    Layout.preferredWidth: 132; Layout.preferredHeight: 36
+                    // Don't allow deleting while a scan is running (could be the
+                    // in-flight session). The password prompt still guards it.
+                    enabled: root.checkedCount > 0 && MotionInterface.state !== 4
+                    hoverEnabled: enabled
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: deleteBtn.enabled ? theme.accentRed : theme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        radius: 6
+                        color: deleteBtn.hovered && deleteBtn.enabled
+                               ? Qt.rgba(0.75, 0.22, 0.17, 0.16) : "transparent"
+                        border.color: deleteBtn.enabled ? theme.accentRed : theme.textTertiary
+                        border.width: 1
+                    }
+                    onClicked: root.requestDelete()
                 }
+
                 Item { Layout.fillWidth: true }
 
                 Button {
-                    text: "Load in viewer →"
-                    Layout.preferredWidth: 140; Layout.preferredHeight: 34
-                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
-                    hoverEnabled: enabled
-                    contentItem: Text {
-                        text: parent.text; font.pixelSize: 13
-                        color: parent.enabled ? theme.textSecondary : theme.textTertiary
-                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
-                    }
-                    background: Rectangle {
-                        color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
-                    }
-                    onClicked: {
-                        root.loadingPlot = true
-                        MotionInterface.loadPastScan(root.focusedRow.label)
-                    }
-                }
-                Button {
+                    id: exportBtn
                     text: "Export CSV"
-                    Layout.preferredWidth: 110; Layout.preferredHeight: 34
+                    Layout.preferredWidth: 112; Layout.preferredHeight: 36
                     enabled: root.focusedRow !== null && !root.focusedRow.interrupted
                     hoverEnabled: enabled
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
-                        color: parent.enabled ? theme.textSecondary : theme.textTertiary
+                        color: exportBtn.enabled ? theme.textSecondary : theme.textTertiary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: !parent.enabled ? theme.bgInput : parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: !parent.enabled ? theme.textTertiary : parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                        radius: 6
+                        color: exportBtn.hovered && exportBtn.enabled ? theme.bgHover : "transparent"
+                        border.color: exportBtn.enabled ? theme.borderStrong : theme.textTertiary
+                        border.width: 1
                     }
                     onClicked: {
                         exportDialog.selectedScanId = root.focusedRow.label
@@ -518,22 +466,26 @@ Item {
                     }
                 }
                 Button {
-                    text: "🔒 Delete" + (root.checkedCount > 0 ? " (" + root.checkedCount + ")" : "")
-                    Layout.preferredWidth: 120; Layout.preferredHeight: 34
-                    // Don't allow deleting while a scan is running (could be the
-                    // in-flight session).
-                    enabled: root.checkedCount > 0 && MotionInterface.state !== 4
+                    id: loadBtn
+                    text: "Load in viewer  →"
+                    Layout.preferredWidth: 156; Layout.preferredHeight: 36
+                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
                     hoverEnabled: enabled
                     contentItem: Text {
-                        text: parent.text; font.pixelSize: 13
-                        color: parent.enabled ? "#E8786A" : theme.textTertiary
+                        text: parent.text; font.pixelSize: 13; font.weight: Font.DemiBold
+                        color: loadBtn.enabled ? "#FFFFFF" : theme.textTertiary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered && parent.enabled ? "#3A1714" : theme.bgInput
-                        border.color: parent.enabled ? "#C0392B" : theme.textTertiary; radius: 4
+                        radius: 6
+                        color: !loadBtn.enabled ? theme.bgInput
+                               : (loadBtn.hovered ? Qt.lighter(theme.accentBlue, 1.12)
+                                                  : theme.accentBlue)
                     }
-                    onClicked: root.requestDelete()
+                    onClicked: {
+                        root.loadingPlot = true
+                        MotionInterface.loadPastScan(root.focusedRow.label)
+                    }
                 }
             }
         }

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -1,0 +1,220 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import QtQuick.Dialogs as Dialogs
+import OpenMotion 1.0
+
+// Audit-log viewer. Lists machine-readable audit entries (newest first)
+// and exports them as CSV. Opened from the password gate in SettingsModal.
+// Governed by ModalManager (see HistoryModal.qml for the modal contract).
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 9998
+
+    AppTheme { id: theme }
+
+    readonly property string label: "Audit Log"
+    property var entries: []
+
+    function open() {
+        // Record the view first, then load (so the view event is included).
+        MotionInterface.recordAuditLogViewed()
+        refresh()
+        root.visible = true
+    }
+    function close() { root.visible = false }
+
+    function refresh() {
+        try { entries = MotionInterface.auditLogEntries(500) || [] }
+        catch (e) { entries = [] }
+    }
+
+    QtObject {
+        id: col
+        readonly property int time: 160
+        readonly property int event: 170
+    }
+
+    // ── backdrop ───────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000AA"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    Rectangle {
+        width: Math.min(parent.width - 60, 980)
+        height: Math.min(parent.height - 60, 700)
+        radius: 12
+        color: theme.bgContainer
+        border.color: theme.borderSubtle
+        border.width: 2
+        anchors.centerIn: parent
+
+        MouseArea { anchors.fill: parent }   // absorb clicks
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 18
+            spacing: 12
+
+            // ── toolbar ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                Text {
+                    text: root.label
+                    font.pixelSize: 20; font.weight: Font.Bold
+                    color: theme.textPrimary
+                }
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Export CSV"
+                    Layout.preferredWidth: 110; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                                    + "/audit_log.csv"
+                        exportDialog.open()
+                    }
+                }
+                Button {
+                    text: "Refresh"
+                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: root.refresh()
+                }
+                Rectangle {
+                    width: 28; height: 28; radius: 14
+                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
+                    border.color: theme.borderHover; border.width: 1
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    MouseArea {
+                        id: xArea; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor; onClicked: root.close()
+                    }
+                }
+            }
+
+            // ── table header ───────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                color: theme.bgCardAlt; radius: 4
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                    spacing: 8
+                    Text { text: "Time"; Layout.preferredWidth: col.time
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Event"; Layout.preferredWidth: col.event
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Details"; Layout.fillWidth: true
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                }
+            }
+
+            // ── table body ─────────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true; Layout.fillHeight: true
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                clip: true
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    model: root.entries
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Rectangle {
+                        width: ListView.view.width
+                        height: 30
+                        color: index % 2 === 0 ? "transparent" : Qt.rgba(1, 1, 1, 0.02)
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 8
+                            spacing: 8
+                            Text {
+                                Layout.preferredWidth: col.time
+                                text: modelData.ts_iso || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.event
+                                text: modelData.event_type || ""
+                                color: theme.textPrimary; font.pixelSize: 12
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.details || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+
+                    Text {
+                        anchors.centerIn: parent
+                        visible: root.entries.length === 0
+                        text: "No audit entries yet."
+                        color: theme.textSecondary; font.pixelSize: 14
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+
+    Dialogs.FileDialog {
+        id: exportDialog
+        title: "Export Audit Log CSV"
+        fileMode: Dialogs.FileDialog.SaveFile
+        nameFilters: ["CSV files (*.csv)", "All files (*)"]
+        onAccepted: {
+            var path = selectedFile.toString().replace("file:///", "")
+            // exportAuditLogCsv returns the written path ("" on failure).
+            var dest = MotionInterface.exportAuditLogCsv(path)
+            if (dest) {
+                MotionInterface.notify("Audit log exported to " + dest, "success")
+                root.refresh()   // pick up the audit_log_exported entry
+            }
+        }
+    }
+
+    // Refresh if the data directory (and therefore the scan DB) changes
+    // while the viewer is open — mirrors HistoryModal's behavior.
+    Connections {
+        target: MotionInterface
+        function onDirectoryChanged() { if (root.visible) root.refresh() }
+    }
+}

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -184,6 +184,17 @@ Rectangle {
             ? (viewer.scanSource.reducedMode === 1)
             : viewer.reducedMode
 
+    // ── Side break ─────────────────────────────────────────────────────
+    // A bit of extra margin between the left and right sensor modules in
+    // dev (non-reduced) mode. The grid reserves an empty spacer column
+    // (col 2) between them, but only when BOTH sides have active cameras —
+    // a single-sided scan keeps filling the width with no dangling gap.
+    readonly property bool _sideGapActive:
+        !viewer.effectiveReduced
+        && (viewer._effLeftMask & 0xFF) !== 0
+        && (viewer._effRightMask & 0xFF) !== 0
+    readonly property real _sideGapPx: 3
+
     // ── Grid model ─────────────────────────────────────────────────────
     // Dev mode (default) — one cell per active camera (bits set in
     // leftMask / rightMask), arranged to mirror the physical U-shape of
@@ -191,14 +202,15 @@ Rectangle {
     // run down one arm of the U and back up the other — 1|8 at the top
     // of the U, 4|5 at the bottom — so display row r pairs 1-based cams
     // (4-r | 5+r): row 0 is 4|5, row 3 is 1|8. Left module owns columns
-    // 0-1, right module 2-3 (a module with nothing selected gives up its
+    // 0-1, right module 3-4 — col 2 is the empty side-break spacer when
+    // both sides are active (a module with nothing selected gives up its
     // column pair). Rows empty on both sides are dropped and the rest
     // compact upward; an unselected camera in a kept row just leaves its
     // slot blank.
     readonly property var _devCellModel: {
         var masks = [viewer._effLeftMask & 0xFF, viewer._effRightMask & 0xFF]
         var sides = ["left", "right"]
-        var colBase = [0, masks[0] !== 0 ? 2 : 0]
+        var colBase = [0, masks[0] !== 0 ? 3 : 0]
         var entries = []
         var displayRow = 0
         for (var r = 0; r < 4; r++) {
@@ -681,10 +693,24 @@ Rectangle {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 // Reduced mode: single column, 2 stacked cells. Dev mode:
-                // 4 columns, rows determined by active-cam count.
-                columns: viewer.effectiveReduced ? 1 : 4
+                // 4 columns; +1 spacer column (col 2) when both sides are
+                // active, for a visual break between the modules.
+                columns: viewer.effectiveReduced ? 1 : (viewer._sideGapActive ? 5 : 4)
                 rowSpacing: 6
                 columnSpacing: 6
+
+                // Side-break spacer — fixed-width empty column 2 between the
+                // left (cols 0-1) and right (cols 3-4) modules. fillWidth is
+                // false so it stays a fixed gap; the plot cells (fillWidth)
+                // absorb the rest of the row width around it.
+                Item {
+                    visible: viewer._sideGapActive
+                    Layout.row: 0
+                    Layout.column: 2
+                    Layout.fillWidth: false
+                    Layout.fillHeight: false
+                    Layout.preferredWidth: viewer._sideGapPx
+                }
 
                 Repeater {
                     model: viewer._activeCellModel

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -69,7 +69,7 @@ Rectangle {
     // Per-cell top-left value labels. Default off in reduced mode — the
     // large side panels show the same numbers there — and toggleable at
     // runtime from the bottom-right ⋯ popup.
-    property bool showCellValues: !viewer.reducedMode
+    property bool showCellValues: !viewer.effectiveReduced
     // Y-axis tick labels (max/mid/min per metric). Config is the single
     // source of truth: the ⋯ popup toggle (hidden in reduced mode) writes
     // through MotionInterface.setConfig, which persists to app_config.json
@@ -173,6 +173,17 @@ Rectangle {
          && viewer.scanSource.rightMask >= 0)
             ? viewer.scanSource.rightMask : viewer.rightMask
 
+    // Replay adopts the loaded scan's recorded mode: when the source reports a
+    // known mode (reducedMode >= 0) use it, else fall back to the live-config
+    // `reducedMode` input. Mirrors _effLeftMask/_effRightMask (#175). Note:
+    // scanSource.reducedMode is an int tri-state (-1/0/1) from Python;
+    // viewer.reducedMode is the bool live-config input.
+    readonly property bool effectiveReduced:
+        (viewer.scanSource && viewer.scanSource.reducedMode !== undefined
+         && viewer.scanSource.reducedMode >= 0)
+            ? (viewer.scanSource.reducedMode === 1)
+            : viewer.reducedMode
+
     // ── Grid model ─────────────────────────────────────────────────────
     // Dev mode (default) — one cell per active camera (bits set in
     // leftMask / rightMask), arranged to mirror the physical U-shape of
@@ -218,7 +229,7 @@ Rectangle {
         { side: "right", camId: -1, row: 1, col: 0 }
     ]
 
-    readonly property var _activeCellModel: viewer.reducedMode
+    readonly property var _activeCellModel: viewer.effectiveReduced
         ? _reducedCellModel
         : _devCellModel
 
@@ -646,7 +657,7 @@ Rectangle {
             // nested layouts default it to true, which would make this
             // column compete with the grid for the whole row width.
             ColumnLayout {
-                visible: viewer.reducedMode
+                visible: viewer.effectiveReduced
                 Layout.fillWidth: false
                 Layout.fillHeight: true
                 Layout.preferredWidth: 250
@@ -671,7 +682,7 @@ Rectangle {
                 Layout.fillHeight: true
                 // Reduced mode: single column, 2 stacked cells. Dev mode:
                 // 4 columns, rows determined by active-cam count.
-                columns: viewer.reducedMode ? 1 : 4
+                columns: viewer.effectiveReduced ? 1 : 4
                 rowSpacing: 6
                 columnSpacing: 6
 
@@ -1014,7 +1025,7 @@ Rectangle {
             // autoscale) are hidden and Cell values is gone, leaving the
             // dev-only Profiler as the sole possible entry. Hide the
             // button entirely when it would open an empty card.
-            visible: !viewer.reducedMode
+            visible: !viewer.effectiveReduced
                      || MotionInterface.appConfig.developerMode === true
             width: 36
             height: 36
@@ -1093,7 +1104,7 @@ Rectangle {
                         // Hidden in reduced (clinical) mode — that view only
                         // ever shows the BFI/BVI side averages, so the
                         // Mean/Contrast alternative isn't offered there.
-                        visible: !viewer.reducedMode
+                        visible: !viewer.effectiveReduced
                         spacing: 8
                         PopupPillSwitch {
                             id: bfiBviSwitch
@@ -1112,7 +1123,7 @@ Rectangle {
                         // Hidden in reduced (clinical) mode — autoscale is
                         // not offered there; the view always uses the
                         // configured manual bounds.
-                        visible: !viewer.reducedMode
+                        visible: !viewer.effectiveReduced
                         spacing: 8
                         PopupPillSwitch {
                             id: autoScaleSwitch
@@ -1128,7 +1139,7 @@ Rectangle {
                         }
                     }
                     Row {
-                        visible: !viewer.reducedMode
+                        visible: !viewer.effectiveReduced
                         spacing: 8
                         PopupPillSwitch {
                             id: axisLabelsSwitch

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -63,6 +63,19 @@ Item {
         )
     }
 
+    // Emitted when the user enters the correct password for the audit log.
+    // BloodFlow.qml opens the (ModalManager-governed) LogsModal in response.
+    signal logsRequested()
+
+    // Password gate for the audit Logs viewer.
+    PasswordPromptModal {
+        id: logsPasswordModal
+        title: "Audit Log"
+        description: "Enter the password to view the audit log."
+        confirmLabel: "View Logs"
+        onAccepted: root.logsRequested()
+    }
+
     // ── Lifecycle ───────────────────────────────────────────────────────────
     function _loadFromConfig() {
         var cfg = MotionInterface.appConfig
@@ -753,6 +766,38 @@ Item {
                                 }
                             }
                         }
+                    }
+                }
+
+                // ── Audit Log ────────────────────────────────────────────────
+                SectionCard {
+                    title: "Audit Log"
+
+                    FieldRow {
+                        label: "Logs"
+                        ActionButton {
+                            text: "View Logs"
+                            Layout.preferredWidth: 130
+                            onClicked: logsPasswordModal.open()
+                        }
+                        ActionButton {
+                            text: "Send Debug Logs"
+                            Layout.preferredWidth: 150
+                            // Direct action — zips the last 48h of app logs,
+                            // reveals the file, and toasts the support address.
+                            onClicked: MotionInterface.prepareDebugLogBundle()
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    Text {
+                        text: "Password-protected, machine-readable record of system "
+                              + "events for auditors. Open the viewer to browse entries "
+                              + "or export them as CSV. Send Debug Logs zips the last "
+                              + "48 hours of app logs to email to support@openwater.cc."
+                        color: root.colTextMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
                     }
                 }
 

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -60,5 +60,9 @@
   "histoThrottle": false,
   "histoCmp": true,
   "commVerbose": false,
-  "verboseCommandHandling": false
+  "verboseCommandHandling": false,
+  "support_email": "support@openwater.health",
+  "connectionTimeoutSec": 30,
+  "requireConsole": true,
+  "minSensors": 1
 }

--- a/data_sources.py
+++ b/data_sources.py
@@ -269,6 +269,10 @@ class ScanDataSource(QObject):
         # #175) so its grid doesn't inherit the current selection.
         self._left_mask: int = -1
         self._right_mask: int = -1
+        # Recorded display mode, tri-state: -1 unknown / 0 per-camera / 1
+        # reduced. -1 for live sources (viewer follows the live config);
+        # PastScanSource derives the real value from its buffer layout.
+        self._reduced_mode: int = -1
         self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
         # Ring-trim threshold for buffers this source creates. Live sources
         # pass a finite value (config) to bound memory; past sources pass None
@@ -315,6 +319,14 @@ class ScanDataSource(QObject):
         """Right-sensor camera mask this source represents, or -1 if unknown.
         See ``leftMask``."""
         return self._right_mask
+
+    @pyqtProperty(int, constant=True)
+    def reducedMode(self) -> int:
+        """Recorded display mode this source represents: -1 unknown, 0
+        per-camera, 1 reduced. Exposed for QML (PlotViewer.effectiveReduced)
+        so a replayed scan renders in its own mode rather than the live config.
+        See ``leftMask`` for why this must be a pyqtProperty."""
+        return self._reduced_mode
 
     @pyqtProperty(float)
     def liveEdge(self) -> float:
@@ -923,6 +935,21 @@ def _derive_masks_from_buffers(buffers: dict) -> tuple[int, int]:
     return masks["left"], masks["right"]
 
 
+def _derive_reduced_from_buffers(buffers) -> int:
+    """Tri-state recorded display mode from a loaded scan's buffer cam_ids:
+    -1 unknown, 0 per-camera, 1 reduced. Reduced-mode scans store only the
+    cam_id=-1 side average; per-camera (dev) scans store cam_id 0..7. Mirrors
+    _derive_masks_from_buffers — the viewer prefers this over the live config
+    so replay renders in the mode the scan was captured in."""
+    if buffers_are_empty(buffers):
+        return -1
+    if any(0 <= key[1] < 8 for key in buffers):
+        return 0
+    if any(key[1] == -1 for key in buffers):
+        return 1
+    return -1
+
+
 def load_past_scan_buffers(
     scan_db,
     session_id: int,
@@ -991,3 +1018,4 @@ class PastScanSource(ScanDataSource):
         self._left_mask, self._right_mask = _derive_masks_from_buffers(
             self.buffers
         )
+        self._reduced_mode = _derive_reduced_from_buffers(self.buffers)

--- a/debug_bundle.py
+++ b/debug_bundle.py
@@ -1,0 +1,117 @@
+"""Build a zip bundle of recent app logs for emailing to support.
+
+Collects the last N hours of app log files plus app_config.json and a
+generated system_info.txt into a single zip. Pure file logic -- no Qt, no
+hardware -- so it is unit-testable against a temp directory.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from audit_log import gather_host_info
+
+logger = logging.getLogger("openmotion.bloodflow-app.debug-bundle")
+
+WINDOW_HOURS = 48
+
+
+def _system_info_text(
+    now_epoch: float, extra_info: Optional[Dict[str, Any]]
+) -> str:
+    """Render host info (+ caller-supplied extras) as sorted key: value
+    lines, with a leading local-time 'generated' stamp."""
+    info = gather_host_info()
+    if extra_info:
+        info.update(extra_info)
+    generated = (
+        datetime.datetime.fromtimestamp(now_epoch)
+        .astimezone()
+        .isoformat(timespec="seconds")
+    )
+    lines = [f"generated: {generated}"]
+    lines += [f"{k}: {info[k]}" for k in sorted(info)]
+    return "\n".join(lines) + "\n"
+
+
+def build_debug_bundle(
+    data_dir: str | Path,
+    dest_dir: str | Path,
+    now_epoch: float,
+    *,
+    window_hours: int = WINDOW_HOURS,
+    config_path: str | Path | None = None,
+    extra_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Zip recent app logs + config + system info into dest_dir.
+
+    Includes <data_dir>/app-logs/*.log with mtime within window_hours,
+    the app_config.json at config_path (default <data_dir>/app_config.json)
+    if present, and a generated system_info.txt. Returns
+    {"path", "file_count", "log_count", "bytes"} where:
+      - log_count  = log files that matched the time window.
+      - file_count = entries actually written into the zip (logs + config
+        if present + system_info). May be < log_count + 1 if a matched log
+        fails to add (skipped fail-soft).
+      - bytes      = size of the written zip on disk.
+    """
+    data_dir = Path(data_dir)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    cutoff = now_epoch - window_hours * 3600
+    log_dir = data_dir / "app-logs"
+    recent_logs = []
+    if log_dir.is_dir():
+        for p in sorted(log_dir.glob("*.log")):
+            try:
+                if p.stat().st_mtime >= cutoff:
+                    recent_logs.append(p)
+            except OSError:
+                logger.warning(
+                    "debug_bundle: stat failed for %s", p, exc_info=True
+                )
+
+    if config_path is None:
+        config_path = data_dir / "app_config.json"
+    config_path = Path(config_path)
+
+    stamp = datetime.datetime.fromtimestamp(now_epoch).strftime(
+        "%Y%m%d_%H%M%S"
+    )
+    dest = dest_dir / f"debug-bundle-{stamp}.zip"
+
+    file_count = 0
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in recent_logs:
+            try:
+                zf.write(p, arcname=f"app-logs/{p.name}")
+                file_count += 1
+            except OSError:
+                logger.warning(
+                    "debug_bundle: could not add %s", p, exc_info=True
+                )
+        if config_path.is_file():
+            try:
+                zf.write(config_path, arcname=config_path.name)
+                file_count += 1
+            except OSError:
+                logger.warning(
+                    "debug_bundle: could not add config %s", config_path,
+                    exc_info=True,
+                )
+        zf.writestr(
+            "system_info.txt", _system_info_text(now_epoch, extra_info)
+        )
+        file_count += 1
+
+    return {
+        "path": str(dest),
+        "file_count": file_count,
+        "log_count": len(recent_logs),
+        "bytes": dest.stat().st_size,
+    }

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,0 +1,127 @@
+# Critical Error Codes
+
+When the BloodFlow app hits a showstopper condition it raises a **critical-error
+modal** carrying a stable code (e.g. `E-101`). The modal is dismissible and
+offers **Copy details** and **Send Bug Report to Openwater**.
+
+Codes are the single source of truth in [`error_codes.py`](../error_codes.py);
+this document is generated from that registry. They are grouped by subsystem:
+
+- **E-1xx** — startup / initialization
+- **E-2xx** — laser safety
+- **E-3xx** — scan / capture
+
+When reporting a problem, quote the code — it tells support exactly which check
+failed.
+
+Not every coded condition is critical: the **startup connection watchdog**
+(E-104 / E-106) is a non-blocking *warning* shown as a yellow toast, not the
+modal — see [Startup warnings](#startup-warnings-connection-watchdog) below.
+
+## E-1xx — Startup / initialization
+
+### E-101 — Sensor self-check failed
+One or more of the sensor's internal I2C devices (the I2C mux, the IMU, a
+camera, or an FPGA) did not respond during the firmware's power-on self-check.
+The system cannot scan reliably in this state.
+
+**What to do:** Power-cycle the sensor and reconnect. If it persists, the sensor
+hardware needs service — send a bug report.
+
+### E-102 — Sensor self-check unreadable
+The sensor connected but did not return its power-on self-check result, so its
+internal device health is unknown (typically older firmware, or the status
+command was rejected).
+
+**What to do:** Power-cycle the sensor and reconnect. If it persists, update the
+sensor firmware or send a bug report.
+
+### E-103 — Console initialization failed
+The console connected but its laser-power configuration could not be applied.
+The laser may not operate correctly until this is resolved.
+
+**What to do:** Power-cycle the console and reconnect. If it persists, send a bug
+report — the console firmware or config may need attention.
+
+### E-105 — Camera power-on failed
+The sensor could not power on its cameras during initialization, so camera
+identities could not be read.
+
+**What to do:** Power-cycle the sensor and reconnect. If only some cameras are
+affected, the camera board may need service.
+
+## E-2xx — Laser safety
+
+### E-201 — Laser safety monitor unresponsive
+The laser-safety monitor stopped reporting a known-good state for longer than
+the allowed transient window, so laser safety cannot be confirmed. The laser was
+shut off as a precaution.
+
+**What to do:** Power-cycle the system and reconnect. Do not scan until this
+clears — send a bug report if it persists; the safety I2C link may be failing.
+
+### E-202 — Laser safety trip
+The laser-safety monitor tripped during a scan and the laser was shut off. The
+scan was stopped.
+
+**What to do:** Remove any obstruction, let the system settle, and start a new
+scan. If it trips repeatedly, stop and send a bug report.
+
+## E-3xx — Scan / capture
+
+### E-301 — Scan aborted before start
+A scan was requested but a precondition check failed, so the scan was aborted
+before the laser fired.
+
+**What to do:** Resolve the reported precondition (connection, safety, or
+configuration) and start the scan again.
+
+### E-302 — Scan could not start
+The system refused to start a new scan, usually because a previous scan is still
+finishing.
+
+**What to do:** Wait a few seconds for the previous scan to finish, then try
+again. Reconnect if the system stays busy.
+
+## Startup warnings (connection watchdog)
+
+A one-shot check armed at app launch flags expected devices that never showed
+up. Unlike the codes above it is **non-blocking**: it shows a **yellow warning
+toast** in the bottom-right, not the critical modal, because the fix is usually
+just "plug it in and reconnect". If the expected devices haven't enumerated
+within `connectionTimeoutSec` (default 30 s) after launch:
+
+- **E-104 — Console not detected** → `"Console not detected. Check the console
+  USB cable and power, then reconnect."`
+- **E-106 — Sensor not detected** → `"Sensor not detected. Check the sensor USB
+  cable and power, then reconnect."`
+- **Both missing** → a single consolidated toast: `"System not found. Check that
+  the console and sensor are connected and powered on."`
+
+The codes E-104/E-106 still appear in the app log for support traceability.
+
+Tunable in [`config/app_config.json`](../config/app_config.json):
+
+- `connectionTimeoutSec` (default `30`) — grace period before the check runs;
+  `0` disables the watchdog.
+- `requireConsole` (default `true`) — warn (E-104) if no console connected.
+- `minSensors` (default `1`) — warn (E-106) if fewer than this many sensors
+  connected.
+
+Disconnects that happen *after* startup are handled by the normal connection
+status UI, not by this watchdog.
+
+## Sending a bug report
+
+The **Send Bug Report to Openwater** button packages the current session log plus
+the error context for support.
+
+- By default it opens your mail client with a pre-filled message to
+  `support@openwater.health`, copies the report to your clipboard, and reveals
+  the session log file so you can attach it before sending.
+- If an SMTP relay is configured (`bug_report_smtp` in
+  [`config/app_config.json`](../config/app_config.json)), the report is sent
+  automatically with the log attached — no manual step.
+
+The support address is configurable via the `support_email` key in
+`config/app_config.json`.

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,0 +1,154 @@
+# Audit Log — User & Auditor Guide
+
+The OpenWater Bloodflow app keeps an **audit log**: a machine-readable,
+append-only record of significant system events. It exists primarily for
+**auditors** who need to reconstruct what the system and its operators did,
+and when. This guide explains how to open it, what it records, and how to
+read or export it.
+
+---
+
+## Opening the audit log
+
+1. Open **Settings** (gear icon).
+2. Scroll to the **Audit Log** section and click **View Logs**.
+3. Enter the access password when prompted.
+
+> The password is the same one used for other protected actions in the app
+> (e.g. starting a calibration or deleting scans). Ask your system
+> administrator if you don't have it. The audit log is read-only from the
+> UI — there is no way to edit or delete individual entries through the app.
+
+The viewer lists entries **newest first**, with three columns:
+
+| Column | Meaning |
+|---|---|
+| **Time** | Local timestamp the event was recorded (ISO-8601 with UTC offset, e.g. `2026-06-15T09:14:02-07:00`). |
+| **Event** | The event type (see the table below). |
+| **Details** | A compact JSON object with event-specific fields. |
+
+Use **Refresh** to reload, and **Export CSV** to save the full log to a file
+(see [Exporting](#exporting-to-csv)).
+
+---
+
+## What gets recorded
+
+Each entry is intentionally **minimal and structured** — a short event type
+plus a small JSON `details` payload. The app records the following events:
+
+| Event type | When it happens | Key details |
+|---|---|---|
+| `system_startup` | The app launches. | `app_version`, `sdk_version`, `data_dir` |
+| `system_info` | At launch, right after startup. | `hostname`, `platform`, `system`, `arch`, `processor`, `python`, `ram_gb` |
+| `system_shutdown` | The app closes cleanly. | `clean` |
+| `device_connected` | The console or a sensor connects. | `device` (`console`/`left`/`right`), `reason` |
+| `device_disconnected` | The console or a sensor disconnects. | `device`, `reason` |
+| `device_stats` | When a device connects, once its IDs are readable. | `device`, `hardware_id`, `firmware_version` |
+| `scan_started` | A scan begins. | `label`, `left_mask`, `right_mask` |
+| `scan_ended` | A scan finishes or is stopped. | `label`, `session_label`, `duration_s`, `outcome` |
+| `calibration_started` | A calibration begins. | `target` (`both`/`left`/`right`) |
+| `calibration_ended` | A calibration finishes. | `target`, `outcome` (`passed`/`failed`/`aborted`), `reason` |
+| `settings_changed` | A setting is changed and saved. | `changes` — only the keys that actually changed, each as `{ "old": …, "new": … }` |
+| `scan_viewed` | A past scan is opened in the viewer. | `label` |
+| `scan_deleted` | One or more scans are deleted. | `session_ids`, `count` |
+| `audit_log_viewed` | The audit log itself is opened. | `entry_count` |
+| `audit_log_exported` | The audit log is exported to CSV. | `dest`, `row_count` |
+| `debug_bundle_created` | The "Send Debug Logs" button is used. | `dest`, `file_count`, `log_count`, `bytes`, `window_hours` |
+
+Notes for auditors:
+
+- **The audit log audits itself.** Opening the viewer and exporting it are
+  both recorded (`audit_log_viewed`, `audit_log_exported`), so access to the
+  audit data leaves its own trail.
+- **System statistics** are split across two events: host/OS facts at launch
+  (`system_info`) and per-device hardware/firmware IDs on connect
+  (`device_stats`).
+- **Settings changes record a diff**, not the full configuration — only the
+  keys whose values changed, with their old and new values. A save that
+  changes nothing produces no entry.
+- Some payloads use a stable scan **label** (e.g. `ow3SW4HD`) and/or a
+  **session label** (e.g. `20260610_163915_ow3SW4HD`) as the identifier,
+  consistent with how scans are named elsewhere in the app and in the scan
+  database.
+
+---
+
+## Where the data lives
+
+Audit entries are stored in a table named **`logs`** inside the app's scan
+database, `scans.db`, which lives in your configured **data directory** (the
+same folder as your scan CSVs and the scan history). The table is
+append-only; the app never updates or removes rows.
+
+Schema:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INTEGER | Auto-incrementing primary key (also the insertion order). |
+| `ts_epoch` | REAL | Event time as a Unix timestamp (seconds since 1970-01-01 UTC). |
+| `ts_iso` | TEXT | Event time as a local ISO-8601 string with UTC offset (unambiguous across DST), e.g. `2026-06-15T09:14:02-07:00`. |
+| `event_type` | TEXT | One of the event types in the table above. |
+| `details` | TEXT | Compact JSON object, or `NULL` when the event has no payload. |
+
+Because it's plain SQLite, auditors can also query the table directly with
+any SQLite tool, for example:
+
+```sql
+SELECT ts_iso, event_type, details
+FROM logs
+ORDER BY id DESC
+LIMIT 50;
+```
+
+---
+
+## Sending debug logs to Openwater
+
+The **Send Debug Logs** button (top of the audit-log viewer) packages the
+app's diagnostic logs for support. It writes a zip to
+`<dataDirectory>/app-logs/debug-bundles/debug-bundle-<timestamp>.zip`
+containing the app log files from the last 48 hours, `app_config.json`,
+and a `system_info.txt` (app/SDK version + host details). The file
+explorer opens with the zip selected, and a message shows the path —
+**email that zip to support@openwater.cc**. No data is sent
+automatically, and the bundle contains no scan data or patient
+information.
+
+## Exporting to CSV
+
+In the audit-log viewer, click **Export CSV** and choose a destination. The
+exported file is UTF-8 and ordered **oldest first** (stable for diffing and
+archiving), with one header row and one row per event:
+
+```
+ts_iso,ts_epoch,event_type,details
+2026-06-15T09:14:02-07:00,1750000442.12,system_startup,"{""app_version"":""1.2.3"",""data_dir"":""C:\\…"",""sdk_version"":""…""}"
+2026-06-15T09:14:02-07:00,1750000442.13,system_info,"{""arch"":""AMD64"",""hostname"":""LAB-PC-01"",…}"
+```
+
+The `details` column holds the raw JSON for each event, quoted per standard
+CSV rules. Every common spreadsheet and data tool can read this directly;
+the JSON keys within `details` are sorted alphabetically so the format is
+deterministic.
+
+---
+
+## Frequently asked
+
+**Can entries be edited or removed?**
+Not through the app. The log is append-only and the viewer is read-only.
+
+**Does deleting a scan remove its audit entries?**
+No. Deleting scans removes the scan data, but the `scan_deleted` event (and
+all earlier `scan_started` / `scan_viewed` entries for that scan) remain in
+the audit log.
+
+**What if the data directory is unavailable at startup?**
+Audit logging fails safe: if the database can't be opened, the app keeps
+running normally and simply records nothing — a failed audit write never
+interrupts a scan or crashes the app.
+
+**Is patient/subject data stored in the log?**
+The log records scan **labels** and masks, not histogram data or computed
+BFI/BVI values. Treat labels according to your site's data-handling policy.

--- a/docs/superpowers/plans/2026-06-15-audit-log.md
+++ b/docs/superpowers/plans/2026-06-15-audit-log.md
@@ -1,0 +1,1544 @@
+# Audit Log Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a machine-readable, append-only audit log to the bloodflow app's `scans.db`, surfaced through a password-gated **Logs** button in Settings with CSV export.
+
+**Architecture:** A standalone `audit_log.py` module (`AuditLog` class) owns a long-lived sqlite3 connection to `scans.db`, lazily creates a `logs` table, and exposes `log()/query()/export_csv()`. `MotionConnector` holds one `AuditLog` instance and calls `self._audit.log(...)` at thin instrumentation sites. A new `LogsModal.qml` (reached via a password gate in `SettingsModal.qml`) lists entries and exports CSV.
+
+**Tech Stack:** Python 3.13, PyQt6, sqlite3 (stdlib), pytest. QML 6.
+
+**Design spec:** [docs/superpowers/specs/2026-06-15-audit-log-design.md](../specs/2026-06-15-audit-log-design.md)
+
+---
+
+## File Structure
+
+- **Create** `audit_log.py` — `AuditLog` class + event-type constants + `gather_host_info()`. One responsibility: the audit logging store.
+- **Create** `tests/test_audit_log.py` — unit tests for the module.
+- **Create** `tests/test_audit_connector.py` — unit tests for connector-level instrumentation.
+- **Create** `components/LogsModal.qml` — the log viewer modal (modeled on `HistoryModal.qml`).
+- **Modify** `motion_connector.py` — construct `AuditLog`, add QML slots, add instrumentation call sites.
+- **Modify** `components/SettingsModal.qml` — Audit Log section + password gate + `logsRequested()` signal.
+- **Modify** `pages/BloodFlow.qml` — add `LogsModal` instance, register it in `ModalManager`, wire `onLogsRequested`.
+
+All call sites are thin one-liners; the existing `motion_connector.py` (4031 lines) gains a small slot block and ~8 single-line log calls.
+
+---
+
+## Task 1: AuditLog module
+
+**Files:**
+- Create: `audit_log.py`
+- Test: `tests/test_audit_log.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_audit_log.py`:
+
+```python
+"""Unit tests for the append-only audit log (audit_log.py)."""
+import csv
+import json
+import sqlite3
+import threading
+
+import pytest
+
+from audit_log import AuditLog, gather_host_info, EV_SYSTEM_STARTUP
+
+pytestmark = pytest.mark.unit
+
+
+def test_log_creates_table_and_inserts_row(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log(EV_SYSTEM_STARTUP, {"app_version": "1.2.3"})
+    a.close()
+
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        "SELECT event_type, details FROM logs"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == EV_SYSTEM_STARTUP
+    assert json.loads(rows[0][1]) == {"app_version": "1.2.3"}
+
+
+def test_reopen_is_idempotent(tmp_path):
+    db = str(tmp_path / "scans.db")
+    AuditLog(db).close()
+    a = AuditLog(db)          # second open must not raise on CREATE
+    a.log("system_info", None)
+    a.close()
+
+
+def test_none_details_stored_as_null(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log("system_shutdown", None)
+    a.close()
+    conn = sqlite3.connect(db)
+    val = conn.execute("SELECT details FROM logs").fetchone()[0]
+    conn.close()
+    assert val is None
+
+
+def test_query_is_newest_first_and_honors_limit(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for i in range(5):
+        a.log("scan_started", {"n": i})
+    out = a.query(limit=3)
+    a.close()
+    assert len(out) == 3
+    # newest (n=4) first
+    assert json.loads(out[0]["details"])["n"] == 4
+
+
+def test_export_csv_roundtrips(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"label": "owABC"})
+    a.log("scan_ended", {"label": "owABC"})
+    dest = tmp_path / "audit.csv"
+    n = a.export_csv(str(dest))
+    a.close()
+    assert n == 2
+    with open(dest, newline="", encoding="utf-8") as f:
+        reader = list(csv.DictReader(f))
+    assert reader[0]["event_type"] == "scan_started"   # oldest first
+    assert json.loads(reader[0]["details"])["label"] == "owABC"
+
+
+def test_no_path_is_silent_noop(tmp_path):
+    a = AuditLog(None)
+    assert a.enabled is False
+    a.log("scan_started", {"x": 1})          # must not raise
+    assert a.query() == []
+    assert a.export_csv(str(tmp_path / "x.csv")) == 0
+    a.close()
+
+
+def test_concurrent_writes_all_land(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+
+    def worker():
+        for _ in range(20):
+            a.log("scan_started", {"t": 1})
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(a.query(limit=1000)) == 60
+    a.close()
+
+
+def test_gather_host_info_has_core_fields():
+    info = gather_host_info()
+    assert "hostname" in info
+    assert "platform" in info
+    assert "python" in info
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_audit_log.py -p no:cacheprovider -q`
+Expected: FAIL at import — `ModuleNotFoundError: No module named 'audit_log'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `audit_log.py`:
+
+```python
+"""Append-only, machine-readable audit log stored in scans.db.
+
+A small, self-contained logger used primarily by auditors. Writes one
+row per event to a ``logs`` table in the same SQLite file the SDK's
+ScanDatabase uses (scans.db). Owns its own long-lived connection so it
+can append alongside ScanDatabase's on-demand handles.
+
+Fail-soft by contract: construction with a missing path, or any DB
+error, degrades the instance to a no-op — a failed audit write must
+never crash or block the app.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import logging
+import platform
+import socket
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openmotion.bloodflow-app.audit")
+
+# ── Event-type constants ────────────────────────────────────────────────
+EV_SYSTEM_STARTUP = "system_startup"
+EV_SYSTEM_INFO = "system_info"
+EV_SYSTEM_SHUTDOWN = "system_shutdown"
+EV_DEVICE_CONNECTED = "device_connected"
+EV_DEVICE_DISCONNECTED = "device_disconnected"
+EV_DEVICE_STATS = "device_stats"
+EV_SCAN_STARTED = "scan_started"
+EV_SCAN_ENDED = "scan_ended"
+EV_CALIBRATION_STARTED = "calibration_started"
+EV_CALIBRATION_ENDED = "calibration_ended"
+EV_SETTINGS_CHANGED = "settings_changed"
+EV_SCAN_VIEWED = "scan_viewed"
+EV_SCAN_DELETED = "scan_deleted"
+EV_AUDIT_LOG_VIEWED = "audit_log_viewed"
+EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+
+# CSV export column order.
+_CSV_FIELDS = ["ts_iso", "ts_epoch", "event_type", "details"]
+
+
+def gather_host_info() -> Dict[str, Any]:
+    """Collect host/system facts for the ``system_info`` event. Best-effort
+    — any probe that fails is simply omitted."""
+    info: Dict[str, Any] = {}
+    try:
+        info["hostname"] = socket.gethostname()
+        info["platform"] = platform.platform()
+        info["system"] = f"{platform.system()} {platform.release()}".strip()
+        info["arch"] = platform.machine()
+        info["processor"] = platform.processor()
+        info["python"] = platform.python_version()
+    except Exception:
+        logger.warning("gather_host_info: core probe failed", exc_info=True)
+    try:
+        if platform.system() == "Windows":
+            import ctypes
+
+            class _MEMSTATUSEX(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            mem = _MEMSTATUSEX()
+            mem.dwLength = ctypes.sizeof(_MEMSTATUSEX)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(mem))
+            info["ram_gb"] = round(mem.ullTotalPhys / (1024 ** 3), 2)
+    except Exception:
+        pass
+    return info
+
+
+class AuditLog:
+    """Append-only audit-event store backed by the ``logs`` table in
+    scans.db. Thread-safe (single connection + write lock). No-op when
+    constructed without a usable path."""
+
+    def __init__(self, db_path: Optional[str | Path]) -> None:
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        if not db_path:
+            logger.info("AuditLog: no db_path — audit logging disabled (no-op).")
+            return
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._conn = conn
+            self._init_schema()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to open %s — disabling audit logging.",
+                db_path, exc_info=True,
+            )
+            self._conn = None
+
+    def _init_schema(self) -> None:
+        assert self._conn is not None
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS logs (
+                id          INTEGER PRIMARY KEY,
+                ts_epoch    REAL NOT NULL,
+                ts_iso      TEXT NOT NULL,
+                event_type  TEXT NOT NULL,
+                details     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
+            """
+        )
+        self._conn.commit()
+
+    @property
+    def enabled(self) -> bool:
+        return self._conn is not None
+
+    def log(self, event_type: str, details: Optional[Dict[str, Any]] = None) -> None:
+        """Append one event. ``details`` (if truthy) is stored as compact,
+        deterministic JSON. Never raises."""
+        if self._conn is None:
+            return
+        ts_epoch = time.time()
+        ts_iso = datetime.datetime.fromtimestamp(ts_epoch).isoformat(
+            timespec="seconds"
+        )
+        details_json = (
+            json.dumps(details, separators=(",", ":"), sort_keys=True, default=str)
+            if details else None
+        )
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO logs (ts_epoch, ts_iso, event_type, details)"
+                    " VALUES (?, ?, ?, ?)",
+                    (ts_epoch, ts_iso, str(event_type), details_json),
+                )
+                self._conn.commit()
+        except Exception:
+            logger.warning(
+                "AuditLog: failed to write %s event", event_type, exc_info=True
+            )
+
+    def query(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` rows, newest first, as plain dicts."""
+        if self._conn is None:
+            return []
+        try:
+            with self._lock:
+                cur = self._conn.execute(
+                    "SELECT id, ts_epoch, ts_iso, event_type, details"
+                    " FROM logs ORDER BY id DESC LIMIT ?",
+                    (int(limit),),
+                )
+                cols = [c[0] for c in cur.description]
+                return [dict(zip(cols, row)) for row in cur.fetchall()]
+        except Exception:
+            logger.warning("AuditLog: query failed", exc_info=True)
+            return []
+
+    def export_csv(self, dest_path: str | Path) -> int:
+        """Write the full log (oldest first) to ``dest_path`` as CSV.
+        Returns the number of data rows written."""
+        if self._conn is None:
+            return 0
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT ts_iso, ts_epoch, event_type, details"
+                " FROM logs ORDER BY id ASC"
+            ).fetchall()
+        with open(dest_path, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(_CSV_FIELDS)
+            w.writerows(rows)
+        return len(rows)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_log.py -p no:cacheprovider -q`
+Expected: PASS (8 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `python -m flake8 audit_log.py tests/test_audit_log.py`
+Expected: no output (clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add audit_log.py tests/test_audit_log.py
+git commit -m "feat: add append-only AuditLog store (audit_log.py)"
+```
+
+---
+
+## Task 2: Wire AuditLog into the connector (startup, system_info, shutdown)
+
+**Files:**
+- Modify: `motion_connector.py` (`__init__` ~line 829; `shutdown` ~line 1338)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_audit_connector.py`:
+
+```python
+"""Unit tests for audit-log instrumentation in MotionConnector."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None, app_config=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface,
+        app_config=app_config or {"developerMode": False},
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+
+
+def _types(c):
+    return [e["event_type"] for e in c.auditLogEntries()]
+
+
+def test_construct_logs_startup_and_system_info(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    t = _types(c)
+    assert "system_startup" in t
+    assert "system_info" in t
+
+
+def test_shutdown_logs_system_shutdown(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.shutdown()
+    assert "system_shutdown" in _types(c)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_construct_logs_startup_and_system_info -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: 'MotionConnector' object has no attribute 'auditLogEntries'` (slots added in Task 3) **or** `system_startup` not present. Either failure is acceptable for this step; both events are wired here and the slot in Task 3.
+
+> NOTE: This test depends on `auditLogEntries()` from Task 3. If executing strictly task-by-task, run this test at the end of Task 3. The implementation edits below (constructing `self._audit` + logging) belong to Task 2.
+
+- [ ] **Step 3: Construct AuditLog in `__init__`**
+
+In `motion_connector.py`, find this line in `__init__` (~line 829):
+
+```python
+        self._directory = resolved_dir
+```
+
+Insert immediately after it:
+
+```python
+
+        # ── Audit log: append-only, machine-readable event record in
+        #    scans.db, surfaced via the password-gated Logs modal. See
+        #    audit_log.py. No-op if the interface has no scan_db_path.
+        from audit_log import AuditLog, gather_host_info
+        self._audit = AuditLog(getattr(self._interface, "scan_db_path", None))
+        try:
+            from version import get_version as _get_app_version
+            _app_version = _get_app_version()
+        except Exception:
+            _app_version = ""
+        try:
+            _sdk_version = self._interface.get_sdk_version()
+            _sdk_version = _sdk_version if isinstance(_sdk_version, str) else ""
+        except Exception:
+            _sdk_version = ""
+        self._audit.log("system_startup", {
+            "app_version": _app_version,
+            "sdk_version": _sdk_version,
+            "data_dir": self._directory,
+        })
+        self._audit.log("system_info", gather_host_info())
+```
+
+- [ ] **Step 4: Log shutdown + close in `shutdown()`**
+
+Find `shutdown` (~line 1338):
+
+```python
+        logger.info("Shutting down MotionConnector...")
+        self.stopCapture()
+        logger.info("MotionConnector shutdown complete.")
+```
+
+Replace with:
+
+```python
+        logger.info("Shutting down MotionConnector...")
+        self.stopCapture()
+        try:
+            self._audit.log("system_shutdown", {"clean": True})
+            self._audit.close()
+        except Exception:
+            logger.warning("audit shutdown log failed", exc_info=True)
+        logger.info("MotionConnector shutdown complete.")
+```
+
+- [ ] **Step 5: (defer test run to end of Task 3)**
+
+`auditLogEntries()` does not exist yet. Proceed to Task 3, then run:
+Run: `python -m pytest tests/test_audit_connector.py -k "startup or shutdown" -p no:cacheprovider -q`
+Expected (after Task 3): PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: log system startup/info/shutdown to audit log"
+```
+
+---
+
+## Task 3: QML-facing slots (entries, record-viewed, export)
+
+**Files:**
+- Modify: `motion_connector.py` (add slots after `deleteScans`, ~line 1730)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_record_viewed_and_entries(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.recordAuditLogViewed()
+    assert "audit_log_viewed" in _types(c)
+
+
+def test_export_csv_writes_file_and_logs_export(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit.csv")
+    out = c.exportAuditLogCsv(dest)
+    assert out == dest
+    assert os.path.exists(dest)
+    assert "audit_log_exported" in _types(c)
+
+
+def test_export_csv_strips_file_url(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit2.csv")
+    out = c.exportAuditLogCsv("file:///" + dest.replace("\\", "/"))
+    assert os.path.exists(out)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_record_viewed_and_entries -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: ... has no attribute 'recordAuditLogViewed'`.
+
+- [ ] **Step 3: Add the slots**
+
+In `motion_connector.py`, find the end of `deleteScans` (the method starting ~line 1703). It ends with a block returning `deleted`. Locate the final `return deleted` of `deleteScans` and insert the following three slots immediately after that method (before the next `@pyqtSlot`/method):
+
+```python
+    # ── Audit log (QML-facing) ───────────────────────────────────────────
+    @pyqtSlot(result="QVariantList")
+    @pyqtSlot(int, result="QVariantList")
+    def auditLogEntries(self, limit: int = 500):
+        """Audit-log rows (newest first) for the Logs modal. Pure read —
+        does not itself log, so refreshing never double-logs."""
+        try:
+            return self._audit.query(int(limit))
+        except Exception:
+            logger.warning("auditLogEntries failed", exc_info=True)
+            return []
+
+    @pyqtSlot()
+    def recordAuditLogViewed(self):
+        """Record that the audit log was opened. Called once from
+        LogsModal.open()."""
+        try:
+            n = len(self._audit.query())
+        except Exception:
+            n = 0
+        self._audit.log("audit_log_viewed", {"entry_count": n})
+
+    @pyqtSlot(str, result=str)
+    def exportAuditLogCsv(self, dest_path: str) -> str:
+        """Export the full audit log to CSV. Accepts a plain path or a
+        file:// URL. Records an ``audit_log_exported`` event. Returns the
+        written path, or '' on failure."""
+        if not dest_path:
+            return ""
+        path = dest_path.replace("file:///", "").replace("file://", "")
+        try:
+            n = self._audit.export_csv(path)
+            self._audit.log("audit_log_exported", {"dest": path, "row_count": n})
+            logger.info("exportAuditLogCsv: wrote %d rows -> %s", n, path)
+            return path
+        except Exception:
+            logger.exception("exportAuditLogCsv failed for %r", path)
+            self.errorOccurred.emit("Audit log export failed.")
+            return ""
+```
+
+- [ ] **Step 4: Run Task 2 + Task 3 tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -p no:cacheprovider -q`
+Expected: PASS (all current tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `python -m flake8 motion_connector.py tests/test_audit_connector.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: add audit-log QML slots (entries, record-viewed, export)"
+```
+
+---
+
+## Task 4: Connect / disconnect + device_stats instrumentation
+
+**Files:**
+- Modify: `motion_connector.py` (`_on_handle_state_changed_impl` ~line 1215; add `_log_device_stats` helper)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_disconnect_logs_device_disconnected(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "left"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.CONNECTED, ConnectionState.DISCONNECTED,
+        "unplugged",
+    )
+    t = _types(c)
+    assert "device_disconnected" in t
+
+
+def test_connect_logs_device_connected_and_stats(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "console"
+    handle.get_hardware_id.return_value = "DEADBEEF"
+    handle.get_version.return_value = "1.0.0"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.DISCONNECTED, ConnectionState.CONNECTED,
+        "found",
+    )
+    t = _types(c)
+    assert "device_connected" in t
+    assert "device_stats" in t
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_disconnect_logs_device_disconnected -p no:cacheprovider -q`
+Expected: FAIL — `assert 'device_disconnected' in [...]` (event not logged yet).
+
+- [ ] **Step 3: Add the device-stats helper**
+
+In `motion_connector.py`, immediately before `def update_state(self):` (~line 1252), add:
+
+```python
+    def _log_device_stats(self, name: str) -> None:
+        """Best-effort audit of a device's hardware + firmware IDs on
+        connect. Missing values are logged as empty strings."""
+        handle = getattr(self._interface, name, None)
+        hwid = ""
+        fw = ""
+        try:
+            if handle is not None and hasattr(handle, "get_hardware_id"):
+                hwid = str(handle.get_hardware_id() or "")
+        except Exception:
+            pass
+        try:
+            if handle is not None and hasattr(handle, "get_version"):
+                fw = str(handle.get_version() or "")
+        except Exception:
+            pass
+        self._audit.log("device_stats", {
+            "device": name, "hardware_id": hwid, "firmware_version": fw,
+        })
+```
+
+- [ ] **Step 4: Instrument the connect/disconnect emit block**
+
+Find this block in `_on_handle_state_changed_impl` (~line 1215):
+
+```python
+        if is_now_connected:
+            logger.info("Handle %s -> CONNECTED (%s)", name, reason)
+            self.signalConnected.emit(name, "")
+        elif is_now_lost:
+            logger.info(
+                "Handle %s -> DISCONNECTED (%s) and state is %s",
+                name, reason, self._state,
+            )
+            self.signalDisconnected.emit(name, "")
+```
+
+Replace with:
+
+```python
+        if is_now_connected:
+            logger.info("Handle %s -> CONNECTED (%s)", name, reason)
+            self.signalConnected.emit(name, "")
+            self._audit.log("device_connected",
+                            {"device": name, "reason": str(reason)})
+            self._log_device_stats(name)
+        elif is_now_lost:
+            logger.info(
+                "Handle %s -> DISCONNECTED (%s) and state is %s",
+                name, reason, self._state,
+            )
+            self.signalDisconnected.emit(name, "")
+            self._audit.log("device_disconnected",
+                            {"device": name, "reason": str(reason)})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k "device or connect" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit device connect/disconnect + hw/fw stats"
+```
+
+---
+
+## Task 5: Calibration instrumentation (started / ended)
+
+**Files:**
+- Modify: `motion_connector.py` (`runCalibration` ~line 3724; `_on_calibration_complete` ~line 3982)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_run_calibration_logs_started(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._interface.start_calibration.return_value = True
+    c.runCalibration("left")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_started"]
+    assert ev
+    assert json.loads(ev[0]["details"])["target"] == "left"
+
+
+def test_calibration_complete_logs_ended(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._calibration_t0 = None
+    result = MagicMock()
+    result.canceled = False
+    result.ok = True
+    result.passed = True
+    result.csv_path = "cal.csv"
+    c._on_calibration_complete(result)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_ended"]
+    assert ev
+    assert json.loads(ev[0]["details"])["outcome"] == "passed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_run_calibration_logs_started -p no:cacheprovider -q`
+Expected: FAIL — no `calibration_started` event.
+
+- [ ] **Step 3: Instrument `runCalibration`**
+
+In `runCalibration`, find (~line 3721):
+
+```python
+        self._calibration_status = "running"
+        self.calibrationStateChanged.emit()
+        self.captureLog.emit("Calibration: starting…")
+        self._calibration_t0 = time.monotonic()
+```
+
+Replace with:
+
+```python
+        self._calibration_status = "running"
+        self._calibration_target = target
+        self.calibrationStateChanged.emit()
+        self.captureLog.emit("Calibration: starting…")
+        self._calibration_t0 = time.monotonic()
+        self._audit.log("calibration_started", {"target": target})
+```
+
+- [ ] **Step 4: Instrument `_on_calibration_complete`**
+
+In `_on_calibration_complete`, find the tail (~line 3979):
+
+```python
+        logger.info(
+            "=== Calibration ended: %s after %.1fs ===",
+            self._calibration_status, elapsed_s,
+        )
+        self.calibrationStateChanged.emit()
+```
+
+Replace with:
+
+```python
+        logger.info(
+            "=== Calibration ended: %s after %.1fs ===",
+            self._calibration_status, elapsed_s,
+        )
+        self._audit.log("calibration_ended", {
+            "target": getattr(self, "_calibration_target", None),
+            "outcome": self._calibration_status,
+            "reason": self._calibration_failure_reason or None,
+        })
+        self.calibrationStateChanged.emit()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k calibration -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit calibration start/end"
+```
+
+---
+
+## Task 6: Settings-changed instrumentation
+
+**Files:**
+- Modify: `motion_connector.py` (`setConfig` ~line 1785; `saveConfigs` ~line 1793)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_set_config_logs_settings_changed(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None      # don't touch the real config file
+    c.setConfig("plotWindowSec", 30)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[0]["details"])
+    assert d["changes"]["plotWindowSec"]["new"] == 30
+
+
+def test_save_configs_logs_only_changed_keys(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None
+    c._app_config["plotWindowSec"] = 15
+    c.saveConfigs({"plotWindowSec": 15, "bfiMax": 12.0})
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[-1]["details"])["changes"]
+    assert "bfiMax" in d            # changed
+    assert "plotWindowSec" not in d  # unchanged -> omitted
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_set_config_logs_settings_changed -p no:cacheprovider -q`
+Expected: FAIL — no `settings_changed` event.
+
+- [ ] **Step 3: Instrument `setConfig`**
+
+Find `setConfig` (~line 1785):
+
+```python
+    @pyqtSlot(str, 'QVariant')
+    def setConfig(self, key: str, value):
+        """Update a single config key, persist to disk, and notify QML."""
+        self._app_config[key] = value
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config set: {key} = {value!r}")
+```
+
+Replace with:
+
+```python
+    @pyqtSlot(str, 'QVariant')
+    def setConfig(self, key: str, value):
+        """Update a single config key, persist to disk, and notify QML."""
+        old = self._app_config.get(key)
+        self._app_config[key] = value
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config set: {key} = {value!r}")
+        if old != value:
+            self._audit.log("settings_changed",
+                            {"changes": {key: {"old": old, "new": value}}})
+```
+
+- [ ] **Step 4: Instrument `saveConfigs`**
+
+Find `saveConfigs` (~line 1793):
+
+```python
+    @pyqtSlot('QVariantMap')
+    def saveConfigs(self, configs: dict):
+        """Update multiple config keys at once, persist to disk, and notify QML."""
+        self._app_config.update(configs)
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
+```
+
+Replace with:
+
+```python
+    @pyqtSlot('QVariantMap')
+    def saveConfigs(self, configs: dict):
+        """Update multiple config keys at once, persist to disk, and notify QML."""
+        changes = {}
+        for k, v in configs.items():
+            old = self._app_config.get(k)
+            if old != v:
+                changes[k] = {"old": old, "new": v}
+        self._app_config.update(configs)
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
+        if changes:
+            self._audit.log("settings_changed", {"changes": changes})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k "config" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit settings changes (changed keys only)"
+```
+
+---
+
+## Task 7: Scan view + delete instrumentation
+
+**Files:**
+- Modify: `motion_connector.py` (`deleteScans` ~line 1703; `loadPastScan` ~line 1923)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_delete_scans_logs_scan_deleted(tmp_path):
+    from omotion.ScanDatabase import ScanDatabase
+    db_path = str(tmp_path / "scans.db")
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label="L1", session_start=1.0,
+                            session_meta={})
+    db.close()
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.deleteScans([sid])
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_deleted"]
+    assert ev
+    assert json.loads(ev[0]["details"])["count"] == 1
+
+
+def test_load_past_scan_logs_scan_viewed(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.loadPastScan("20260101_000000_owABC")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_viewed"]
+    assert ev
+    assert json.loads(ev[0]["details"])["label"] == "20260101_000000_owABC"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_delete_scans_logs_scan_deleted -p no:cacheprovider -q`
+Expected: FAIL — no `scan_deleted` event.
+
+- [ ] **Step 3: Instrument `deleteScans`**
+
+In `deleteScans`, find the final return (~line 1730, the method's last line). It looks like:
+
+```python
+        return deleted
+```
+
+Immediately before that `return deleted`, insert:
+
+```python
+        self._audit.log("scan_deleted", {
+            "session_ids": [int(s) for s in session_ids],
+            "count": deleted,
+        })
+```
+
+(There is exactly one `return deleted` in `deleteScans` — anchor on it within that method.)
+
+- [ ] **Step 4: Instrument `loadPastScan`**
+
+In `loadPastScan`, find this block (~line 1923):
+
+```python
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            logger.warning(
+                "loadPastScan: scan_db_path unavailable on interface"
+            )
+            self.pastScanLoadFinished.emit(session_label, False)
+            return
+```
+
+Immediately after that block (before the `# Per-cam corrected CSV` comment), insert:
+
+```python
+        self._audit.log("scan_viewed", {"label": session_label})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k "delete or past_scan" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+python -m flake8 motion_connector.py tests/test_audit_connector.py
+git add motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: audit scan view + delete"
+```
+
+---
+
+## Task 8: Scan start / end instrumentation (manual-verified)
+
+**Files:**
+- Modify: `motion_connector.py` (`startCapture` ~line 2231; nested `_on_pipeline_complete` ~line 2375)
+
+> **No unit test:** `scan_started` lives deep inside `startCapture` (after the live-source/laser kickoff path) and `scan_ended` lives inside the nested `_on_pipeline_complete` closure, which only runs when the SDK scan pipeline completes. Neither is callable in isolation without a full hardware scan, so these two events are verified manually in Task 10 (run a scan, inspect the `logs` table). This is a deliberate coverage gap, not an oversight.
+
+- [ ] **Step 1: Instrument `scan_started`**
+
+In `startCapture`, find (~line 2230):
+
+```python
+        self._capture_running = True
+        self._capture_start_time = time.time()
+```
+
+Insert immediately after:
+
+```python
+        self._audit.log("scan_started", {
+            "label": subject_id,
+            "left_mask": int(left_camera_mask),
+            "right_mask": int(right_camera_mask),
+            "session_id": None,
+        })
+```
+
+- [ ] **Step 2: Instrument `scan_ended`**
+
+In the nested `_on_pipeline_complete` closure, find (~line 2372):
+
+```python
+            self._capture_left_path = ""
+            self._capture_right_path = ""
+            self._capture_running = False
+            self._safety_cancel_scheduled = False
+            self._capture_thread = None
+            self.captureFinished.emit(True, "", "", "")
+```
+
+Replace with:
+
+```python
+            self._capture_left_path = ""
+            self._capture_right_path = ""
+            self._capture_running = False
+            self._safety_cancel_scheduled = False
+            self._capture_thread = None
+            try:
+                _outcome_kind = outcome.kind
+            except Exception:
+                _outcome_kind = None
+            try:
+                _dur = (time.time() - self._capture_start_time
+                        if self._capture_start_time else None)
+            except Exception:
+                _dur = None
+            self._audit.log("scan_ended", {
+                "label": subject_id,
+                "session_label": session_label or None,
+                "duration_s": round(_dur, 1) if _dur is not None else None,
+                "outcome": _outcome_kind,
+            })
+            self.captureFinished.emit(True, "", "", "")
+```
+
+(`subject_id` is the `startCapture` argument captured by the closure; `session_label` is assigned ~line 2342 in the same closure; `outcome` is assigned ~line 2351 and guarded above in case classification raised.)
+
+- [ ] **Step 3: Verify import + lint (no unit test here)**
+
+Run: `python -c "import motion_connector"`
+Expected: no error.
+Run: `python -m flake8 motion_connector.py`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add motion_connector.py
+git commit -m "feat: audit scan start/end"
+```
+
+---
+
+## Task 9: LogsModal + Settings button + BloodFlow wiring
+
+**Files:**
+- Create: `components/LogsModal.qml`
+- Modify: `components/SettingsModal.qml` (add signal + password modal + Audit Log card)
+- Modify: `pages/BloodFlow.qml` (add `LogsModal`, register in `ModalManager`, wire `onLogsRequested`)
+
+> **No automated test:** QML is not unit-tested in this repo (no hot reload; HIL tests require hardware). Verified visually in Task 10.
+
+- [ ] **Step 1: Create `components/LogsModal.qml`**
+
+```qml
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import QtQuick.Dialogs as Dialogs
+import OpenMotion 1.0
+
+// Audit-log viewer. Lists machine-readable audit entries (newest first)
+// and exports them as CSV. Opened from the password gate in SettingsModal.
+// Governed by ModalManager (see HistoryModal.qml for the modal contract).
+Item {
+    id: root
+    anchors.fill: parent
+    visible: false
+    z: 9998
+
+    AppTheme { id: theme }
+
+    readonly property string label: "Audit Log"
+    property var entries: []
+
+    function open() {
+        // Record the view first, then load (so the view event is included).
+        MotionInterface.recordAuditLogViewed()
+        refresh()
+        root.visible = true
+    }
+    function close() { root.visible = false }
+
+    function refresh() {
+        try { entries = MotionInterface.auditLogEntries(500) || [] }
+        catch (e) { entries = [] }
+    }
+
+    QtObject {
+        id: col
+        readonly property int time: 160
+        readonly property int event: 170
+    }
+
+    // ── backdrop ───────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000AA"
+        MouseArea { anchors.fill: parent; onClicked: root.close() }
+    }
+
+    Rectangle {
+        width: Math.min(parent.width - 60, 980)
+        height: Math.min(parent.height - 60, 700)
+        radius: 12
+        color: theme.bgContainer
+        border.color: theme.borderSubtle
+        border.width: 2
+        anchors.centerIn: parent
+
+        MouseArea { anchors.fill: parent }   // absorb clicks
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 18
+            spacing: 12
+
+            // ── toolbar ────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                Text {
+                    text: root.label
+                    font.pixelSize: 20; font.weight: Font.Bold
+                    color: theme.textPrimary
+                }
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Export CSV"
+                    Layout.preferredWidth: 110; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: {
+                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                                    + "/audit_log.csv"
+                        exportDialog.open()
+                    }
+                }
+                Button {
+                    text: "Refresh"
+                    Layout.preferredWidth: 80; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    onClicked: root.refresh()
+                }
+                Rectangle {
+                    width: 28; height: 28; radius: 14
+                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
+                    border.color: theme.borderHover; border.width: 1
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    MouseArea {
+                        id: xArea; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor; onClicked: root.close()
+                    }
+                }
+            }
+
+            // ── table header ───────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                color: theme.bgCardAlt; radius: 4
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                    spacing: 8
+                    Text { text: "Time"; Layout.preferredWidth: col.time
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Event"; Layout.preferredWidth: col.event
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                    Text { text: "Details"; Layout.fillWidth: true
+                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                }
+            }
+
+            // ── table body ─────────────────────────────────────────
+            Rectangle {
+                Layout.fillWidth: true; Layout.fillHeight: true
+                radius: 6; color: theme.bgCardAlt
+                border.color: theme.borderSubtle; border.width: 1
+                clip: true
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    model: root.entries
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Rectangle {
+                        width: ListView.view.width
+                        height: 30
+                        color: index % 2 === 0 ? "transparent" : Qt.rgba(1, 1, 1, 0.02)
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 8
+                            spacing: 8
+                            Text {
+                                Layout.preferredWidth: col.time
+                                text: modelData.ts_iso || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"; verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.preferredWidth: col.event
+                                text: modelData.event_type || ""
+                                color: theme.textPrimary; font.pixelSize: 12
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: modelData.details || ""
+                                color: theme.textSecondary; font.pixelSize: 12
+                                font.family: "Consolas"
+                                elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+
+                    Text {
+                        anchors.centerIn: parent
+                        visible: root.entries.length === 0
+                        text: "No audit entries yet."
+                        color: theme.textSecondary; font.pixelSize: 14
+                    }
+                }
+            }
+        }
+
+        Keys.onReleased: function(event) {
+            if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true }
+        }
+    }
+
+    Dialogs.FileDialog {
+        id: exportDialog
+        title: "Export Audit Log CSV"
+        fileMode: Dialogs.FileDialog.SaveFile
+        nameFilters: ["CSV files (*.csv)", "All files (*)"]
+        onAccepted: {
+            var path = selectedFile.toString().replace("file:///", "")
+            var ok = MotionInterface.exportAuditLogCsv(path)
+            if (ok) {
+                MotionInterface.notify("Audit log exported to " + ok, "success")
+                root.refresh()   // pick up the audit_log_exported entry
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the signal + password modal + Audit Log card to `SettingsModal.qml`**
+
+In `components/SettingsModal.qml`, find the existing calibration password modal (~line 56):
+
+```qml
+    // Password gate for the Calibrate action.
+    PasswordPromptModal {
+        id: calibrationPasswordModal
+        title: "Calibration"
+        description: "Enter the password to start calibration."
+        confirmLabel: "Calibrate"
+        onAccepted: MotionInterface.runCalibration(
+            calibrationTargetCombo.currentText.toLowerCase()
+        )
+    }
+```
+
+Immediately after that block, add:
+
+```qml
+    // Emitted when the user enters the correct password for the audit log.
+    // BloodFlow.qml opens the (ModalManager-governed) LogsModal in response.
+    signal logsRequested()
+
+    // Password gate for the audit Logs viewer.
+    PasswordPromptModal {
+        id: logsPasswordModal
+        title: "Audit Log"
+        description: "Enter the password to view the audit log."
+        confirmLabel: "View Logs"
+        onAccepted: root.logsRequested()
+    }
+```
+
+Then find the end of the **Appearance** `SectionCard` (the closing `}` right before the `// ── Developer ──` comment, ~line 757) and insert a new card between Appearance and Developer:
+
+```qml
+                // ── Audit Log ────────────────────────────────────────────────
+                SectionCard {
+                    title: "Audit Log"
+
+                    FieldRow {
+                        label: "Logs"
+                        ActionButton {
+                            text: "View Logs"
+                            Layout.preferredWidth: 130
+                            onClicked: logsPasswordModal.open()
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    Text {
+                        text: "Password-protected, machine-readable record of system "
+                              + "events for auditors. Open the viewer to browse entries "
+                              + "or export them as CSV."
+                        color: root.colTextMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                }
+```
+
+- [ ] **Step 3: Add `LogsModal` + wiring to `BloodFlow.qml`**
+
+In `pages/BloodFlow.qml`, find the `SettingsModal` block (~line 333):
+
+```qml
+    SettingsModal {
+        id: settingsModal
+    }
+```
+
+Replace with:
+
+```qml
+    SettingsModal {
+        id: settingsModal
+        // Audit Log: the password gate lives in SettingsModal; on success
+        // close Settings and open the ModalManager-governed LogsModal.
+        onLogsRequested: {
+            settingsModal.close()
+            modalManager.toggle(logsModal)
+        }
+    }
+
+    LogsModal {
+        id: logsModal
+    }
+```
+
+Then find the `ModalManager` modals list (~line 231):
+
+```qml
+        modals: [scanSettingsModal, notesModal, historyModal,
+                 settingsModal, contactQualityModal]
+```
+
+Replace with:
+
+```qml
+        modals: [scanSettingsModal, notesModal, historyModal,
+                 settingsModal, contactQualityModal, logsModal]
+```
+
+- [ ] **Step 4: Smoke-check QML parses**
+
+Run: `python -c "import main"`
+Expected: no error (imports only; does not launch the app).
+
+> Full visual verification happens in Task 10.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/LogsModal.qml components/SettingsModal.qml pages/BloodFlow.qml
+git commit -m "feat: add password-gated Logs modal with CSV export"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit-test set for this feature**
+
+Run: `python -m pytest tests/test_audit_log.py tests/test_audit_connector.py tests/test_developer_password.py -p no:cacheprovider -q`
+Expected: all PASS.
+
+- [ ] **Step 2: Lint everything touched**
+
+Run: `python -m flake8 audit_log.py motion_connector.py tests/test_audit_log.py tests/test_audit_connector.py`
+Expected: clean.
+
+- [ ] **Step 3: Visual + behavioral check (hardware-optional)**
+
+Launch the app from source (see memory: use the conda python, not background Bash; `dataDirectory` null → DB lands in cwd):
+
+```
+python main.py
+```
+
+Verify:
+1. Open **Settings** → an **Audit Log** card with a **View Logs** button is visible (even with `developerMode: false`).
+2. Click **View Logs** → password prompt appears. Wrong password → "Incorrect password". Correct password (`OpenwaterHealth`) → LogsModal opens.
+3. The list already contains `system_startup` and `system_info` rows (newest first), plus an `audit_log_viewed` row for opening it.
+4. Change a setting (e.g. time window) and reopen the log → a `settings_changed` row appears with the changed key.
+5. Click **Export CSV**, save, and open the file → header `ts_iso,ts_epoch,event_type,details` with one row per event.
+6. (If hardware attached) connect/disconnect a device, run a scan, run a calibration → `device_connected`/`device_stats`, `scan_started`/`scan_ended`, `calibration_started`/`calibration_ended` rows appear. This is the verification path for the Task 8 scan events that have no unit test.
+
+Inspect the table directly if needed:
+
+```
+python -c "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); [print(r) for r in c.execute('SELECT ts_iso,event_type,details FROM logs ORDER BY id DESC LIMIT 20')]" <dataDirectory>\scans.db
+```
+
+- [ ] **Step 4: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "test: verify audit-log feature end to end"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- system_startup/info/shutdown → Task 2 ✓
+- device connect/disconnect + hw/fw stats → Task 4 ✓
+- scan start/end → Task 8 ✓
+- calibration start/end → Task 5 ✓
+- settings changes (diff) → Task 6 ✓
+- scan view + delete → Task 7 ✓
+- audit_log_viewed + exported → Tasks 3 (slots) + 9 (UI) ✓
+- typed-event + JSON details schema, app-side `logs` table in scans.db, fail-soft, thread-safe → Task 1 ✓
+- password-gated Logs button (reused developer password) + CSV export → Task 9 ✓
+
+**Placeholder scan:** none (all steps contain concrete code/commands).
+
+**Type/name consistency:** `self._audit` (AuditLog), `auditLogEntries`/`recordAuditLogViewed`/`exportAuditLogCsv` slots, `logsRequested()` signal, `logsModal` id, event-type strings, and CSV field order are consistent across Tasks 1, 3, 9.
+
+**Known coverage gap (intentional, not silent):** Task 8 (`scan_started`/`scan_ended`) has no unit test — both sites are unreachable without a full hardware scan; verified manually in Task 10 Step 3.6.

--- a/docs/superpowers/plans/2026-06-15-history-data-management.md
+++ b/docs/superpowers/plans/2026-06-15-history-data-management.md
@@ -1,3 +1,399 @@
+# History Data-Management Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the History modal into a sortable, searchable, multi-select table of scans driven entirely by the scan DB, with Load / Export / password-gated Delete.
+
+**Architecture:** New DB-only connector slots (`get_scan_sessions`, `get_session_stats`, `deleteScans`) read the `sessions` table and the `session_meta` JSON the SDK already writes; the camera-config name mapping is computed in Python so it's unit-testable. `HistoryModal.qml` is rebuilt around a header + `ListView` table with multiselect checkboxes, a read-only detail pane, and actions; Delete reuses the existing `PasswordPromptModal` (developer password). No SDK changes.
+
+**Tech Stack:** Python 3.13, PyQt6, QML (QtQuick 6), pytest, SQLite (omotion `ScanDatabase`).
+
+**Spec:** [docs/superpowers/specs/2026-06-15-history-data-management-design.md](../specs/2026-06-15-history-data-management-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `motion_connector.py` — add module-level `_CONFIG_NAMES` + `_config_name()`, and three `@pyqtSlot`s + one private `_session_to_row()` helper, inserted right after `get_scan_details` (ends ~line 1559, before the `directory` property at ~1561). The existing `get_scan_list` / `get_scan_details` stay (still used by `loadPastScan` and `test_scan_history_list.py`).
+- **Create** `tests/test_history_sessions.py` — unit tests (no hardware) for the three new slots + the config-name helper.
+- **Rewrite** `components/HistoryModal.qml` — table UI. Same root contract (`label`, `open()`, `close()`, `visible`, busy overlay, `MotionInterface` `Connections`) so `ModalManager` and `BloodFlow.qml` need no changes.
+- **Modify** `tests/test_history.py` — HIL (`@pytest.mark.dev`) UI test; update for the new table (no ComboBox; "Load in viewer →" button). **Cannot be validated in this environment — requires the self-hosted hardware runner.**
+
+---
+
+## Task 1: Connector — `get_scan_sessions()` + config-name helper
+
+**Files:**
+- Modify: `motion_connector.py` (module-level helper near other module helpers ~line 75; `_session_to_row` + `get_scan_sessions` after `get_scan_details` ~line 1559)
+- Test: `tests/test_history_sessions.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_history_sessions.py`:
+
+```python
+"""History data-management connector slots — DB-only, no hardware."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector, _config_name
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _make_session(db_path, label, start, end, left_mask, right_mask,
+                  reduced=True, notes=None, subject=None, operator="ethan"):
+    # Default the subject_id to the label's trailing user-label segment so
+    # rows carry distinct userLabels (matches how scans are really named).
+    if subject is None:
+        parts = label.split("_", 2)
+        subject = parts[2] if len(parts) > 2 else ""
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(
+        session_label=label, session_start=start, session_end=end,
+        session_notes=notes,
+        session_meta={
+            "scan_id": label.rsplit("_", 1)[0], "subject_id": subject,
+            "operator": operator, "duration_sec": (end - start) if end else 0,
+            "sdk_flags": {
+                "reduced_mode": reduced,
+                "left_camera_mask": left_mask,
+                "right_camera_mask": right_mask,
+            },
+        },
+    )
+    db.close()
+    return sid
+
+
+def test_config_name_known_and_unknown():
+    assert _config_name(0x5A) == "Near"
+    assert _config_name(0xC3) == "Far"
+    assert _config_name(0x00) == "None"
+    assert _config_name(0x12) == "0x12"   # unmapped -> hex
+    assert _config_name(-1) == "—"        # unknown
+
+
+def test_get_scan_sessions_rows_and_sort(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _make_session(db_path, "20260612_093100_subjB", 200.0, 215.0, 0x5A, 0x66)
+    c = _connector(tmp_path, db_path)
+
+    rows = c.get_scan_sessions()
+    assert [r["userLabel"] for r in rows] == ["subjB", "subjA"]  # newest first
+    top = rows[0]
+    assert top["configL"] == "Near" and top["configR"] == "Middle"
+    assert top["durationSec"] == 15.0
+    assert top["leftMask"] == 0x5A and top["rightMask"] == 0x66
+    assert top["interrupted"] is False
+    assert top["dateTime"] == "2026-06-12 09:31:00"
+
+
+def test_get_scan_sessions_interrupted_open_session(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_100000_subjC", 300.0, None, 0xFF, 0xFF)
+    c = _connector(tmp_path, db_path)
+    row = c.get_scan_sessions()[0]
+    assert row["interrupted"] is True
+    assert row["durationSec"] == -1.0
+
+
+def test_get_scan_sessions_empty_without_db(tmp_path):
+    c = _connector(tmp_path, None)
+    assert c.get_scan_sessions() == []
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/test_history_sessions.py -v`
+Expected: FAIL — `ImportError: cannot import name '_config_name'` / `AttributeError: ... 'get_scan_sessions'`.
+
+- [ ] **Step 3: Add the module-level config-name helper**
+
+In `motion_connector.py`, just after the `developer_password_matches` function (~line 90, module scope — NOT inside the class), add:
+
+```python
+# Camera-mask → human config name, mirroring CameraSelectionModal's
+# pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
+# reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.
+_CONFIG_NAMES = {
+    0x00: "None", 0x5A: "Near", 0x66: "Middle", 0xC3: "Far",
+    0x99: "Outer", 0x0F: "Left", 0xF0: "Right", 0x42: "Third Row",
+    0xFF: "All",
+}
+
+
+def _config_name(mask) -> str:
+    if mask is None or mask < 0:
+        return "—"
+    m = int(mask) & 0xFF
+    return _CONFIG_NAMES.get(m, f"0x{m:02X}")
+```
+
+- [ ] **Step 4: Add `_session_to_row` + `get_scan_sessions`**
+
+In `motion_connector.py`, immediately after `get_scan_details` returns (~line 1559, before `@pyqtProperty(str, notify=directoryChanged) def directory`), add:
+
+```python
+    @staticmethod
+    def _friendly_ts(ts: str) -> str:
+        """'YYYYMMDD_HHMMSS' -> 'YYYY-MM-DD HH:MM:SS'; pass through otherwise."""
+        if not ts or len(ts) != 15:
+            return ts or "-"
+        return (f"{ts[0:4]}-{ts[4:6]}-{ts[6:8]} "
+                f"{ts[9:11]}:{ts[11:13]}:{ts[13:15]}")
+
+    def _session_to_row(self, s: dict) -> dict:
+        """Flatten one ScanDatabase session dict into the QVariantMap the
+        History table consumes. Masks/operator come from session_meta
+        (written by ScanDBSink); duration from session_start/end."""
+        label = (s.get("session_label") or "").strip()
+        meta = s.get("session_meta")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except Exception:
+                meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        flags = meta.get("sdk_flags") or {}
+
+        left_mask = flags.get("left_camera_mask", -1)
+        right_mask = flags.get("right_camera_mask", -1)
+        if left_mask is None:
+            left_mask = -1
+        if right_mask is None:
+            right_mask = -1
+
+        user_label = meta.get("subject_id") or ""
+        timestamp = ""
+        m = re.match(r"^(\d{8}_\d{6})_?(.*)$", label)
+        if m:
+            timestamp = m.group(1)
+            if not user_label:
+                user_label = m.group(2)
+
+        start = s.get("session_start")
+        end = s.get("session_end")
+        if start is not None and end is not None:
+            duration = float(end) - float(start)
+        else:
+            duration = -1.0
+
+        return {
+            "sessionId": int(s.get("id")),
+            "label": label,
+            "userLabel": user_label,
+            "operator": meta.get("operator") or "",
+            "timestamp": timestamp or label,
+            "dateTime": self._friendly_ts(timestamp),
+            "durationSec": duration,
+            "leftMask": int(left_mask),
+            "rightMask": int(right_mask),
+            "configL": _config_name(left_mask),
+            "configR": _config_name(right_mask),
+            "reducedMode": bool(flags.get("reduced_mode", False)),
+            "notes": s.get("session_notes") or "",
+            "interrupted": end is None,
+        }
+
+    @pyqtSlot(result="QVariantList")
+    def get_scan_sessions(self):
+        """Return one row per scan-DB session, newest first, for the
+        History table. DB-only — does not list CSV-derived scans.
+        Best-effort: a missing/unreadable DB yields []."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return []
+        rows = []
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for s in db.iter_sessions():
+                    rows.append(self._session_to_row(s))
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("get_scan_sessions: could not read scan DB",
+                           exc_info=True)
+            return []
+        rows.sort(key=lambda r: r["timestamp"], reverse=True)
+        return rows
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_history_sessions.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add motion_connector.py tests/test_history_sessions.py
+git commit -m "feat: add get_scan_sessions connector slot for History table"
+```
+
+---
+
+## Task 2: Connector — `get_session_stats()` + `deleteScans()`
+
+**Files:**
+- Modify: `motion_connector.py` (directly after `get_scan_sessions`)
+- Test: `tests/test_history_sessions.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_history_sessions.py`:
+
+```python
+def _insert_rows(db_path, session_id, n):
+    db = ScanDatabase(db_path=db_path)
+    for i in range(n):
+        db.insert_session_data(
+            session_id=session_id, cam_id=0, side=0,
+            timestamp_s=float(i), frame_id=i, bfi=1.0, bvi=2.0,
+        )
+    db.close()
+
+
+def test_get_session_stats_counts_rows(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sid = _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _insert_rows(db_path, sid, 7)
+    c = _connector(tmp_path, db_path)
+    assert c.get_session_stats(sid)["sampleCount"] == 7
+
+
+def test_delete_scans_removes_session_and_cascades(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    keep = _make_session(db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    drop = _make_session(db_path, "20260612_093000_drop", 200.0, 205.0, 0x5A, 0x5A)
+    _insert_rows(db_path, drop, 5)
+    c = _connector(tmp_path, db_path)
+
+    removed = c.deleteScans([drop])
+    assert removed == 1
+    remaining = [r["sessionId"] for r in c.get_scan_sessions()]
+    assert remaining == [keep]
+    # session_data cascade-deleted with the session
+    assert c.get_session_stats(drop)["sampleCount"] == 0
+
+
+def test_delete_scans_empty_list_is_noop(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    c = _connector(tmp_path, db_path)
+    assert c.deleteScans([]) == 0
+    assert len(c.get_scan_sessions()) == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/test_history_sessions.py -k "stats or delete" -v`
+Expected: FAIL — `AttributeError: ... 'get_session_stats'` / `'deleteScans'`.
+
+- [ ] **Step 3: Add the two slots**
+
+In `motion_connector.py`, immediately after `get_scan_sessions`, add:
+
+```python
+    @pyqtSlot(int, result="QVariantMap")
+    def get_session_stats(self, session_id: int):
+        """Lazily fetch heavier per-scan stats (row count) when a History
+        row is focused, so the list query itself stays cheap."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return {"sampleCount": 0}
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                row = next(
+                    db._connection().execute(
+                        "SELECT COUNT(*) FROM session_data WHERE session_id = ?",
+                        (int(session_id),),
+                    ),
+                    None,
+                )
+                return {"sampleCount": int(row[0]) if row else 0}
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("get_session_stats failed for %s", session_id,
+                           exc_info=True)
+            return {"sampleCount": 0}
+
+    @pyqtSlot("QVariantList", result=int)
+    def deleteScans(self, session_ids):
+        """Delete the given scan-DB sessions (CASCADE removes their
+        session_data). Returns the count actually deleted. The developer-
+        password gate is enforced in QML before this is called."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return 0
+        deleted = 0
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for sid in session_ids:
+                    try:
+                        if db.delete_session(int(sid)):
+                            deleted += 1
+                            logger.info("deleteScans: removed session %s", sid)
+                    except Exception:
+                        logger.warning("deleteScans: failed to delete %s", sid,
+                                       exc_info=True)
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("deleteScans: could not open scan DB", exc_info=True)
+        return deleted
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_history_sessions.py -v`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_history_sessions.py
+git commit -m "feat: add get_session_stats and deleteScans connector slots"
+```
+
+---
+
+## Task 3: Rewrite `HistoryModal.qml` as a table
+
+QML can't be unit-tested; verify by launching the app against a seeded DB and screenshotting (per the project's "QML changes need a visual check" rule). The root contract (`label`, `open()`, `close()`, busy overlay, `Connections`) is preserved so `BloodFlow.qml` / `ModalManager` are untouched.
+
+**Files:**
+- Rewrite: `components/HistoryModal.qml`
+
+- [ ] **Step 1: Replace the file contents**
+
+Overwrite `components/HistoryModal.qml` with:
+
+```qml
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
@@ -55,13 +451,7 @@ Item {
     function rebuildView() {
         var q = (searchText || "").toLowerCase()
         var cfg = configFilter
-        // In reduced (clinical) mode, omit scans not shot in reduced mode —
-        // the reduced viewer can't render their per-camera data. Dev mode
-        // lists everything. A scan with no recorded mode counts as non-reduced.
-        var appReduced = MotionInterface.appConfig.reducedMode === true
         var arr = scans.filter(function(r) {
-            if (appReduced && !r.reducedMode)
-                return false
             if (q.length > 0
                 && (r.userLabel || "").toLowerCase().indexOf(q) < 0
                 && (r.label || "").toLowerCase().indexOf(q) < 0)
@@ -133,14 +523,6 @@ Item {
         var m = Math.floor(sec / 60)
         var s = Math.round(sec % 60)
         return m + ":" + (s < 10 ? "0" + s : s)
-    }
-
-    // Format an 8-bit mask as "0xNN", or "—" when unknown (< 0). Keeps the
-    // detail pane consistent with the Config cell, which also shows "—" for
-    // an unknown mask (a -1 rendered as 0xFF would misread as "All").
-    function maskLabel(m) {
-        if (m === undefined || m === null || m < 0) return "—"
-        return "0x" + (m & 0xFF).toString(16).toUpperCase()
     }
 
     // Re-filter whenever the search/config filter changes.
@@ -434,8 +816,8 @@ Item {
                         Text {
                             color: theme.textPrimary; font.pixelSize: 12
                             text: root.focusedRow
-                                  ? (root.maskLabel(root.focusedRow.leftMask)
-                                     + " / " + root.maskLabel(root.focusedRow.rightMask))
+                                  ? ("0x" + (root.focusedRow.leftMask & 0xFF).toString(16).toUpperCase()
+                                     + " / 0x" + (root.focusedRow.rightMask & 0xFF).toString(16).toUpperCase())
                                   : ""
                         }
                         Text { text: "Config (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
@@ -587,9 +969,6 @@ Item {
             if (ok) root.close()
         }
         function onDirectoryChanged() { if (root.visible) root.refresh() }
-        // Re-apply the reduced-mode row filter if the app's mode changes
-        // while History is open.
-        function onAppConfigChanged() { if (root.visible) root.rebuildView() }
         function onErrorOccurred(msg) {
             root.loadingPlot = false
             histErrDialog.text = msg || "Unknown error."
@@ -597,3 +976,246 @@ Item {
         }
     }
 }
+```
+
+- [ ] **Step 2: Create the sortable header-cell component**
+
+The header uses a small reusable cell. It takes its sort state via properties
+and reports clicks via a signal — a child `.qml` component has its own id
+scope and **cannot** see the `root` id defined in `HistoryModal.qml`, so all
+coupling goes through the public interface. Create `components/HistoryHeaderCell.qml`:
+
+```qml
+import QtQuick 6.0
+import QtQuick.Layouts 6.0
+
+// One clickable, sort-aware column header in the History table.
+Item {
+    id: cell
+    property string text: ""
+    property string sortName: ""
+    property string activeSort: ""   // the table's current sort key
+    property bool ascending: false
+    signal sortRequested(string name)
+
+    Layout.preferredHeight: 30
+
+    AppTheme { id: theme }
+
+    Row {
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 4
+        Text {
+            text: cell.text
+            color: theme.textSecondary
+            font.pixelSize: 12; font.weight: Font.DemiBold
+        }
+        Text {
+            visible: cell.activeSort === cell.sortName
+            text: cell.ascending ? "▲" : "▼"
+            color: theme.textSecondary; font.pixelSize: 9
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        onClicked: cell.sortRequested(cell.sortName)
+    }
+}
+```
+
+- [ ] **Step 3: Sanity-check the QML parses on launch**
+
+The Delete guard binds `MotionInterface.state !== 4` — confirmed valid: `state` is a `pyqtProperty(int, notify=stateChanged)` at `motion_connector.py:1055`, and `4 == RUNNING` per the state machine at `motion_connector.py:72`. No code change here; the parse check happens implicitly when the app launches in Step 5 (a QML syntax error aborts startup and prints the offending line to the console — watch for it).
+
+- [ ] **Step 4: Seed a scan DB for visual verification**
+
+The app needs a `scans.db` with sessions to show anything. Create one in the app's data directory (`dataDirectory` in `config/app_config.json`; default `C:\Users\ethan\Projects\scan_data`). Run:
+
+```bash
+python -c "
+from omotion.ScanDatabase import ScanDatabase
+import time
+db = ScanDatabase(db_path=r'C:\Users\ethan\Projects\scan_data\scans.db')
+def mk(label, dt, lm, rm, dur, notes):
+    sid = db.create_session(session_label=label, session_start=time.time(),
+        session_end=time.time()+dur, session_notes=notes,
+        session_meta={'scan_id':label.rsplit('_',1)[0],'subject_id':label.split('_',2)[2],
+            'operator':'ethan','duration_sec':dur,
+            'sdk_flags':{'reduced_mode':True,'left_camera_mask':lm,'right_camera_mask':rm}})
+    for i in range(50):
+        db.insert_session_data(session_id=sid,cam_id=0,side=0,timestamp_s=float(i),frame_id=i,bfi=1.0,bvi=2.0)
+mk('20260615_093100_Patient14', None, 0x5A, 0x5A, 15, 'Resting baseline. 00:08 subject moved.')
+mk('20260615_092000_Patient14', None, 0xC3, 0xC3, 5, 'Far config check.')
+mk('20260614_164000_BaselineA', None, 0x66, 0x66, 15, 'Middle row.')
+db.close(); print('seeded')
+"
+```
+
+Expected: `seeded`.
+
+- [ ] **Step 5: Launch the app and screenshot the History modal**
+
+Run `python main.py`, click the **History** sidebar panel, then capture the window (per the project's visual-check rule — PrintWindow flag 2). From a second terminal:
+
+```bash
+python -c "
+import win32gui, win32ui, win32con
+from ctypes import windll
+h = win32gui.FindWindow(None, 'OpenWater Bloodflow')
+l,t,r,b = win32gui.GetWindowRect(h); w,ht=r-l,b-t
+dc = win32gui.GetWindowDC(h); mdc = win32ui.CreateDCFromHandle(dc); sdc = mdc.CreateCompatibleDC()
+bmp = win32ui.CreateBitmap(); bmp.CreateCompatibleBitmap(mdc,w,ht); sdc.SelectObject(bmp)
+windll.user32.PrintWindow(h, sdc.GetSafeHdc(), 2)
+bmp.SaveBitmapFile(sdc, 'history_check.bmp'); print('saved history_check.bmp')
+"
+```
+
+Verify in `history_check.bmp`: three rows; columns User Label / Date-Time / Config (L/R, e.g. "Near / Near") / Duration ("0:15") / status dot; clicking a row fills the detail pane (label, operator, masks, config, samples ~50, notes); clicking a checkbox shows "N selected" and enables Delete; sorting by a header reorders rows; the search box filters. Confirm Load opens the viewer and Delete pops the password prompt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/HistoryModal.qml components/HistoryHeaderCell.qml
+git commit -m "feat: rework History into a sortable multiselect data table"
+```
+
+---
+
+## Task 4: Update the HIL History UI test
+
+`tests/test_history.py` is `@pytest.mark.dev` and drives the real UI with pyautogui/UIA. The old version keys off the ComboBox and the "View in plot →" button, both gone. **This task cannot be validated in this environment — it runs on the self-hosted hardware runner.** Make the edits, eyeball them for correctness, and flag for runner validation.
+
+**Files:**
+- Modify: `tests/test_history.py`
+
+- [ ] **Step 1: Replace the open-detection + seed-skip helpers**
+
+The seed fixture uses `selected_scan_text()` (ComboBox) to decide whether to skip, and `_is_history_open()` detects the modal via a ComboBox. The new modal has neither. Replace both with a text scan for the modal title.
+
+In `tests/test_history.py`, replace the `_is_history_open` function (lines ~246–255) with:
+
+```python
+def _history_text_present(needle: str) -> bool:
+    """True iff any UIA element under the app window shows ``needle``."""
+    try:
+        win = uia_window()
+        for elem in win.descendants():
+            try:
+                if needle.lower() in (elem.window_text() or "").lower():
+                    return True
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return False
+
+
+def _is_history_open() -> bool:
+    """The History modal is up iff its 'Scan History' title is visible."""
+    return _history_text_present("Scan History")
+```
+
+- [ ] **Step 2: Fix the seed fixture's skip probe**
+
+In `_seed_with_short_scan` (the `try` block ~lines 198–211), replace the `selected_scan_text()` skip check with a row-presence check. Change:
+
+```python
+        click_panel("History")
+        time.sleep(SLEEP)
+        if selected_scan_text():
+            log.info("Skipping seed scan — History already has entries")
+```
+
+to:
+
+```python
+        click_panel("History")
+        time.sleep(SLEEP)
+        # A populated table shows the column header; an empty one shows
+        # "No scans yet." Either way the modal is open here.
+        if _history_text_present("User Label") and not _history_text_present("No scans yet"):
+            log.info("Skipping seed scan — History already has entries")
+```
+
+- [ ] **Step 3: Rewrite `test_02` to assert a table row, not a ComboBox**
+
+Replace `test_02_latest_scan_listed` (lines ~283–302) with:
+
+```python
+    def test_02_latest_scan_listed(self, app):
+        _ensure_history_open()
+        # Poll up to 5 s for the table to populate (the seed scan was
+        # Middle/Middle, so its config cell reads "Middle / Middle").
+        deadline = time.time() + 5.0
+        found = False
+        while time.time() < deadline:
+            if _history_text_present("Middle") or not _history_text_present("No scans yet"):
+                found = True
+                break
+            time.sleep(0.3)
+        assert found, (
+            "History table is empty after 5 s — no scans found. Run a "
+            "scan first, or the History modal failed to open."
+        )
+```
+
+- [ ] **Step 4: Rewrite `test_03` to focus a row then Load**
+
+The Load button needs a focused row first. Replace `test_03_view_in_plot` (lines ~304–307) with:
+
+```python
+    def test_03_view_in_plot(self, app):
+        """Focus the first row, then 'Load in viewer →' loads it into the
+        embedded PlotViewer."""
+        # Click the first data row to focus it (just below the header).
+        win = uia_window()
+        rows = [e for e in win.descendants(control_type="Text")
+                if "Middle" in (e.window_text() or "")]
+        if rows:
+            click_element_center(rows[0], "first history row")
+            time.sleep(SLEEP)
+        click_by_name("Load in viewer →")
+        time.sleep(SLEEP)
+```
+
+- [ ] **Step 5: Verify no remaining references to the removed ComboBox helpers**
+
+Run: `python -c "s=open('tests/test_history.py',encoding='utf-8').read(); assert 'selected_scan_text' not in s, 'still references selected_scan_text'; assert 'View in plot' not in s, 'still references old button'; print('clean')"`
+Expected: `clean`. (`read_combobox_values` is still used by the seed `_select_sensor` flow for Scan Settings — that's a different ComboBox and stays.)
+
+- [ ] **Step 6: Byte-compile the test to catch syntax errors**
+
+Run: `python -m py_compile tests/test_history.py`
+Expected: no output (exit 0). Full execution requires the hardware runner — note that in the commit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_history.py
+git commit -m "test: update HIL History test for the new table UI (runner-validate)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the unit suite for the new slots: `python -m pytest tests/test_history_sessions.py -v` → all PASS.
+- [ ] Run the kept listing test to confirm no regression: `python -m pytest tests/test_scan_history_list.py -v` → all PASS.
+- [ ] Lint the touched Python: `python -m flake8 motion_connector.py tests/test_history_sessions.py` → no errors.
+- [ ] Confirm the visual check from Task 3 Step 5 looked correct (table, detail pane, multiselect, sort, delete prompt).
+- [ ] `tests/test_history.py` edited and byte-compiles; flagged for hardware-runner validation.
+
+## Spec coverage check
+
+- Modal container, DB-only source → Task 1/3. ✓
+- Columns User Label / Date-Time / Config (L/R) / Duration / status → Task 3 delegate. ✓
+- Sortable headers, search, config filter → Task 3 (`setSort`, `rebuildView`, toolbar). ✓
+- Multiselect + select-all → Task 3 (`checked`, `setAllChecked`). ✓
+- Read-only detail pane w/ notes + lazy sample count → Task 3 + `get_session_stats` (Task 2). ✓
+- Load (single, reuse `loadPastScan`) / Export (reuse `exportScanCsv`) → Task 3. ✓
+- Password-gated delete via `PasswordPromptModal` → `deleteScans` (Task 2) + Task 3. ✓
+- Delete disabled while RUNNING; interrupted rows block Load/Export → Task 3. ✓
+- Config name mapping unit-tested → Task 1 (`_config_name`). ✓
+- No SDK changes. ✓

--- a/docs/superpowers/plans/2026-06-15-replay-mode-awareness.md
+++ b/docs/superpowers/plans/2026-06-15-replay-mode-awareness.md
@@ -1,0 +1,369 @@
+# Replay Mode Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make past-scan replay render in the mode the scan was recorded in (Part A), and hide non-reduced scans from History while the app is in reduced mode (Part B).
+
+**Architecture:** A tri-state `reducedMode` indicator on `ScanDataSource` (derived from the loaded buffer layout on `PastScanSource`, `-1` on live), an `effectiveReduced` resolve in `PlotViewer.qml` that prefers the source's mode over the live config (mirrors the #175 mask resolve), and one filter condition in `HistoryModal.rebuildView()` keyed on the `reducedMode` field already present in each scan row.
+
+**Tech Stack:** Python 3.13, PyQt6, QML (QtQuick 6), pytest.
+
+**Spec:** [docs/superpowers/specs/2026-06-15-replay-mode-awareness-design.md](../specs/2026-06-15-replay-mode-awareness-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `data_sources.py` — add module helper `_derive_reduced_from_buffers()`, a `reducedMode` `pyqtProperty(int)` on `ScanDataSource` (backing field `self._reduced_mode`, default `-1`), and set it in `PastScanSource.__init__`.
+- **Modify** `tests/test_data_sources.py` — append unit tests next to the existing #175 mask tests (~line 668).
+- **Modify** `components/PlotViewer.qml` — add `effectiveReduced` computed property; swap the viewer's internal `reducedMode` reads over to it.
+- **Modify** `components/HistoryModal.qml` — add the reduced-mode filter in `rebuildView()` + re-filter on `appConfigChanged`.
+
+No connector changes, no `BloodFlow.qml` changes.
+
+---
+
+## Task 1: `data_sources.py` — tri-state `reducedMode` on the source
+
+**Files:**
+- Modify: `data_sources.py`
+- Test: `tests/test_data_sources.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_data_sources.py` immediately after `test_past_scan_source_masks_unknown_when_no_per_cam_streams` (~line 668):
+
+```python
+# ── Replay mode awareness — source reports its recorded reduced/dev mode ──
+# The viewer renders in the mode the scan was recorded in. reducedMode is a
+# tri-state: -1 unknown, 0 per-camera, 1 reduced — derived from the loaded
+# buffer cam_ids (reduced scans store only cam_id=-1; per-camera store 0..7).
+
+from data_sources import _derive_reduced_from_buffers
+
+
+def _one_sample_buffer():
+    buf = _CameraBuffer(max_capacity=None)
+    buf.append(t=0.0, v=1.0, frame_id=0)
+    return buf
+
+
+def test_derive_reduced_per_camera():
+    buffers = {("left", 0, "bfi"): _one_sample_buffer(),
+               ("right", 7, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 0
+
+
+def test_derive_reduced_side_average():
+    buffers = {("left", -1, "bfi"): _one_sample_buffer(),
+               ("right", -1, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 1
+
+
+def test_derive_reduced_empty_is_unknown():
+    assert _derive_reduced_from_buffers({}) == -1
+    # A buffer dict whose buffers hold no samples is also "unknown".
+    assert _derive_reduced_from_buffers({("left", -1, "bfi"): _CameraBuffer()}) == -1
+
+
+def test_past_scan_source_reduced_mode_for_side_average():
+    buffers = {}
+    for side in ("left", "right"):
+        buffers[(side, -1, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 1
+
+
+def test_past_scan_source_reduced_mode_for_per_camera():
+    buffers = {}
+    for cam_id in (0, 1, 6, 7):
+        buffers[("left", cam_id, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 0
+
+
+def test_live_scan_source_reduced_mode_unknown():
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.reducedMode == -1
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_data_sources.py -k "reduced_mode or derive_reduced" -v`
+Expected: FAIL — `ImportError: cannot import name '_derive_reduced_from_buffers'`.
+
+- [ ] **Step 3: Add the module helper**
+
+In `data_sources.py`, immediately after the `_derive_masks_from_buffers` function, add:
+
+```python
+def _derive_reduced_from_buffers(buffers) -> int:
+    """Tri-state recorded display mode from a loaded scan's buffer cam_ids:
+    -1 unknown, 0 per-camera, 1 reduced. Reduced-mode scans store only the
+    cam_id=-1 side average; per-camera (dev) scans store cam_id 0..7. Mirrors
+    _derive_masks_from_buffers — the viewer prefers this over the live config
+    so replay renders in the mode the scan was captured in."""
+    if buffers_are_empty(buffers):
+        return -1
+    if any(0 <= key[1] < 8 for key in buffers):
+        return 0
+    if any(key[1] == -1 for key in buffers):
+        return 1
+    return -1
+```
+
+- [ ] **Step 4: Add the backing field + property to `ScanDataSource`**
+
+In `data_sources.py`, in `ScanDataSource.__init__`, next to where `self._left_mask` / `self._right_mask` are initialized to `-1`, add:
+
+```python
+        # Recorded display mode, tri-state: -1 unknown / 0 per-camera / 1
+        # reduced. -1 for live sources (viewer follows the live config);
+        # PastScanSource derives the real value from its buffer layout.
+        self._reduced_mode: int = -1
+```
+
+Then add this property next to the `leftMask` / `rightMask` `pyqtProperty` definitions:
+
+```python
+    @pyqtProperty(int, constant=True)
+    def reducedMode(self) -> int:
+        """Recorded display mode this source represents: -1 unknown, 0
+        per-camera, 1 reduced. Exposed for QML (PlotViewer.effectiveReduced)
+        so a replayed scan renders in its own mode rather than the live config.
+        See ``leftMask`` for why this must be a pyqtProperty."""
+        return self._reduced_mode
+```
+
+- [ ] **Step 5: Set it in `PastScanSource.__init__`**
+
+In `data_sources.py`, in `PastScanSource.__init__`, immediately after the existing
+`self._left_mask, self._right_mask = _derive_masks_from_buffers(self.buffers)` line, add:
+
+```python
+        self._reduced_mode = _derive_reduced_from_buffers(self.buffers)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_data_sources.py -k "reduced_mode or derive_reduced" -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 7: Run the full data_sources suite (no regression) + lint**
+
+Run: `python -m pytest tests/test_data_sources.py -q`
+Expected: all pass.
+Run: `python -m flake8 data_sources.py tests/test_data_sources.py`
+Expected: no new errors on the added lines.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add data_sources.py tests/test_data_sources.py
+git commit -m "feat: PastScanSource reports its recorded reduced/dev mode"
+```
+
+---
+
+## Task 2: `PlotViewer.qml` — render in the scan's recorded mode
+
+QML isn't unit-tested; verify by launching against reduced and per-camera seed scans.
+
+**Files:**
+- Modify: `components/PlotViewer.qml`
+
+- [ ] **Step 1: Add the `effectiveReduced` resolve**
+
+In `components/PlotViewer.qml`, immediately after the `_effectiveRightMask` `readonly property`
+block (the #175 mask resolve, ~lines 168–174), add:
+
+```qml
+    // Replay adopts the loaded scan's recorded mode: when the source reports a
+    // known mode (reducedMode >= 0) use it, else fall back to the live-config
+    // `reducedMode` input. Mirrors _effectiveLeftMask/_effectiveRightMask (#175).
+    // Note: scanSource.reducedMode is an int tri-state (-1/0/1) from Python;
+    // viewer.reducedMode is the bool live-config input.
+    readonly property bool effectiveReduced:
+        (viewer.scanSource && viewer.scanSource.reducedMode !== undefined
+         && viewer.scanSource.reducedMode >= 0)
+            ? (viewer.scanSource.reducedMode === 1)
+            : viewer.reducedMode
+```
+
+- [ ] **Step 2: Swap the four `!viewer.reducedMode` reads**
+
+Replace all occurrences of `!viewer.reducedMode` with `!viewer.effectiveReduced` in
+`components/PlotViewer.qml` (5 sites: `showCellValues` at ~72, and the `visible: !viewer.reducedMode`
+toolbar/menu gates at ~1017, ~1096, ~1115, ~1131). None of these is the input-property declaration
+or the new `effectiveReduced` fallback (that fallback uses `viewer.reducedMode` *without* `!`), so a
+global `!viewer.reducedMode` → `!viewer.effectiveReduced` replacement is safe.
+
+Use Edit with `replace_all: true`, `old_string: "!viewer.reducedMode"`, `new_string: "!viewer.effectiveReduced"`.
+
+- [ ] **Step 3: Swap the three remaining (non-`!`) rendering reads**
+
+Three sites use `viewer.reducedMode` without a leading `!`. Edit each individually (do NOT touch the
+property declaration `property bool reducedMode: false` at ~line 68, nor the `effectiveReduced`
+fallback you just added):
+
+a) The active cell model (~line 221):
+```qml
+    readonly property var _activeCellModel: viewer.reducedMode
+        ? _reducedCellModel
+        : _devCellModel
+```
+→ change the first line to `readonly property var _activeCellModel: viewer.effectiveReduced`.
+
+b) The reduced side-readout footer `visible` (~line 649): `visible: viewer.reducedMode`
+→ `visible: viewer.effectiveReduced`.
+
+c) The cell grid columns (~line 674): `columns: viewer.reducedMode ? 1 : 4`
+→ `columns: viewer.effectiveReduced ? 1 : 4`.
+
+- [ ] **Step 4: Confirm all internal reads were swapped**
+
+Run: `python -c "s=open(r'components/PlotViewer.qml',encoding='utf-8').read(); print('viewer.reducedMode:', s.count('viewer.reducedMode')); print('effectiveReduced:', s.count('effectiveReduced'))"`
+Expected: `viewer.reducedMode` count is exactly **1** — the only remaining occurrence is the
+`effectiveReduced` fallback (`: viewer.reducedMode`). The property *declaration* is
+`property bool reducedMode` with no `viewer.` prefix, so it isn't counted. `effectiveReduced` count
+is **≥ 9** (its own declaration + the 8 swapped sites). If `viewer.reducedMode` > 1, a swap was
+missed — find and fix it.
+
+- [ ] **Step 5: Seed a per-camera (dev) scan alongside the reduced ones**
+
+The worktree already has a `scans.db` with reduced scans (`cam_id=-1`). Add one per-camera scan so
+you can verify both render paths. Run (adjust the path if `dataDirectory` is set):
+
+```bash
+python -c "
+from omotion.ScanDatabase import ScanDatabase
+import math, time
+db = ScanDatabase(db_path=r'scans.db')
+sid = db.create_session(session_label='20260613_101500_DevScan', session_start=time.time(),
+    session_end=time.time()+10, session_notes='Per-camera dev scan.',
+    session_meta={'scan_id':'20260613_101500','subject_id':'DevScan','operator':'ethan',
+        'duration_sec':10,'sdk_flags':{'reduced_mode':False,'left_camera_mask':0xC3,'right_camera_mask':0xC3}})
+rows=[]
+for i in range(400):
+    t=i/40.0
+    for side in (0,1):
+        for cam in (0,1,6,7):
+            rows.append(dict(session_id=sid,cam_id=cam,side=side,timestamp_s=t,frame_id=i,
+                             bfi=1.0+0.3*math.sin(t+cam),bvi=2.0+0.4*math.sin(t*0.8+cam),mean=120.0,contrast=0.05))
+db.insert_session_data_rows(rows); db.close(); print('seeded dev scan')
+"
+```
+
+- [ ] **Step 6: Launch in DEV mode and verify both render paths**
+
+Set `developerMode: true` and `reducedMode: false` in `config/app_config.json` (note the originals to
+restore). Launch with the conda interpreter (the background Bash `python` is not on PATH — exits 127):
+
+```
+Start-Process -FilePath "C:\Users\ethan\miniconda3\python.exe" -ArgumentList "main.py" -WorkingDirectory "<worktree>" -PassThru
+```
+
+Open History → load the **reduced** scan (e.g. `Patient14`): the plot must show the two big BFI/BVI
+**side panels** (reduced layout) with data. Then "Back to live" / load the **DevScan**: the plot must
+show the **per-camera grid** with traces. Screenshot the window (PrintWindow flag 2) and confirm.
+Check the newest `app-logs/ow-bloodflowapp-*.log` for zero QML errors. Restart the app to pick up QML
+edits (QML does not hot-reload).
+
+- [ ] **Step 7: Restore config and commit**
+
+Restore `developerMode` / `reducedMode` in `config/app_config.json` to their original values.
+```bash
+git add components/PlotViewer.qml
+git commit -m "feat: replay renders in the scan's recorded reduced/dev mode"
+```
+(Do not commit `scans.db` — it is gitignored.)
+
+---
+
+## Task 3: `HistoryModal.qml` — reduced mode hides non-reduced scans
+
+**Files:**
+- Modify: `components/HistoryModal.qml`
+
+- [ ] **Step 1: Add the filter condition in `rebuildView()`**
+
+In `components/HistoryModal.qml`, in `rebuildView()`, the filter currently reads:
+
+```qml
+        var q = (searchText || "").toLowerCase()
+        var cfg = configFilter
+        var arr = scans.filter(function(r) {
+            if (q.length > 0
+                && (r.userLabel || "").toLowerCase().indexOf(q) < 0
+                && (r.label || "").toLowerCase().indexOf(q) < 0)
+                return false
+            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
+                return false
+            return true
+        })
+```
+
+Insert an app-reduced read before the filter and an AND-condition inside it:
+
+```qml
+        var q = (searchText || "").toLowerCase()
+        var cfg = configFilter
+        // In reduced (clinical) mode, omit scans not shot in reduced mode —
+        // the reduced viewer can't render their per-camera data. Dev mode
+        // lists everything. A scan with no recorded mode counts as non-reduced.
+        var appReduced = MotionInterface.appConfig.reducedMode === true
+        var arr = scans.filter(function(r) {
+            if (appReduced && !r.reducedMode)
+                return false
+            if (q.length > 0
+                && (r.userLabel || "").toLowerCase().indexOf(q) < 0
+                && (r.label || "").toLowerCase().indexOf(q) < 0)
+                return false
+            if (cfg !== "All" && r.configL !== cfg && r.configR !== cfg)
+                return false
+            return true
+        })
+```
+
+- [ ] **Step 2: Re-filter when the app's reduced flag changes**
+
+In `components/HistoryModal.qml`, in the existing `Connections { target: MotionInterface ... }` block,
+add a handler so a runtime mode change while History is open re-applies the filter:
+
+```qml
+        function onAppConfigChanged() { if (root.visible) root.rebuildView() }
+```
+
+- [ ] **Step 3: Verify in both modes**
+
+With the reduced + dev seed scans from Task 2 present:
+- Launch with `reducedMode: true` → open History → the `DevScan` row must be **absent**; only the
+  reduced scans (Patient14 / BaselineA) appear.
+- Launch with `reducedMode: false` (dev) → open History → **all** scans appear, `DevScan` included.
+
+Screenshot each and confirm. Check the newest app log for zero QML errors. Restore
+`config/app_config.json` afterward.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/HistoryModal.qml
+git commit -m "feat: hide non-reduced scans from History while in reduced mode"
+```
+
+---
+
+## Final verification
+
+- [ ] `python -m pytest tests/test_data_sources.py -q` → all pass (new + existing).
+- [ ] `python -m pytest tests/test_history_sessions.py -q` → still pass (no regression).
+- [ ] `python -m flake8 data_sources.py tests/test_data_sources.py` → clean on new code.
+- [ ] Manual matrix confirmed: dev mode loads reduced→side-panels and dev→grid; reduced mode hides the dev scan from History; "Back to live" reverts the viewer to the config mode.
+- [ ] `config/app_config.json` restored to its original `developerMode` / `reducedMode` values.
+
+## Spec coverage check
+
+- Part A: source reports recorded mode (Task 1); viewer prefers it, reverts on Back-to-live (Task 2). ✓
+- Part B: reduced mode hides non-reduced scans, dev mode unfiltered (Task 3). ✓
+- Buffer-derived detection; viewer-only scope; no connector/BloodFlow/config-persistence changes. ✓
+- Unit tests for the derivation; manual matrix for the QML wiring. ✓

--- a/docs/superpowers/plans/2026-06-16-debug-log-bundle.md
+++ b/docs/superpowers/plans/2026-06-16-debug-log-bundle.md
@@ -1,0 +1,573 @@
+# Debug Log Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Send Debug Logs to Openwater" button to the LogsModal that zips the last 48h of app logs (+ config + system info), reveals the zip in the file explorer, and tells the user to email it to support@openwater.cc.
+
+**Architecture:** A pure `debug_bundle.py` module (`build_debug_bundle`) does the file-gathering/zipping (unit-testable against a temp dir). A thin `prepareDebugLogBundle()` connector slot calls it, reveals the file, toasts, and records an audit event. One QML button wires it up.
+
+**Tech Stack:** Python 3.13, PyQt6, stdlib `zipfile`/`glob`/`subprocess`, pytest. QML 6.
+
+**Design spec:** [docs/superpowers/specs/2026-06-16-debug-log-bundle-design.md](../specs/2026-06-16-debug-log-bundle-design.md)
+
+---
+
+## File Structure
+
+- **Create** `debug_bundle.py` — `build_debug_bundle(...)` + `WINDOW_HOURS`. Pure file logic, no Qt.
+- **Create** `tests/test_debug_bundle.py` — unit tests for the module.
+- **Modify** `audit_log.py` — add `EV_DEBUG_BUNDLE_CREATED` constant.
+- **Modify** `motion_connector.py` — add `prepareDebugLogBundle()` slot + `_reveal_in_explorer()` helper.
+- **Modify** `tests/test_audit_connector.py` — slot test.
+- **Modify** `components/LogsModal.qml` — "Send Debug Logs" toolbar button.
+- **Modify** `docs/audit-log.md` — document the button + the new event.
+
+---
+
+## Task 1: debug_bundle module
+
+**Files:**
+- Create: `debug_bundle.py`
+- Test: `tests/test_debug_bundle.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_debug_bundle.py`:
+
+```python
+"""Unit tests for the debug-log bundle builder (debug_bundle.py)."""
+import os
+import zipfile
+
+import pytest
+
+from debug_bundle import build_debug_bundle, WINDOW_HOURS
+
+pytestmark = pytest.mark.unit
+
+_NOW = 1_750_000_000.0  # fixed epoch for deterministic tests
+
+
+def _write(path, text="x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_window_hours_default_is_48():
+    assert WINDOW_HOURS == 48
+
+
+def test_includes_recent_logs_excludes_old(tmp_path):
+    data = tmp_path / "data"
+    logs = data / "app-logs"
+    for name in ("ow-bloodflowapp-A.log", "ow-bloodflowapp-B.log"):
+        _write(logs / name, "log")
+        os.utime(logs / name, (_NOW - 3600, _NOW - 3600))   # 1h ago
+    old = logs / "ow-bloodflowapp-OLD.log"
+    _write(old, "old")
+    os.utime(old, (_NOW - 49 * 3600, _NOW - 49 * 3600))     # 49h ago
+    _write(data / "app_config.json", '{"k":1}')
+
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert "app-logs/ow-bloodflowapp-A.log" in names
+    assert "app-logs/ow-bloodflowapp-B.log" in names
+    assert "app-logs/ow-bloodflowapp-OLD.log" not in names
+    assert "app_config.json" in names
+    assert "system_info.txt" in names
+    assert meta["log_count"] == 2
+    assert meta["bytes"] == os.path.getsize(meta["path"])
+    base = os.path.basename(meta["path"])
+    assert base.startswith("debug-bundle-") and base.endswith(".zip")
+
+
+def test_empty_window_still_writes_system_info(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert names == ["system_info.txt"]   # no logs, no config present
+    assert meta["log_count"] == 0
+    assert meta["file_count"] == 1
+
+
+def test_system_info_contains_versions_and_host(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+    txt = zipfile.ZipFile(meta["path"]).read("system_info.txt").decode("utf-8")
+    assert "app_version: 1.2.3" in txt
+    assert "sdk_version: 9.9" in txt
+    assert "hostname:" in txt
+    assert "generated:" in txt
+
+
+def test_explicit_config_path_is_used(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    cfg = tmp_path / "elsewhere" / "app_config.json"
+    _write(cfg, '{"x":2}')
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW, config_path=str(cfg),
+    )
+    names = zipfile.ZipFile(meta["path"]).namelist()
+    assert "app_config.json" in names
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_debug_bundle.py -p no:cacheprovider -q`
+Expected: FAIL at import — `ModuleNotFoundError: No module named 'debug_bundle'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `debug_bundle.py`:
+
+```python
+"""Build a zip bundle of recent app logs for emailing to support.
+
+Collects the last N hours of app log files plus app_config.json and a
+generated system_info.txt into a single zip. Pure file logic — no Qt, no
+hardware — so it is unit-testable against a temp directory.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from audit_log import gather_host_info
+
+logger = logging.getLogger("openmotion.bloodflow-app.debug-bundle")
+
+WINDOW_HOURS = 48
+
+
+def _system_info_text(now_epoch: float, extra_info: Optional[Dict[str, Any]]) -> str:
+    """Render host info (+ caller-supplied extras) as sorted key: value
+    lines, with a leading local-time 'generated' stamp."""
+    info = gather_host_info()
+    if extra_info:
+        info.update(extra_info)
+    generated = (
+        datetime.datetime.fromtimestamp(now_epoch)
+        .astimezone()
+        .isoformat(timespec="seconds")
+    )
+    lines = [f"generated: {generated}"]
+    lines += [f"{k}: {info[k]}" for k in sorted(info)]
+    return "\n".join(lines) + "\n"
+
+
+def build_debug_bundle(
+    data_dir: str | Path,
+    dest_dir: str | Path,
+    now_epoch: float,
+    *,
+    window_hours: int = WINDOW_HOURS,
+    config_path: str | Path | None = None,
+    extra_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Zip recent app logs + config + system info into dest_dir.
+
+    Includes <data_dir>/app-logs/*.log with mtime within window_hours,
+    the app_config.json at config_path (default <data_dir>/app_config.json)
+    if present, and a generated system_info.txt. Returns
+    {"path", "file_count", "log_count", "bytes"}.
+    """
+    data_dir = Path(data_dir)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    cutoff = now_epoch - window_hours * 3600
+    log_dir = data_dir / "app-logs"
+    recent_logs = []
+    if log_dir.is_dir():
+        for p in sorted(log_dir.glob("*.log")):
+            try:
+                if p.stat().st_mtime >= cutoff:
+                    recent_logs.append(p)
+            except OSError:
+                logger.warning("debug_bundle: stat failed for %s", p, exc_info=True)
+
+    if config_path is None:
+        config_path = data_dir / "app_config.json"
+    config_path = Path(config_path)
+
+    stamp = datetime.datetime.fromtimestamp(now_epoch).strftime("%Y%m%d_%H%M%S")
+    dest = dest_dir / f"debug-bundle-{stamp}.zip"
+
+    file_count = 0
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in recent_logs:
+            try:
+                zf.write(p, arcname=f"app-logs/{p.name}")
+                file_count += 1
+            except OSError:
+                logger.warning("debug_bundle: could not add %s", p, exc_info=True)
+        if config_path.is_file():
+            try:
+                zf.write(config_path, arcname=config_path.name)
+                file_count += 1
+            except OSError:
+                logger.warning(
+                    "debug_bundle: could not add config %s", config_path,
+                    exc_info=True,
+                )
+        zf.writestr("system_info.txt", _system_info_text(now_epoch, extra_info))
+        file_count += 1
+
+    return {
+        "path": str(dest),
+        "file_count": file_count,
+        "log_count": len(recent_logs),
+        "bytes": dest.stat().st_size,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_debug_bundle.py -p no:cacheprovider -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `python -m flake8 debug_bundle.py tests/test_debug_bundle.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add debug_bundle.py tests/test_debug_bundle.py
+git commit -m "feat: add debug_bundle module (zip recent app logs)"
+```
+(Commit message must end with the trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`)
+
+---
+
+## Task 2: Connector slot + reveal helper + event constant
+
+**Files:**
+- Modify: `audit_log.py` (event-type constants block)
+- Modify: `motion_connector.py` (add slot + helper after `exportAuditLogCsv`)
+- Test: `tests/test_audit_connector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_connector.py`:
+
+```python
+def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
+    import os
+    import zipfile
+    db = str(tmp_path / "scans.db")
+    logs = tmp_path / "app-logs"
+    logs.mkdir()
+    (logs / "ow-bloodflowapp-x.log").write_text("hello", encoding="utf-8")
+    c = _connector(tmp_path, scan_db_path=db)
+    # Don't spawn a real file-explorer process during the test.
+    c._reveal_in_explorer = lambda p: None
+    path = c.prepareDebugLogBundle()
+    assert path and os.path.exists(path)
+    assert path.endswith(".zip")
+    names = zipfile.ZipFile(path).namelist()
+    assert any(n.startswith("app-logs/") for n in names)
+    assert "system_info.txt" in names
+    assert "debug_bundle_created" in _types(c)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_connector.py::test_prepare_debug_bundle_creates_zip_and_logs -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: 'MotionConnector' object has no attribute 'prepareDebugLogBundle'`.
+
+- [ ] **Step 3: Add the event constant**
+
+In `audit_log.py`, find:
+
+```python
+EV_AUDIT_LOG_EXPORTED = "audit_log_exported"
+```
+
+Insert immediately after it:
+
+```python
+EV_DEBUG_BUNDLE_CREATED = "debug_bundle_created"
+```
+
+- [ ] **Step 4: Add the slot + helper to the connector**
+
+In `motion_connector.py`, find the end of `exportAuditLogCsv` (it returns `""` on failure / the path on success — the method directly above is the audit-log block added earlier). Immediately after the end of `exportAuditLogCsv`, insert:
+
+```python
+    @pyqtSlot(result=str)
+    def prepareDebugLogBundle(self) -> str:
+        """Zip the last 48h of app logs (+ config + system info) into
+        app-logs/debug-bundles/, reveal it in the file explorer, and toast
+        the support address. Returns the zip path, or '' on failure."""
+        try:
+            from debug_bundle import build_debug_bundle, WINDOW_HOURS
+            try:
+                from version import get_version as _gv
+                app_version = _gv()
+            except Exception:
+                app_version = ""
+            try:
+                sdk_version = self._interface.get_sdk_version()
+                sdk_version = sdk_version if isinstance(sdk_version, str) else ""
+            except Exception:
+                sdk_version = ""
+            dest_dir = os.path.join(self._directory, "app-logs", "debug-bundles")
+            meta = build_debug_bundle(
+                self._directory,
+                dest_dir,
+                time.time(),
+                config_path=resource_path("config", "app_config.json"),
+                extra_info={"app_version": app_version, "sdk_version": sdk_version},
+            )
+        except Exception:
+            logger.exception("prepareDebugLogBundle: failed to build bundle")
+            self.errorOccurred.emit("Could not create the debug log bundle.")
+            return ""
+
+        path = meta["path"]
+        self._reveal_in_explorer(path)
+        from audit_log import EV_DEBUG_BUNDLE_CREATED
+        self._audit.log(EV_DEBUG_BUNDLE_CREATED, {
+            "dest": path,
+            "file_count": meta["file_count"],
+            "log_count": meta["log_count"],
+            "bytes": meta["bytes"],
+            "window_hours": WINDOW_HOURS,
+        })
+        self.notify(
+            "Debug logs saved to " + path
+            + ". Please email this file to support@openwater.cc.",
+            "success", 0, True, "debug-bundle",
+        )
+        return path
+
+    def _reveal_in_explorer(self, path: str) -> None:
+        """Best-effort: open the OS file browser with the file selected.
+        Never raises — a failed reveal must not lose the bundle."""
+        try:
+            import subprocess
+            import sys
+            if sys.platform.startswith("win"):
+                subprocess.Popen(["explorer", "/select,", os.path.normpath(path)])
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", "-R", path])
+            else:
+                subprocess.Popen(["xdg-open", os.path.dirname(path)])
+        except Exception:
+            logger.warning(
+                "could not reveal %s in file explorer", path, exc_info=True
+            )
+```
+
+(`os`, `time`, `resource_path`, `logger`, `pyqtSlot`, and the `errorOccurred`/`notify` members all already exist in this module — do not re-import or redefine them.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_connector.py -k debug_bundle -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 6: Lint**
+
+Run: `python -m flake8 audit_log.py tests/test_audit_connector.py`
+Expected: clean (the test file must be clean; `motion_connector.py` has pre-existing violations — confirm the slot's added lines introduce none by checking the violation count is unchanged: `python -m flake8 motion_connector.py | wc -l` before/after should both be the same baseline).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add audit_log.py motion_connector.py tests/test_audit_connector.py
+git commit -m "feat: prepareDebugLogBundle connector slot + reveal + audit event"
+```
+(Trailer required.)
+
+---
+
+## Task 3: LogsModal "Send Debug Logs" button
+
+**Files:**
+- Modify: `components/LogsModal.qml` (toolbar)
+
+> **No automated test:** QML is not unit-tested in this repo. Verified by `python -c "import main"` and visually in Task 4.
+
+- [ ] **Step 1: Add the button**
+
+In `components/LogsModal.qml`, find the toolbar spacer immediately before the Export CSV button:
+
+```qml
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Export CSV"
+```
+
+Replace with (inserts the new button between the spacer and Export CSV):
+
+```qml
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Send Debug Logs"
+                    Layout.preferredWidth: 140; Layout.preferredHeight: 32
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.hovered ? theme.accentBlue : theme.bgInput
+                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                    }
+                    // Connector builds the zip, reveals it, and toasts the
+                    // support address; refresh so the debug_bundle_created
+                    // entry shows up in the list.
+                    onClicked: {
+                        MotionInterface.prepareDebugLogBundle()
+                        root.refresh()
+                    }
+                }
+
+                Button {
+                    text: "Export CSV"
+```
+
+- [ ] **Step 2: Verify QML parses + balance**
+
+Run: `python -c "import main; print('import ok')"`
+Expected: `import ok` (no traceback).
+Run: `python -c "s=open('components/LogsModal.qml',encoding='utf-8').read(); print('braces',s.count('{')-s.count('}'),'parens',s.count('(')-s.count(')'),'brackets',s.count('[')-s.count(']'))"`
+Expected: `braces 0 parens 0 brackets 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/LogsModal.qml
+git commit -m "feat: add Send Debug Logs button to LogsModal"
+```
+(Trailer required.)
+
+---
+
+## Task 4: Docs + verification
+
+**Files:**
+- Modify: `docs/audit-log.md`
+
+- [ ] **Step 1: Document the button + event**
+
+In `docs/audit-log.md`, find the event-types table row:
+
+```
+| `audit_log_exported` | The audit log is exported to CSV. | `dest`, `row_count` |
+```
+
+Insert immediately after it:
+
+```
+| `debug_bundle_created` | The "Send Debug Logs" button is used. | `dest`, `file_count`, `log_count`, `bytes`, `window_hours` |
+```
+
+Then find the `## Exporting to CSV` heading and insert this new section immediately before it:
+
+```markdown
+## Sending debug logs to Openwater
+
+The **Send Debug Logs** button (top of the audit-log viewer) packages the
+app's diagnostic logs for support. It writes a zip to
+`<dataDirectory>/app-logs/debug-bundles/debug-bundle-<timestamp>.zip`
+containing the app log files from the last 48 hours, `app_config.json`,
+and a `system_info.txt` (app/SDK version + host details). The file
+explorer opens with the zip selected, and a message shows the path —
+**email that zip to support@openwater.cc**. No data is sent automatically,
+and the bundle contains no scan data or patient information.
+
+```
+
+- [ ] **Step 2: Run the feature's full test set**
+
+Run: `python -m pytest tests/test_debug_bundle.py tests/test_audit_connector.py tests/test_audit_log.py -p no:cacheprovider -q`
+Expected: all PASS.
+
+- [ ] **Step 3: Lint touched Python**
+
+Run: `python -m flake8 debug_bundle.py tests/test_debug_bundle.py tests/test_audit_connector.py`
+Expected: clean.
+
+- [ ] **Step 4: End-to-end smoke (no hardware)**
+
+Run this script to confirm the slot produces a real zip with the expected members:
+
+```bash
+python - <<'PY'
+import sys, os, tempfile, zipfile
+sys.path.insert(0, os.getcwd())
+from unittest.mock import MagicMock
+from PyQt6.QtCore import QCoreApplication
+app = QCoreApplication(sys.argv)
+from motion_connector import MotionConnector
+d = tempfile.mkdtemp()
+os.makedirs(os.path.join(d, "app-logs"))
+open(os.path.join(d, "app-logs", "ow-bloodflowapp-demo.log"), "w").write("demo log\n")
+iface = MagicMock()
+iface.is_device_connected.return_value = (False, False, False)
+iface.scan_workflow.running = False
+iface.scan_workflow.config_running = False
+iface.scan_db_path = os.path.join(d, "scans.db")
+iface.get_sdk_version.return_value = "1.5.8"
+c = MotionConnector(interface=iface, app_config={"developerMode": False},
+                    data_dir=d, config_dir="config")
+c._reveal_in_explorer = lambda p: None
+path = c.prepareDebugLogBundle()
+print("bundle:", path)
+print("members:", zipfile.ZipFile(path).namelist())
+PY
+```
+Expected: prints a `debug-bundle-*.zip` path under `app-logs/debug-bundles/` whose members include `app-logs/ow-bloodflowapp-demo.log` and `system_info.txt`.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add docs/audit-log.md
+git commit -m "docs: document Send Debug Logs button + debug_bundle_created event"
+```
+(Trailer required.)
+
+- [ ] **Step 6: Manual/visual check (controller does this after execution)**
+
+Launch `python main.py`, open Settings → Audit Log → View Logs (password `OpenwaterHealth`), click **Send Debug Logs**: confirm the file explorer opens with the zip selected, a success toast shows the path + support@openwater.cc, and a `debug_bundle_created` row appears after the list refreshes.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Zip last 48h of `app-logs/*.log` → Task 1 (`build_debug_bundle`, mtime filter) ✓
+- Include `app_config.json` + `system_info.txt` (host + app/SDK version) → Task 1 ✓
+- Output to `app-logs/debug-bundles/debug-bundle-<ts>.zip` → Task 2 (`dest_dir`) ✓
+- Reveal in explorer (Windows `/select`, best-effort) → Task 2 (`_reveal_in_explorer`) ✓
+- Toast with support@openwater.cc (sticky) → Task 2 ✓
+- `debug_bundle_created` audit event with `{dest,file_count,log_count,bytes,window_hours}` → Task 2 ✓
+- Fail-soft (build/reveal never crash) → Task 2 (try/except around build; `_reveal_in_explorer` never raises) ✓
+- Button in LogsModal → Task 3 ✓
+- Pure-module unit tests + connector slot test → Tasks 1, 2 ✓
+- Docs → Task 4 ✓
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type/name consistency:** `build_debug_bundle(data_dir, dest_dir, now_epoch, *, window_hours, config_path, extra_info)` and its return keys (`path`/`file_count`/`log_count`/`bytes`) are used identically in Tasks 1, 2, and 4. `prepareDebugLogBundle`, `_reveal_in_explorer`, `EV_DEBUG_BUNDLE_CREATED`, and the `debug_bundle_created` string are consistent across tasks.
+
+**Known limitation (intentional):** the QML button (Task 3) and the reveal/toast side effects have no automated test (QML isn't unit-tested here; the reveal spawns an OS process) — verified via import smoke + the Task 4 end-to-end script + the Task 4 Step 6 manual check.

--- a/docs/superpowers/specs/2026-06-15-audit-log-design.md
+++ b/docs/superpowers/specs/2026-06-15-audit-log-design.md
@@ -1,0 +1,203 @@
+# Audit Log — Design
+
+**Date:** 2026-06-15
+**Status:** Approved (design); pending spec review
+**Branch base:** `next-next`
+
+## Goal
+
+Add a machine-readable, append-only audit log to the bloodflow app's
+SQLite database (`scans.db`). Entries are intended primarily for
+**auditors**: minimal, structured, and exportable. The log is reached
+through a password-gated **Logs** button in the Settings panel, which
+opens a modal that lists entries and can export them as CSV.
+
+## Decisions (locked)
+
+- **Password gate:** reuse the existing developer password
+  (`_DEVELOPER_PASSWORD` / `MotionInterface.checkDeveloperPassword`,
+  motion_connector.py:71) — same mechanism as the Calibrate gate.
+- **Entry shape:** minimal fixed core columns + a JSON `details` blob
+  (typed-event + JSON details).
+- **Table location:** app-side, in the same `scans.db` file. No SDK
+  (`openmotion-sdk`) edits.
+
+## Architecture
+
+A new standalone module **`audit_log.py`** with an `AuditLog` class.
+
+- Owns its own `sqlite3` connection to `scan_db_path`
+  (`check_same_thread=False`), lazily creates the `logs` table, and
+  exposes a small API: `log(event_type, details=None)`, `query(limit)`,
+  `export_csv(dest_path)`, `close()`.
+- The connector (`MotionConnector`) holds a single `AuditLog` instance,
+  constructed in `__init__` from
+  `getattr(self._interface, "scan_db_path", None)`. Call sites are thin
+  one-liners (`self._audit.log("scan_started", {...})`).
+- Rationale: keeps the already-oversized `motion_connector.py` (4031
+  lines) from growing materially, mirrors the `motion_config.py`
+  extraction precedent, and makes the logger unit-testable against a
+  tmp DB with no app launch / no hardware.
+
+### Concurrency
+
+Audit events fire from multiple threads — the SDK connection-monitor
+thread (`_on_handle_state_changed_impl`), scan-worker threads
+(scan end), and the Qt UI thread (settings, view, delete). Therefore:
+
+- `sqlite3.connect(path, check_same_thread=False)`.
+- A `threading.Lock` guarding every write.
+- `PRAGMA journal_mode=WAL`, `PRAGMA busy_timeout=5000` — coexists with
+  the SDK's `ScanDatabase`, which also opens WAL connections to the same
+  file on demand.
+
+### Fail-soft
+
+`AuditLog` must never crash or block the app. If `scan_db_path` is
+`None` (e.g. headless/unit context) or the connection/insert raises,
+the instance degrades to a no-op and logs a single warning via the
+standard `logging` logger. A failed audit write never propagates.
+
+## Schema
+
+Created by `AuditLog._init_schema()` (idempotent, `IF NOT EXISTS`):
+
+```sql
+CREATE TABLE IF NOT EXISTS logs (
+    id          INTEGER PRIMARY KEY,
+    ts_epoch    REAL NOT NULL,   -- time.time()
+    ts_iso      TEXT NOT NULL,   -- ISO-8601 local time, sortable
+    event_type  TEXT NOT NULL,   -- one of the event-type constants below
+    details     TEXT             -- compact JSON object; NULL when no payload
+);
+
+CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts_epoch);
+```
+
+`details` is `json.dumps(obj, separators=(",", ":"), sort_keys=True)` —
+compact and deterministic. Stored as `NULL` when there is no payload.
+
+## Event types & instrumentation points
+
+Event-type strings are module-level constants in `audit_log.py`.
+
+| event_type | Fired at (file:line anchor) | `details` |
+|---|---|---|
+| `system_startup` | `MotionConnector.__init__` | `app_version`, `sdk_version`, `data_dir` |
+| `system_info` | `__init__`, immediately after `system_startup` | `hostname`, `platform`, `system`, `arch`, `processor`, `python`, `ram_gb` (host info, mirrors SDK `log_system_info`) |
+| `system_shutdown` | `MotionConnector.shutdown()` (called from `main.py` `handle_exit`, :294) | `clean: true` |
+| `device_connected` | `_on_handle_state_changed_impl` (motion_connector.py:1137) | `device` (`console`/`left`/`right`), `reason` |
+| `device_disconnected` | `_on_handle_state_changed_impl` | `device`, `reason` |
+| `device_stats` | on connect, once IDs are readable (same handler) | `device`, `hardware_id`, `firmware_version` |
+| `scan_started` | `startCapture` (motion_connector.py:2183) | `label`, `left_mask`, `right_mask`, `session_id` (`null` if not yet assigned — `ScanDBSink` may create the session row after this point; `scan_ended` carries the authoritative id) |
+| `scan_ended` | `stopCapture` (motion_connector.py:1320) / scan-complete | `session_id`, `duration_s`, `outcome` |
+| `calibration_started` | `runCalibration` (motion_connector.py:3645, status→running at :3721) | `target` (`both`/`left`/`right`) |
+| `calibration_ended` | `_on_calibration_complete` (motion_connector.py:3935) | `target`, `outcome` (`passed`/`failed`/`aborted`), `reason` |
+| `settings_changed` | `setConfig` (:1785) and `saveConfigs` (:1793) | changed keys only, as `{key: {old, new}}` (diff computed before the update is applied) |
+| `scan_viewed` | `loadPastScan` (motion_connector.py:1923) | `session_id`, `label` |
+| `scan_deleted` | `deleteScans` (motion_connector.py:1703) | `session_ids`, `count` |
+| `audit_log_viewed` | LogsModal opened (connector slot called from QML on open) | `entry_count` |
+| `audit_log_exported` | `exportAuditLogCsv` (connector slot) | `dest`, `row_count` |
+
+Notes:
+- `device_stats` reads `get_hardware_id()` and `get_version()` off the
+  console/sensor handle (SDK: `MotionConsole.get_hardware_id` :556,
+  `MotionSensor.get_hardware_id` :451, `*.get_version`). Best-effort:
+  missing values logged as empty strings.
+- `settings_changed` only records keys whose value actually changed, so
+  a no-op save produces no entry (or an entry with an empty diff —
+  implementation may skip empty diffs entirely).
+- `audit_log_viewed` / `audit_log_exported` make audit-data access
+  itself auditable, per the requirement to log viewing.
+
+## UI
+
+### Settings — Logs button
+
+In `components/SettingsModal.qml`, add an **"Audit Log"** `SectionCard`
+containing a **Logs** `ActionButton`. The card is **not** gated on
+`developerMode` (auditors are not developers). On click it opens a
+`PasswordPromptModal` (reused; title "Audit Log", description "Enter the
+password to view the audit log."); `onAccepted` opens the LogsModal.
+
+### LogsModal
+
+New `components/LogsModal.qml`, modeled on `HistoryModal.qml`:
+
+- Standard modal shell (backdrop, title bar with ✕, ESC-to-close,
+  click-outside-to-close) consistent with existing modals.
+- Exposes `readonly property string label: "Audit Log"`, `visible`, and
+  `function open()` / `function close()` so `ModalManager` governs it.
+- A scrollable, newest-first table with columns **Time** (`ts_iso`),
+  **Event** (`event_type`), **Details** (the JSON string, elided/wrapped).
+  Rows come from `MotionInterface.auditLogEntries(limit)`.
+- `open()` calls a connector slot to (a) record the `audit_log_viewed`
+  event and (b) load entries.
+- An **Export CSV** button using `QtQuick.Dialogs` `FileDialog`
+  (default folder = `MotionInterface.directory`), wired to
+  `MotionInterface.exportAuditLogCsv(destPath)`.
+
+Register `logsModal` in `BloodFlow.qml`'s `ModalManager { modals: [...] }`
+list.
+
+### Connector slots (QML-facing)
+
+Added to `MotionConnector`:
+
+- `@pyqtSlot(int, result="QVariantList") auditLogEntries(limit=500)` —
+  pure read: returns rows as `{id, ts_iso, ts_epoch, event_type,
+  details}` dicts, newest first. Does **not** log (so re-querying/
+  refreshing the table never double-logs).
+- `@pyqtSlot() recordAuditLogViewed()` — records the single
+  `audit_log_viewed` event. Called exactly once from `LogsModal.open()`,
+  separately from `auditLogEntries()`.
+- `@pyqtSlot(str, result=str) exportAuditLogCsv(dest_path)` — writes the
+  full log to CSV (columns: `ts_iso, ts_epoch, event_type, details`),
+  records `audit_log_exported`, returns the written path (or "" on
+  failure). Accepts a `file://` URL or plain path (normalize like the
+  existing `FolderDialog` handlers in SettingsModal).
+
+## CSV export format
+
+Header row, then one row per entry, ordered oldest→newest (stable for
+diffing):
+
+```
+ts_iso,ts_epoch,event_type,details
+2026-06-15T09:14:02,1750000442.12,system_startup,"{""app_version"":""1.2.3"",...}"
+```
+
+`details` is the raw JSON string, quoted per `csv` module rules. UTF-8,
+`newline=""` (matches the existing FT-CSV writer at
+motion_connector.py:2593).
+
+## Testing
+
+`tests/test_audit_log.py`, all `@pytest.mark.unit` (no app launch, no
+hardware — conftest autouse fixtures short-circuit on `unit`):
+
+- Table is created on first use; `IF NOT EXISTS` is idempotent on reopen.
+- `log()` inserts a row with epoch + ISO timestamps and round-trips the
+  JSON `details`.
+- `log()` with `details=None` stores SQL `NULL`.
+- `query(limit)` returns newest-first and honors the limit.
+- `export_csv()` writes the expected header and quoting; round-trips
+  through `csv.DictReader`.
+- `AuditLog(None)` (no path) is a silent no-op: `log()`/`query()`/
+  `export_csv()` don't raise, `query()` returns `[]`.
+- Concurrent writes from two threads don't raise and both land (lock).
+
+Optional connector-level unit test: constructing `MotionConnector` with
+a tmp `scan_db_path` produces `system_startup` + `system_info` rows.
+
+The existing `tests/test_developer_password.py` already covers the
+password check being reused here.
+
+## Out of scope / YAGNI
+
+- No log rotation / retention policy (append-only; auditors keep the
+  file). Revisit only if table size becomes a real problem.
+- No in-app filtering/search UI beyond newest-first listing (CSV export
+  covers downstream analysis).
+- No SDK changes.
+- No new config flags.

--- a/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
+++ b/docs/superpowers/specs/2026-06-15-critical-error-codes-design.md
@@ -1,0 +1,129 @@
+# Critical-Error Codes + Modal — Design
+
+Date: 2026-06-15
+Branch: `feature/critical-error-codes-modal` (off `next-next`)
+
+## Goal
+
+Surface critical/showstopper conditions (e.g. the boot-time I2C check failing) to
+the clinician as a dismissible modal carrying a stable **error code**, and publish
+the authoritative list of codes in the docs.
+
+Today these conditions are only written to the app log; nothing blocks or alerts
+the user in the UI. The app already has a toast path (`MotionInterface.notify`)
+and a generic `errorOccurred(str)` signal, but neither is coded, blocking, or
+self-documenting.
+
+## Scope
+
+In scope (categories chosen by product owner):
+
+- **E-1xx** Startup / initialization failures (I2C check, connect, camera power).
+- **E-2xx** Laser-safety showstoppers.
+- **E-3xx** Scan / capture aborts.
+
+Out of scope: calibration failures, contact-quality soft warnings (these keep
+their existing toast/inline handling).
+
+## Architecture
+
+`motion_connector.py` is ~4031 lines; CLAUDE.md warns against growing it. So:
+
+- **New module `error_codes.py`** — frozen registry of codes. Each entry:
+  `code`, `category`, `title`, `message`, `suggested_action`. Plus a
+  `CriticalError` dataclass and `lookup(code) -> CriticalError`. Pure, no Qt,
+  unit-testable.
+- **Connector additions (thin):**
+  - `criticalErrorRaised = pyqtSignal(str, str, str, str)  # code, title, message, detail`
+  - `_raise_critical(self, code: str, detail: str = "")` — looks up the registry,
+    logs, and emits the signal. Emitted via `Qt.QueuedConnection` semantics so
+    worker-thread call sites (USB I/O, scanner) are safe.
+  - `@pyqtSlot(str) sendBugReport(code)` — see Bug report.
+- Existing failure sites add a `self._raise_critical(...)` call. The failure
+  paths' own behavior is unchanged; this is an additive surfacing layer.
+
+## Catalog (authoritative list → `docs/ERROR_CODES.md`)
+
+| Code | Condition | Source site |
+|---|---|---|
+| E-101 | Sensor I2C self-check: expected device(s) missing at boot (mux / IMU / camera / FPGA) | `_check_sensor_i2c_health` (reads `MotionSensor.i2c_health`) |
+| E-102 | I2C health unreadable — firmware returned no snapshot | `_check_sensor_i2c_health` (`i2c_health is None`) |
+| E-103 | Console init failed — laser-power params didn't apply at connect | `_on_handle_state_changed_impl` console branch |
+| E-104 | Console not detected within startup timeout | connection watchdog — **warning toast, not modal** |
+| E-105 | Camera power-on failed during init | `_run_sensor_init` |
+| E-106 | Fewer sensors than required within startup timeout | connection watchdog — **warning toast, not modal** |
+| E-201 | Laser safety monitor unresponsive beyond transient window | safety_known streak block (issue #119) |
+| E-202 | Laser safety trip during scan | `_on_safety_trip_during_capture` |
+| E-301 | Capture aborted before laser fired (precondition fail) | `startCapture` abort (with reason) |
+| E-302 | SDK refused to spawn a new scan | `startCapture` (no reason) |
+
+**Reshaped from the original proposal so every documented code has a real
+trigger.** E-103 was repurposed from "sensor not detected" to "console init
+failed", which has a clean site. E-203 was merged into E-201; E-303 was dropped
+(capture is fail-soft — `captureFinished` always emits success).
+
+**Connection watchdog (added):** because the SDK exposes only
+CONNECTED/DISCONNECTED (it retries enumeration internally, with no
+"failed attempt" event), E-104/E-106 are driven by a one-shot timer armed at
+startup. After `connectionTimeoutSec` (default 30 s) it checks the cached
+connection state. Config: `connectionTimeoutSec` / `requireConsole` /
+`minSensors`. Post-startup disconnects remain the job of the existing
+connection-status UI.
+
+**Severity (updated):** E-104/E-106 are **non-blocking warnings**, not the
+critical modal — a missing system at startup is a "plug it in" situation. They
+surface as a single yellow toast (bottom-right, `tag="connection-watchdog"`,
+sticky); when both are missing it collapses to `"System not found"`. So they are
+**not** in the `error_codes.py` modal registry — `_check_connection_watchdog`
+calls `notify(..., "warning", ...)` directly and logs the codes for support. The
+modal registry holds 8 codes (E-101/102/103/105, E-201/202, E-301/302).
+
+## Modal — `components/CriticalErrorModal.qml`
+
+- Style matches `PasswordPromptModal`. Hosted top-level in `main.qml` so it
+  overlays every page. Connected to `MotionInterface.criticalErrorRaised`.
+- Dismissible: backdrop click, Dismiss button, Esc.
+- Content: red header with **code badge** (`E-101`), title, message,
+  suggested-action line, collapsible detail block.
+- **Queue**: if several fire, show one at a time; show a "N more" affordance.
+- Buttons: **Copy details**, **Send Bug Report to Openwater**, **Dismiss**.
+
+## Bug report (hybrid — works today, upgrades cleanly)
+
+No Openwater backend / mail relay exists today, and embedding SMTP credentials in
+a clinical desktop app is undesirable. So:
+
+- **Default (zero infra):** `sendBugReport(code)` builds a report (code, message,
+  timestamp, app version, device IDs), reveals the current session log in
+  Explorer (`explorer /select,<logpath>`), copies the prefilled report to the
+  clipboard, and opens the default mail client via
+  `mailto:support@openwater.health?subject=...&body=...`. The user attaches the
+  highlighted log and sends. (Desktop apps cannot silently attach a file to an
+  arbitrary mail client — this is the honest limitation.)
+- **Upgrade (opt-in, true one-click):** if an optional `bug_report_smtp` block is
+  present and complete in `app_config.json`, send directly via `smtplib` on a
+  background thread with the log **attached automatically**; emit a result toast.
+  Absent by default → fallback above.
+
+Config additions:
+- `support_email` (default `"support@openwater.health"`).
+- optional `bug_report_smtp: { host, port, username, password, use_tls, from_addr }`.
+
+The connector must expose the **current session log path**. `main.py` sets up the
+timestamped per-launch log; we surface its path to the connector for the report.
+
+## Testing
+
+- Unit (`@pytest.mark.unit`, mock the seam — no app launch, per repo rule):
+  - registry completeness: every catalog code resolves; no dup codes.
+  - `_raise_critical` emits the correct 4-tuple payload for a known code.
+  - bug-report builder: produces expected report text; selects SMTP vs mailto
+    fallback based on config presence.
+- QML modal: visual screenshot check (PrintWindow flag 2) after layout — boot-log
+  grep won't catch geometry bugs.
+
+## Non-goals / YAGNI
+
+- No retry/auto-recovery from the modal (dismiss only + bug report).
+- No new backend service.
+- No reworking of the existing toast/`errorOccurred` paths.

--- a/docs/superpowers/specs/2026-06-15-history-data-management-design.md
+++ b/docs/superpowers/specs/2026-06-15-history-data-management-design.md
@@ -1,0 +1,130 @@
+# History → Data Management Tool — Design
+
+**Date:** 2026-06-15
+**Status:** Approved for planning
+**Component:** `components/HistoryModal.qml`, `motion_connector.py`
+
+## Problem
+
+Today's History view ([HistoryModal.qml](../../../components/HistoryModal.qml)) is a single-select
+`ComboBox` picker plus a details pane. It works for "open one past scan" but is not a tool for
+*managing* a growing scan archive: you can't see all scans at a glance, can't sort or search,
+can't act on several at once, and can't delete anything.
+
+Rework it into a proper data-management tool: a sortable, searchable, multi-select **table** of
+scans with a detail pane and Load / Export / Delete actions.
+
+## Decisions (locked during brainstorming)
+
+| Question | Decision |
+|---|---|
+| Container | **Modal** — rebuild the existing `HistoryModal`, not a new page. Lowest-risk, fits `ModalManager`. |
+| List source | **DB `sessions` table only.** Drop the CSV-filename listing. Matches DB-as-system-of-record; CSVs are being phased out. Legacy pre-DB CSV-only scans (no session row) no longer appear. |
+| Delete scope | **DB session only** — `delete_session(id)` (CASCADE-deletes `session_data`). No file deletion. |
+| Delete auth | **Reuse the developer password** via the existing `PasswordPromptModal` + `checkDeveloperPassword()`. |
+| Notes | **Read-only** in the detail pane (viewable, not editable). |
+| "Time" column | **Duration** (`session_end − session_start`). |
+| Mode column | **Omitted.** |
+| Config column | Show **left / right** named configs, always both sides. |
+| Export CSV | **Kept** (existing `exportScanCsv`). |
+
+No SDK changes are required. Everything the table needs already exists in the scan DB:
+`ScanDBSink` writes `session_meta` at scan start with
+`sdk_flags.{left_camera_mask, right_camera_mask, reduced_mode}`, `duration_sec`, `operator`,
+`started_at_iso`, and `scan_id`/`subject_id`; `session_start`/`session_end` give real duration;
+`session_notes` holds notes. Empty/interrupted-before-any-data sessions are already pruned by
+`ScanDBSink.on_complete`.
+
+## UI
+
+A modal (same dimmed-backdrop + centered panel as today, slightly larger) containing:
+
+**Toolbar:** title · search field (filters by user label, case-insensitive substring) ·
+`Config ▾` filter (All + each named config) · Open Folder · Refresh · ✕.
+
+**Table** (header row + scrollable `ListView` of styled row delegates — matches the app's existing
+hand-styled control idiom; not `TableView`):
+
+| ☑ | User Label | Date / Time | Config (L / R) | Duration | status |
+|---|---|---|---|---|---|
+
+- Header checkbox = select-all / clear-all (respects the active search/config filter).
+- Per-row checkbox = multiselect membership.
+- Single-click anywhere on a row = **focus** it (highlights, fills the detail pane). Focus and
+  checkbox-membership are independent.
+- Clicking a column header sorts by it; click again to reverse. Default: **Date / Time descending.**
+- `status`: green dot = ok; amber ⚠ = interrupted (`session_end` is null).
+
+**Detail pane** (below the table, for the focused row): full label · operator · left/right mask
+(hex) · Config (L / R) · started-at · sample-row count · **read-only** Notes box (scrollable).
+Sample count is fetched lazily when a row is focused (keeps the list query cheap).
+
+**Actions** (bottom): "N selected" counter · `Load in viewer →` · `Export CSV` · `🔒 Delete (N)`.
+- **Load** — enabled when exactly one row is focused; calls the existing async
+  `loadPastScan(label)` with the busy overlay, closes on success (unchanged behavior).
+- **Export CSV** — acts on the focused row; existing `exportScanCsv(label, path)` + `FileDialog`.
+- **Delete (N)** — acts on all checked rows. Opens `PasswordPromptModal`; on `accepted()` calls
+  the new `deleteScans([sessionId…])`, then refreshes and clears the selection. Disabled while a
+  scan is RUNNING (don't delete the in-flight session).
+
+## Connector API (new)
+
+All read/delete use a short-lived `ScanDatabase(db_path)` handle (WAL allows concurrent
+read/write with a live scan). Best-effort: a missing/unreadable DB yields an empty list, never an
+exception into QML.
+
+- `get_scan_sessions() -> QVariantList[QVariantMap]` — one entry per `sessions` row, newest first.
+  Each map: `sessionId` (int DB id), `label`, `userLabel`, `operator`, `dateTime` (display string),
+  `timestamp` (raw `YYYYMMDD_HHMMSS` for sort), `durationSec` (float or −1 if open),
+  `leftMask`/`rightMask` (int), `reducedMode` (bool), `notes`, `interrupted` (bool,
+  `session_end is None`). Masks come from `session_meta.sdk_flags`; for older rows lacking meta,
+  fall back to deriving per-camera masks from `session_data` (returns −1/unknown for reduced-mode
+  rows that only stored the cam_id=−1 average). The list query does **not** count rows.
+- `get_session_stats(sessionId: int) -> QVariantMap` — `{ "sampleCount": int }`. Called on focus so
+  the per-row `COUNT(*)` cost is paid once per selection, not once per listed scan.
+- `deleteScans(sessionIds: list[int]) -> int` — `delete_session()` per id; returns the count
+  deleted. The password gate lives in QML (`PasswordPromptModal`); the slot itself is unguarded
+  glue. Logs each deletion.
+
+`loadPastScan` and `exportScanCsv` are reused unchanged. `get_scan_list` / `get_scan_details`
+stay (still used by `loadPastScan` and existing tests).
+
+## Config-name mapping
+
+Masks → names mirror `CameraSelectionModal`'s pattern table:
+`0x00→None, 0x5A→Near, 0x66→Middle, 0xC3→Far, 0x99→Outer, 0x0F→Left, 0xF0→Right, 0x42→Third Row,
+0xFF→All`; anything else → `0xNN` hex; unknown (−1) → `—`. Column renders `"{left} / {right}"`.
+Mapping lives in a new `components/ScanConfigNames.js` (`.pragma library`) imported by
+`HistoryModal`; `CameraSelectionModal` is left untouched for now.
+
+## Components & tidiness
+
+- Rewrite `HistoryModal.qml` around the table. Reuse `PasswordPromptModal` (instantiated inside,
+  like `DeveloperUnlockModal`), the busy overlay, the `friendlyDate`/`formatMasks` helpers, and the
+  `MotionInterface` `Connections` block (`onPastScanLoadFinished`, `onDirectoryChanged`,
+  `onErrorOccurred`).
+- New `components/ScanConfigNames.js` for the mask→name mapping.
+- New connector slots grouped next to `get_scan_list` (~line 1384). Keep them small and DB-only;
+  do not grow the existing 4031-line file with table-rendering logic — that stays in QML.
+
+## Error handling
+
+- Empty archive → table shows an "No scans yet" empty state; actions disabled.
+- DB read failure → empty list + a logged warning (current best-effort pattern).
+- Delete of an already-removed id → `delete_session` returns False; counted as not-deleted, no error.
+- Interrupted rows (`⚠`) → Load/Export disabled (no replayable data), Delete still allowed.
+
+## Testing
+
+- Connector unit tests (no hardware): `get_scan_sessions` shape + sort + mask/config derivation
+  from `session_meta` and from `session_data` fallback; `deleteScans` removes rows and cascades;
+  `get_session_stats` count. Build a temp `ScanDatabase`, insert sessions/data, assert.
+- Update the existing UI tests that drive the old `ComboBox` History
+  (`tests/test_history.py`, and `tests/test_scan_history_list.py` if it touches the modal) to the
+  new table interaction.
+
+## Out of scope
+
+- Deleting on-disk CSV/raw/telemetry files (DB-only delete by decision).
+- Editing notes from History (read-only by decision).
+- A full-page History route, renaming labels, bulk export, date-range filtering.

--- a/docs/superpowers/specs/2026-06-15-replay-mode-awareness-design.md
+++ b/docs/superpowers/specs/2026-06-15-replay-mode-awareness-design.md
@@ -1,0 +1,133 @@
+# Replay Mode Awareness — Design
+
+**Date:** 2026-06-15
+**Status:** Approved for planning
+**Components:** `data_sources.py`, `components/PlotViewer.qml`, `components/HistoryModal.qml`
+**Rides on:** the History data-management branch (`claude/determined-kalam-a1d23d`, PR #194)
+
+## Problem
+
+The plot viewer's reduced-vs-per-camera **display mode** follows the live app config
+(`reducedMode`), not the mode a loaded past scan was *recorded* in. A reduced-mode scan stores
+its data under `cam_id = -1` (the side average); a per-camera/dev scan stores `cam_id = 0..7`. So
+loading a reduced scan while the app is in dev mode (or vice-versa) renders a blank/empty plot —
+the viewer queries cells that have no data.
+
+This is the same class of mismatch that [#175](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/pull/190)
+fixed for camera *masks* (replay uses the scan's own config, not the live selection); it was
+simply never extended to the reduced/dev mode itself.
+
+Two complementary fixes:
+
+- **A. The viewer adopts the loaded scan's recorded mode** (both directions), reverting to the
+  live config on "Back to live".
+- **B. In reduced mode, History hides scans not shot in reduced mode** — so a clinician in the
+  reduced clinical view never sees or loads an engineering/dev scan they can't render.
+
+Together they cover every case: reduced app shows only reduced scans (always renderable);
+dev app shows everything, and a reduced scan loaded in dev mode renders correctly via A.
+
+## Part A — Viewer adopts the loaded scan's recorded mode
+
+### Decisions
+
+- **Scope: plot viewer only.** Loading a scan changes only how the plot area renders. The sidebar,
+  settings access, and `BloodFlow.qml` page layout stay on the live config. (User decision.)
+- **Temporary.** The effective mode is tied to the active scan source, so it reverts to the live
+  config automatically when the viewer returns to the live source ("Back to live").
+- **Detection source: the loaded buffer layout**, not `session_meta`. What the viewer can actually
+  render is determined by which `cam_id`s are present; deriving from the buffers guarantees the
+  render mode matches renderable data (and is self-consistent with how #175 derives masks). For
+  well-formed scans this is identical to `session_meta.sdk_flags.reduced_mode`.
+
+### `data_sources.py`
+
+Add a tri-state indicator on `ScanDataSource`, exposed exactly like `leftMask`/`rightMask`:
+
+- New `pyqtProperty(int, constant=True) reducedMode` backed by `self._reduced_mode`, default `-1`.
+  Values: `-1` unknown, `0` per-camera, `1` reduced.
+- `LiveScanSource` leaves it `-1` (unknown → viewer follows the live config; no behavior change).
+- `PastScanSource.__init__` sets `self._reduced_mode` from its loaded buffers, alongside the
+  existing `_derive_masks_from_buffers` call, via a new module helper:
+
+  ```python
+  def _derive_reduced_from_buffers(buffers) -> int:
+      """-1 unknown / 0 per-camera / 1 reduced, from which cam_ids a loaded
+      scan carries. Reduced scans store only the cam_id=-1 side average;
+      per-camera scans store cam_id 0..7. Mirrors _derive_masks_from_buffers."""
+      if buffers_are_empty(buffers):
+          return -1
+      if any(0 <= key[1] < 8 for key in buffers):
+          return 0
+      if any(key[1] == -1 for key in buffers):
+          return 1
+      return -1
+  ```
+
+### `components/PlotViewer.qml`
+
+- Add `readonly property bool effectiveReduced` resolving the source's mode with a fallback,
+  mirroring the `_effectiveLeftMask` resolve at lines 168–174:
+
+  ```qml
+  readonly property bool effectiveReduced:
+      (viewer.scanSource && viewer.scanSource.reducedMode !== undefined
+       && viewer.scanSource.reducedMode >= 0)
+          ? (viewer.scanSource.reducedMode === 1)
+          : viewer.reducedMode
+  ```
+
+- Swap the viewer's **internal rendering/visibility** reads of `viewer.reducedMode` over to
+  `viewer.effectiveReduced`. Known sites (verify exhaustively during implementation):
+  `showCellValues` (72), `_activeCellModel` (221), the reduced side-readout footer `visible` (649),
+  the cell grid `columns` (674), and the `!reducedMode`-gated toolbar/menu items (1017, 1096, 1115,
+  1131). Leave the external **input** property `reducedMode` (68) and its `BloodFlow.qml` binding
+  untouched — it remains the live-config fallback.
+
+No connector and no `BloodFlow.qml` changes. Masks already follow the source (#175); with
+`effectiveReduced` driving the cell model, replay now fully self-describes its layout.
+
+## Part B — Reduced mode hides non-reduced scans in History
+
+### Decision
+
+One-directional: **when the app is in reduced mode, the History table omits any scan whose recorded
+mode is not reduced.** Dev mode lists everything (reduced scans included, rendered correctly by
+Part A). A legacy scan with no recorded mode is treated as non-reduced, so it is hidden in reduced
+mode — the conservative choice for the clinical view. (User-confirmed.)
+
+### `components/HistoryModal.qml`
+
+The row map from `get_scan_sessions()` already carries `reducedMode`
+(`_session_to_row` reads `session_meta.sdk_flags.reduced_mode`), so no connector change.
+
+In `rebuildView()`, add one AND-condition to the existing filter chain (search + Config dropdown):
+when the app is in reduced mode, drop rows where `reducedMode` is falsy. The app's reduced flag is
+read from `MotionInterface.appConfig.reducedMode` (the same source `BloodFlow.qml` uses), reactive
+via `appConfigChanged`. The existing empty-state ("No scans match the filter.") covers the case
+where the filter removes everything.
+
+## Error handling
+
+- Unknown source mode (`-1`, e.g. a live source or an empty past scan) → viewer falls back to the
+  live config, i.e. today's behavior. No blank-plot regression for empty scans (already guarded by
+  `buffers_are_empty` in the load path).
+- Part A and Part B both key off the scan's recorded mode; for well-formed scans the buffer-derived
+  value (Part A) and `session_meta.reduced_mode` (Part B) agree. A malformed scan where they
+  disagree is a pre-existing data defect, not introduced here.
+
+## Testing
+
+- **Unit (`tests/test_data_sources.py`):** `PastScanSource(preloaded_buffers=…).reducedMode` returns
+  `1` for cam_id=-1-only buffers, `0` for per-camera buffers, `-1` for empty; and
+  `_derive_reduced_from_buffers` directly for the three cases.
+- **Manual:** launch against two seed DBs (one reduced `cam_id=-1` scan, one per-camera `cam_id=0..7`
+  scan) and confirm: (1) in dev mode, loading the reduced scan renders the reduced panels and
+  loading the per-camera scan renders the grid; (2) "Back to live" reverts to the config mode;
+  (3) in reduced mode, the dev scan is absent from the History list.
+
+## Out of scope
+
+- Hiding reduced scans while in dev mode (only the reduced-mode direction was requested).
+- Switching any UI outside the plot viewer (sidebar/settings/page layout stay on live config).
+- Persisting any mode change to `app_config.json`.

--- a/docs/superpowers/specs/2026-06-16-debug-log-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-16-debug-log-bundle-design.md
@@ -1,0 +1,185 @@
+# Debug Log Bundle — Design
+
+**Date:** 2026-06-16
+**Status:** Approved (design); pending spec review
+**Branch:** `claude/dreamy-borg-0c01f8` (builds on the audit-log feature)
+
+## Goal
+
+Add a **"Send Debug Logs to Openwater"** button to the audit-log viewer
+(`LogsModal`). It zips the last 48 hours of app logs (plus minimal
+diagnostic context), reveals the zip in the file explorer, and tells the
+user to email it to **support@openwater.cc**. No mail client is launched
+and nothing is auto-sent (a `mailto:` link cannot attach a file, and
+true one-click send would require new SMTP/HTTP infrastructure that is
+out of scope).
+
+## Decisions (locked)
+
+- **Behavior:** zip → reveal in file explorer → toast with the support
+  address. No mail-client launch, no auto-send.
+- **Bundle contents:** `app-logs/*.log` modified in the last 48h, plus
+  `app_config.json` and a generated `system_info.txt`. No `scans.db`,
+  no scan CSVs, no patient/subject data.
+- **Recipient shown in the toast:** `support@openwater.cc`.
+
+## Architecture
+
+A new standalone module **`debug_bundle.py`** with a pure function, plus
+a thin connector slot and one QML button.
+
+- `build_debug_bundle(data_dir, dest_dir, now_epoch, window_hours=48)
+  -> dict` — walks `<data_dir>/app-logs/*.log`, keeps files whose mtime
+  is `>= now_epoch - window_hours*3600`, adds `<data_dir>/app_config.json`
+  (if present) and a generated `system_info.txt`, writes a zip into
+  `dest_dir`, and returns metadata
+  `{"path", "file_count", "log_count", "bytes"}`. `now_epoch` is a
+  parameter so tests are deterministic (the connector passes
+  `time.time()`).
+- The connector slot `prepareDebugLogBundle()` calls the builder, reveals
+  the file, shows a toast, and records an audit event.
+- Rationale: file-gathering/zipping logic is unit-testable against a tmp
+  directory with no app launch; the 4031-line `motion_connector.py`
+  stays lean (one thin slot). Mirrors the `audit_log.py` precedent.
+
+### `system_info.txt`
+
+Reuses `audit_log.gather_host_info()` and adds app + SDK version. Plain
+key/value text lines, e.g.:
+
+```
+app_version: 1.2.0-dev.4
+sdk_version: 1.5.8
+generated: 2026-06-16T10:30:00-07:00
+hostname: LAB-PC-01
+platform: Windows-11-10.0.26200-SP0
+...
+```
+
+The builder owns host probing (`gather_host_info()`) and the `generated`
+timestamp (derived from `now_epoch`). The connector supplies the app/SDK
+versions via `extra_info` (it can't probe them from the pure module).
+The builder merges `extra_info` over the host info and writes the
+combined key/value lines to `system_info.txt`.
+
+## Module API (`debug_bundle.py`)
+
+```python
+WINDOW_HOURS = 48
+
+def build_debug_bundle(
+    data_dir: str | Path,
+    dest_dir: str | Path,
+    now_epoch: float,
+    *,
+    window_hours: int = WINDOW_HOURS,
+    config_path: str | Path | None = None,
+    extra_info: dict | None = None,
+) -> dict:
+    """Zip recent app logs + config + system info into dest_dir.
+
+    Returns {"path": str, "file_count": int, "log_count": int,
+             "bytes": int}. Creates dest_dir if needed. The zip name is
+    debug-bundle-<YYYYMMDD_HHMMSS>.zip derived from now_epoch (local).
+    """
+```
+
+- `config_path`: path to `app_config.json`. Defaults to
+  `<data_dir>/app_config.json` when `None`. The connector passes the
+  real location (`resource_path("config", "app_config.json")`), since
+  the config does **not** live under the data directory. Included at the
+  zip root if the path exists; silently skipped if not.
+- `extra_info`: version info (`app_version`, `sdk_version`) merged into
+  `system_info.txt`. Not a path carrier.
+
+Behavior details:
+- Source logs: `<data_dir>/app-logs/*.log` with
+  `mtime >= now_epoch - window_hours*3600`. Stored in the zip under
+  `app-logs/<filename>`.
+- `app_config.json`: include the file at `config_path` (default
+  `<data_dir>/app_config.json`) at the zip root, if it exists.
+- `system_info.txt`: written at the zip root from `gather_host_info()`
+  merged with `extra_info` (app_version, sdk_version) and a `generated`
+  local-ISO-8601 timestamp from `now_epoch`.
+- Output filename: `debug-bundle-<YYYYMMDD_HHMMSS>.zip` (timestamp from
+  `now_epoch`, local time).
+- Returns metadata; never partially writes — builds into the named file
+  and closes it. Best-effort per-file: a log that can't be read is
+  skipped (logged), not fatal.
+
+## Connector slot (`motion_connector.py`)
+
+```python
+@pyqtSlot(result=str)
+def prepareDebugLogBundle(self) -> str:
+    """Zip the last 48h of app logs (+ config + system info) into
+    app-logs/debug-bundles/, reveal it in the file explorer, and toast
+    the support address. Returns the zip path, or '' on failure."""
+```
+
+- `dest_dir = <self._directory>/app-logs/debug-bundles`.
+- `extra_info = {"app_version": get_version(), "sdk_version":
+  self._interface.get_sdk_version()}` (each guarded; "" on failure),
+  and `config_path = resource_path("config", "app_config.json")`.
+- On success: reveal the file (Windows: `subprocess.run(["explorer",
+  "/select,", path])`; other OS: `QDesktopServices.openUrl` on the
+  folder — best-effort, wrapped in try/except), then
+  `self.notify("Debug logs saved to <path>. Please email this file to
+  support@openwater.cc.", "success", 0, True, "debug-bundle")` (sticky
+  so the path stays readable), and
+  `self._audit.log("debug_bundle_created", {...})`.
+- On failure: log the exception, `self.errorOccurred.emit(...)` and/or a
+  warning toast, return "".
+
+## UI (`components/LogsModal.qml`)
+
+Add a button **"Send Debug Logs"** in the toolbar, before "Export CSV"
+(same button styling as the existing toolbar buttons). `onClicked:
+MotionInterface.prepareDebugLogBundle()`. The connector handles the
+reveal + toast, so the button has no further logic. A short helper text
+or tooltip is not required (the toast explains what happened).
+
+## Audit integration
+
+New event **`debug_bundle_created`**, `details:
+{"dest", "file_count", "log_count", "bytes", "window_hours"}`. Added as
+an event-type constant in `audit_log.py` (`EV_DEBUG_BUNDLE_CREATED`) for
+consistency; it appears in the same Logs viewer.
+
+## Error handling
+
+Fail-soft throughout. Zipping failure → error toast, return "", no
+crash. Reveal failure → still toast the path. Missing `app_config.json`
+or zero recent logs → still produce a valid zip (with whatever exists +
+`system_info.txt`); the metadata reflects the actual counts.
+
+## Testing
+
+`tests/test_debug_bundle.py` (`@pytest.mark.unit`):
+- Create a tmp `data_dir/app-logs` with three `*.log` files; backdate one
+  past 48h via `os.utime`. Add a tmp `app_config.json`. Call
+  `build_debug_bundle(data_dir, dest, now_epoch=<fixed>)`.
+- Assert the resulting zip (via `zipfile.ZipFile.namelist()`) contains
+  the two recent logs under `app-logs/`, `app_config.json`, and
+  `system_info.txt`; excludes the aged log.
+- Assert returned metadata: `log_count == 2`, `file_count`,
+  `bytes == os.path.getsize(path)`, `path` ends with the expected name.
+- `system_info.txt` contains `app_version` / `sdk_version` keys from
+  `extra_info`.
+- Empty case: no recent logs → zip still contains `system_info.txt`
+  (and config if present), `log_count == 0`, no exception.
+
+Connector-level (`tests/test_audit_connector.py`, `@pytest.mark.unit`):
+- `prepareDebugLogBundle()` returns a path that exists under
+  `app-logs/debug-bundles/`, and a `debug_bundle_created` audit event is
+  recorded. (Reveal/notify side effects are best-effort and not
+  asserted; the slot must not raise when `explorer` is unavailable.)
+
+## Out of scope / YAGNI
+
+- No SMTP/HTTP auto-send; no mail-client launch.
+- No retention/cleanup of old bundles (they're small; revisit only if
+  this becomes a problem).
+- No configurable window in the UI (fixed 48h; the constant is the one
+  tuning point).
+- No inclusion of `scans.db` or scan CSVs.

--- a/error_codes.py
+++ b/error_codes.py
@@ -1,0 +1,152 @@
+"""Critical-error code catalog for the BloodFlow app.
+
+Single source of truth for the showstopper conditions surfaced to the user
+through the critical-error modal. Pure data — no Qt, no hardware — so it stays
+unit-testable and importable from anywhere.
+
+Codes are grouped by subsystem:
+
+    E-1xx  startup / initialization
+    E-2xx  laser safety
+    E-3xx  scan / capture
+
+The human-readable catalog lives in ``docs/ERROR_CODES.md`` and is generated
+from this registry; keep the two in sync.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CriticalError:
+    """One showstopper condition.
+
+    Attributes:
+        code: stable identifier, e.g. ``"E-101"``.
+        category: ``"startup"`` | ``"safety"`` | ``"scan"``.
+        title: short headline shown in the modal.
+        message: one or two sentences describing what happened.
+        suggested_action: what the operator should try.
+    """
+
+    code: str
+    category: str
+    title: str
+    message: str
+    suggested_action: str
+
+
+def _e(code, category, title, message, suggested_action) -> CriticalError:
+    return CriticalError(code, category, title, message, suggested_action)
+
+
+# --- E-1xx: startup / initialization ----------------------------------------
+_STARTUP = [
+    _e(
+        "E-101", "startup",
+        "Sensor self-check failed",
+        "The sensor reported that one or more internal devices (I2C mux, IMU, "
+        "a camera, or an FPGA) did not respond during its power-on self-check. "
+        "The system cannot scan reliably in this state.",
+        "Power-cycle the sensor and reconnect. If it persists, the sensor "
+        "hardware needs service — send a bug report.",
+    ),
+    _e(
+        "E-102", "startup",
+        "Sensor self-check unreadable",
+        "The sensor connected but did not return its power-on self-check "
+        "result, so its internal device health is unknown.",
+        "Power-cycle the sensor and reconnect. If it persists, update the "
+        "sensor firmware or send a bug report.",
+    ),
+    _e(
+        "E-103", "startup",
+        "Console initialization failed",
+        "The console connected but its laser-power configuration could not be "
+        "applied. The laser may not operate correctly until this is resolved.",
+        "Power-cycle the console and reconnect. If it persists, send a bug "
+        "report — the console firmware or config may need attention.",
+    ),
+    _e(
+        "E-105", "startup",
+        "Camera power-on failed",
+        "The sensor could not power on its cameras during initialization, so "
+        "camera identities could not be read.",
+        "Power-cycle the sensor and reconnect. If only some cameras are "
+        "affected, the camera board may need service.",
+    ),
+]
+
+# Note: E-104 (console not detected) and E-106 (sensor not detected) are NOT in
+# this critical-modal registry. The startup connection watchdog surfaces them as
+# a non-blocking yellow warning toast instead (see
+# MotionConnector._check_connection_watchdog). They remain documented in
+# docs/ERROR_CODES.md under "Startup warnings".
+
+# --- E-2xx: laser safety -----------------------------------------------------
+_SAFETY = [
+    _e(
+        "E-201", "safety",
+        "Laser safety monitor unresponsive",
+        "The laser-safety monitor stopped reporting a known-good state for "
+        "longer than the allowed transient window, so laser safety cannot be "
+        "confirmed. The laser was shut off as a precaution.",
+        "Power-cycle the system and reconnect. Do not scan until this clears "
+        "— send a bug report if it persists; the safety I2C link may be "
+        "failing.",
+    ),
+    _e(
+        "E-202", "safety",
+        "Laser safety trip",
+        "The laser-safety monitor tripped during a scan and the laser was shut "
+        "off. The scan was stopped.",
+        "Remove any obstruction, let the system settle, and start a new scan. "
+        "If it trips repeatedly, stop and send a bug report.",
+    ),
+]
+
+# --- E-3xx: scan / capture ---------------------------------------------------
+_SCAN = [
+    _e(
+        "E-301", "scan",
+        "Scan aborted before start",
+        "A scan was requested but a precondition check failed, so the scan was "
+        "aborted before the laser fired.",
+        "Resolve the reported precondition (connection, safety, or "
+        "configuration) and start the scan again.",
+    ),
+    _e(
+        "E-302", "scan",
+        "Scan could not start",
+        "The system refused to start a new scan, usually because a previous "
+        "scan is still finishing.",
+        "Wait a few seconds for the previous scan to finish, then try again. "
+        "Reconnect if the system stays busy.",
+    ),
+]
+
+
+ERROR_CODES: dict[str, CriticalError] = {
+    err.code: err for err in (*_STARTUP, *_SAFETY, *_SCAN)
+}
+
+
+def lookup(code: str) -> CriticalError:
+    """Return the catalog entry for ``code``.
+
+    Never raises: an unknown code yields a generic entry that preserves the
+    code, so the modal can always show *something* even for a code that
+    predates this build.
+    """
+    err = ERROR_CODES.get(code)
+    if err is not None:
+        return err
+    return CriticalError(
+        code=code,
+        category="startup",
+        title="Critical error",
+        message="A critical error occurred.",
+        suggested_action="Send a bug report with the session log attached.",
+    )

--- a/main.py
+++ b/main.py
@@ -140,6 +140,13 @@ def _load_app_config() -> dict:
         # painted. Gated on `developerMode && showProfiling` so clinical
         # users never see it.
         "showProfiling": False,
+        # Critical-error bug report (see error_codes.py / CriticalErrorModal).
+        "support_email": "support@openwater.health",
+        "bug_report_smtp": None,
+        # Startup connection watchdog (E-104/E-106).
+        "connectionTimeoutSec": 30,
+        "requireConsole": True,
+        "minSensors": 1,
     }
     config_path = resource_path("config", "app_config.json")
     if not config_path.exists():
@@ -272,7 +279,10 @@ def main():
 
     engine = QQmlApplicationEngine()
 
-    connector = MotionConnector(motion_interface, app_config=app_config, data_dir=_data_dir)
+    connector = MotionConnector(
+        motion_interface, app_config=app_config, data_dir=_data_dir,
+        app_version=APP_VERSION, log_path=logfile_path,
+    )
     qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", connector)
     engine.rootContext().setContextProperty("appVersion", APP_VERSION)
 

--- a/main.qml
+++ b/main.qml
@@ -204,4 +204,12 @@ ApplicationWindow {
     TestResultsWindow {
         id: testResultsWindow
     }
+
+    // Critical-error modal — top-level so it overlays every page and toast.
+    // Listens to MotionInterface.criticalErrorRaised; see docs/ERROR_CODES.md.
+    CriticalErrorModal {
+        id: criticalErrorModal
+        anchors.fill: parent
+        z: 100000
+    }
 }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -38,6 +38,8 @@ from processing.visualize_bloodflow import VisualizeBloodflow
 from motion_config import (
     load_tec_params,
 )
+import error_codes
+import bug_report
 from nan_gap_tracker import NanGapTracker, gap_note_line
 from utils.resource_path import resource_path
 from data_sources import (
@@ -583,6 +585,10 @@ class MotionConnector(QObject):
     gyroscopeSensorUpdated = pyqtSignal(float, float, float)  # (x, y, z)
     rgbStateReceived = pyqtSignal(int, str)  # (state, state_text)
     errorOccurred = pyqtSignal(str)
+    # Critical/showstopper conditions surfaced to the user as a blocking,
+    # dismissible modal with a stable error code (see error_codes.py).
+    # Payload: (code, title, message, suggestedAction, detail).
+    criticalErrorRaised = pyqtSignal(str, str, str, str, str)
     notificationRequested = pyqtSignal('QVariant')  # toast notification payload dict
     notificationDismissByIdRequested = pyqtSignal(int)   # dismiss the toast with this id
     notificationDismissByTagRequested = pyqtSignal(str)  # dismiss the toast with this tag
@@ -678,12 +684,27 @@ class MotionConnector(QObject):
         config_dir="config",
         parent=None,
         log_level=logging.INFO,
+        app_version="",
+        log_path="",
     ):
         super().__init__(parent)
         cfg = app_config or {}
 
         # Store the full config dict — exposed to QML as appConfig property
         self._app_config = dict(cfg)
+
+        # Bug-report context (see sendBugReport). app_version + log_path come
+        # from main.py; support_email / bug_report_smtp from app config.
+        self._app_version = app_version
+        self._log_path = log_path
+        self._support_email = cfg.get("support_email", "support@openwater.health")
+        self._bug_report_smtp = cfg.get("bug_report_smtp")
+
+        # Connection watchdog (E-104/E-106): one-shot check armed at startup
+        # that flags expected devices that never enumerated. 0 disables it.
+        self._connection_timeout_sec = float(cfg.get("connectionTimeoutSec", 30))
+        self._require_console = bool(cfg.get("requireConsole", True))
+        self._min_sensors = int(cfg.get("minSensors", 1))
 
         self._interface = interface
         self._scan_workflow = self._interface.scan_workflow
@@ -898,6 +919,11 @@ class MotionConnector(QObject):
 
         self._interface.console.telemetry.add_listener(self._on_telemetry_update)
 
+        # Arm the startup connection watchdog (E-104/E-106). The timer starts
+        # once the Qt event loop runs — by which point motion_interface.start()
+        # has had its window to enumerate already-attached devices.
+        self._arm_connection_watchdog()
+
     def set_ft_thresholds(
         self,
         min_mean_per_camera=None,
@@ -975,6 +1001,11 @@ class MotionConnector(QObject):
 
         self.getFanControlStatus(side)
 
+        # Surface the firmware's boot-time I2C self-check (E-101/E-102) — the
+        # canonical "I2C check at the beginning". Best-effort: never blocks
+        # init, just raises the modal if the sensor reports trouble.
+        self._check_sensor_i2c_health(side)
+
         # Power on all cameras, fill the ID cache (serial numbers, connection info), then power off
         try:
             sensor = getattr(self._interface, side, None) if self._interface else None
@@ -994,6 +1025,7 @@ class MotionConnector(QObject):
                             "Could not power on cameras on %s sensor for ID cache fill",
                             side,
                         )
+                        self._raise_critical("E-105", detail=f"{side} sensor")
                         refresh_cache()  # try anyway in case some cameras are already on
                 elif refresh_cache:
                     refresh_cache()  # fallback: fill cache without power cycle (may get zeros for off cameras)
@@ -1005,6 +1037,91 @@ class MotionConnector(QObject):
         self._read_and_log_camera_uids(side)
 
         self.connectionStatusChanged.emit()
+
+    def _check_sensor_i2c_health(self, side: str) -> None:
+        """Raise E-101/E-102 if a sensor's boot-time I2C self-check is bad.
+
+        Reads the firmware's cached snapshot (no disruptive rescan). Never
+        raises out — it's a best-effort surfacing layer over the SDK's
+        ``MotionSensor.i2c_health``.
+        """
+        try:
+            sensor = getattr(self._interface, side, None) if self._interface else None
+            if sensor is None or not sensor.is_connected():
+                return
+            health = getattr(sensor, "i2c_health", None)
+            if health is None:
+                self._raise_critical("E-102", detail=f"{side} sensor")
+            elif not health.get("all_present", False):
+                missing = self._i2c_missing_devices(health)
+                self._raise_critical("E-101", detail=f"{side} sensor: {missing}")
+        except Exception:
+            logger.exception("I2C health check failed for %s sensor", side)
+
+    def _arm_connection_watchdog(self) -> None:
+        """Schedule the one-shot startup connection check (E-104/E-106)."""
+        if self._connection_timeout_sec > 0:
+            QTimer.singleShot(
+                int(self._connection_timeout_sec * 1000),
+                self._check_connection_watchdog,
+            )
+
+    def _check_connection_watchdog(self) -> None:
+        """Warn about devices that never connected within the startup timeout.
+
+        One-shot: reads the current cached connection state. A missing console
+        (E-104) and/or too few sensors (E-106) are non-blocking — they surface
+        as a single yellow warning toast (bottom-right), not the critical
+        modal, since the fix is usually just "plug it in". If *both* are
+        missing the toast collapses to a plain "System not found". Disconnects
+        that happen *after* startup are handled by the connection-status UI.
+        """
+        try:
+            console_missing = self._require_console and not self._consoleConnected
+            n_sensors = (int(bool(self._leftSensorConnected))
+                         + int(bool(self._rightSensorConnected)))
+            sensors_missing = n_sensors < self._min_sensors
+            if not console_missing and not sensors_missing:
+                return
+
+            if console_missing and sensors_missing:
+                logger.warning(
+                    "Connection watchdog: console and sensors missing "
+                    "(E-104/E-106: %d of %d sensors)", n_sensors, self._min_sensors)
+                msg = ("System not found. Check that the console and sensor "
+                       "are connected and powered on.")
+            elif console_missing:
+                logger.warning("Connection watchdog: console not detected (E-104)")
+                msg = ("Console not detected. Check the console USB cable and "
+                       "power, then reconnect.")
+            else:
+                logger.warning(
+                    "Connection watchdog: sensor not detected "
+                    "(E-106: %d of %d)", n_sensors, self._min_sensors)
+                msg = ("Sensor not detected. Check the sensor USB cable and "
+                       "power, then reconnect.")
+            # Sticky, single (tagged) yellow toast — the user must act, but it
+            # never blocks the UI like the critical modal.
+            self.notify(msg, "warning", duration_ms=0, dismissible=True,
+                        tag="connection-watchdog")
+        except Exception:
+            logger.exception("connection watchdog check failed")
+
+    @staticmethod
+    def _i2c_missing_devices(health: dict) -> str:
+        """Human-readable summary of which I2C devices didn't respond."""
+        parts = []
+        if not health.get("mux", True):
+            parts.append("mux")
+        if not health.get("imu", True):
+            parts.append("imu")
+        cams = [i for i, ok in enumerate(health.get("cameras", [])) if not ok]
+        if cams:
+            parts.append("cameras " + ",".join(str(i) for i in cams))
+        fpgas = [i for i, ok in enumerate(health.get("fpgas", [])) if not ok]
+        if fpgas:
+            parts.append("fpgas " + ",".join(str(i) for i in fpgas))
+        return "; ".join(parts) or "unknown device"
 
     # --- GETTERS/SETTERS FOR Qt PROPERTIES ---
     def getUserLabel(self) -> str:
@@ -1233,6 +1350,8 @@ class MotionConnector(QObject):
                         logger.info("Laser power params applied from config")
                     else:
                         logger.error("Failed to apply laser power params from config")
+                        self._raise_critical(
+                            "E-103", detail="laser power params not applied")
                 except Exception as e:
                     logger.warning(
                         f"Console connect-time setup interrupted "
@@ -2692,12 +2811,14 @@ class MotionConnector(QObject):
                 logger.warning("startCapture aborted: %s", reason)
                 self.captureLog.emit(f"Scan aborted: {reason}")
                 self.errorOccurred.emit(reason)
+                self._raise_critical("E-301", detail=reason)
             else:
                 logger.warning(
                     "startCapture aborted: SDK refused to spawn a new scan "
                     "(usually a previous worker thread that didn't exit cleanly)."
                 )
                 self.captureLog.emit("Capture already running.")
+                self._raise_critical("E-302")
         return bool(started)
 
     def _log_scan_image_stats(self, left_csv: str, right_csv: str) -> None:
@@ -2875,6 +2996,7 @@ class MotionConnector(QObject):
         self.captureLog.emit(
             "Laser safety system tripped. Scan will be cancelled in 5 seconds."
         )
+        self._raise_critical("E-202")
         QTimer.singleShot(5000, self.stopCapture)
 
     @pyqtSlot(result=QVariant)
@@ -2972,6 +3094,7 @@ class MotionConnector(QObject):
                     logger.error(f"Laser safety failure: {fault_detail}")
                     self.safetyFailure = True
                     self._fire_safety_notification(fault_detail)
+                    self._raise_critical("E-201", detail=fault_detail)
                     self.stopTrigger()
                     self._laserOn = False
                     self.laserStateChanged.emit()
@@ -3862,6 +3985,87 @@ class MotionConnector(QObject):
         cb = QGuiApplication.clipboard()
         if cb is not None:
             cb.setText(text)
+
+    # --- CRITICAL ERROR SURFACING -----------------------------------------
+    def _raise_critical(self, code: str, detail: str = "") -> None:
+        """Surface a showstopper to the user via the critical-error modal.
+
+        Looks ``code`` up in :mod:`error_codes`, logs it, and emits
+        ``criticalErrorRaised``. Safe to call from worker threads — the QML
+        side connects with a queued connection. Never raises.
+        """
+        try:
+            err = error_codes.lookup(code)
+            logger.error("CRITICAL %s — %s%s", code, err.title,
+                         f" ({detail})" if detail else "")
+            self.criticalErrorRaised.emit(
+                code, err.title, err.message, err.suggested_action, detail)
+        except Exception:
+            logger.exception("Failed to raise critical error %s", code)
+
+    def _device_info_str(self) -> str:
+        """Best-effort one-line device identity for bug reports."""
+        try:
+            console, left, right = self._interface.is_device_connected()
+            return f"console={'yes' if console else 'no'} " \
+                   f"left={'yes' if left else 'no'} " \
+                   f"right={'yes' if right else 'no'}"
+        except Exception:
+            return "unknown"
+
+    @pyqtSlot(str)
+    def sendBugReport(self, code: str) -> None:
+        """Send the current session log + error context to Openwater support.
+
+        If a complete ``bug_report_smtp`` block is configured the email is sent
+        directly (with the log attached) on a background thread. Otherwise we
+        fall back to opening the user's mail client and revealing the log file
+        so they can attach it manually.
+        """
+        err = error_codes.lookup(code)
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        subject = f"BloodFlow Bug Report — {code} {err.title}"
+        body = bug_report.build_report_text(
+            code=code, title=err.title, message=err.message,
+            timestamp=timestamp, app_version=self._app_version or "unknown",
+            device_info=self._device_info_str(),
+            log_path=self._log_path or "(no log file)",
+        )
+        if bug_report.smtp_config_complete(self._bug_report_smtp):
+            self._send_bug_report_smtp(subject, body)
+        else:
+            self._send_bug_report_fallback(subject, body)
+
+    def _send_bug_report_smtp(self, subject: str, body: str) -> None:
+        """Send the report via SMTP on a daemon thread; toast the result."""
+        def _worker():
+            try:
+                bug_report.send_via_smtp(
+                    self._bug_report_smtp, to_addr=self._support_email,
+                    subject=subject, body=body, log_path=self._log_path or None,
+                )
+                self.notify("Bug report sent to Openwater.", "success")
+            except Exception as exc:
+                logger.exception("SMTP bug report failed")
+                self.notify(f"Could not send bug report: {exc}", "error")
+                # Fall back so the user can still get the report out.
+                self._send_bug_report_fallback(subject, body)
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _send_bug_report_fallback(self, subject: str, body: str) -> None:
+        """Open the mail client, copy the report, and reveal the log file."""
+        import webbrowser
+        self.copyToClipboard(body)
+        if self._log_path:
+            bug_report.reveal_in_file_manager(self._log_path)
+        try:
+            webbrowser.open(bug_report.build_mailto_url(
+                self._support_email, subject=subject, body=body))
+        except Exception:
+            logger.exception("Could not open mail client for bug report")
+        self.notify(
+            "Bug report copied to clipboard. Attach the highlighted log "
+            "file and send the email to Openwater.", "info", 8000, True)
 
     def connect_signals(self):
         """Subscribe to per-handle state changes on the SDK interface."""

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -688,6 +688,14 @@ class MotionConnector(QObject):
         self._interface = interface
         self._scan_workflow = self._interface.scan_workflow
 
+        # Audit log constructed early — before connect_signals() — so the
+        # connect/disconnect handler and other instrumentation can call
+        # self._audit.log(...) safely. No-op if there's no scan_db_path.
+        # The system_startup / system_info events are logged later, once
+        # self._directory is resolved.
+        from audit_log import AuditLog
+        self._audit = AuditLog(getattr(self._interface, "scan_db_path", None))
+
         # Unpack operational settings from config
         self._force_laser_fail            = bool(cfg.get("forceLaserFail", False))
         self._camera_temp_alert_threshold_c = float(cfg.get("cameraTempAlertThresholdC", 105.0))
@@ -809,6 +817,7 @@ class MotionConnector(QObject):
         )
         self._calibration_status = ""  # "", "running", "passed", "failed", "aborted"
         self._calibration_failure_reason = ""  # populated only on FAIL in dev mode
+        self._calibration_target = None  # last runCalibration() target
         self._test_scan_status = ""              # "", "running", "done", "aborted", "failed"
         self._test_scan_failure_reason = ""
         self._test_scan_rows: list[dict] = []
@@ -849,6 +858,29 @@ class MotionConnector(QObject):
 
         os.makedirs(resolved_dir, exist_ok=True)
         self._directory = resolved_dir
+
+        # ── Audit log startup events (the AuditLog itself was constructed
+        #    earlier, before connect_signals). Logged here now that
+        #    self._directory is resolved.
+        from audit_log import gather_host_info
+        try:
+            from version import get_version as _get_app_version
+            _app_version = _get_app_version()
+        except Exception:
+            _app_version = ""
+        try:
+            _sdk_version = self._interface.get_sdk_version()
+            _sdk_version = (
+                _sdk_version if isinstance(_sdk_version, str) else ""
+            )
+        except Exception:
+            _sdk_version = ""
+        self._audit.log("system_startup", {
+            "app_version": _app_version,
+            "sdk_version": _sdk_version,
+            "data_dir": self._directory,
+        })
+        self._audit.log("system_info", gather_host_info())
         logger.info(f"[Connector] Directory initialized to: {self._directory}")
 
         self._user_label = self.generate_user_label()
@@ -1237,12 +1269,17 @@ class MotionConnector(QObject):
         if is_now_connected:
             logger.info("Handle %s -> CONNECTED (%s)", name, reason)
             self.signalConnected.emit(name, "")
+            self._audit.log("device_connected",
+                            {"device": name, "reason": str(reason)})
+            self._log_device_stats(name)
         elif is_now_lost:
             logger.info(
                 "Handle %s -> DISCONNECTED (%s) and state is %s",
                 name, reason, self._state,
             )
             self.signalDisconnected.emit(name, "")
+            self._audit.log("device_disconnected",
+                            {"device": name, "reason": str(reason)})
             # Abort an in-flight FPGA flash / sensor-configure pipeline.
             # The SDK does not subscribe to disconnect events for the
             # configure-cameras flow (only start_scan does), so without
@@ -1270,6 +1307,26 @@ class MotionConnector(QObject):
         if is_now_connected or is_now_lost:
             self.connectionStatusChanged.emit()
             self.update_state()
+
+    def _log_device_stats(self, name: str) -> None:
+        """Best-effort audit of a device's hardware + firmware IDs on
+        connect. Missing values are logged as empty strings."""
+        handle = getattr(self._interface, name, None)
+        hwid = ""
+        fw = ""
+        try:
+            if handle is not None and hasattr(handle, "get_hardware_id"):
+                hwid = str(handle.get_hardware_id() or "")
+        except Exception:
+            pass
+        try:
+            if handle is not None and hasattr(handle, "get_version"):
+                fw = str(handle.get_version() or "")
+        except Exception:
+            pass
+        self._audit.log("device_stats", {
+            "device": name, "hardware_id": hwid, "firmware_version": fw,
+        })
 
     def update_state(self):
         """Update system state based on connection and configuration."""
@@ -1363,6 +1420,11 @@ class MotionConnector(QObject):
         teardown) right after this returns."""
         logger.info("Shutting down MotionConnector...")
         self.stopCapture()
+        try:
+            self._audit.log("system_shutdown", {"clean": True})
+            self._audit.close()
+        except Exception:
+            logger.warning("audit shutdown log failed", exc_info=True)
         logger.info("MotionConnector shutdown complete.")
 
     # --- SCAN MANAGEMENT METHODS ---
@@ -1749,7 +1811,135 @@ class MotionConnector(QObject):
         except Exception:
             logger.warning(
                 "deleteScans: could not open scan DB", exc_info=True)
+        # Tolerate non-int ids the same way the delete loop above does —
+        # this comprehension runs outside AuditLog.log's fail-soft wrapper.
+        _ids = []
+        for s in session_ids:
+            try:
+                _ids.append(int(s))
+            except (TypeError, ValueError):
+                pass
+        self._audit.log("scan_deleted", {
+            "session_ids": _ids,
+            "count": deleted,
+        })
         return deleted
+
+    # ── Audit log (QML-facing) ───────────────────────────────────────────
+    @pyqtSlot(result="QVariantList")
+    @pyqtSlot(int, result="QVariantList")
+    def auditLogEntries(self, limit: int = 500):
+        """Audit-log rows (newest first) for the Logs modal. Pure read —
+        does not itself log, so refreshing never double-logs."""
+        try:
+            return self._audit.query(int(limit))
+        except Exception:
+            logger.warning("auditLogEntries failed", exc_info=True)
+            return []
+
+    @pyqtSlot()
+    def recordAuditLogViewed(self):
+        """Record that the audit log was opened. Called once from
+        LogsModal.open()."""
+        try:
+            n = self._audit.count()
+        except Exception:
+            n = 0
+        self._audit.log("audit_log_viewed", {"entry_count": n})
+
+    @pyqtSlot(str, result=str)
+    def exportAuditLogCsv(self, dest_path: str) -> str:
+        """Export the full audit log to CSV. Accepts a plain path or a
+        file:// URL. Records an ``audit_log_exported`` event. Returns the
+        written path, or '' on failure."""
+        if not dest_path:
+            return ""
+        path = dest_path.replace("file:///", "").replace("file://", "")
+        try:
+            n = self._audit.export_csv(path)
+            self._audit.log(
+                "audit_log_exported", {"dest": path, "row_count": n}
+            )
+            logger.info("exportAuditLogCsv: wrote %d rows -> %s", n, path)
+            return path
+        except Exception:
+            logger.exception("exportAuditLogCsv failed for %r", path)
+            self.errorOccurred.emit("Audit log export failed.")
+            return ""
+
+    @pyqtSlot(result=str)
+    def prepareDebugLogBundle(self) -> str:
+        """Zip the last 48h of app logs (+ config + system info) into
+        app-logs/debug-bundles/, reveal it in the file explorer, and toast
+        the support address. Returns the zip path, or '' on failure."""
+        try:
+            from debug_bundle import build_debug_bundle, WINDOW_HOURS
+            try:
+                from version import get_version as _gv
+                app_version = _gv()
+            except Exception:
+                app_version = ""
+            try:
+                sdk_version = self._interface.get_sdk_version()
+                sdk_version = (
+                    sdk_version if isinstance(sdk_version, str) else ""
+                )
+            except Exception:
+                sdk_version = ""
+            dest_dir = os.path.join(
+                self._directory, "app-logs", "debug-bundles"
+            )
+            meta = build_debug_bundle(
+                self._directory,
+                dest_dir,
+                time.time(),
+                config_path=resource_path("config", "app_config.json"),
+                extra_info={
+                    "app_version": app_version,
+                    "sdk_version": sdk_version,
+                },
+            )
+        except Exception:
+            logger.exception("prepareDebugLogBundle: failed to build bundle")
+            self.errorOccurred.emit("Could not create the debug log bundle.")
+            return ""
+
+        path = meta["path"]
+        self._reveal_in_explorer(path)
+        from audit_log import EV_DEBUG_BUNDLE_CREATED
+        self._audit.log(EV_DEBUG_BUNDLE_CREATED, {
+            "dest": path,
+            "file_count": meta["file_count"],
+            "log_count": meta["log_count"],
+            "bytes": meta["bytes"],
+            "window_hours": WINDOW_HOURS,
+        })
+        self.notify(
+            "Debug logs saved to " + path
+            + ". Please email this file to support@openwater.cc.",
+            type_="success", duration_ms=0, dismissible=True,
+            tag="debug-bundle",
+        )
+        return path
+
+    def _reveal_in_explorer(self, path: str) -> None:
+        """Best-effort: open the OS file browser with the file selected.
+        Never raises — a failed reveal must not lose the bundle."""
+        try:
+            import subprocess
+            import sys
+            if sys.platform.startswith("win"):
+                subprocess.Popen(
+                    ["explorer", "/select,", os.path.normpath(path)]
+                )
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", "-R", path])
+            else:
+                subprocess.Popen(["xdg-open", os.path.dirname(path)])
+        except Exception:
+            logger.warning(
+                "could not reveal %s in file explorer", path, exc_info=True
+            )
 
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):
@@ -1806,18 +1996,29 @@ class MotionConnector(QObject):
     @pyqtSlot(str, 'QVariant')
     def setConfig(self, key: str, value):
         """Update a single config key, persist to disk, and notify QML."""
+        old = self._app_config.get(key)
         self._app_config[key] = value
         self._save_app_config()
         self.appConfigChanged.emit()
         logger.debug(f"[Connector] Config set: {key} = {value!r}")
+        if old != value:
+            self._audit.log("settings_changed",
+                            {"changes": {key: {"old": old, "new": value}}})
 
     @pyqtSlot('QVariantMap')
     def saveConfigs(self, configs: dict):
         """Update multiple config keys at once, persist to disk, and notify QML."""
+        changes = {}
+        for k, v in configs.items():
+            old = self._app_config.get(k)
+            if old != v:
+                changes[k] = {"old": old, "new": v}
         self._app_config.update(configs)
         self._save_app_config()
         self.appConfigChanged.emit()
         logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
+        if changes:
+            self._audit.log("settings_changed", {"changes": changes})
 
     @pyqtSlot(bool)
     def setWriteRawCsv(self, enabled: bool) -> None:
@@ -1949,6 +2150,7 @@ class MotionConnector(QObject):
             )
             self.pastScanLoadFinished.emit(session_label, False)
             return
+        self._audit.log("scan_viewed", {"label": session_label})
         # Per-cam corrected CSV ({scan_id}.csv, 82-col wide format)
         # is the only source of per-cam BFI/BVI/mean/contrast for
         # past replay — the DB's session_data only holds side-
@@ -2251,6 +2453,11 @@ class MotionConnector(QObject):
         self.scanNotesChanged.emit()
         self._capture_running = True
         self._capture_start_time = time.time()
+        self._audit.log("scan_started", {
+            "label": subject_id,
+            "left_mask": int(left_camera_mask),
+            "right_mask": int(right_camera_mask),
+        })
         # Per-scan monotonic zero for plot timestamps. sample.timestamp_s comes
         # from each sensor's firmware clock, which resets on sensor reboot — so
         # after a mid-scan unplug/replug, the two sides' clocks diverge and the
@@ -2395,6 +2602,21 @@ class MotionConnector(QObject):
             self._capture_running = False
             self._safety_cancel_scheduled = False
             self._capture_thread = None
+            try:
+                _outcome_kind = outcome.kind
+            except Exception:
+                _outcome_kind = None
+            try:
+                _dur = (time.time() - self._capture_start_time
+                        if self._capture_start_time else None)
+            except Exception:
+                _dur = None
+            self._audit.log("scan_ended", {
+                "label": subject_id,
+                "session_label": session_label or None,
+                "duration_s": round(_dur, 1) if _dur is not None else None,
+                "outcome": _outcome_kind,
+            })
             self.captureFinished.emit(True, "", "", "")
             self.scanNotesReady.emit()
 
@@ -3742,9 +3964,11 @@ class MotionConnector(QObject):
         )
 
         self._calibration_status = "running"
+        self._calibration_target = target
         self.calibrationStateChanged.emit()
         self.captureLog.emit("Calibration: starting…")
         self._calibration_t0 = time.monotonic()
+        self._audit.log("calibration_started", {"target": target})
         logger.info(
             "=== Calibration started: target=%s left=0x%02X right=0x%02X "
             "scan_duration=%ss ===",
@@ -4003,6 +4227,11 @@ class MotionConnector(QObject):
             "=== Calibration ended: %s after %.1fs ===",
             self._calibration_status, elapsed_s,
         )
+        self._audit.log("calibration_ended", {
+            "target": self._calibration_target,
+            "outcome": self._calibration_status,
+            "reason": self._calibration_failure_reason or None,
+        })
         self.calibrationStateChanged.emit()
 
     @property

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -76,6 +76,23 @@ def developer_password_matches(pw) -> bool:
     return isinstance(pw, str) and pw == _DEVELOPER_PASSWORD
 
 
+# Camera-mask → human config name, mirroring CameraSelectionModal's
+# pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
+# reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.
+_CONFIG_NAMES = {
+    0x00: "None", 0x5A: "Near", 0x66: "Middle", 0xC3: "Far",
+    0x99: "Outer", 0x0F: "Left", 0xF0: "Right", 0x42: "Third Row",
+    0xFF: "All",
+}
+
+
+def _config_name(mask) -> str:
+    if mask is None or mask < 0:
+        return "—"
+    m = int(mask) & 0xFF
+    return _CONFIG_NAMES.get(m, f"0x{m:02X}")
+
+
 logger = logging.getLogger("openmotion.bloodflow-app.connector")
 
 # Define system states
@@ -1579,6 +1596,160 @@ class MotionConnector(QObject):
             "notes": notes,
             "hasData": bool(has_db_rows or corrected or left or right),
         }
+
+    @staticmethod
+    def _friendly_ts(ts: str) -> str:
+        """'YYYYMMDD_HHMMSS' -> 'YYYY-MM-DD HH:MM:SS'; pass through."""
+        if not ts or len(ts) != 15:
+            return ts or "-"
+        return (f"{ts[0:4]}-{ts[4:6]}-{ts[6:8]} "
+                f"{ts[9:11]}:{ts[11:13]}:{ts[13:15]}")
+
+    def _session_to_row(self, s: dict) -> dict:
+        """Flatten one ScanDatabase session dict into the QVariantMap the
+        History table consumes. Masks/operator come from session_meta
+        (written by ScanDBSink); duration from session_start/end."""
+        label = (s.get("session_label") or "").strip()
+        meta = s.get("session_meta")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except Exception:
+                meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        flags = meta.get("sdk_flags") or {}
+
+        left_mask = flags.get("left_camera_mask", -1)
+        right_mask = flags.get("right_camera_mask", -1)
+        if left_mask is None:
+            left_mask = -1
+        if right_mask is None:
+            right_mask = -1
+
+        user_label = meta.get("subject_id") or ""
+        timestamp = ""
+        m = re.match(r"^(\d{8}_\d{6})_?(.*)$", label)
+        if m:
+            timestamp = m.group(1)
+            if not user_label:
+                user_label = m.group(2)
+
+        start = s.get("session_start")
+        end = s.get("session_end")
+        if start is not None and end is not None:
+            duration = float(end) - float(start)
+        else:
+            duration = -1.0
+
+        return {
+            "sessionId": int(s.get("id")),
+            "label": label,
+            "userLabel": user_label,
+            "operator": meta.get("operator") or "",
+            "timestamp": timestamp or label,
+            "dateTime": self._friendly_ts(timestamp),
+            "durationSec": duration,
+            "leftMask": int(left_mask),
+            "rightMask": int(right_mask),
+            "configL": _config_name(left_mask),
+            "configR": _config_name(right_mask),
+            "reducedMode": bool(flags.get("reduced_mode", False)),
+            "notes": s.get("session_notes") or "",
+            "interrupted": end is None,
+        }
+
+    @pyqtSlot(result="QVariantList")
+    def get_scan_sessions(self):
+        """Return one row per scan-DB session, newest first, for the
+        History table. DB-only — does not list CSV-derived scans.
+        Best-effort: a missing/unreadable DB yields []."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return []
+        rows = []
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for s in db.iter_sessions():
+                    # Per-row guard: one malformed session must not blank the
+                    # whole History view — skip it and keep the rest.
+                    try:
+                        rows.append(self._session_to_row(s))
+                    except Exception:
+                        logger.warning(
+                            "get_scan_sessions: skipping malformed session %s",
+                            s.get("id"), exc_info=True)
+            finally:
+                db.close()
+        except Exception:
+            logger.warning("get_scan_sessions: could not read scan DB",
+                           exc_info=True)
+            return []
+        rows.sort(key=lambda r: r["timestamp"], reverse=True)
+        return rows
+
+    @pyqtSlot(int, result="QVariantMap")
+    def get_session_stats(self, session_id: int):
+        """Lazily fetch heavier per-scan stats (row count) when a History
+        row is focused, so the list query itself stays cheap."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return {"sampleCount": 0}
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                # Raw COUNT via the connection — ScanDatabase exposes no
+                # public row-count API; get_scan_details reaches for
+                # _connection() the same way for its EXISTS probe.
+                row = next(
+                    db._connection().execute(
+                        "SELECT COUNT(*) FROM session_data"
+                        " WHERE session_id = ?",
+                        (int(session_id),),
+                    ),
+                    None,
+                )
+                return {"sampleCount": int(row[0]) if row else 0}
+            finally:
+                db.close()
+        except Exception:
+            logger.warning(
+                "get_session_stats failed for %s", session_id,
+                exc_info=True)
+            return {"sampleCount": 0}
+
+    @pyqtSlot("QVariantList", result=int)
+    def deleteScans(self, session_ids):
+        """Delete the given scan-DB sessions (CASCADE removes their
+        session_data). Returns the count actually deleted. The developer-
+        password gate is enforced in QML before this is called."""
+        db_path = getattr(self._interface, "scan_db_path", None)
+        if not db_path:
+            return 0
+        deleted = 0
+        try:
+            from omotion.ScanDatabase import ScanDatabase
+            db = ScanDatabase(db_path)
+            try:
+                for sid in session_ids:
+                    try:
+                        if db.delete_session(int(sid)):
+                            deleted += 1
+                            logger.info(
+                                "deleteScans: removed session %s", sid)
+                    except Exception:
+                        logger.warning(
+                            "deleteScans: failed to delete %s", sid,
+                            exc_info=True)
+            finally:
+                db.close()
+        except Exception:
+            logger.warning(
+                "deleteScans: could not open scan DB", exc_info=True)
+        return deleted
 
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -191,7 +191,7 @@ Rectangle {
                 if (bloodFlow.reducedMode) {
                     reducedStartPending = true
                     contactQualityModal.preScanMode = true
-                    contactQualityModal.reset(true, 0)
+                    contactQualityModal.reset(true)
                     qualityCheckRunner.start()
                 } else {
                     beginScanWhenReady()
@@ -200,7 +200,7 @@ Rectangle {
         }
         onCheckClicked: {
             modalManager.closeCurrent()
-            contactQualityModal.reset(false, 0)
+            contactQualityModal.reset(false)
             qualityCheckRunner.start()
         }
 
@@ -381,7 +381,7 @@ Rectangle {
         }
         onRetestRequested: {
             contactQualityModal.preScanMode = bloodFlow.reducedStartPending
-            contactQualityModal.reset(bloodFlow.reducedStartPending, 0)
+            contactQualityModal.reset(bloodFlow.reducedStartPending)
             qualityCheckRunner.start()
         }
         onDismissed: {
@@ -530,8 +530,10 @@ Rectangle {
 
         // Contact-quality quick-check lifecycle
         function onContactQualityCheckStarted(seconds) {
+            // ``seconds`` is no longer shown as a countdown — the modal is
+            // now just an indeterminate spinner during the check.
             contactQualityModal.preScanMode = bloodFlow.reducedStartPending
-            contactQualityModal.reset(bloodFlow.reducedStartPending, seconds)
+            contactQualityModal.reset(bloodFlow.reducedStartPending)
         }
         function onContactQualityCheckFinished(ok, error, warnings) {
             if (bloodFlow.reducedStartPending) {

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -229,7 +229,7 @@ Rectangle {
     ModalManager {
         id: modalManager
         modals: [scanSettingsModal, notesModal, historyModal,
-                 settingsModal, contactQualityModal]
+                 settingsModal, contactQualityModal, logsModal]
     }
 
     // Data viewer — fills remaining space to the right of ButtonPanel.
@@ -332,6 +332,18 @@ Rectangle {
 
     SettingsModal {
         id: settingsModal
+        // Audit Log: the password gate lives in SettingsModal; on success
+        // close Settings first so toggle() sees current === null and goes
+        // straight to logsModal.open() (no redundant close), then open the
+        // ModalManager-governed LogsModal.
+        onLogsRequested: {
+            settingsModal.close()
+            modalManager.toggle(logsModal)
+        }
+    }
+
+    LogsModal {
+        id: logsModal
     }
 
     ContactQualityModal {

--- a/tests/test_app_config_defaults.py
+++ b/tests/test_app_config_defaults.py
@@ -69,6 +69,33 @@ def test_unknown_keys_are_dropped(tmp_path, monkeypatch):
     assert "autoConfigureOnStartup" not in cfg
 
 
+def test_critical_error_config_keys_preserved(tmp_path, monkeypatch):
+    """Bug-report + connection-watchdog keys must survive the whitelist.
+
+    `_load_app_config` drops any key not present in the in-code defaults, so
+    these keys must be registered there or they silently never reach the
+    connector (e.g. `bug_report_smtp` could never enable SMTP send).
+    """
+    config_path = tmp_path / "app_config.json"
+    config_path.write_text(
+        json.dumps({
+            "support_email": "x@y.z",
+            "bug_report_smtp": {"host": "h"},
+            "connectionTimeoutSec": 12,
+            "requireConsole": True,
+            "minSensors": 2,
+        }),
+        encoding="utf-8",
+    )
+    _patch_config_path(monkeypatch, config_path)
+    cfg = app_main._load_app_config()
+    assert cfg["support_email"] == "x@y.z"
+    assert cfg["bug_report_smtp"] == {"host": "h"}
+    assert cfg["connectionTimeoutSec"] == 12
+    assert cfg["minSensors"] == 2
+    assert cfg["requireConsole"] is True
+
+
 def test_auto_configure_flag_is_gone():
     """Tombstone for issue #154: the startup auto-flash flag must not
     come back — not in the in-code defaults, not in the shipped config,

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -1,0 +1,235 @@
+"""Unit tests for audit-log instrumentation in MotionConnector."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None, app_config=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface,
+        app_config=app_config or {"developerMode": False},
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+
+
+def _types(c):
+    return [e["event_type"] for e in c.auditLogEntries()]
+
+
+def test_construct_logs_startup_and_system_info(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    t = _types(c)
+    assert "system_startup" in t
+    assert "system_info" in t
+
+
+def test_shutdown_logs_system_shutdown(tmp_path):
+    # shutdown() also closes the audit handle, so read the committed
+    # rows straight from the DB file rather than via the live connector.
+    import sqlite3
+    db = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db)
+    c.shutdown()
+    conn = sqlite3.connect(db)
+    types = [r[0] for r in conn.execute("SELECT event_type FROM logs")]
+    conn.close()
+    assert "system_shutdown" in types
+
+
+def test_record_viewed_and_entries(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c.recordAuditLogViewed()
+    assert "audit_log_viewed" in _types(c)
+
+
+def test_export_csv_writes_file_and_logs_export(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit.csv")
+    out = c.exportAuditLogCsv(dest)
+    assert out == dest
+    assert os.path.exists(dest)
+    assert "audit_log_exported" in _types(c)
+
+
+def test_export_csv_strips_file_url(tmp_path):
+    import os
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    dest = str(tmp_path / "audit2.csv")
+    out = c.exportAuditLogCsv("file:///" + dest.replace("\\", "/"))
+    assert out                     # returned path must be non-empty
+    assert os.path.exists(out)
+
+
+def test_no_db_path_noop(tmp_path):
+    # With no scan_db_path the audit log is a no-op; the connector must
+    # still construct and the slots must return gracefully (no raise).
+    import os
+    c = _connector(tmp_path, scan_db_path=None)
+    assert c.auditLogEntries() == []
+    c.recordAuditLogViewed()       # must not raise
+    dest = str(tmp_path / "out.csv")
+    c.exportAuditLogCsv(dest)      # no raise; nothing written when disabled
+    assert not os.path.exists(dest)
+
+
+def test_disconnect_logs_device_disconnected(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "left"
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.CONNECTED, ConnectionState.DISCONNECTED,
+        "unplugged",
+    )
+    assert "device_disconnected" in _types(c)
+
+
+def test_connect_logs_device_connected_and_stats(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    handle = MagicMock()
+    handle.name = "console"
+    handle.get_hardware_id.return_value = "DEADBEEF"
+    handle.get_version.return_value = "1.0.0"
+    # _log_device_stats resolves the handle via getattr(self._interface,
+    # name) — in production that IS the same object the callback receives.
+    # Wire the mock interface so the test exercises that real resolution
+    # and can assert the captured IDs.
+    c._interface.console = handle
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.DISCONNECTED, ConnectionState.CONNECTED,
+        "found",
+    )
+    t = _types(c)
+    assert "device_connected" in t
+    assert "device_stats" in t
+    stats = [e for e in c.auditLogEntries()
+             if e["event_type"] == "device_stats"]
+    assert stats
+    d = json.loads(stats[0]["details"])
+    assert d["hardware_id"] == "DEADBEEF"
+    assert d["firmware_version"] == "1.0.0"
+
+
+def test_run_calibration_logs_started(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._interface.start_calibration.return_value = True
+    c.runCalibration("left")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_started"]
+    assert ev
+    assert json.loads(ev[0]["details"])["target"] == "left"
+
+
+def test_calibration_complete_logs_ended(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._calibration_t0 = None
+    result = MagicMock()
+    result.canceled = False
+    result.ok = True
+    result.passed = True
+    result.csv_path = "cal.csv"
+    c._on_calibration_complete(result)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "calibration_ended"]
+    assert ev
+    assert json.loads(ev[0]["details"])["outcome"] == "passed"
+
+
+def test_set_config_logs_settings_changed(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None      # don't touch the real config
+    c.setConfig("plotWindowSec", 30)
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[0]["details"])
+    assert d["changes"]["plotWindowSec"]["new"] == 30
+
+
+def test_save_configs_logs_only_changed_keys(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._save_app_config = lambda: None
+    c._app_config["plotWindowSec"] = 15
+    c.saveConfigs({"plotWindowSec": 15, "bfiMax": 12.0})
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "settings_changed"]
+    assert ev
+    d = json.loads(ev[-1]["details"])["changes"]
+    assert "bfiMax" in d
+    assert "plotWindowSec" not in d
+
+
+def test_delete_scans_logs_scan_deleted(tmp_path):
+    from omotion.ScanDatabase import ScanDatabase
+    db_path = str(tmp_path / "scans.db")
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label="L1", session_start=1.0,
+                            session_meta={})
+    db.close()
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.deleteScans([sid])
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_deleted"]
+    assert ev
+    assert json.loads(ev[0]["details"])["count"] == 1
+
+
+def test_load_past_scan_logs_scan_viewed(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db_path)
+    c.loadPastScan("20260101_000000_owABC")
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_viewed"]
+    assert ev
+    assert json.loads(ev[0]["details"])["label"] == "20260101_000000_owABC"
+
+
+def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
+    import os
+    import zipfile
+    db = str(tmp_path / "scans.db")
+    logs = tmp_path / "app-logs"
+    logs.mkdir()
+    (logs / "ow-bloodflowapp-x.log").write_text("hello", encoding="utf-8")
+    c = _connector(tmp_path, scan_db_path=db)
+    # Don't spawn a real file-explorer process during the test.
+    c._reveal_in_explorer = lambda p: None
+    path = c.prepareDebugLogBundle()
+    assert path and os.path.exists(path)
+    assert path.endswith(".zip")
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+    assert any(n.startswith("app-logs/") for n in names)
+    assert "system_info.txt" in names
+    assert "debug_bundle_created" in _types(c)
+
+
+def test_prepare_debug_bundle_failure_returns_empty(tmp_path, monkeypatch):
+    # If the bundle build raises, the slot must return "" and NOT log a
+    # debug_bundle_created event (fail-soft, mirrors the other slots).
+    import debug_bundle
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._reveal_in_explorer = lambda p: None
+
+    def boom(*a, **k):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(debug_bundle, "build_debug_bundle", boom)
+    assert c.prepareDebugLogBundle() == ""
+    assert "debug_bundle_created" not in _types(c)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,135 @@
+"""Unit tests for the append-only audit log (audit_log.py)."""
+import csv
+import json
+import sqlite3
+import threading
+
+import pytest
+
+from audit_log import AuditLog, gather_host_info, EV_SYSTEM_STARTUP
+
+pytestmark = pytest.mark.unit
+
+
+def test_log_creates_table_and_inserts_row(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log(EV_SYSTEM_STARTUP, {"app_version": "1.2.3"})
+    a.close()
+
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        "SELECT event_type, details FROM logs"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == EV_SYSTEM_STARTUP
+    assert json.loads(rows[0][1]) == {"app_version": "1.2.3"}
+
+
+def test_reopen_is_idempotent(tmp_path):
+    db = str(tmp_path / "scans.db")
+    AuditLog(db).close()
+    a = AuditLog(db)          # second open must not raise on CREATE
+    a.log("system_info", None)
+    assert len(a.query()) == 1
+    a.close()
+
+
+def test_none_details_stored_as_null(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log("system_shutdown", None)
+    a.close()
+    conn = sqlite3.connect(db)
+    val = conn.execute("SELECT details FROM logs").fetchone()[0]
+    conn.close()
+    assert val is None
+
+
+def test_query_is_newest_first_and_honors_limit(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for i in range(5):
+        a.log("scan_started", {"n": i})
+    out = a.query(limit=3)
+    a.close()
+    assert len(out) == 3
+    # newest (n=4) first
+    assert json.loads(out[0]["details"])["n"] == 4
+
+
+def test_export_csv_roundtrips(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"label": "owABC"})
+    a.log("scan_ended", {"label": "owABC"})
+    dest = tmp_path / "audit.csv"
+    n = a.export_csv(str(dest))
+    a.close()
+    assert n == 2
+    with open(dest, newline="", encoding="utf-8") as f:
+        reader = list(csv.DictReader(f))
+    assert reader[0]["event_type"] == "scan_started"   # oldest first
+    assert json.loads(reader[0]["details"])["label"] == "owABC"
+
+
+def test_no_path_is_silent_noop(tmp_path):
+    a = AuditLog(None)
+    assert a.enabled is False
+    a.log("scan_started", {"x": 1})          # must not raise
+    assert a.query() == []
+    assert a.export_csv(str(tmp_path / "x.csv")) == 0
+    a.close()
+
+
+def test_concurrent_writes_all_land(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+
+    def worker():
+        for _ in range(20):
+            a.log("scan_started", {"t": 1})
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(a.query(limit=1000)) == 60
+    a.close()
+
+
+def test_count_returns_total_rows(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for _ in range(7):
+        a.log("scan_started", {"x": 1})
+    assert a.count() == 7
+    a.close()
+    assert a.count() == 0          # no-op after close
+
+
+def test_gather_host_info_has_core_fields():
+    info = gather_host_info()
+    assert "hostname" in info
+    assert "platform" in info
+    assert "python" in info
+
+
+def test_log_and_query_after_close_do_not_raise(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"x": 1})
+    a.close()
+    # After close the instance must stay fail-soft.
+    a.log("scan_started", {"x": 2})   # must not raise
+    assert a.query() == []
+    assert a.export_csv(str(tmp_path / "after_close.csv")) == 0
+
+
+def test_empty_dict_details_is_serialized_not_null(tmp_path):
+    db = str(tmp_path / "scans.db")
+    a = AuditLog(db)
+    a.log("scan_ended", {})
+    a.close()
+    import sqlite3 as _sql
+    conn = _sql.connect(db)
+    val = conn.execute("SELECT details FROM logs").fetchone()[0]
+    conn.close()
+    assert val == "{}"

--- a/tests/test_bug_report.py
+++ b/tests/test_bug_report.py
@@ -1,0 +1,64 @@
+"""Bug-report builder — pure helpers, no I/O (no SMTP, no shell, no Qt)."""
+
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+import bug_report
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_report_text_includes_code_and_context():
+    text = bug_report.build_report_text(
+        code="E-101",
+        title="Sensor self-check failed",
+        message="One or more devices did not respond.",
+        timestamp="2026-06-15 23:00:00",
+        app_version="1.2.3",
+        device_info="left=ABC123 console=XYZ",
+        log_path=r"C:\scan_data\app-logs\ow.log",
+    )
+    assert "E-101" in text
+    assert "Sensor self-check failed" in text
+    assert "One or more devices did not respond." in text
+    assert "2026-06-15 23:00:00" in text
+    assert "1.2.3" in text
+    assert "ABC123" in text
+    assert r"C:\scan_data\app-logs\ow.log" in text
+
+
+def test_smtp_config_complete_true_when_all_fields_present():
+    cfg = {
+        "host": "smtp.example.com",
+        "port": 587,
+        "username": "u",
+        "password": "p",
+        "from_addr": "app@example.com",
+    }
+    assert bug_report.smtp_config_complete(cfg) is True
+
+
+@pytest.mark.parametrize("cfg", [
+    None,
+    {},
+    {"host": "smtp.example.com"},  # missing the rest
+    {"host": "", "port": 587, "username": "u", "password": "p",
+     "from_addr": "a@b.c"},  # empty host
+])
+def test_smtp_config_incomplete_returns_false(cfg):
+    assert bug_report.smtp_config_complete(cfg) is False
+
+
+def test_build_mailto_url_encodes_subject_and_body():
+    url = bug_report.build_mailto_url(
+        "support@openwater.health",
+        subject="BloodFlow Bug Report — E-101",
+        body="line one\nline two & more",
+    )
+    split = urlsplit(url)
+    assert split.scheme == "mailto"
+    assert split.path == "support@openwater.health"
+    q = parse_qs(split.query)
+    assert q["subject"] == ["BloodFlow Bug Report — E-101"]
+    assert q["body"] == ["line one\nline two & more"]

--- a/tests/test_critical_error_signal.py
+++ b/tests/test_critical_error_signal.py
@@ -1,0 +1,211 @@
+"""Connector glue for critical errors: signal payload + bug-report routing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import error_codes
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, app_config=None, connected=(True, True, True)):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = connected
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    cfg = {"developerMode": False}
+    if app_config:
+        cfg.update(app_config)
+    return MotionConnector(
+        interface=iface, app_config=cfg,
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+_FULL_SMTP = {
+    "host": "smtp.example.com", "port": 587, "username": "u",
+    "password": "p", "from_addr": "app@example.com",
+}
+
+
+def test_raise_critical_emits_registry_payload(tmp_path):
+    conn = _connector(tmp_path)
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._raise_critical("E-101", detail="mux missing")
+
+    assert len(received) == 1
+    code, title, message, action, detail = received[0]
+    entry = error_codes.lookup("E-101")
+    assert code == "E-101"
+    assert title == entry.title
+    assert message == entry.message
+    assert action == entry.suggested_action
+    assert detail == "mux missing"
+
+
+def test_raise_critical_unknown_code_still_emits(tmp_path):
+    conn = _connector(tmp_path)
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._raise_critical("E-777")
+
+    assert len(received) == 1
+    assert received[0][0] == "E-777"
+    assert received[0][1]  # generic title, non-empty
+
+
+def _healthy():
+    return {"mux": True, "imu": True, "cameras": [True] * 8,
+            "fpgas": [True] * 8, "all_present": True}
+
+
+def test_i2c_health_all_present_raises_nothing(tmp_path):
+    conn = _connector(tmp_path)
+    conn._interface.left.is_connected.return_value = True
+    conn._interface.left.i2c_health = _healthy()
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_sensor_i2c_health("left")
+
+    assert received == []
+
+
+def test_i2c_health_missing_device_raises_e101_with_detail(tmp_path):
+    conn = _connector(tmp_path)
+    conn._interface.left.is_connected.return_value = True
+    snap = _healthy()
+    snap["cameras"] = [True, True, False, True, True, True, True, True]
+    snap["imu"] = False
+    snap["all_present"] = False
+    conn._interface.left.i2c_health = snap
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_sensor_i2c_health("left")
+
+    assert len(received) == 1
+    code, _title, _msg, _action, detail = received[0]
+    assert code == "E-101"
+    assert "imu" in detail
+    assert "2" in detail  # camera index 2 missing
+
+
+def test_i2c_health_none_raises_e102(tmp_path):
+    conn = _connector(tmp_path)
+    conn._interface.left.is_connected.return_value = True
+    conn._interface.left.i2c_health = None
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._check_sensor_i2c_health("left")
+
+    assert len(received) == 1
+    assert received[0][0] == "E-102"
+
+
+def _notifs(conn):
+    """Capture toast payloads emitted via notificationRequested."""
+    out = []
+    conn.notificationRequested.connect(lambda p: out.append(p))
+    return out
+
+
+def test_watchdog_all_connected_no_notification(tmp_path):
+    conn = _connector(tmp_path, connected=(True, True, True))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert notifs == []
+
+
+def test_watchdog_is_a_warning_not_a_critical_modal(tmp_path):
+    """E-104/E-106 are downgraded: a yellow warning toast, never the modal."""
+    conn = _connector(tmp_path, connected=(False, False, False))
+    crit = []
+    conn.criticalErrorRaised.connect(lambda *a: crit.append(a))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert crit == []
+    assert all(n["type"] == "warning" for n in notifs)
+
+
+def test_watchdog_both_missing_shows_single_system_not_found(tmp_path):
+    conn = _connector(tmp_path, connected=(False, False, False))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "System not found" in notifs[0]["text"]
+
+
+def test_watchdog_console_only_missing_warns(tmp_path):
+    conn = _connector(tmp_path, connected=(False, True, False))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "Console" in notifs[0]["text"]
+    assert "System not found" not in notifs[0]["text"]
+
+
+def test_watchdog_sensor_only_missing_warns(tmp_path):
+    conn = _connector(tmp_path, connected=(True, False, False))
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "Sensor" in notifs[0]["text"]
+
+
+def test_watchdog_respects_min_sensors_config(tmp_path):
+    conn = _connector(tmp_path, app_config={"minSensors": 2},
+                      connected=(True, True, False))  # only one sensor
+    notifs = _notifs(conn)
+
+    conn._check_connection_watchdog()
+
+    assert len(notifs) == 1
+    assert notifs[0]["type"] == "warning"
+    assert "Sensor" in notifs[0]["text"]
+
+
+def test_send_bug_report_selects_smtp_when_configured(tmp_path, monkeypatch):
+    conn = _connector(tmp_path, app_config={"bug_report_smtp": _FULL_SMTP})
+    chosen = []
+    monkeypatch.setattr(conn, "_send_bug_report_smtp",
+                        lambda *a, **k: chosen.append("smtp"))
+    monkeypatch.setattr(conn, "_send_bug_report_fallback",
+                        lambda *a, **k: chosen.append("fallback"))
+
+    conn.sendBugReport("E-101")
+
+    assert chosen == ["smtp"]
+
+
+def test_send_bug_report_falls_back_without_smtp(tmp_path, monkeypatch):
+    conn = _connector(tmp_path)  # no bug_report_smtp configured
+    chosen = []
+    monkeypatch.setattr(conn, "_send_bug_report_smtp",
+                        lambda *a, **k: chosen.append("smtp"))
+    monkeypatch.setattr(conn, "_send_bug_report_fallback",
+                        lambda *a, **k: chosen.append("fallback"))
+
+    conn.sendBugReport("E-101")
+
+    assert chosen == ["fallback"]

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -668,6 +668,60 @@ def test_past_scan_source_masks_unknown_when_no_per_cam_streams():
     assert src.rightMask == -1
 
 
+# ── Replay mode awareness — source reports its recorded reduced/dev mode ──
+# The viewer renders in the mode the scan was recorded in. reducedMode is a
+# tri-state: -1 unknown, 0 per-camera, 1 reduced — derived from the loaded
+# buffer cam_ids (reduced scans store only cam_id=-1; per-camera store 0..7).
+
+from data_sources import _derive_reduced_from_buffers
+
+
+def _one_sample_buffer():
+    buf = _CameraBuffer(max_capacity=None)
+    buf.append(t=0.0, v=1.0, frame_id=0)
+    return buf
+
+
+def test_derive_reduced_per_camera():
+    buffers = {("left", 0, "bfi"): _one_sample_buffer(),
+               ("right", 7, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 0
+
+
+def test_derive_reduced_side_average():
+    buffers = {("left", -1, "bfi"): _one_sample_buffer(),
+               ("right", -1, "bfi"): _one_sample_buffer()}
+    assert _derive_reduced_from_buffers(buffers) == 1
+
+
+def test_derive_reduced_empty_is_unknown():
+    assert _derive_reduced_from_buffers({}) == -1
+    # A buffer dict whose buffers hold no samples is also "unknown".
+    empty_buf = {("left", -1, "bfi"): _CameraBuffer()}
+    assert _derive_reduced_from_buffers(empty_buf) == -1
+
+
+def test_past_scan_source_reduced_mode_for_side_average():
+    buffers = {}
+    for side in ("left", "right"):
+        buffers[(side, -1, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 1
+
+
+def test_past_scan_source_reduced_mode_for_per_camera():
+    buffers = {}
+    for cam_id in (0, 1, 6, 7):
+        buffers[("left", cam_id, "bfi")] = _one_sample_buffer()
+    src = PastScanSource(scan_db=None, session_id=1, preloaded_buffers=buffers)
+    assert src.reducedMode == 0
+
+
+def test_live_scan_source_reduced_mode_unknown():
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.reducedMode == -1
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # currentScanSource holder pattern — verified via a parallel mini-class
 # (MotionConnector uses the same pattern; see motion_connector.py)

--- a/tests/test_debug_bundle.py
+++ b/tests/test_debug_bundle.py
@@ -1,0 +1,129 @@
+"""Unit tests for the debug-log bundle builder (debug_bundle.py)."""
+import os
+import zipfile
+
+import pytest
+
+from debug_bundle import build_debug_bundle, WINDOW_HOURS
+
+pytestmark = pytest.mark.unit
+
+_NOW = 1_750_000_000.0  # fixed epoch for deterministic tests
+
+
+def _write(path, text="x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_window_hours_default_is_48():
+    assert WINDOW_HOURS == 48
+
+
+def test_includes_recent_logs_excludes_old(tmp_path):
+    data = tmp_path / "data"
+    logs = data / "app-logs"
+    for name in ("ow-bloodflowapp-A.log", "ow-bloodflowapp-B.log"):
+        _write(logs / name, "log")
+        os.utime(logs / name, (_NOW - 3600, _NOW - 3600))   # 1h ago
+    old = logs / "ow-bloodflowapp-OLD.log"
+    _write(old, "old")
+    os.utime(old, (_NOW - 49 * 3600, _NOW - 49 * 3600))     # 49h ago
+    _write(data / "app_config.json", '{"k":1}')
+
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert "app-logs/ow-bloodflowapp-A.log" in names
+    assert "app-logs/ow-bloodflowapp-B.log" in names
+    assert "app-logs/ow-bloodflowapp-OLD.log" not in names
+    assert "app_config.json" in names
+    assert "system_info.txt" in names
+    assert meta["log_count"] == 2
+    assert meta["bytes"] == os.path.getsize(meta["path"])
+    base = os.path.basename(meta["path"])
+    assert base.startswith("debug-bundle-") and base.endswith(".zip")
+
+
+def test_empty_window_still_writes_system_info(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert names == ["system_info.txt"]   # no logs, no config present
+    assert meta["log_count"] == 0
+    assert meta["file_count"] == 1
+
+
+def test_system_info_contains_versions_and_host(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW,
+        extra_info={"app_version": "1.2.3", "sdk_version": "9.9"},
+    )
+    with zipfile.ZipFile(meta["path"]) as zf:
+        txt = zf.read("system_info.txt").decode("utf-8")
+    assert "app_version: 1.2.3" in txt
+    assert "sdk_version: 9.9" in txt
+    assert "hostname:" in txt
+    assert "generated:" in txt
+
+
+def test_explicit_config_path_is_used(tmp_path):
+    data = tmp_path / "data"
+    (data / "app-logs").mkdir(parents=True)
+    cfg = tmp_path / "elsewhere" / "app_config.json"
+    _write(cfg, '{"x":2}')
+    meta = build_debug_bundle(
+        str(data), str(tmp_path / "out"), now_epoch=_NOW, config_path=str(cfg),
+    )
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert "app_config.json" in names
+
+
+def test_missing_app_logs_dir_still_produces_zip(tmp_path):
+    # No app-logs/ directory at all — must still produce a valid zip
+    # containing just system_info.txt, no exception.
+    data = tmp_path / "data"
+    data.mkdir()
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert names == ["system_info.txt"]
+    assert meta["log_count"] == 0
+
+
+def test_unreadable_log_is_skipped_not_fatal(tmp_path, monkeypatch):
+    # A log that passes the mtime filter but fails zf.write must be
+    # skipped (counted in log_count, absent from the zip) rather than
+    # aborting the bundle.
+    data = tmp_path / "data"
+    logs = data / "app-logs"
+    _write(logs / "ow-bloodflowapp-good.log", "ok")
+    os.utime(logs / "ow-bloodflowapp-good.log", (_NOW - 3600, _NOW - 3600))
+    _write(logs / "ow-bloodflowapp-bad.log", "bad")
+    os.utime(logs / "ow-bloodflowapp-bad.log", (_NOW - 3600, _NOW - 3600))
+
+    real_write = zipfile.ZipFile.write
+
+    def flaky_write(self, filename, arcname=None, *a, **k):
+        if str(filename).endswith("ow-bloodflowapp-bad.log"):
+            raise OSError("simulated read failure")
+        return real_write(self, filename, arcname, *a, **k)
+
+    monkeypatch.setattr(zipfile.ZipFile, "write", flaky_write)
+    meta = build_debug_bundle(str(data), str(tmp_path / "out"), now_epoch=_NOW)
+    with zipfile.ZipFile(meta["path"]) as zf:
+        names = zf.namelist()
+    assert "app-logs/ow-bloodflowapp-good.log" in names
+    assert "app-logs/ow-bloodflowapp-bad.log" not in names
+    assert "system_info.txt" in names
+    assert meta["log_count"] == 2          # both matched the window
+    assert meta["file_count"] == 2         # good log + system_info only

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -1,0 +1,57 @@
+"""Critical-error code registry — pure data, no hardware or Qt."""
+
+import pytest
+
+import error_codes
+
+pytestmark = pytest.mark.unit
+
+
+def test_lookup_known_code_returns_entry():
+    err = error_codes.lookup("E-101")
+    assert err.code == "E-101"
+    assert err.category == "startup"
+    assert err.title  # non-empty
+    assert err.message
+    assert err.suggested_action
+
+
+def test_registry_entries_are_complete_and_unique():
+    codes = list(error_codes.ERROR_CODES.keys())
+    assert codes, "registry is empty"
+    assert len(codes) == len(set(codes)), "duplicate codes"
+    for code, err in error_codes.ERROR_CODES.items():
+        assert err.code == code, f"key/value code mismatch for {code}"
+        assert err.title.strip()
+        assert err.message.strip()
+        assert err.suggested_action.strip()
+        assert err.category in {"startup", "safety", "scan"}
+
+
+def test_category_matches_code_prefix():
+    prefix_to_category = {"E-1": "startup", "E-2": "safety", "E-3": "scan"}
+    for code, err in error_codes.ERROR_CODES.items():
+        prefix = code[:3]
+        assert prefix in prefix_to_category, f"unexpected prefix for {code}"
+        assert err.category == prefix_to_category[prefix], (
+            f"{code} category {err.category!r} != {prefix_to_category[prefix]!r}"
+        )
+
+
+def test_lookup_unknown_code_returns_generic_fallback():
+    err = error_codes.lookup("E-999")
+    # Never raise inside an error path — return a usable generic entry.
+    assert err.code == "E-999"
+    assert err.title.strip()
+    assert err.message.strip()
+
+
+def test_expected_catalog_codes_present():
+    expected = {
+        "E-101", "E-102", "E-103", "E-105",
+        "E-201", "E-202",
+        "E-301", "E-302",
+    }
+    # E-104/E-106 are intentionally absent: the connection watchdog surfaces
+    # them as warning toasts, not via this critical-modal registry.
+    assert expected == set(error_codes.ERROR_CODES.keys())

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -27,7 +27,6 @@ from hil_helpers import (
     click_element_center,
     click_panel,
     force_app_config_value,
-    selected_scan_text,
     write_app_config_value,
 )
 
@@ -198,7 +197,13 @@ def _seed_with_short_scan(app):
     try:
         click_panel("History")
         time.sleep(SLEEP)
-        if selected_scan_text():
+        # A populated table shows the column header; an empty one shows
+        # "No scans yet." Either way the modal is open here.
+        has_data = (
+            _history_text_present("User Label")
+            and not _history_text_present("No scans yet")
+        )
+        if has_data:
             log.info("Skipping seed scan — History already has entries")
             require_focus()
             pyautogui.press("escape")
@@ -243,16 +248,24 @@ def _seed_with_short_scan(app):
     yield
 
 
-def _is_history_open() -> bool:
-    """True iff the History modal appears to be on top — detected via
-    the presence of any ComboBox in the UIA tree (the scan picker is
-    the only ComboBox the bloodflow page exposes when no other modal
-    is up)."""
+def _history_text_present(needle: str) -> bool:
+    """True iff any UIA element under the app window shows ``needle``."""
     try:
         win = uia_window()
-        return bool(win.descendants(control_type="ComboBox"))
+        for elem in win.descendants():
+            try:
+                if needle.lower() in (elem.window_text() or "").lower():
+                    return True
+            except Exception:
+                continue
     except Exception:
-        return False
+        pass
+    return False
+
+
+def _is_history_open() -> bool:
+    """The History modal is up iff its 'Scan History' title is visible."""
+    return _history_text_present("Scan History")
 
 
 def _ensure_history_open() -> None:
@@ -281,35 +294,39 @@ class TestHistory:
         _ensure_history_open()
 
     def test_02_latest_scan_listed(self, app):
-        # Defensive: re-ensure the modal is up before reading. The
-        # seed fixture's close-with-escape doesn't actually fire
-        # (HistoryModal has no Keys handler), so we can't trust the
-        # state coming into this test.
         _ensure_history_open()
-        # Poll for up to 5 s — the ComboBox can take a moment to
-        # populate on a slow runner.
+        # Poll up to 5 s for the table to populate (the seed scan was
+        # Middle/Middle, so its config cell reads "Middle / Middle").
         deadline = time.time() + 5.0
-        scan_text = ""
+        found = False
         while time.time() < deadline:
-            scan_text = selected_scan_text()
-            if scan_text:
+            no_data = _history_text_present("No scans yet")
+            if _history_text_present("Middle") or not no_data:
+                found = True
                 break
             time.sleep(0.3)
-        assert len(scan_text) > 0, (
-            "ComboBox is empty after 5 s -- no scans found. Run a "
+        assert found, (
+            "History table is empty after 5 s — no scans found. Run a "
             "scan first, or the History modal failed to open."
         )
-        log.info(f"  Scan ComboBox text: '{scan_text}'")
 
     def test_03_view_in_plot(self, app):
-        """'View in plot →' loads the scan into the embedded PlotViewer."""
-        click_by_name("View in plot →")
+        """Focus the first row, then 'Load in viewer →' loads it into the
+        embedded PlotViewer."""
+        # Click the first data row to focus it (just below the header).
+        win = uia_window()
+        rows = [e for e in win.descendants(control_type="Text")
+                if "Middle" in (e.window_text() or "")]
+        if rows:
+            click_element_center(rows[0], "first history row")
+            time.sleep(SLEEP)
+        click_by_name("Load in viewer →")
         time.sleep(SLEEP)
 
     def test_04_history_closed_by_view(self, app):
         """The button closes the History modal itself after loading."""
         assert not _is_history_open(), (
-            "History modal still open after 'View in plot →' — expected "
+            "History modal still open after 'Load in viewer →' — expected "
             "it to close itself after loading the scan."
         )
 

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -1,0 +1,163 @@
+"""History data-management connector slots — DB-only, no hardware."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector, _config_name
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _make_session(db_path, label, start, end, left_mask, right_mask,
+                  reduced=True, notes=None, subject=None, operator="ethan"):
+    # Default the subject_id to the label's trailing user-label segment so
+    # rows carry distinct userLabels (matches how scans are really named).
+    if subject is None:
+        parts = label.split("_", 2)
+        subject = parts[2] if len(parts) > 2 else ""
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(
+        session_label=label, session_start=start, session_end=end,
+        session_notes=notes,
+        session_meta={
+            "scan_id": label.rsplit("_", 1)[0], "subject_id": subject,
+            "operator": operator, "duration_sec": (end - start) if end else 0,
+            "sdk_flags": {
+                "reduced_mode": reduced,
+                "left_camera_mask": left_mask,
+                "right_camera_mask": right_mask,
+            },
+        },
+    )
+    db.close()
+    return sid
+
+
+def test_config_name_known_and_unknown():
+    assert _config_name(0x5A) == "Near"
+    assert _config_name(0xC3) == "Far"
+    assert _config_name(0x00) == "None"
+    assert _config_name(0x12) == "0x12"   # unmapped -> hex
+    assert _config_name(-1) == "—"        # unknown
+    assert _config_name(None) == "—"      # missing
+
+
+def test_get_scan_sessions_skips_malformed_row_keeps_rest(tmp_path):
+    """One unparseable session must not blank the whole History view."""
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    c = _connector(tmp_path, db_path)
+
+    real = MotionConnector._session_to_row
+
+    def flaky(self, s):
+        if s.get("session_label", "").endswith("boom"):
+            raise ValueError("malformed row")
+        return real(self, s)
+
+    db = ScanDatabase(db_path=db_path)
+    db.create_session(session_label="20260612_093000_boom",
+                      session_start=200.0, session_end=205.0,
+                      session_notes=None, session_meta={})
+    db.close()
+
+    c._session_to_row = flaky.__get__(c, MotionConnector)
+    rows = c.get_scan_sessions()
+    labels = [r["label"] for r in rows]
+    assert "20260612_092000_subjA" in labels
+    assert "20260612_093000_boom" not in labels
+
+
+def test_get_scan_sessions_rows_and_sort(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _make_session(db_path, "20260612_093100_subjB", 200.0, 215.0, 0x5A, 0x66)
+    c = _connector(tmp_path, db_path)
+
+    rows = c.get_scan_sessions()
+    assert [r["userLabel"] for r in rows] == ["subjB", "subjA"]  # newest first
+    top = rows[0]
+    assert top["configL"] == "Near" and top["configR"] == "Middle"
+    assert top["durationSec"] == 15.0
+    assert top["leftMask"] == 0x5A and top["rightMask"] == 0x66
+    assert top["interrupted"] is False
+    assert top["dateTime"] == "2026-06-12 09:31:00"
+
+
+def test_get_scan_sessions_interrupted_open_session(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_100000_subjC", 300.0, None, 0xFF, 0xFF)
+    c = _connector(tmp_path, db_path)
+    row = c.get_scan_sessions()[0]
+    assert row["interrupted"] is True
+    assert row["durationSec"] == -1.0
+
+
+def test_get_scan_sessions_empty_without_db(tmp_path):
+    c = _connector(tmp_path, None)
+    assert c.get_scan_sessions() == []
+
+
+def _insert_rows(db_path, session_id, n):
+    db = ScanDatabase(db_path=db_path)
+    for i in range(n):
+        db.insert_session_data(
+            session_id=session_id, cam_id=0, side=0,
+            timestamp_s=float(i), frame_id=i, bfi=1.0, bvi=2.0,
+        )
+    db.close()
+
+
+def test_get_session_stats_counts_rows(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sid = _make_session(
+        db_path, "20260612_092000_subjA", 100.0, 105.0, 0xC3, 0xC3)
+    _insert_rows(db_path, sid, 7)
+    c = _connector(tmp_path, db_path)
+    assert c.get_session_stats(sid)["sampleCount"] == 7
+
+
+def test_delete_scans_removes_session_and_cascades(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    keep = _make_session(
+        db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    drop = _make_session(
+        db_path, "20260612_093000_drop", 200.0, 205.0, 0x5A, 0x5A)
+    _insert_rows(db_path, drop, 5)
+    c = _connector(tmp_path, db_path)
+
+    removed = c.deleteScans([drop])
+    assert removed == 1
+    remaining = [r["sessionId"] for r in c.get_scan_sessions()]
+    assert remaining == [keep]
+    # session_data cascade-deleted with the session
+    assert c.get_session_stats(drop)["sampleCount"] == 0
+
+
+def test_delete_scans_empty_list_is_noop(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260612_092000_keep", 100.0, 105.0, 0xC3, 0xC3)
+    c = _connector(tmp_path, db_path)
+    assert c.deleteScans([]) == 0
+    assert len(c.get_scan_sessions()) == 1
+
+
+def test_stats_and_delete_without_db_are_safe(tmp_path):
+    """No scan DB configured → both slots no-op rather than raise."""
+    c = _connector(tmp_path, None)
+    assert c.get_session_stats(1) == {"sampleCount": 0}
+    assert c.deleteScans([1, 2]) == 0

--- a/tests/test_plot_viewer_masks.py
+++ b/tests/test_plot_viewer_masks.py
@@ -330,8 +330,11 @@ def test_zero_masks_render_empty_grid(viewer_factory):
 # A sensor module arranges cameras 1-8 in a U: 1 and 8 at the top of the
 # U, 4 and 5 at the bottom. The grid displays an upside-down U — row 0
 # pairs cams 4|5, then 3|6, 2|7, and 1|8 at the bottom. Left module owns
-# columns 0-1, right module columns 2-3; rows with no selected camera on
-# either side are dropped (the remaining rows compact upward).
+# columns 0-1. When BOTH sides have active cameras a fixed side-break
+# spacer occupies column 2 and the right module sits at columns 3-4; when
+# only one side is active there is no spacer and that side starts at
+# column 0. Rows with no selected camera on either side are dropped (the
+# remaining rows compact upward).
 
 
 def _pos(cells, side, cam_id):
@@ -349,11 +352,13 @@ def test_all_masks_lay_out_as_upside_down_u(viewer_factory):
     cells = _cells(viewer)
     assert len(cells) == 16
     # Row r pairs 1-based cams (4-r | 5+r): zero-based camIds 3-r | 4+r.
+    # Both sides active → the side-break spacer occupies column 2, so the
+    # right module sits at columns 3-4 (left stays at 0-1).
     for r in range(4):
         assert _pos(cells, "left", 3 - r) == (r, 0)
         assert _pos(cells, "left", 4 + r) == (r, 1)
-        assert _pos(cells, "right", 3 - r) == (r, 2)
-        assert _pos(cells, "right", 4 + r) == (r, 3)
+        assert _pos(cells, "right", 3 - r) == (r, 3)
+        assert _pos(cells, "right", 4 + r) == (r, 4)
 
 
 def test_middle_masks_compact_to_4x2(viewer_factory):
@@ -363,14 +368,15 @@ def test_middle_masks_compact_to_4x2(viewer_factory):
     cells = _cells(viewer)
     assert len(cells) == 8
     # Middle = cams 3,6 (U row 1) and 2,7 (U row 2) — rows compact to 0,1.
+    # Both sides active → right module shifts to columns 3-4 (spacer at 2).
     assert _pos(cells, "left", 2) == (0, 0)
     assert _pos(cells, "left", 5) == (0, 1)
-    assert _pos(cells, "right", 2) == (0, 2)
-    assert _pos(cells, "right", 5) == (0, 3)
+    assert _pos(cells, "right", 2) == (0, 3)
+    assert _pos(cells, "right", 5) == (0, 4)
     assert _pos(cells, "left", 1) == (1, 0)
     assert _pos(cells, "left", 6) == (1, 1)
-    assert _pos(cells, "right", 1) == (1, 2)
-    assert _pos(cells, "right", 6) == (1, 3)
+    assert _pos(cells, "right", 1) == (1, 3)
+    assert _pos(cells, "right", 6) == (1, 4)
 
 
 def test_right_module_alone_takes_first_column_pair(viewer_factory):
@@ -394,7 +400,8 @@ def test_unselected_slot_leaves_gap_in_its_row(viewer_factory):
     cells = _cells(viewer)
     assert len(cells) == 2
     assert _pos(cells, "left", 3) == (0, 0)
-    assert _pos(cells, "right", 4) == (0, 3)
+    # Both sides active → spacer at col 2 pushes the right module to col 3-4.
+    assert _pos(cells, "right", 4) == (0, 4)
 
 
 def test_row_compaction_is_shared_across_modules(viewer_factory):
@@ -406,14 +413,15 @@ def test_row_compaction_is_shared_across_modules(viewer_factory):
     viewer.setProperty("rightMask", MIDDLE_MASK)
     cells = _cells(viewer)
     assert len(cells) == 8
+    # Both sides have active cameras → spacer at col 2, right module at 3-4.
     # U row 1 (cams 3|6) → display row 0: right side only.
-    assert _pos(cells, "right", 2) == (0, 2)
-    assert _pos(cells, "right", 5) == (0, 3)
+    assert _pos(cells, "right", 2) == (0, 3)
+    assert _pos(cells, "right", 5) == (0, 4)
     # U row 2 (cams 2|7) → display row 1: both sides.
     assert _pos(cells, "left", 1) == (1, 0)
     assert _pos(cells, "left", 6) == (1, 1)
-    assert _pos(cells, "right", 1) == (1, 2)
-    assert _pos(cells, "right", 6) == (1, 3)
+    assert _pos(cells, "right", 1) == (1, 3)
+    assert _pos(cells, "right", 6) == (1, 4)
     # U row 3 (cams 1|8) → display row 2: left side only.
     assert _pos(cells, "left", 0) == (2, 0)
     assert _pos(cells, "left", 7) == (2, 1)


### PR DESCRIPTION
Folds `next-next` forward onto `next` by **rebasing** next-next's 6 commits in front of next's tip (per "paste next-next in front of next"). `next` is a direct ancestor of these commits, so next's released fixes (#201 duration, #199-era dropdown) all carry.

### What's included (replayed from next-next)
- feat: rework History into a data-management tool (#194)
- refactor: tidy History modal — drop toolbar filters/buttons, widen notes, restyle actions
- feat: audit log + Logs viewer (CSV export + debug-log bundle) (#195)
- feat: critical-error codes + dismissible modal (#196)
- refactor: simplify contact-quality checking modal to a single spinner
- feat: add visual break between left and right sensor plots in dev mode

Plus one new commit:
- **test: update plot-mask layout for the sensor side-break spacer**

### Conflict resolutions
- **`components/HistoryModal.qml`** — took next-next's **reworked (ListView-based) History**. The old `next` version carried a ComboBox-popup scroll fix (the #199 work); the rework removed the dropdown entirely (ListView scrolls natively), so that fix is **obsolete** and was dropped. No behavior lost — the rework's list is inherently scrollable.
- **`motion_connector.py`** — auto-merged; the #201 trigger-duration fix (`_trigger_on_ts`) is **preserved** alongside next-next's History/audit-log/error-code additions. File parses; #201 unit tests pass.

### Why the extra test commit
The "visual break" feature reserves a 3px spacer column (col 2) when both sensor modules have active cameras, shifting the right module to columns 3-4. `test_plot_viewer_masks.py` still encoded the old no-spacer layout and was **red on next-next** (4 failures). Updated the 4 both-sides-active assertions to the spacer layout; single-sided cases unchanged.

### Verification
- `pytest -m unit` → **277 passed, 0 failed** (121 HIL deselected). Includes the reworked-History tests, the #201 duration test, and the corrected plot-mask tests.
- `motion_connector.py` parses (UTF-8).

After merge, `next-next` will be behind `next` — it can be reset to `next` or re-pointed for the next round of staged work.