### PR TITLE
feat: enable powerOffUnusedCameras (drop cameras outside the scan mask)

### DIFF
--- a/config/app_config.json
+++ b/config/app_config.json
@@ -55,7 +55,7 @@
   "forceLaserFail": false,
   "cameraFakeData": false,
   "cameraTempAlertThresholdC": 110,
-  "powerOffUnusedCameras": false,
+  "powerOffUnusedCameras": true,
   "sensorDebugLogging": false,
   "histoThrottle": false,
   "histoCmp": true,


### PR DESCRIPTION
## What

Flips the existing `powerOffUnusedCameras` flag in `config/app_config.json` from `false` to `true`. The feature was already fully wired (connector + SDK `ScanWorkflow`) but gated off; this just enables it.

## Behavior

- **Connect / contact-quality check** — cameras still power on fully (all 8). The CQ runner always flashes `0xFF`, so contact quality continues to evaluate every physically-present camera.
- **Scan start** — the SDK configure step powers off any camera not in the scan mask, then programs FPGAs only for the masked cameras. The unused cameras stay off for the capture.
- Calibration and test-scan flash paths are unaffected (they hardcode `power_off_unused_cameras=False`).

## Verified on hardware

Console 1.7.0, both sensors. From the app log on a reduced-mode scan (mask `0xC3`):

```
=== Contact-quality check started: duration=1.0s left=0xFF right=0xFF ===
...
left:  powered off cameras not in mask (0x3C)
left:  powered on  cameras (mask 0xC3)
right: powered off cameras not in mask (0x3C)
right: powered on  cameras (mask 0xC3)
=== Full scan started: left=0xC3 right=0xC3 laser=on ===
```

`0xC3` = cameras 1,2,7,8 (kept on); `0x3C` = cameras 3,4,5,6 (powered off). Only positions 1,2,7,8 were FPGA-programmed.

## Follow-up (not in this PR)

SDK `MotionSensor.get_camera_power_status()` uses a 0.12s timeout and silently returns all-off on timeout, which would make `off_mask=0` and the power-off silently no-op (scan still succeeds). Did not trigger in testing, but worth hardening separately (e.g. compute `off_mask = ~mask & 0xFF` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)