### PR TITLE
feat: MSI installer (Program Files + auto driver) and in-app in-place updater

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -98,6 +98,36 @@ jobs:
           conda activate omotion
           python -m PyInstaller -y openwater.spec
 
+      - name: Install WiX v5
+        shell: pwsh
+        run: |
+          dotnet tool install --global wix
+          wix extension add -g WixToolset.Bal.wixext
+          echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Build clinical installer
+        shell: pwsh
+        env:
+          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
+        run: |
+          powershell -NoProfile -File installer\build_installer.ps1 -Variant clinical
+
+      - name: Build RUO installer
+        shell: pwsh
+        env:
+          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
+        run: |
+          $cfg = "dist\OpenWaterApp\_internal\config\app_config.json"
+          $orig = Get-Content -Raw $cfg
+          $ruo = $orig -replace '"reducedMode"\s*:\s*true', '"reducedMode": false'
+          if ($ruo -eq $orig) { throw "RUO build: did not find reducedMode: true to flip" }
+          Set-Content -Path $cfg -Value $ruo -Encoding UTF8 -NoNewline
+          try {
+            powershell -NoProfile -File installer\build_installer.ps1 -Variant ruo
+          } finally {
+            Set-Content -Path $cfg -Value $orig -Encoding UTF8 -NoNewline
+          }
+
       # ── package ──────────────────────────────────────────────────
       - name: Determine version tag
         id: meta
@@ -202,6 +232,7 @@ jobs:
           files: |
             ${{ steps.meta.outputs.ARTIFACT_ZIP }}
             ${{ steps.meta.outputs.ARTIFACT_ZIP_RUO }}
+            build/installer/OpenWater-Setup-*.exe
             resources/OpenMotionDriver-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -101,8 +101,12 @@ jobs:
       - name: Install WiX v5
         shell: pwsh
         run: |
-          dotnet tool install --global wix
-          wix extension add -g WixToolset.Bal.wixext
+          # Pin to 5.0.2 — the last MIT-licensed WiX. v6/v7 require accepting the
+          # paid Open Source Maintenance Fee EULA (WIX7015) and would fail CI.
+          dotnet tool install --global wix --version 5.0.2
+          # In WiX v5 the standard bootstrapper application ships in this package
+          # (not WixToolset.Bal.wixext); the bal: namespace in bundle.wxs is unchanged.
+          wix extension add -g WixToolset.BootstrapperApplications.wixext/5.0.2
           echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: Build clinical installer

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ tests/New_UI_TestScripts/scan_data/
 tests/New_UI_TestScripts/app-logs/
 tests/New_UI_TestScripts/debug_uia.py
 test_logs/
+
+# Runtime config overrides (written by setConfig; ProgramData in prod, cwd in dev)
+app_config.local.json
+data/

--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -23,6 +23,10 @@ Rectangle {
 
     property string latestVersion: ""
     property string downloadUrl: ""
+    // True from the moment Update is clicked until the download/install
+    // either fails or the app quits for the in-place upgrade.
+    property bool updating: false
+    property string statusText: "Update"
 
     color: theme.accentBlue
     radius: 0
@@ -58,7 +62,7 @@ Rectangle {
             Text {
                 id: downloadBtn
                 anchors.centerIn: parent
-                text: "Update"
+                text: banner.updating ? banner.statusText : "Update"
                 color: theme.accentBlue
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
@@ -66,10 +70,18 @@ Rectangle {
 
             MouseArea {
                 anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
+                enabled: !banner.updating
+                cursorShape: banner.updating ? Qt.ArrowCursor : Qt.PointingHandCursor
                 hoverEnabled: true
-                onClicked: MotionInterface.applyUpdate(banner.downloadUrl)
-                onContainsMouseChanged: parent.color = containsMouse ? "#E0E0E0" : "#FFFFFF"
+                // Guard against double-clicks spawning racing downloads; the
+                // connector also guards re-entry, this just reflects it in UI.
+                onClicked: {
+                    banner.updating = true
+                    banner.statusText = "Starting…"
+                    MotionInterface.applyUpdate(banner.downloadUrl)
+                }
+                onContainsMouseChanged: parent.color =
+                    (containsMouse && !banner.updating) ? "#E0E0E0" : "#FFFFFF"
             }
         }
 
@@ -108,6 +120,15 @@ Rectangle {
             banner.latestVersion = version
             banner.downloadUrl = url
             banner.shown = true
+        }
+        // Reflect download/install progress on the button.
+        function onUpdateProgress(message) {
+            banner.statusText = message
+        }
+        // Re-enable the button so a failed update can be retried.
+        function onUpdateCheckFailed(error) {
+            banner.updating = false
+            banner.statusText = "Update"
         }
     }
 

--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -58,7 +58,7 @@ Rectangle {
             Text {
                 id: downloadBtn
                 anchors.centerIn: parent
-                text: "Download"
+                text: "Update"
                 color: theme.accentBlue
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
@@ -68,7 +68,7 @@ Rectangle {
                 anchors.fill: parent
                 cursorShape: Qt.PointingHandCursor
                 hoverEnabled: true
-                onClicked: MotionInterface.openDownloadUrl(banner.downloadUrl)
+                onClicked: MotionInterface.applyUpdate(banner.downloadUrl)
                 onContainsMouseChanged: parent.color = containsMouse ? "#E0E0E0" : "#FFFFFF"
             }
         }

--- a/docs/superpowers/plans/2026-06-17-msi-installer-in-app-update.md
+++ b/docs/superpowers/plans/2026-06-17-msi-installer-in-app-update.md
@@ -11,7 +11,9 @@
 **Spec:** [docs/superpowers/specs/2026-06-17-msi-installer-in-app-update-design.md](../specs/2026-06-17-msi-installer-in-app-update-design.md)
 
 **Conventions for this plan:**
-- New unit tests are marked `@pytest.mark.unit` so conftest's autouse fixtures skip app launch (see `tests/conftest.py:575`). Run them with `python -m pytest -m unit <path> -v`.
+- **Symbol names (verified at tip-of-`next`):** the connector class is `MotionConnector` and the QML singleton is `MotionInterface` (registered in `main.py` via `qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", connector)`). Use these exact names in Python imports and QML.
+- **Line numbers are approximate.** `motion_connector.py` is ~4500 lines and grows; locate every edit site by the quoted symbol/code, not the line number.
+- New unit tests are marked `@pytest.mark.unit` so conftest's autouse fixtures skip app launch (see `tests/conftest.py`). Run them with `python -m pytest -m unit <path> -v`.
 - Tests redirect the writable root via the `OPENWATER_DATA_ROOT` env var (added in Task 1) to a `tmp_path`, never the real ProgramData.
 - WiX/installer/CI tasks cannot be unit-tested; their "test" is a successful build + the manual VM verification in Task 16.
 - Commit after every task.
@@ -221,9 +223,7 @@ def shipped_baseline(defaults: dict) -> dict:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 loaded = json.load(f)
-            base.update(
-                {k: v for k, v in loaded.items() if k in defaults or k == "output_path"}
-            )
+            base.update({k: v for k, v in loaded.items() if k in defaults})
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Could not load %s: %s; using defaults", path, e)
     return _coerce_ints(base)
@@ -248,7 +248,7 @@ def load_app_config(defaults: dict):
     overrides = load_overrides()
     merged = {
         **baseline,
-        **{k: v for k, v in overrides.items() if k in baseline or k == "output_path"},
+        **{k: v for k, v in overrides.items() if k in baseline},
     }
     return baseline, _coerce_ints(merged)
 
@@ -281,7 +281,7 @@ git commit -m "feat: add config_store with layered load and overrides-diff save"
 ### Task 3: Wire `main.py` to the layered store + ProgramData log/data root
 
 **Files:**
-- Modify: `main.py:67-153` (`_load_app_config`), `main.py:188-200` (output_base default), `main.py:255` (connector construction)
+- Modify: `main.py` — `_load_app_config` (delegate to the store), the `_data_dir` default block in `main()`, and the `MotionConnector(...)` construction
 - Test: `tests/test_main_config_wiring.py`
 
 - [ ] **Step 1: Write the failing test**
@@ -314,13 +314,13 @@ Expected: FAIL — `_load_app_config` does not consult overrides / `_APP_CONFIG_
 
 - [ ] **Step 3: Write minimal implementation**
 
-In `main.py`, add the import near the other `utils` imports (after line 34):
+In `main.py`, add the import near the other `utils` imports (next to `from utils.resource_path import resource_path`):
 
 ```python
 from utils import app_paths, config_store
 ```
 
-Add a module-level baseline stash (just below the imports / logger setup, before `_load_app_config`):
+Add a module-level baseline stash (just below the imports, before `_load_app_config`):
 
 ```python
 # Shipped baseline (defaults + read-only bundled config), captured at load so
@@ -328,7 +328,7 @@ Add a module-level baseline stash (just below the imports / logger setup, before
 _APP_CONFIG_BASELINE: dict = {}
 ```
 
-Replace the body of `_load_app_config` from the `config_path = resource_path(...)` line (line 132) through its `return` statements (line 153) with delegation to the store. Keep the big `defaults = {...}` dict (lines 69-131) exactly as-is; only the tail changes:
+Replace the body of `_load_app_config` from the `config_path = resource_path("config", "app_config.json")` line through its `return` statements with delegation to the store. Keep the big `defaults = {...}` dict exactly as-is; only the tail changes:
 
 ```python
     # (defaults = { ... } stays unchanged above this point)
@@ -339,30 +339,29 @@ Replace the body of `_load_app_config` from the `config_path = resource_path(...
     return merged
 ```
 
-Change the `output_base` default (lines 190-199) so a frozen install logs/scans under ProgramData instead of cwd:
+Change the data-dir default so a frozen install logs/scans under ProgramData instead of cwd. In `main()`, find the block that sets `_data_dir` (currently `_data_dir = app_config.get("dataDirectory")` followed by the `if not _data_dir:` fallback to `os.getcwd()`) and change the fallback line:
 
 ```python
-    output_base = app_config.get("output_path")
-    if not output_base:
+    _data_dir = app_config.get("dataDirectory")
+    if not _data_dir:
         # Installed (frozen) build → ProgramData; dev run → cwd (unchanged),
         # falling back to ~/Documents if cwd is not writable.
         candidate = str(app_paths.writable_root()) if getattr(sys, "frozen", False) else os.getcwd()
         if os.access(candidate, os.W_OK):
-            output_base = candidate
+            _data_dir = candidate
         else:
-            output_base = os.path.join(
+            _data_dir = os.path.join(
                 os.path.expanduser("~"), "Documents", "OpenWater Bloodflow"
             )
 ```
 
-Pass the baseline into the connector at line 255:
+Pass the baseline into the connector. Find the `connector = MotionConnector(...)` construction and add the `baseline_config` kwarg, preserving the existing `data_dir`, `app_version`, and `log_path` kwargs:
 
 ```python
-    connector = MOTIONConnector(
-        motion_interface,
-        app_config=app_config,
+    connector = MotionConnector(
+        motion_interface, app_config=app_config, data_dir=_data_dir,
         baseline_config=_APP_CONFIG_BASELINE,
-        output_path=output_base,
+        app_version=APP_VERSION, log_path=logfile_path,
     )
 ```
 
@@ -383,7 +382,7 @@ git commit -m "feat: load config via layered store; route logs/data to ProgramDa
 ### Task 4: Connector saves overrides instead of overwriting bundled config
 
 **Files:**
-- Modify: `motion_connector.py:346-356` (`__init__` signature + baseline capture), `motion_connector.py:1469-1481` (`_save_app_config`)
+- Modify: `motion_connector.py` — the `MotionConnector.__init__` signature + baseline capture, and the `_save_app_config` method
 - Test: `tests/test_connector_save_overrides.py`
 
 - [ ] **Step 1: Write the failing test**
@@ -393,7 +392,7 @@ git commit -m "feat: load config via layered store; route logs/data to ProgramDa
 import json
 import pytest
 import motion_connector
-from motion_connector import MOTIONConnector
+from motion_connector import MotionConnector
 
 
 @pytest.mark.unit
@@ -404,9 +403,9 @@ def test_save_app_config_delegates_diff_to_store(tmp_path, monkeypatch):
     (tmp_path / "app_config.json").write_text("{}", encoding="utf-8")
     monkeypatch.setenv("OPENWATER_CONFIG_DIR", str(tmp_path))
 
-    # MOTIONConnector.__init__ wires hardware/telemetry, so bypass it with
+    # MotionConnector.__init__ wires hardware/telemetry, so bypass it with
     # __new__ and set only the attributes _save_app_config reads.
-    conn = MOTIONConnector.__new__(MOTIONConnector)
+    conn = MotionConnector.__new__(MotionConnector)
     conn._app_config = {"developerMode": True, "reducedMode": False}
     conn._baseline_config = {"developerMode": False, "reducedMode": False}
 
@@ -431,19 +430,19 @@ Expected: FAIL — `__init__` has no `baseline_config` kwarg.
 
 - [ ] **Step 3: Write minimal implementation**
 
-Add the import near the top of `motion_connector.py` (after line 43's `from utils.resource_path import resource_path`):
+Add the import near the top of `motion_connector.py` (next to `from utils.resource_path import resource_path`):
 
 ```python
 from utils import config_store
 ```
 
-In `__init__` (around line 346-356), add the `baseline_config` parameter and capture it. The signature currently includes `app_config=None`; add `baseline_config=None` alongside it, and after `self._app_config = dict(cfg)` add:
+In `MotionConnector.__init__`, add the `baseline_config` parameter and capture it. The current signature is `def __init__(self, interface, app_config=None, data_dir=None, config_dir="config", parent=None, log_level=logging.INFO, app_version="", log_path="")` — add `baseline_config=None` after `app_config=None`. Then, right after `self._app_config = dict(cfg)`, add:
 
 ```python
         self._baseline_config = dict(baseline_config or {})
 ```
 
-Replace `_save_app_config` (lines 1469-1481) with:
+Replace the `_save_app_config` method (the one that does `config_path = resource_path("config", "app_config.json")` then `json.dump`) with:
 
 ```python
     def _save_app_config(self):
@@ -455,7 +454,7 @@ Replace `_save_app_config` (lines 1469-1481) with:
         config_store.save_overrides(self._app_config, self._baseline_config)
 ```
 
-The now-unused `_INT_CONFIG_KEYS` set (line 1467) is superseded by `config_store._INT_KEYS`; delete it if no other reference remains (grep `_INT_CONFIG_KEYS` first — if referenced elsewhere, leave it).
+The class attribute `_INT_CONFIG_KEYS = {"leftMask", "rightMask"}` is now superseded by `config_store._INT_KEYS`; delete it if no other reference remains (grep `_INT_CONFIG_KEYS` first — if referenced elsewhere, leave it).
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -505,7 +504,7 @@ git commit -m "chore: gitignore runtime config overrides + dev data dir"
 ### Task 6: Variant-aware update-asset selector
 
 **Files:**
-- Modify: `motion_connector.py` (add module-level `_select_update_asset` near the other module functions ~line 60-110, and a `_REQUIRE_SIGNED_UPDATES` flag), `motion_connector.py:3891-3896` (asset loop in `_check_for_updates_worker`)
+- Modify: `motion_connector.py` (add module-level `_select_update_asset` + a `_REQUIRE_SIGNED_UPDATES` flag near the other module functions, e.g. just after `developer_password_matches`), and the `.zip` asset loop inside `_check_for_updates_worker`
 - Test: `tests/test_update_asset_select.py`
 
 - [ ] **Step 1: Write the failing test**
@@ -543,7 +542,7 @@ Expected: FAIL — `cannot import name '_select_update_asset'`
 
 - [ ] **Step 3: Write minimal implementation**
 
-Add near the other module-level helpers in `motion_connector.py` (e.g. just after the `_DEVELOPER_PASSWORD` block around line 72-77):
+Add near the other module-level helpers in `motion_connector.py` (e.g. just after the `developer_password_matches` function):
 
 ```python
 # Flip to True once release builds are Authenticode-signed; until then an
@@ -568,7 +567,7 @@ def _select_update_asset(assets: list, is_ruo: bool):
     return None
 ```
 
-Replace the `.zip` asset loop in `_check_for_updates_worker` (lines 3891-3896) with:
+Replace the `.zip` asset loop in `_check_for_updates_worker` (the `# Find the .zip asset download URL` block that loops over `data.get("assets", [])` and breaks on `asset["name"].endswith(".zip")`) with:
 
 ```python
             # Find the Setup bundle matching this build's variant.
@@ -836,10 +835,10 @@ In `components/UpdateBanner.qml`, change the download button text from `"Downloa
             }
 ```
 
-And change the click handler from `openDownloadUrl` to `applyUpdate`:
+And change the click handler from `openDownloadUrl` to `applyUpdate` (note the singleton is `MotionInterface`, the name the existing line already uses):
 
 ```qml
-                onClicked: MOTIONInterface.applyUpdate(banner.downloadUrl)
+                onClicked: MotionInterface.applyUpdate(banner.downloadUrl)
 ```
 
 - [ ] **Step 2: Verify the app still loads the QML**

--- a/docs/superpowers/plans/2026-06-17-msi-installer-in-app-update.md
+++ b/docs/superpowers/plans/2026-06-17-msi-installer-in-app-update.md
@@ -1,0 +1,1285 @@
+# MSI Installer + In-App Updater Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the bloodflow app as a signed WiX Burn bundle that installs the WinUSB driver + the app into Program Files in one run, with an in-app "Update" button that performs an in-place upgrade.
+
+**Architecture:** PyInstaller is unchanged — `openwater.spec` still produces `dist\OpenWaterApp\`. WiX v5 wraps that folder into an app MSI; a Burn bundle chains the existing driver MSI → app MSI into one `OpenWater-Setup-X.Y.Z.exe`. Because Program Files is read-only at runtime, writable state (config overrides, logs, scan data) relocates to `%PROGRAMDATA%\OpenWater\`. The in-app updater (RUO build only — clinical builds suppress it per issue #96) downloads the matching bundle, verifies its Authenticode signature, and runs it for an in-place upgrade.
+
+**Tech Stack:** Python 3.13 / PyQt6 / pytest, PyInstaller 6.11, WiX Toolset v5 (`wix` .NET CLI), WiX Burn + BAL extension, PowerShell, GitHub Actions.
+
+**Spec:** [docs/superpowers/specs/2026-06-17-msi-installer-in-app-update-design.md](../specs/2026-06-17-msi-installer-in-app-update-design.md)
+
+**Conventions for this plan:**
+- New unit tests are marked `@pytest.mark.unit` so conftest's autouse fixtures skip app launch (see `tests/conftest.py:575`). Run them with `python -m pytest -m unit <path> -v`.
+- Tests redirect the writable root via the `OPENWATER_DATA_ROOT` env var (added in Task 1) to a `tmp_path`, never the real ProgramData.
+- WiX/installer/CI tasks cannot be unit-tested; their "test" is a successful build + the manual VM verification in Task 16.
+- Commit after every task.
+
+---
+
+## Phase A — Writable-state relocation (app code)
+
+### Task 1: `utils/app_paths.py` — writable-root resolver
+
+**Files:**
+- Create: `utils/app_paths.py`
+- Test: `tests/test_app_paths.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_app_paths.py
+import os
+import pytest
+from pathlib import Path
+from utils import app_paths
+
+
+@pytest.mark.unit
+def test_writable_root_honors_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path / "ow"))
+    root = app_paths.writable_root()
+    assert root == tmp_path / "ow"
+    assert root.is_dir()  # created on access
+
+
+@pytest.mark.unit
+def test_local_config_and_data_dir_under_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path / "ow"))
+    assert app_paths.local_config_path() == tmp_path / "ow" / "app_config.local.json"
+    assert app_paths.default_data_dir() == tmp_path / "ow" / "data"
+    assert (tmp_path / "ow" / "data").is_dir()
+
+
+@pytest.mark.unit
+def test_dev_root_is_cwd_when_not_frozen(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    # not frozen in test → root is cwd, behavior unchanged for local dev
+    assert app_paths.writable_root() == tmp_path
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_app_paths.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'utils.app_paths'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# utils/app_paths.py
+"""Resolve writable, user-data locations outside the (read-only) install dir.
+
+When the app is installed to Program Files, its bundled files are read-only.
+Runtime-writable state (config overrides, logs, scan data) lives under
+%PROGRAMDATA%\\OpenWater\\ instead. In a dev (non-frozen) run, everything stays
+under the cwd so local development is unchanged.
+
+Override the root with the OPENWATER_DATA_ROOT env var (used by tests and as a
+power-user escape hatch).
+"""
+from pathlib import Path
+import os
+import sys
+
+_APP_DIRNAME = "OpenWater"
+
+
+def writable_root() -> Path:
+    """Return the writable data root, creating it if necessary."""
+    env = os.environ.get("OPENWATER_DATA_ROOT")
+    if env:
+        root = Path(env)
+    elif getattr(sys, "frozen", False):
+        base = os.environ.get("PROGRAMDATA", r"C:\ProgramData")
+        root = Path(base) / _APP_DIRNAME
+    else:
+        # dev: keep everything under the cwd, unchanged from before
+        root = Path.cwd()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def local_config_path() -> Path:
+    """Path to the writable config-overrides file."""
+    return writable_root() / "app_config.local.json"
+
+
+def default_data_dir() -> Path:
+    """Default scan-data / logs root when dataDirectory is unset."""
+    d = writable_root() / "data"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_app_paths.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/app_paths.py tests/test_app_paths.py
+git commit -m "feat: add app_paths writable-root resolver for ProgramData relocation"
+```
+
+---
+
+### Task 2: `utils/config_store.py` — layered load + overrides-diff save
+
+**Files:**
+- Create: `utils/config_store.py`
+- Test: `tests/test_config_store.py`
+
+The store layers config: code `defaults` → read-only bundled `config/app_config.json` → writable `app_config.local.json`. Runtime changes save as a **diff** against the first two layers so future shipped-default changes still reach untouched keys.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config_store.py
+import json
+import pytest
+from utils import config_store
+
+
+DEFAULTS = {"developerMode": False, "reducedMode": False, "leftMask": 0x66, "bfiMax": 10.0}
+
+
+@pytest.mark.unit
+def test_load_merges_overrides_over_baseline(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    (tmp_path / "app_config.local.json").write_text(
+        json.dumps({"developerMode": True}), encoding="utf-8"
+    )
+    baseline, merged = config_store.load_app_config(DEFAULTS)
+    assert baseline["developerMode"] is False      # baseline untouched
+    assert merged["developerMode"] is True          # override wins
+    assert merged["bfiMax"] == 10.0                 # untouched key flows through
+
+
+@pytest.mark.unit
+def test_save_writes_only_diff_against_baseline(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    baseline = dict(DEFAULTS)
+    current = {**DEFAULTS, "developerMode": True}
+    config_store.save_overrides(current, baseline)
+    written = json.loads((tmp_path / "app_config.local.json").read_text(encoding="utf-8"))
+    assert written == {"developerMode": True}       # only the changed key
+
+
+@pytest.mark.unit
+def test_load_with_no_override_file_returns_baseline(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    baseline, merged = config_store.load_app_config(DEFAULTS)
+    assert merged == baseline
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_config_store.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'utils.config_store'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# utils/config_store.py
+"""Load app config from layered sources and persist runtime overrides.
+
+Layers (lowest to highest precedence):
+  1. code defaults (passed in by the caller)
+  2. shipped, read-only config/app_config.json (PyInstaller bundle)
+  3. writable overrides: %PROGRAMDATA%\\OpenWater\\app_config.local.json
+
+Runtime changes are written as a *diff* against layers 1+2 so future changes to
+shipped defaults still reach keys the operator never touched.
+"""
+import json
+import logging
+
+from utils.resource_path import resource_path
+from utils import app_paths
+
+logger = logging.getLogger(__name__)
+
+_INT_KEYS = ("leftMask", "rightMask", "reducedModeLeftMask", "reducedModeRightMask")
+
+
+def _coerce_ints(cfg: dict) -> dict:
+    for key in _INT_KEYS:
+        if cfg.get(key) is not None:
+            cfg[key] = int(cfg[key])
+    return cfg
+
+
+def shipped_baseline(defaults: dict) -> dict:
+    """defaults merged with the read-only bundled app_config.json."""
+    base = dict(defaults)
+    path = resource_path("config", "app_config.json")
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            base.update(
+                {k: v for k, v in loaded.items() if k in defaults or k == "output_path"}
+            )
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Could not load %s: %s; using defaults", path, e)
+    return _coerce_ints(base)
+
+
+def load_overrides() -> dict:
+    """Read the writable overrides file (empty dict if absent/invalid)."""
+    path = app_paths.local_config_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Could not load overrides %s: %s", path, e)
+        return {}
+
+
+def load_app_config(defaults: dict):
+    """Return (baseline, merged); merged = baseline + writable overrides."""
+    baseline = shipped_baseline(defaults)
+    overrides = load_overrides()
+    merged = {
+        **baseline,
+        **{k: v for k, v in overrides.items() if k in baseline or k == "output_path"},
+    }
+    return baseline, _coerce_ints(merged)
+
+
+def save_overrides(current: dict, baseline: dict) -> None:
+    """Persist only keys whose value differs from the baseline."""
+    diff = _coerce_ints({k: v for k, v in current.items() if baseline.get(k) != v})
+    path = app_paths.local_config_path()
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(diff, f, indent=2)
+    except OSError as e:
+        logger.warning("Could not write overrides %s: %s", path, e)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_config_store.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/config_store.py tests/test_config_store.py
+git commit -m "feat: add config_store with layered load and overrides-diff save"
+```
+
+---
+
+### Task 3: Wire `main.py` to the layered store + ProgramData log/data root
+
+**Files:**
+- Modify: `main.py:67-153` (`_load_app_config`), `main.py:188-200` (output_base default), `main.py:255` (connector construction)
+- Test: `tests/test_main_config_wiring.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_main_config_wiring.py
+import json
+import importlib
+import pytest
+
+
+@pytest.mark.unit
+def test_load_app_config_applies_local_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    (tmp_path / "app_config.local.json").write_text(
+        json.dumps({"developerMode": True}), encoding="utf-8"
+    )
+    main = importlib.import_module("main")
+    cfg = main._load_app_config()
+    assert cfg["developerMode"] is True              # override applied over baseline
+    # baseline is stashed for the connector (value comes from the shipped
+    # config file, so assert presence, not a specific value).
+    assert "developerMode" in main._APP_CONFIG_BASELINE
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_main_config_wiring.py -v`
+Expected: FAIL — `_load_app_config` does not consult overrides / `_APP_CONFIG_BASELINE` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `main.py`, add the import near the other `utils` imports (after line 34):
+
+```python
+from utils import app_paths, config_store
+```
+
+Add a module-level baseline stash (just below the imports / logger setup, before `_load_app_config`):
+
+```python
+# Shipped baseline (defaults + read-only bundled config), captured at load so
+# the connector can diff runtime changes against it when saving overrides.
+_APP_CONFIG_BASELINE: dict = {}
+```
+
+Replace the body of `_load_app_config` from the `config_path = resource_path(...)` line (line 132) through its `return` statements (line 153) with delegation to the store. Keep the big `defaults = {...}` dict (lines 69-131) exactly as-is; only the tail changes:
+
+```python
+    # (defaults = { ... } stays unchanged above this point)
+    baseline, merged = config_store.load_app_config(defaults)
+    _APP_CONFIG_BASELINE.clear()
+    _APP_CONFIG_BASELINE.update(baseline)
+    logger.info("Loaded app config (overrides from %s)", app_paths.local_config_path())
+    return merged
+```
+
+Change the `output_base` default (lines 190-199) so a frozen install logs/scans under ProgramData instead of cwd:
+
+```python
+    output_base = app_config.get("output_path")
+    if not output_base:
+        # Installed (frozen) build → ProgramData; dev run → cwd (unchanged),
+        # falling back to ~/Documents if cwd is not writable.
+        candidate = str(app_paths.writable_root()) if getattr(sys, "frozen", False) else os.getcwd()
+        if os.access(candidate, os.W_OK):
+            output_base = candidate
+        else:
+            output_base = os.path.join(
+                os.path.expanduser("~"), "Documents", "OpenWater Bloodflow"
+            )
+```
+
+Pass the baseline into the connector at line 255:
+
+```python
+    connector = MOTIONConnector(
+        motion_interface,
+        app_config=app_config,
+        baseline_config=_APP_CONFIG_BASELINE,
+        output_path=output_base,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_main_config_wiring.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main.py tests/test_main_config_wiring.py
+git commit -m "feat: load config via layered store; route logs/data to ProgramData when frozen"
+```
+
+---
+
+### Task 4: Connector saves overrides instead of overwriting bundled config
+
+**Files:**
+- Modify: `motion_connector.py:346-356` (`__init__` signature + baseline capture), `motion_connector.py:1469-1481` (`_save_app_config`)
+- Test: `tests/test_connector_save_overrides.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_connector_save_overrides.py
+import json
+import pytest
+import motion_connector
+from motion_connector import MOTIONConnector
+
+
+@pytest.mark.unit
+def test_save_app_config_delegates_diff_to_store(tmp_path, monkeypatch):
+    # Redirect resource_path("config", ...) to a throwaway dir so the pre-impl
+    # ("red") version of _save_app_config can't clobber the repo's real
+    # config/app_config.json when this test first runs.
+    (tmp_path / "app_config.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OPENWATER_CONFIG_DIR", str(tmp_path))
+
+    # MOTIONConnector.__init__ wires hardware/telemetry, so bypass it with
+    # __new__ and set only the attributes _save_app_config reads.
+    conn = MOTIONConnector.__new__(MOTIONConnector)
+    conn._app_config = {"developerMode": True, "reducedMode": False}
+    conn._baseline_config = {"developerMode": False, "reducedMode": False}
+
+    captured = {}
+    monkeypatch.setattr(
+        motion_connector.config_store,
+        "save_overrides",
+        lambda current, baseline: captured.update(current=current, baseline=baseline),
+    )
+    conn._save_app_config()
+
+    assert captured["current"] == conn._app_config
+    assert captured["baseline"] == conn._baseline_config
+```
+
+This proves the connector delegates to `config_store.save_overrides` with the right args; the *diff* behavior itself is already covered by `tests/test_config_store.py` (Task 2), and the end-to-end ProgramData write is verified manually in Task 16 Step 2.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_connector_save_overrides.py -v`
+Expected: FAIL — `__init__` has no `baseline_config` kwarg.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the import near the top of `motion_connector.py` (after line 43's `from utils.resource_path import resource_path`):
+
+```python
+from utils import config_store
+```
+
+In `__init__` (around line 346-356), add the `baseline_config` parameter and capture it. The signature currently includes `app_config=None`; add `baseline_config=None` alongside it, and after `self._app_config = dict(cfg)` add:
+
+```python
+        self._baseline_config = dict(baseline_config or {})
+```
+
+Replace `_save_app_config` (lines 1469-1481) with:
+
+```python
+    def _save_app_config(self):
+        """Persist runtime config changes as a diff against the shipped baseline.
+
+        Writes only changed keys to %PROGRAMDATA%\\OpenWater\\app_config.local.json
+        — never the read-only bundled config under Program Files.
+        """
+        config_store.save_overrides(self._app_config, self._baseline_config)
+```
+
+The now-unused `_INT_CONFIG_KEYS` set (line 1467) is superseded by `config_store._INT_KEYS`; delete it if no other reference remains (grep `_INT_CONFIG_KEYS` first — if referenced elsewhere, leave it).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_connector_save_overrides.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_connector_save_overrides.py
+git commit -m "feat: connector persists config as ProgramData overrides diff"
+```
+
+---
+
+### Task 5: Gitignore the dev-mode overrides file
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add the ignore entry**
+
+Append to `.gitignore`:
+
+```
+# Runtime config overrides (written by setConfig; ProgramData in prod, cwd in dev)
+app_config.local.json
+data/
+```
+
+- [ ] **Step 2: Verify nothing is already tracked**
+
+Run: `git status --porcelain app_config.local.json`
+Expected: no output (file is not tracked).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: gitignore runtime config overrides + dev data dir"
+```
+
+---
+
+## Phase B — In-app updater (app code)
+
+### Task 6: Variant-aware update-asset selector
+
+**Files:**
+- Modify: `motion_connector.py` (add module-level `_select_update_asset` near the other module functions ~line 60-110, and a `_REQUIRE_SIGNED_UPDATES` flag), `motion_connector.py:3891-3896` (asset loop in `_check_for_updates_worker`)
+- Test: `tests/test_update_asset_select.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_update_asset_select.py
+import pytest
+from motion_connector import _select_update_asset
+
+
+CLINICAL = {"name": "OpenWater-Setup-1.2.3.exe", "browser_download_url": "u/clinical"}
+RUO = {"name": "OpenWater-Setup-1.2.3_RUO.exe", "browser_download_url": "u/ruo"}
+ZIP = {"name": "OpenMotionDriver-x64.zip", "browser_download_url": "u/zip"}
+
+
+@pytest.mark.unit
+def test_selects_ruo_bundle_for_ruo_variant():
+    assert _select_update_asset([CLINICAL, RUO, ZIP], is_ruo=True) == "u/ruo"
+
+
+@pytest.mark.unit
+def test_selects_clinical_bundle_for_clinical_variant():
+    assert _select_update_asset([CLINICAL, RUO, ZIP], is_ruo=False) == "u/clinical"
+
+
+@pytest.mark.unit
+def test_returns_none_when_no_matching_exe():
+    assert _select_update_asset([ZIP], is_ruo=True) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_update_asset_select.py -v`
+Expected: FAIL — `cannot import name '_select_update_asset'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add near the other module-level helpers in `motion_connector.py` (e.g. just after the `_DEVELOPER_PASSWORD` block around line 72-77):
+
+```python
+# Flip to True once release builds are Authenticode-signed; until then an
+# unsigned (NotSigned) update bundle is allowed through with a logged warning.
+_REQUIRE_SIGNED_UPDATES = False
+
+
+def _select_update_asset(assets: list, is_ruo: bool):
+    """Return the download URL of the Setup bundle matching the running variant.
+
+    RUO builds match ``OpenWater-Setup-*_RUO.exe``; clinical builds match the
+    non-RUO ``OpenWater-Setup-*.exe``. Returns None if no matching .exe asset.
+    """
+    for asset in assets:
+        name = (asset.get("name") or "")
+        low = name.lower()
+        if not low.endswith(".exe"):
+            continue
+        asset_is_ruo = low.endswith("_ruo.exe")
+        if asset_is_ruo == is_ruo:
+            return asset.get("browser_download_url")
+    return None
+```
+
+Replace the `.zip` asset loop in `_check_for_updates_worker` (lines 3891-3896) with:
+
+```python
+            # Find the Setup bundle matching this build's variant.
+            # reducedMode True = clinical build; False = RUO/full build.
+            is_ruo = not bool(self._app_config.get("reducedMode", False))
+            download_url = _select_update_asset(data.get("assets", []), is_ruo) or data.get(
+                "html_url", ""
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_update_asset_select.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_update_asset_select.py
+git commit -m "feat: select update bundle asset by build variant"
+```
+
+---
+
+### Task 7: Authenticode status helper
+
+**Files:**
+- Modify: `motion_connector.py` (add `_authenticode_status` near `_select_update_asset`)
+- Test: `tests/test_authenticode_status.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_authenticode_status.py
+import subprocess
+import types
+import pytest
+import motion_connector
+
+
+@pytest.mark.unit
+def test_authenticode_status_parses_powershell_output(monkeypatch):
+    def fake_run(*a, **k):
+        return types.SimpleNamespace(stdout="Valid\n", returncode=0)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert motion_connector._authenticode_status("C:/x.exe") == "Valid"
+
+
+@pytest.mark.unit
+def test_authenticode_status_returns_error_on_exception(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no powershell")
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert motion_connector._authenticode_status("C:/x.exe") == "Error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_authenticode_status.py -v`
+Expected: FAIL — `module 'motion_connector' has no attribute '_authenticode_status'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `motion_connector.py` next to `_select_update_asset`:
+
+```python
+def _authenticode_status(path: str) -> str:
+    """Return the Authenticode signature status of ``path``.
+
+    Uses PowerShell's Get-AuthenticodeSignature (always present on Windows).
+    Returns one of 'Valid', 'NotSigned', 'HashMismatch', 'UnknownError', ... or
+    'Error' if the check itself could not run.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                f"(Get-AuthenticodeSignature -LiteralPath '{path}').Status",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip() or "Error"
+    except Exception:
+        return "Error"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_authenticode_status.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_authenticode_status.py
+git commit -m "feat: add Authenticode status helper for update verification"
+```
+
+---
+
+### Task 8: `applyUpdate` slot — download, verify, launch, quit
+
+**Files:**
+- Modify: `motion_connector.py:1` (add `QCoreApplication` to the QtCore import), `motion_connector.py` (add slot near `openDownloadUrl` ~line 3945)
+- Test: `tests/test_apply_update.py`
+
+The installer spawn + app-quit is integration-only (verified in Task 16). The unit-testable part is the **signature decision**: extract it into a pure `_update_decision(status, require_signed) -> (should_launch, error)` function and test that. `_apply_update_worker` then just acts on the decision.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_apply_update.py
+import pytest
+from motion_connector import _update_decision
+
+
+@pytest.mark.unit
+def test_valid_signature_launches():
+    assert _update_decision("Valid", require_signed=True) == (True, None)
+
+
+@pytest.mark.unit
+def test_invalid_signature_aborts_with_message():
+    launch, err = _update_decision("HashMismatch", require_signed=False)
+    assert launch is False
+    assert "HashMismatch" in err
+
+
+@pytest.mark.unit
+def test_unsigned_allowed_when_not_required():
+    assert _update_decision("NotSigned", require_signed=False) == (True, None)
+
+
+@pytest.mark.unit
+def test_unsigned_rejected_when_required():
+    launch, err = _update_decision("NotSigned", require_signed=True)
+    assert launch is False
+    assert "not signed" in err.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -m unit tests/test_apply_update.py -v`
+Expected: FAIL — `cannot import name '_update_decision'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the pure decision function next to `_authenticode_status` (module level):
+
+```python
+def _update_decision(status: str, require_signed: bool):
+    """Decide whether to launch the downloaded bundle given its signature status.
+
+    Returns (should_launch: bool, error_message: str | None).
+    """
+    if status == "Valid":
+        return True, None
+    if status == "NotSigned":
+        if require_signed:
+            return False, "Update is not signed; refusing to install."
+        return True, None  # transition period: allow with a warning logged by caller
+    return False, f"Update signature check failed: {status}"
+```
+
+Add `QCoreApplication` to the QtCore import (lines 1-10):
+
+```python
+from PyQt6.QtCore import (
+    QObject,
+    pyqtSignal,
+    pyqtProperty,
+    pyqtSlot,
+    QVariant,
+    QThread,
+    QTimer,
+    QRecursiveMutex,
+    QCoreApplication,
+)
+```
+
+Add the slot + worker near `openDownloadUrl` (~line 3945). Keep `openDownloadUrl` for now (still referenced until Task 9 switches the QML):
+
+```python
+    @pyqtSlot(str)
+    def applyUpdate(self, download_url: str):
+        """Download the update bundle, verify it, and launch the in-place upgrade."""
+        t = threading.Thread(
+            target=self._apply_update_worker, args=(download_url,), daemon=True
+        )
+        t.start()
+
+    def _apply_update_worker(self, download_url: str):
+        import urllib.request
+        import subprocess
+        from utils import app_paths
+
+        try:
+            updates_dir = app_paths.writable_root() / "updates"
+            updates_dir.mkdir(parents=True, exist_ok=True)
+            dest = updates_dir / download_url.rsplit("/", 1)[-1]
+            logger.info("Downloading update %s -> %s", download_url, dest)
+            urllib.request.urlretrieve(download_url, str(dest))
+
+            status = _authenticode_status(str(dest))
+            should_launch, error = _update_decision(status, _REQUIRE_SIGNED_UPDATES)
+            if not should_launch:
+                self.updateCheckFailed.emit(error)
+                return
+            if status == "NotSigned":
+                logger.warning("Update bundle is not signed (transition period) — proceeding")
+
+            # Launch the Burn bundle detached, then quit so our files unlock and
+            # the in-place major upgrade can replace them. Burn relaunches us.
+            logger.info("Launching installer; quitting app for in-place upgrade")
+            subprocess.Popen(
+                [str(dest)],
+                close_fds=True,
+                creationflags=getattr(subprocess, "DETACHED_PROCESS", 0),
+            )
+            QCoreApplication.quit()
+        except Exception as e:
+            logger.error("applyUpdate failed: %s", e)
+            self.updateCheckFailed.emit(str(e))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -m unit tests/test_apply_update.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add motion_connector.py tests/test_apply_update.py
+git commit -m "feat: applyUpdate slot downloads, verifies, and runs in-place upgrade"
+```
+
+---
+
+### Task 9: Point `UpdateBanner.qml` at the in-place updater
+
+**Files:**
+- Modify: `components/UpdateBanner.qml` (button label + `onClicked`)
+
+QML has no hot-reload — verify by restarting the app (Task 16). No automated test.
+
+- [ ] **Step 1: Change the button label and action**
+
+In `components/UpdateBanner.qml`, change the download button text from `"Download"` to `"Update"`:
+
+```qml
+            Text {
+                id: downloadBtn
+                anchors.centerIn: parent
+                text: "Update"
+                color: theme.accentBlue
+                font.pixelSize: 12
+                font.weight: Font.DemiBold
+            }
+```
+
+And change the click handler from `openDownloadUrl` to `applyUpdate`:
+
+```qml
+                onClicked: MOTIONInterface.applyUpdate(banner.downloadUrl)
+```
+
+- [ ] **Step 2: Verify the app still loads the QML**
+
+Run (from a conda env with the app deps; hardware not required to reach the banner code path, but the window must open):
+`python main.py`
+Expected: app launches with no QML error for `UpdateBanner.qml` in the console/log. Close the app.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/UpdateBanner.qml
+git commit -m "feat: UpdateBanner triggers in-place update instead of browser download"
+```
+
+---
+
+## Phase C — WiX installer sources
+
+### Task 10: App MSI source (`installer/app.wxs`)
+
+**Files:**
+- Create: `installer/app.wxs`
+
+Built and verified in Task 13 (needs a `dist\` to harvest). This task just authors the source. Uses WiX v5 syntax; `$(var.X)` values are supplied by `wix build -d` flags in Task 13.
+
+- [ ] **Step 1: Author the app MSI source**
+
+```xml
+<!-- installer/app.wxs — packages dist\OpenWaterApp\ into Program Files. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="$(var.ProductName)"
+           Manufacturer="Openwater"
+           Version="$(var.Version)"
+           UpgradeCode="$(var.UpgradeCode)"
+           Scope="perMachine"
+           Compressed="yes">
+
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="VENDORFOLDER" Name="OpenWater">
+        <Directory Id="APPFOLDER" Name="Bloodflow" />
+      </Directory>
+    </StandardDirectory>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="AppShortcutFolder" Name="$(var.ProductName)" />
+    </StandardDirectory>
+
+    <Feature Id="Main" Title="$(var.ProductName)" Level="1">
+      <ComponentGroupRef Id="AppFiles" />
+      <ComponentRef Id="AppShortcut" />
+    </Feature>
+
+    <!-- Harvest the entire PyInstaller one-folder output. -->
+    <ComponentGroup Id="AppFiles" Directory="APPFOLDER">
+      <Files Include="$(var.SourceDir)\**" />
+    </ComponentGroup>
+
+    <Component Id="AppShortcut" Directory="AppShortcutFolder" Guid="*">
+      <Shortcut Id="StartMenuShortcut"
+                Name="$(var.ProductName)"
+                Target="[APPFOLDER]OpenWaterApp.exe"
+                WorkingDirectory="APPFOLDER" />
+      <RemoveFolder Id="RemoveAppShortcutFolder" On="uninstall" />
+      <RegistryValue Root="HKLM" Key="Software\Openwater\Bloodflow"
+                     Name="installed" Type="integer" Value="1" KeyPath="yes" />
+    </Component>
+  </Package>
+</Wix>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add installer/app.wxs
+git commit -m "feat: WiX app MSI source (Program Files, major-upgrade)"
+```
+
+---
+
+### Task 11: Burn bundle source (`installer/bundle.wxs`)
+
+**Files:**
+- Create: `installer/bundle.wxs`
+
+Chains the driver MSI → app MSI. Burn auto-detects the driver MSI's install state from its ProductCode, so it is skipped when already current — no manual `DetectCondition` needed. The BAL extension provides the standard UI.
+
+- [ ] **Step 1: Author the bundle source**
+
+```xml
+<!-- installer/bundle.wxs — one setup.exe: driver MSI then app MSI. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+  <Bundle Name="$(var.ProductName)"
+          Manufacturer="Openwater"
+          Version="$(var.Version)"
+          UpgradeCode="$(var.BundleUpgradeCode)">
+
+    <BootstrapperApplication>
+      <bal:WixStandardBootstrapperApplication Theme="hyperlinkLicense"
+                                              LicenseUrl="" />
+    </BootstrapperApplication>
+
+    <Chain>
+      <!-- WinUSB driver. Vital but its absence on uninstall is fine (Permanent). -->
+      <MsiPackage Id="DriverMsi"
+                  SourceFile="$(var.DriverMsi)"
+                  Vital="yes"
+                  Permanent="yes"
+                  Visible="no" />
+      <!-- The app itself. -->
+      <MsiPackage Id="AppMsi"
+                  SourceFile="$(var.AppMsi)"
+                  Vital="yes" />
+    </Chain>
+  </Bundle>
+</Wix>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add installer/bundle.wxs
+git commit -m "feat: WiX Burn bundle chaining driver MSI + app MSI"
+```
+
+---
+
+### Task 12: Skippable signing helper (`installer/sign.ps1`)
+
+**Files:**
+- Create: `installer/sign.ps1`
+
+A no-op until `CODESIGN_THUMBPRINT` is set; signs the given files when it is. Bundle signing (insignia detach/reattach) lives in the build script (Task 13) because it is multi-step.
+
+- [ ] **Step 1: Author the helper**
+
+```powershell
+# installer/sign.ps1 — Authenticode-sign the given files, or skip if no cert.
+param([Parameter(Mandatory = $true)][string[]]$Files)
+
+$thumb = $env:CODESIGN_THUMBPRINT
+if (-not $thumb) {
+    Write-Host "signing skipped (CODESIGN_THUMBPRINT not set)" -ForegroundColor Yellow
+    return
+}
+
+foreach ($f in $Files) {
+    Write-Host "signing $f" -ForegroundColor Cyan
+    & signtool sign /sha1 $thumb /fd SHA256 `
+        /tr http://timestamp.digicert.com /td SHA256 $f
+    if ($LASTEXITCODE -ne 0) { throw "signtool failed for $f" }
+}
+```
+
+- [ ] **Step 2: Verify it no-ops cleanly**
+
+Run: `powershell -NoProfile -File installer/sign.ps1 -Files installer/sign.ps1`
+Expected: prints `signing skipped (CODESIGN_THUMBPRINT not set)` and exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add installer/sign.ps1
+git commit -m "feat: skippable Authenticode signing helper"
+```
+
+---
+
+### Task 13: Installer build orchestrator (`installer/build_installer.ps1`)
+
+**Files:**
+- Create: `installer/build_installer.ps1`
+
+Resolves the numeric `X.Y.Z`, extracts the driver MSI from the zip, builds the app MSI + bundle for the requested variant, signs the launcher/MSI, then signs the bundle via the insignia dance. Constant GUIDs are stored here (distinct per variant).
+
+- [ ] **Step 1: Author the orchestrator**
+
+```powershell
+# installer/build_installer.ps1 — build the app MSI + Burn bundle for one variant.
+param(
+    [ValidateSet("clinical", "ruo")][string]$Variant = "clinical",
+    [string]$DistDir = "dist\OpenWaterApp"
+)
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
+Set-Location $root
+
+# ── constant, never-changing GUIDs (distinct per variant so they never
+#    cross-upgrade). Generate once with [guid]::NewGuid() and paste here. ──
+$guids = @{
+    clinical = @{
+        ProductName       = "OpenWater Bloodflow"
+        UpgradeCode       = "11111111-1111-1111-1111-111111111111"
+        BundleUpgradeCode = "22222222-2222-2222-2222-222222222222"
+        Suffix            = ""
+    }
+    ruo = @{
+        ProductName       = "OpenWater Bloodflow (RUO)"
+        UpgradeCode       = "33333333-3333-3333-3333-333333333333"
+        BundleUpgradeCode = "44444444-4444-4444-4444-444444444444"
+        Suffix            = "_RUO"
+    }
+}
+$g = $guids[$Variant]
+
+# ── numeric X.Y.Z from the git tag/describe (drop any -dev/-rc suffix) ──
+try {
+    $desc = (git describe --tags --always 2>$null).Trim()
+} catch { $desc = "" }
+if ($desc -match '(\d+)\.(\d+)\.(\d+)') {
+    $version = "$($matches[1]).$($matches[2]).$($matches[3])"
+} else {
+    $version = "0.0.0"
+}
+Write-Host "Variant=$Variant  Version=$version  Product='$($g.ProductName)'" -ForegroundColor Green
+
+# ── extract the driver MSI from the bundled zip ──
+$drvZip = "resources\OpenMotionDriver-x64.zip"
+$drvDir = "build\driver"
+Remove-Item -Recurse -Force $drvDir -ErrorAction SilentlyContinue
+Expand-Archive -Path $drvZip -DestinationPath $drvDir -Force
+$driverMsi = Join-Path $drvDir "OpenMotionDriver-x64.msi"
+if (-not (Test-Path $driverMsi)) { throw "driver MSI not found in $drvZip" }
+
+# ── output names ──
+$outDir = "build\installer"
+New-Item -ItemType Directory -Force $outDir | Out-Null
+$appMsi    = Join-Path $outDir "OpenWaterApp$($g.Suffix).msi"
+$bundleExe = Join-Path $outDir "OpenWater-Setup-$version$($g.Suffix).exe"
+
+# ── build the app MSI ──
+wix build installer\app.wxs -o $appMsi `
+    -d "ProductName=$($g.ProductName)" `
+    -d "Version=$version" `
+    -d "UpgradeCode=$($g.UpgradeCode)" `
+    -d "SourceDir=$DistDir"
+if ($LASTEXITCODE -ne 0) { throw "app MSI build failed" }
+
+# sign the app MSI (skippable)
+powershell -NoProfile -File installer\sign.ps1 -Files $appMsi
+
+# ── build the Burn bundle ──
+wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.Bal.wixext `
+    -d "ProductName=$($g.ProductName)" `
+    -d "Version=$version" `
+    -d "BundleUpgradeCode=$($g.BundleUpgradeCode)" `
+    -d "DriverMsi=$driverMsi" `
+    -d "AppMsi=$appMsi"
+if ($LASTEXITCODE -ne 0) { throw "bundle build failed" }
+
+# ── sign the bundle (insignia detach → sign engine → reattach → sign) ──
+if ($env:CODESIGN_THUMBPRINT) {
+    $engine = Join-Path $outDir "engine.exe"
+    wix burn detach $bundleExe -engine $engine
+    powershell -NoProfile -File installer\sign.ps1 -Files $engine
+    wix burn reattach $bundleExe -engine $engine -o $bundleExe
+    powershell -NoProfile -File installer\sign.ps1 -Files $bundleExe
+} else {
+    Write-Host "bundle signing skipped (no cert)" -ForegroundColor Yellow
+}
+
+Write-Host "Built $bundleExe" -ForegroundColor Green
+```
+
+- [ ] **Step 2: Install WiX v5 and the BAL extension locally**
+
+Run:
+```
+dotnet tool install --global wix
+wix extension add -g WixToolset.Bal.wixext
+```
+Expected: both succeed (or report "already installed").
+
+- [ ] **Step 3: Build a fresh `dist\` then build the clinical installer**
+
+Run:
+```
+python -m PyInstaller -y openwater.spec
+powershell -NoProfile -File installer\build_installer.ps1 -Variant clinical
+```
+Expected: `build\installer\OpenWater-Setup-<ver>.exe` is produced; "bundle signing skipped (no cert)" printed.
+
+- [ ] **Step 4: Build the RUO installer**
+
+Flip `reducedMode` in the built config, then build the RUO bundle:
+```
+$cfg = "dist\OpenWaterApp\_internal\config\app_config.json"
+(Get-Content -Raw $cfg) -replace '"reducedMode"\s*:\s*true', '"reducedMode": false' | Set-Content -NoNewline -Encoding UTF8 $cfg
+powershell -NoProfile -File installer\build_installer.ps1 -Variant ruo
+```
+Expected: `build\installer\OpenWater-Setup-<ver>_RUO.exe` produced. (Restore the config afterward or rebuild `dist\` for the clinical artifact.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/build_installer.ps1
+git commit -m "feat: installer build orchestrator (app MSI + Burn bundle, both variants)"
+```
+
+---
+
+## Phase D — CI
+
+### Task 14: Build installers in `release-build.yml`
+
+**Files:**
+- Modify: `.github/workflows/release-build.yml`
+
+Add WiX install + installer builds after the existing PyInstaller step, and publish the two `setup.exe` files as release assets alongside the driver zip. The existing RUO config-flip step (lines 132-151) is reused to produce the RUO `dist\` before building the RUO bundle.
+
+- [ ] **Step 1: Add a WiX setup step after "Build with PyInstaller" (after line 99)**
+
+```yaml
+      - name: Install WiX v5
+        shell: pwsh
+        run: |
+          dotnet tool install --global wix
+          wix extension add -g WixToolset.Bal.wixext
+          echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Build clinical installer
+        shell: pwsh
+        env:
+          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
+        run: |
+          powershell -NoProfile -File installer\build_installer.ps1 -Variant clinical
+
+      - name: Build RUO installer
+        shell: pwsh
+        env:
+          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
+        run: |
+          $cfg = "dist\OpenWaterApp\_internal\config\app_config.json"
+          $orig = Get-Content -Raw $cfg
+          $ruo = $orig -replace '"reducedMode"\s*:\s*true', '"reducedMode": false'
+          if ($ruo -eq $orig) { throw "RUO build: did not find reducedMode: true to flip" }
+          Set-Content -Path $cfg -Value $ruo -Encoding UTF8 -NoNewline
+          try {
+            powershell -NoProfile -File installer\build_installer.ps1 -Variant ruo
+          } finally {
+            Set-Content -Path $cfg -Value $orig -Encoding UTF8 -NoNewline
+          }
+```
+
+Note: `CODESIGN_THUMBPRINT` is an as-yet-unset repo secret; until it exists the signing steps no-op (Task 12). When a cloud signing service is chosen instead of a local thumbprint, swap `sign.ps1`'s body accordingly — the workflow wiring stays.
+
+- [ ] **Step 2: Add the installers to the release `files:` list (lines 202-205)**
+
+```yaml
+          files: |
+            ${{ steps.meta.outputs.ARTIFACT_ZIP }}
+            ${{ steps.meta.outputs.ARTIFACT_ZIP_RUO }}
+            build/installer/OpenWater-Setup-*.exe
+            resources/OpenMotionDriver-x64.zip
+```
+
+(The legacy `.zip` artifacts stay for one transition release per the spec; remove those two lines in a later release.)
+
+- [ ] **Step 3: Validate the workflow YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-build.yml'))"`
+Expected: no exception (valid YAML).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release-build.yml
+git commit -m "ci: build and publish WiX installers for both variants"
+```
+
+---
+
+## Phase E — Full-suite check + manual verification
+
+### Task 15: Run the unit suite
+
+**Files:** none
+
+- [ ] **Step 1: Run all new unit tests together**
+
+Run: `python -m pytest -m unit tests/test_app_paths.py tests/test_config_store.py tests/test_main_config_wiring.py tests/test_connector_save_overrides.py tests/test_update_asset_select.py tests/test_authenticode_status.py tests/test_apply_update.py -v`
+Expected: all PASS, no app launch (unit-marked).
+
+- [ ] **Step 2: Lint touched Python**
+
+Run: `python -m flake8 utils/app_paths.py utils/config_store.py main.py motion_connector.py`
+Expected: no errors (match existing style; the repo pins flake8 7.1.1).
+
+- [ ] **Step 3: Commit any lint fixes**
+
+```bash
+git add -A
+git commit -m "chore: lint installer/updater changes" || echo "nothing to commit"
+```
+
+---
+
+### Task 16: Manual clean-VM verification (per spec verification plan)
+
+**Files:** none — this is the acceptance gate for the installer/updater that cannot be unit-tested.
+
+- [ ] **Step 1: Fresh install on a clean Windows VM (no prior app, no driver)**
+
+Copy `build\installer\OpenWater-Setup-<ver>.exe` to a clean VM and run it.
+Expected: single UAC prompt; on completion the WinUSB driver is present (Device Manager), the app is under `C:\Program Files\OpenWater\Bloodflow\`, and a Start-menu shortcut exists.
+
+- [ ] **Step 2: Verify writable-state relocation**
+
+Launch the app, double-click the logo, enter the developer password to unlock developer mode, close and relaunch.
+Expected: `C:\ProgramData\OpenWater\app_config.local.json` exists and contains `{"developerMode": true}` (only the changed key); the bundled `Program Files\...\_internal\config\app_config.json` is unchanged; developer mode persists across the restart.
+
+- [ ] **Step 3: Verify scan data + logs land in ProgramData**
+
+Run any scan / let the app log.
+Expected: `C:\ProgramData\OpenWater\app-logs\ow-bloodflowapp-*.log` and scan output / `scans.db` appear under `C:\ProgramData\OpenWater\` (not under Program Files).
+
+- [ ] **Step 4: Verify the in-place update flow (RUO build)**
+
+Install the **RUO** bundle (its banner is the one that appears — clinical suppresses it per issue #96). Publish a newer release (higher tag) to the GitHub repo, then in the running app wait for / trigger the update banner and click **Update**.
+Expected: bundle downloads to `C:\ProgramData\OpenWater\updates\`, one UAC prompt, in-place upgrade, app relaunches reporting the new version; ProgramData state preserved.
+
+- [ ] **Step 5: Verify RUO ↔ clinical do not cross-upgrade**
+
+On a box with the clinical product installed, run the RUO bundle.
+Expected: both appear as separate entries in "Apps & features" (distinct ProductCodes); neither replaced the other.
+
+- [ ] **Step 6: Record results**
+
+Note the outcomes of Steps 1-5 in the PR description. Any failure → return to the relevant task before merging.
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Signing is intentionally unfinished:** every artifact gets a *skippable* signing pass (Tasks 12-14) and the updater allows `NotSigned` bundles through with a warning (`_REQUIRE_SIGNED_UPDATES = False`, Task 6). When the EV cert lands: set the `CODESIGN_THUMBPRINT` secret (or swap `sign.ps1` for the chosen cloud signer) and flip `_REQUIRE_SIGNED_UPDATES = True`.
+- **GUIDs in Task 13 are placeholders to replace once:** generate four real GUIDs with `[guid]::NewGuid()` and paste them in before the first real release; thereafter they are constant forever.
+- **Hand-off to workstream #2 (tamper):** the overrides-file hardening (ACLs / signing), `developerMode` persistence policy, and password-constant handling are out of scope here (spec §Out of scope).
+- **Clinical builds never auto-update** by existing design (issue #96) — the in-app updater is exercised only on the RUO build (Task 16 Step 4).

--- a/docs/superpowers/specs/2026-06-17-msi-installer-handoff-and-known-limitations.md
+++ b/docs/superpowers/specs/2026-06-17-msi-installer-handoff-and-known-limitations.md
@@ -1,0 +1,121 @@
+# MSI Installer + In-App Updater — Hand-off & Known Limitations
+
+**Date:** 2026-06-17
+**Companion to:** [design](2026-06-17-msi-installer-in-app-update-design.md) ·
+[plan](../plans/2026-06-17-msi-installer-in-app-update.md)
+**Source:** adversarial audit of the implemented branch (35 findings raised, 31
+confirmed). The clearly in-scope, low-risk fixes were applied on the branch
+("Bucket 1"). This document records the items that are **deliberately not
+fixed here** because they require a cross-workstream decision (most belong to
+workstream #2, tamper-resistance) or a deployment-policy call.
+
+---
+
+## Decisions for workstream #2 / deployment owner
+
+### 1. `%PROGRAMDATA%\OpenWater\` multi-user ACL (design tension — needs a call)
+
+The writable state lives in `%PROGRAMDATA%\OpenWater\` so settings + data are
+machine-wide and survive Windows user-switching on a shared clinical cart
+(design §a). But **default `%PROGRAMDATA%` ACLs let a standard user create files
+yet only the *creator* (and admins) can later modify them.** So if user A first
+runs the app and writes `app_config.local.json`, a different non-admin user B
+**cannot overwrite it** — B's settings changes silently fail (the write is
+already try/except-guarded, so no crash, just lost persistence).
+
+Making multi-user shared settings actually work requires the installer (the
+elevated moment) to **create `%PROGRAMDATA%\OpenWater\` and grant `Users` modify**.
+But that **directly conflicts with #2's tamper-resistance goal** — an open ACL
+means any user can tamper with the config the gate persists into.
+
+**This is a genuine fork that should not be resolved unilaterally. Options:**
+- **(A) Per-user settings** — relocate the writable overrides to
+  `%LOCALAPPDATA%\OpenWater\` (each Windows user gets their own). Clean ACLs, no
+  cross-user write problem, but settings are *not* shared across operators on a
+  cart. (Data/logs can stay machine-wide or move too.)
+- **(B) Machine-wide, open ACL** — installer grants `Users` modify on
+  `%PROGRAMDATA%\OpenWater\`. Shared settings work; weakest tamper posture.
+- **(C) Machine-wide, locked ACL** — installer grants only admins write;
+  `developerMode`/threshold changes require elevation. Strong tamper posture;
+  routine settings changes need an admin.
+
+The installer currently does **neither create nor ACL** the directory (the app
+creates it on first run, inheriting default ACLs → option-B-minus, with the
+multi-user-write gap). Whatever #2 decides, the `app.wxs` `CreateFolder` +
+`util:PermissionEx` (WiX Util extension) is the place to implement A/B/C.
+
+### 2. Update variant identity comes from a mutable runtime flag
+
+`is_ruo = not reducedMode` (`motion_connector.py`), and `reducedMode` is a
+persisted, runtime-toggleable config key (Settings UI). So which installer the
+updater pulls is derived from mutable state, not a fixed property of the build.
+In practice the risk is bounded (the updater is only active when
+`reducedMode == false`, i.e. already "RUO mode"), but the robust fix is a
+**build-time variant stamp** (e.g. a `_VARIANT` constant written into
+`version.py` at build, or a marker file in the bundle) that the updater reads
+instead of inferring from `reducedMode`. Low effort; worth doing when #2
+touches the gating model.
+
+### 3. Clinical build has no in-app updater (confirm this is intended)
+
+By existing design (issue #96) the update banner is hidden and the auto-check is
+skipped whenever `reducedMode == true` — which is the **shipped clinical
+default**. So the shipped clinical product **never self-updates**; clinical
+carts are expected to be updated by IT / re-imaged. The audit flagged this as
+"headline feature dead in the primary product." Confirm this is the intended
+deployment model (clinical = managed updates; RUO = self-update). If clinical
+*should* self-update, the banner gating needs revisiting.
+
+### 4. Single-instance mutex vs. Fast User Switching
+
+`utils/single_instance.py` uses a `Global\` mutex, which blocks a **second
+Windows user** from launching the app at all on a shared / Fast-User-Switching
+clinical PC. Combined with item 1, this affects the multi-user story. If
+multi-user concurrent use is a requirement, switch to a `Local\` (per-session)
+mutex; if the cart is strictly single-session, leave as-is and document it.
+
+---
+
+## Installer-policy items to decide (lower stakes)
+
+- **Uninstall leaves `%PROGRAMDATA%\OpenWater\`** (settings, scans, logs, `scans.db`).
+  This is the conventional choice (don't delete user data on uninstall), but it
+  should be an explicit decision. If clean removal is wanted, add a
+  `RemoveFolderEx` (Util extension) guarded by an "also remove data" checkbox.
+- **Driver MSI is `Vital="yes" Permanent="yes"`** — a driver-install failure
+  aborts the whole bundle, and the driver is never removed on uninstall and
+  can't be repaired by a later run. Acceptable for a shared WinUSB driver, but
+  note there's no rollback path if a future driver MSI is broken.
+- **`MajorUpgrade AllowSameVersionUpgrades="yes"`** with auto-GUID file
+  components can raise ICE61 / same-version component-rule warnings. Harmless
+  for function (verified building), but expect the warnings.
+- **Burn bundle signing** (`build_installer.ps1`, dormant until a cert exists)
+  does `wix burn reattach ... -o <samepath>` — reattaching to the same path it
+  read. Re-verify that read/write-in-place is safe (or write to a temp then
+  move) when signing is turned on.
+
+---
+
+## Already fixed on this branch (for reference)
+
+From the same audit, these were applied (Bucket 1):
+- In-app updater now relaunches via a detached PowerShell helper that waits for
+  the app to exit, runs the bundle `/passive /norestart`, then restarts the app
+  — fixing the missing relaunch, the FilesInUse race, and the interactive-BA
+  surprise in one place.
+- Updater rejects non-`.exe` URLs and non-PE (truncated/HTML) downloads before
+  launching; no more `html_url` fallback.
+- Re-entrancy guard + `updateProgress` feedback (banner shows Downloading /
+  Installing, re-enables on failure).
+- `updates/` download dir is cleared before each download.
+- Config overrides written atomically (temp + `os.replace`).
+- `build_installer.ps1` is ASCII-only (no PowerShell 5.1 mojibake).
+- App MSI harvests from an absolute `SourceDir` with a hard-fail guard (a
+  relative path silently produced an app-less 36 KB MSI).
+
+## Verified on this machine (not yet on a clean VM)
+- Both variants build end-to-end: `OpenWater-Setup-1.3.0.exe` and
+  `..._RUO.exe`, 183 MB each, with distinct ProductName + UpgradeCode (confirmed
+  they can't cross-upgrade).
+- Still pending (manual, needs clean VM + hardware + the future cert): actual
+  install/upgrade behavior, driver install, the relaunch flow, signing.

--- a/docs/superpowers/specs/2026-06-17-msi-installer-in-app-update-design.md
+++ b/docs/superpowers/specs/2026-06-17-msi-installer-in-app-update-design.md
@@ -1,0 +1,259 @@
+# MSI Installer + In-App Updater — Design
+
+**Date:** 2026-06-17
+**Branch:** `claude/naughty-booth-e77327` (off `next` once rebased)
+**Scope:** Workstream #1 of three. Workstreams #2 (tamper resistance) and #3
+(cleanup) are running in parallel agent threads and are **out of scope here**,
+except for one documented hand-off (config-overrides hardening → #2).
+
+## Summary
+
+Replace the current "PyInstaller `.zip` + manual unzip + manual Zadig driver
+install" distribution with a real Windows installer and a real in-app updater:
+
+1. **A single signed `OpenWater-Setup-X.Y.Z.exe`** (WiX Burn bundle) that
+   installs the WinUSB **driver** and the **app into Program Files** in one run,
+   one UAC prompt.
+2. **An in-app "Update" button** that downloads that same bundle, verifies its
+   signature, and performs an **in-place upgrade** (one UAC prompt), then
+   relaunches — "like a regular app," within the constraints of a Program Files
+   install.
+3. The minimum **app-code change** required for a read-only Program Files
+   install to work: relocate runtime-writable state to `%PROGRAMDATA%\OpenWater\`.
+
+PyInstaller stays. The existing `openwater.spec` build is untouched — it already
+solves the hard problem on this app (vendored `libusb` + runtime hooks for USB
+enumeration). WiX wraps its output.
+
+## Decisions (confirmed with user)
+
+- **Toolchain:** WiX path, **not** Briefcase. Keep PyInstaller; WiX v5 packages
+  `dist\OpenWaterApp\`. (Briefcase rejected: replaces the working build, expects
+  a `src/` restructure, and its supported GUI bootstraps are Toga/PySide6 — not
+  PyQt6+QML — so migrating a feature-complete app onto it is avoidable risk.)
+- **Driver install:** WiX **Burn bundle** chaining driver MSI → app MSI. One
+  artifact, one UAC prompt, install-time driver install; the same bundle is what
+  the in-app updater downloads and runs.
+- **Install location:** **Program Files** (per-machine).
+- **Writable state:** **`%PROGRAMDATA%\OpenWater\`** (machine-wide, all users
+  share settings + data; survives user-switching on a shared clinical PC).
+- **Config split:** this spec owns the *mechanism* (read-only shipped defaults +
+  writable overrides file). **#2 owns the hardening policy.**
+- **Code signing:** no cert yet ("soon"). Signing is **wired-but-skippable** —
+  a real `signtool` step that is a no-op until a cert is configured, so turning
+  it on later is a config change, not a re-architecture. Target an **EV** cert
+  (instant SmartScreen trust) for a clinical product.
+- **Update friction:** **one UAC prompt per update** accepted. No privileged
+  updater service (would add a persistent elevated component = new attack
+  surface, against the tamper goal).
+- **RUO variant:** **two distinct products** — separate clinical and RUO
+  bundles with distinct `ProductName` + `UpgradeCode`, `reducedMode` baked into
+  each variant's read-only config. They cannot cross-upgrade; each variant's
+  updater pulls only its matching bundle.
+
+## Background (current state)
+
+- **Build:** `openwater.spec` → `dist\OpenWaterApp\` (one-dir). `build_and_zip.ps1`
+  and `.github/workflows/release-build.yml` zip it and also produce an **RUO**
+  zip by flipping `reducedMode: true → false` in the bundled
+  `_internal\config\app_config.json`.
+- **Driver:** `resources/OpenMotionDriver-x64.zip` already contains a signed
+  **`OpenMotionDriver-x64.msi`** (+ `cab1.cab`). It is attached to every GitHub
+  release today. Install is currently manual (Zadig / run the MSI by hand).
+- **Update flow today:** `motion_connector.py:checkForUpdates()` (~line 3870)
+  hits `GET /repos/OpenwaterHealth/openmotion-bloodflow-app/releases/latest`,
+  finds the **`.zip`** asset, and `_version_newer` (tag-string comparison)
+  decides if newer. On newer → `updateAvailable(version, url)` →
+  `UpdateBanner.qml` shows a button that calls `openDownloadUrl()` =
+  **opens the browser** to the zip. No in-place install.
+- **Config today:**
+  - `main.py:_load_app_config()` (~line 67) builds a `defaults` dict, then merges
+    `resource_path("config", "app_config.json")` (the bundled file) over it
+    (known keys only). `developerMode` already defaults to `false`.
+  - `motion_connector.py:_save_app_config()` (~line 1469) writes the **whole**
+    in-memory dict back to `resource_path("config", "app_config.json")`.
+    `setConfig` / `setConfigs` / raw-CSV setters / `dataDirectory` setter all
+    call it. The write is already wrapped in try/except (line ~1481) — so a
+    read-only target fails *soft* (logged warning), it does not crash, but
+    persistence is silently lost.
+  - `dataDirectory` (null by default) controls where `app-logs/`, scan CSVs, and
+    `scans.db` land; null → cwd. In a Program Files install, cwd is read-only.
+
+## Architecture
+
+Five units, each independently understandable and testable:
+
+```
+ CI / local build
+ ┌──────────────────────────────────────────────────────────────┐
+ │ PyInstaller (openwater.spec)  →  dist\OpenWaterApp\           │  (unchanged)
+ │            │                                                   │
+ │            ▼                                                   │
+ │ installer\build_installer.ps1                                 │
+ │   wix build app.wxs     → OpenWaterApp[-RUO].msi              │
+ │   wix build bundle.wxs  → OpenWater-Setup-X.Y.Z[_RUO].exe ────┼─┐ chains
+ │   Invoke-Sign (skippable)                                     │ │  driver MSI
+ └──────────────────────────────────────────────────────────────┘ │
+                                                                    ▼
+ Runtime                                          Program Files\OpenWater\Bloodflow\
+ ┌────────────────────────────────┐               %PROGRAMDATA%\OpenWater\
+ │ app_paths.py (writable root)   │──────────────▶  app_config.local.json
+ │ main.py load / connector save  │                 data\  (scans, app-logs, db)
+ │ in-app updater (connector+QML) │──┐
+ └────────────────────────────────┘  │ downloads + runs the same bundle
+                                      ▼
+                          GitHub release: OpenWater-Setup-*.exe
+```
+
+### Unit 1 — Installer sources (`installer/`)
+
+New top-level `installer/` directory:
+
+- **`app.wxs`** — the app MSI.
+  - Installs `dist\OpenWaterApp\` (harvested at build time) into
+    `Program Files\OpenWater\Bloodflow\`.
+  - **`UpgradeCode`**: a single constant GUID, fixed forever, per variant
+    (clinical ≠ RUO). **`ProductCode`**: regenerated each build (`*`).
+  - `MajorUpgrade` with `AllowSameVersionUpgrades="yes"` (so a `-dev.N`/`-rc.N`
+    build whose numeric `X.Y.Z` equals a prior one still upgrades during
+    testing) and a clear "newer version already installed" downgrade message.
+  - Start-menu shortcut; desktop shortcut optional.
+  - `ProductName` differs per variant ("OpenWater Bloodflow" vs
+    "OpenWater Bloodflow (RUO)").
+- **`bundle.wxs`** — the Burn bundle.
+  - Chains: `OpenMotionDriver-x64.msi` (from `resources/`) **then** the app MSI.
+  - Driver `MsiPackage` gets a `DetectCondition` / uses the driver MSI's own
+    `UpgradeCode` so it is skipped when already current.
+  - Bundle `UpgradeCode` is also per-variant and constant.
+- **`build_installer.ps1`** — orchestrates: resolve version (§Unit 4), harvest
+  `dist\`, `wix build` app + bundle for the requested variant, then `Invoke-Sign`.
+  Parameterized `-Variant clinical|ruo`.
+
+WiX v5 CLI (`dotnet tool install --global wix`). File harvesting via WiX v5's
+directory/file harvesting (no separate `heat` step needed in v5).
+
+### Unit 2 — Code signing (wired, skippable)
+
+- **`Invoke-Sign`** helper (in `build_installer.ps1` or a sibling
+  `installer/sign.ps1`): signs the launcher `.exe` inside the staged app dir,
+  the app `.msi`, and the bundle.
+  - Bundle signing uses the **`insignia`** detach → sign engine → reattach →
+    sign bundle sequence (the documented Burn signing dance), scripted once.
+  - **No-op gate:** if the signing identity env var / CI secret (e.g.
+    `CODESIGN_THUMBPRINT` or an Azure Trusted Signing config) is unset, the
+    helper logs "signing skipped (no cert configured)" and returns success.
+    Everything builds and ships unsigned today; the day the EV cert lands,
+    setting the secret turns signing on with no other change.
+- **CI signing note:** post-2023 CA/B rules require code-signing keys on FIPS
+  hardware, so CI signing means a cloud service (Azure Trusted Signing /
+  SignPath / DigiCert KeyLocker) **or** signing on a self-hosted runner with the
+  token. The skippable hook is provider-agnostic; the provider is chosen when
+  the cert is procured.
+
+### Unit 3 — Writable-state relocation (app code)
+
+New module **`app_paths.py`**:
+
+- `writable_root() -> Path` — returns `%PROGRAMDATA%\OpenWater\` when frozen
+  (PyInstaller), created on first access (with the dir created if missing); in a
+  dev (non-frozen) run, falls back to the repo/cwd so local development is
+  unchanged.
+- Helpers: `local_config_path()` → `<root>\app_config.local.json`;
+  `default_data_dir()` → `<root>\data`.
+
+Wiring:
+
+- **`main.py:_load_app_config()`** — load order becomes
+  **defaults → bundled read-only `app_config.json` → `app_config.local.json`**
+  (deep-merge the local overrides last, known keys only). The bundled file stays
+  the shipped baseline; the local file holds only keys the user changed at
+  runtime.
+- **`motion_connector.py:_save_app_config()`** — write **only** to
+  `app_paths.local_config_path()`. Write only the keys that differ from the
+  shipped baseline (keep the file small and legible), creating the ProgramData
+  dir if needed. Never write into Program Files.
+- **`dataDirectory` default** — when null/unset, resolve to
+  `app_paths.default_data_dir()` instead of cwd. `app-logs/` and `scans.db`
+  follow `dataDirectory` as they do today, so they land under ProgramData.
+
+**Hand-off to #2 (documented, not implemented here):** whether `developerMode`
+should persist across restarts at all, and whether `app_config.local.json`
+should be ACL-restricted or signed, is #2's hardening policy. This spec only
+provides the read-only-baseline + writable-overrides *mechanism*.
+
+### Unit 4 — Versioning
+
+- MSI/bundle `ProductVersion` must be numeric `X.Y.Z` (and `≤ 255.255.65535`),
+  so the git tag's pre-release suffix (`-dev.N` / `-rc.N`) is **dropped** for the
+  installer version. `AllowSameVersionUpgrades="yes"` covers the resulting
+  equal-version reinstalls during dev/rc testing.
+- The **full** human version (with suffix) stays in `version.py` and the GitHub
+  tag. The in-app updater compares the **GitHub tag string** via the existing
+  `_version_newer`, which already understands suffixes — so "is there an update"
+  is correct even though the MSI version is coarser.
+- `build_installer.ps1` derives `X.Y.Z` from the same git-describe/tag logic the
+  existing build already uses (`build_and_zip.ps1` / `release-build.yml`).
+
+### Unit 5 — In-app updater
+
+- **`checkForUpdates` / `_check_for_updates_worker`** (motion_connector.py
+  ~3870): change the asset matcher from `name.endswith(".zip")` to the matching
+  **`OpenWater-Setup-*.exe`** — clinical build matches the non-RUO bundle, RUO
+  build matches `*_RUO.exe`. Variant is known from the baked `reducedMode` / a
+  build-stamped marker so the right asset is selected. `updateAvailable` still
+  carries `(latest_version, download_url)`.
+- **New connector slot** (replacing the browser hop) — e.g.
+  `@pyqtSlot(str) def applyUpdate(self, download_url)`:
+  1. Download the bundle to `%PROGRAMDATA%\OpenWater\updates\` (or `%TEMP%`).
+  2. **Verify Authenticode signature + expected publisher** (when signing is
+     live; until then, log a warning and proceed — never silently trust).
+  3. Spawn the bundle **detached**, then quit the app so its files unlock.
+  4. Burn detects the installed app and performs an in-place major upgrade
+     (one UAC prompt), then relaunches the app on completion.
+  Progress/errors surfaced via existing signals (`updateCheckFailed` and/or new
+  `updateProgress`/`updateFailed`).
+- **`UpdateBanner.qml`** — the Update button calls `applyUpdate(...)` instead of
+  `openDownloadUrl(...)`. Show a downloading/installing state.
+
+### Unit 6 — CI (`release-build.yml`)
+
+After the existing PyInstaller build step, add:
+
+- Install WiX v5 (`dotnet tool install --global wix`).
+- Run `installer\build_installer.ps1 -Variant clinical` and `-Variant ruo`
+  (the RUO run reuses the existing reducedMode-flip step to produce the RUO
+  `dist\`, then packages it).
+- `Invoke-Sign` (skippable) runs inside the script.
+- Publish **`OpenWater-Setup-X.Y.Z.exe`** and **`OpenWater-Setup-X.Y.Z_RUO.exe`**
+  as the GitHub release assets. Keep attaching `OpenMotionDriver-x64.zip` as
+  today. The legacy `.zip` app artifacts may be retired, or kept for one release
+  as a transition.
+
+## Verification plan
+
+- **Local, clean VM (no prior install, no driver):**
+  1. Build both bundles; run `OpenWater-Setup-X.Y.Z.exe` → confirm single UAC
+     prompt, driver installed, app under `Program Files\OpenWater\Bloodflow\`,
+     Start-menu shortcut present.
+  2. Launch app → change a setting (e.g. unlock developer mode) → confirm
+     `%PROGRAMDATA%\OpenWater\app_config.local.json` is written and the bundled
+     Program Files config is untouched; restart → setting persists.
+  3. Run a scan → confirm CSVs / `scans.db` / `app-logs/` land under
+     `%PROGRAMDATA%\OpenWater\data`.
+- **Update path:** bump version, publish a newer release, click **Update**
+  in-app → one UAC prompt → in-place upgrade → app relaunches on the new
+  version; ProgramData state preserved.
+- **RUO isolation:** install the RUO bundle on a box with the clinical product
+  → confirm they coexist / do not cross-upgrade (distinct ProductCodes in
+  Programs & Features).
+- **Signing:** once the EV cert exists, set the secret, rebuild → confirm signed
+  `.exe`/`.msi`/bundle and that `applyUpdate`'s signature verification passes.
+
+## Out of scope
+
+- **#2 (tamper resistance):** hardening of `app_config.local.json` (ACLs /
+  signing), `developerMode` persistence policy, password-constant handling.
+- **#3 (cleanup):** dead-flag removal, `motion_connector.py` refactor, etc.
+- **No privileged updater service** (rejected — keeps the elevated-surface area
+  flat for #2). One UAC prompt per update is accepted.
+- **macOS packaging** (`openwater_macos.spec`) — unchanged; this is Windows-only.

--- a/installer/app.wxs
+++ b/installer/app.wxs
@@ -1,0 +1,44 @@
+<!-- installer/app.wxs — packages dist\OpenWaterApp\ into Program Files. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="$(var.ProductName)"
+           Manufacturer="Openwater"
+           Version="$(var.Version)"
+           UpgradeCode="$(var.UpgradeCode)"
+           Scope="perMachine"
+           Compressed="yes">
+
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="VENDORFOLDER" Name="OpenWater">
+        <Directory Id="APPFOLDER" Name="Bloodflow" />
+      </Directory>
+    </StandardDirectory>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="AppShortcutFolder" Name="$(var.ProductName)" />
+    </StandardDirectory>
+
+    <Feature Id="Main" Title="$(var.ProductName)" Level="1">
+      <ComponentGroupRef Id="AppFiles" />
+      <ComponentRef Id="AppShortcut" />
+    </Feature>
+
+    <!-- Harvest the entire PyInstaller one-folder output. -->
+    <ComponentGroup Id="AppFiles" Directory="APPFOLDER">
+      <Files Include="$(var.SourceDir)\**" />
+    </ComponentGroup>
+
+    <Component Id="AppShortcut" Directory="AppShortcutFolder" Guid="*">
+      <Shortcut Id="StartMenuShortcut"
+                Name="$(var.ProductName)"
+                Target="[APPFOLDER]OpenWaterApp.exe"
+                WorkingDirectory="APPFOLDER" />
+      <RemoveFolder Id="RemoveAppShortcutFolder" On="uninstall" />
+      <RegistryValue Root="HKLM" Key="Software\Openwater\Bloodflow"
+                     Name="installed" Type="integer" Value="1" KeyPath="yes" />
+    </Component>
+  </Package>
+</Wix>

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -62,7 +62,7 @@ if ($LASTEXITCODE -ne 0) { throw "app MSI build failed" }
 powershell -NoProfile -File installer\sign.ps1 -Files $appMsi
 
 # ── build the Burn bundle ──
-wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.Bal.wixext `
+wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.BootstrapperApplications.wixext `
     -d "ProductName=$($g.ProductName)" `
     -d "Version=$version" `
     -d "BundleUpgradeCode=$($g.BundleUpgradeCode)" `

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -1,0 +1,84 @@
+# installer/build_installer.ps1 — build the app MSI + Burn bundle for one variant.
+param(
+    [ValidateSet("clinical", "ruo")][string]$Variant = "clinical",
+    [string]$DistDir = "dist\OpenWaterApp"
+)
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
+Set-Location $root
+
+# ── constant, never-changing GUIDs (distinct per variant so they never
+#    cross-upgrade). Generated once with [guid]::NewGuid(). ──
+$guids = @{
+    clinical = @{
+        ProductName       = "OpenWater Bloodflow"
+        UpgradeCode       = "3d5dec27-6f62-484b-85f0-1b7b07076022"
+        BundleUpgradeCode = "2e60deaa-8959-4f57-912b-71f60fc6ad5a"
+        Suffix            = ""
+    }
+    ruo = @{
+        ProductName       = "OpenWater Bloodflow (RUO)"
+        UpgradeCode       = "81f5e9b0-36d8-4aeb-8457-461fe4fe6c2f"
+        BundleUpgradeCode = "e363d244-2161-4a28-a855-835643b14a10"
+        Suffix            = "_RUO"
+    }
+}
+$g = $guids[$Variant]
+
+# ── numeric X.Y.Z from the git tag/describe (drop any -dev/-rc suffix) ──
+try {
+    $desc = (git describe --tags --always 2>$null).Trim()
+} catch { $desc = "" }
+if ($desc -match '(\d+)\.(\d+)\.(\d+)') {
+    $version = "$($matches[1]).$($matches[2]).$($matches[3])"
+} else {
+    $version = "0.0.0"
+}
+Write-Host "Variant=$Variant  Version=$version  Product='$($g.ProductName)'" -ForegroundColor Green
+
+# ── extract the driver MSI from the bundled zip ──
+$drvZip = "resources\OpenMotionDriver-x64.zip"
+$drvDir = "build\driver"
+Remove-Item -Recurse -Force $drvDir -ErrorAction SilentlyContinue
+Expand-Archive -Path $drvZip -DestinationPath $drvDir -Force
+$driverMsi = Join-Path $drvDir "OpenMotionDriver-x64.msi"
+if (-not (Test-Path $driverMsi)) { throw "driver MSI not found in $drvZip" }
+
+# ── output names ──
+$outDir = "build\installer"
+New-Item -ItemType Directory -Force $outDir | Out-Null
+$appMsi    = Join-Path $outDir "OpenWaterApp$($g.Suffix).msi"
+$bundleExe = Join-Path $outDir "OpenWater-Setup-$version$($g.Suffix).exe"
+
+# ── build the app MSI ──
+wix build installer\app.wxs -o $appMsi `
+    -d "ProductName=$($g.ProductName)" `
+    -d "Version=$version" `
+    -d "UpgradeCode=$($g.UpgradeCode)" `
+    -d "SourceDir=$DistDir"
+if ($LASTEXITCODE -ne 0) { throw "app MSI build failed" }
+
+# sign the app MSI (skippable)
+powershell -NoProfile -File installer\sign.ps1 -Files $appMsi
+
+# ── build the Burn bundle ──
+wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.Bal.wixext `
+    -d "ProductName=$($g.ProductName)" `
+    -d "Version=$version" `
+    -d "BundleUpgradeCode=$($g.BundleUpgradeCode)" `
+    -d "DriverMsi=$driverMsi" `
+    -d "AppMsi=$appMsi"
+if ($LASTEXITCODE -ne 0) { throw "bundle build failed" }
+
+# ── sign the bundle (insignia detach → sign engine → reattach → sign) ──
+if ($env:CODESIGN_THUMBPRINT) {
+    $engine = Join-Path $outDir "engine.exe"
+    wix burn detach $bundleExe -engine $engine
+    powershell -NoProfile -File installer\sign.ps1 -Files $engine
+    wix burn reattach $bundleExe -engine $engine -o $bundleExe
+    powershell -NoProfile -File installer\sign.ps1 -Files $bundleExe
+} else {
+    Write-Host "bundle signing skipped (no cert)" -ForegroundColor Yellow
+}
+
+Write-Host "Built $bundleExe" -ForegroundColor Green

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -1,4 +1,4 @@
-# installer/build_installer.ps1 — build the app MSI + Burn bundle for one variant.
+# installer/build_installer.ps1 - build the app MSI + Burn bundle for one variant.
 param(
     [ValidateSet("clinical", "ruo")][string]$Variant = "clinical",
     [string]$DistDir = "dist\OpenWaterApp"
@@ -7,8 +7,8 @@ $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 Set-Location $root
 
-# ── constant, never-changing GUIDs (distinct per variant so they never
-#    cross-upgrade). Generated once with [guid]::NewGuid(). ──
+# -- constant, never-changing GUIDs (distinct per variant so they never
+#    cross-upgrade). Generated once with [guid]::NewGuid(). --
 $guids = @{
     clinical = @{
         ProductName       = "OpenWater Bloodflow"
@@ -25,7 +25,7 @@ $guids = @{
 }
 $g = $guids[$Variant]
 
-# ── numeric X.Y.Z from the git tag/describe (drop any -dev/-rc suffix) ──
+# -- numeric X.Y.Z from the git tag/describe (drop any -dev/-rc suffix) --
 try {
     $desc = (git describe --tags --always 2>$null).Trim()
 } catch { $desc = "" }
@@ -36,7 +36,7 @@ if ($desc -match '(\d+)\.(\d+)\.(\d+)') {
 }
 Write-Host "Variant=$Variant  Version=$version  Product='$($g.ProductName)'" -ForegroundColor Green
 
-# ── extract the driver MSI from the bundled zip ──
+# -- extract the driver MSI from the bundled zip --
 $drvZip = "resources\OpenMotionDriver-x64.zip"
 $drvDir = "build\driver"
 Remove-Item -Recurse -Force $drvDir -ErrorAction SilentlyContinue
@@ -44,7 +44,7 @@ Expand-Archive -Path $drvZip -DestinationPath $drvDir -Force
 $driverMsi = Join-Path $drvDir "OpenMotionDriver-x64.msi"
 if (-not (Test-Path $driverMsi)) { throw "driver MSI not found in $drvZip" }
 
-# ── output names ──
+# -- output names --
 $outDir = "build\installer"
 New-Item -ItemType Directory -Force $outDir | Out-Null
 $appMsi    = Join-Path $outDir "OpenWaterApp$($g.Suffix).msi"
@@ -76,7 +76,7 @@ if ((Get-Item $appMsi).Length -lt 1MB) {
 # sign the app MSI (skippable)
 powershell -NoProfile -File installer\sign.ps1 -Files $appMsi
 
-# ── build the Burn bundle ──
+# -- build the Burn bundle --
 wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.BootstrapperApplications.wixext `
     -d "ProductName=$($g.ProductName)" `
     -d "Version=$version" `
@@ -85,7 +85,7 @@ wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.BootstrapperApplica
     -d "AppMsi=$appMsi"
 if ($LASTEXITCODE -ne 0) { throw "bundle build failed" }
 
-# ── sign the bundle (insignia detach → sign engine → reattach → sign) ──
+# -- sign the bundle (insignia detach -> sign engine -> reattach -> sign) --
 if ($env:CODESIGN_THUMBPRINT) {
     $engine = Join-Path $outDir "engine.exe"
     wix burn detach $bundleExe -engine $engine

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -50,13 +50,28 @@ New-Item -ItemType Directory -Force $outDir | Out-Null
 $appMsi    = Join-Path $outDir "OpenWaterApp$($g.Suffix).msi"
 $bundleExe = Join-Path $outDir "OpenWater-Setup-$version$($g.Suffix).exe"
 
-# ── build the app MSI ──
+# -- build the app MSI --
+# Resolve the PyInstaller output to an ABSOLUTE path. WiX resolves the
+# <Files Include> harvest glob relative to the .wxs file's own directory
+# (installer\), NOT the cwd, so a relative SourceDir silently harvests
+# nothing (WIX8601 is only a warning, so the build would otherwise "succeed"
+# with an app-less MSI). Fail hard if the build output is not there.
+if (-not (Test-Path $DistDir)) { throw "PyInstaller output '$DistDir' not found; run PyInstaller first" }
+$DistAbs = (Resolve-Path -LiteralPath $DistDir).Path
+if (-not (Test-Path (Join-Path $DistAbs 'OpenWaterApp.exe'))) {
+    throw "OpenWaterApp.exe not found under $DistAbs; PyInstaller build looks incomplete"
+}
+
 wix build installer\app.wxs -o $appMsi `
     -d "ProductName=$($g.ProductName)" `
     -d "Version=$version" `
     -d "UpgradeCode=$($g.UpgradeCode)" `
-    -d "SourceDir=$DistDir"
+    -d "SourceDir=$DistAbs"
 if ($LASTEXITCODE -ne 0) { throw "app MSI build failed" }
+# Guard against the silent empty-harvest: a real app MSI is far larger than this.
+if ((Get-Item $appMsi).Length -lt 1MB) {
+    throw "app MSI is only $((Get-Item $appMsi).Length) bytes; file harvesting from $DistAbs produced an empty package"
+}
 
 # sign the app MSI (skippable)
 powershell -NoProfile -File installer\sign.ps1 -Files $appMsi

--- a/installer/bundle.wxs
+++ b/installer/bundle.wxs
@@ -1,0 +1,27 @@
+<!-- installer/bundle.wxs — one setup.exe: driver MSI then app MSI. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+  <Bundle Name="$(var.ProductName)"
+          Manufacturer="Openwater"
+          Version="$(var.Version)"
+          UpgradeCode="$(var.BundleUpgradeCode)">
+
+    <BootstrapperApplication>
+      <bal:WixStandardBootstrapperApplication Theme="hyperlinkLicense"
+                                              LicenseUrl="" />
+    </BootstrapperApplication>
+
+    <Chain>
+      <!-- WinUSB driver. Vital but its absence on uninstall is fine (Permanent). -->
+      <MsiPackage Id="DriverMsi"
+                  SourceFile="$(var.DriverMsi)"
+                  Vital="yes"
+                  Permanent="yes"
+                  Visible="no" />
+      <!-- The app itself. -->
+      <MsiPackage Id="AppMsi"
+                  SourceFile="$(var.AppMsi)"
+                  Vital="yes" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/installer/sign.ps1
+++ b/installer/sign.ps1
@@ -1,0 +1,15 @@
+# installer/sign.ps1 — Authenticode-sign the given files, or skip if no cert.
+param([Parameter(Mandatory = $true)][string[]]$Files)
+
+$thumb = $env:CODESIGN_THUMBPRINT
+if (-not $thumb) {
+    Write-Host "signing skipped (CODESIGN_THUMBPRINT not set)" -ForegroundColor Yellow
+    return
+}
+
+foreach ($f in $Files) {
+    Write-Host "signing $f" -ForegroundColor Cyan
+    & signtool sign /sha1 $thumb /fd SHA256 `
+        /tr http://timestamp.digicert.com /td SHA256 $f
+    if ($LASTEXITCODE -ne 0) { throw "signtool failed for $f" }
+}

--- a/main.py
+++ b/main.py
@@ -32,10 +32,14 @@ from omotion import MotionInterface
 from utils.single_instance import check_single_instance, cleanup_single_instance
 from version import get_version
 from utils.resource_path import resource_path
+from utils import app_paths, config_store
 
 
 APP_VERSION = get_version()
 
+# Shipped baseline (defaults + read-only bundled config), captured at load so
+# the connector can diff runtime changes against it when saving overrides.
+_APP_CONFIG_BASELINE: dict = {}
 
 logger = logging.getLogger("openmotion.bloodflow-app")
 logger.setLevel(logging.INFO)  # or INFO depending on what you want to see
@@ -148,28 +152,12 @@ def _load_app_config() -> dict:
         "requireConsole": True,
         "minSensors": 1,
     }
-    config_path = resource_path("config", "app_config.json")
-    if not config_path.exists():
-        logger.info("No app_config.json found at %s, using defaults", config_path)
-        return defaults
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            loaded = json.load(f)
-        out = {
-            **defaults,
-            **{k: v for k, v in loaded.items() if k in defaults},
-        }
-        # Ensure mask fields are always integers (guard against float drift from JSON)
-        for key in ("leftMask", "rightMask", "reducedModeLeftMask", "reducedModeRightMask"):
-            if key in out and out[key] is not None:
-                out[key] = int(out[key])
-        logger.info("Loaded app config from %s", config_path)
-        return out
-    except (json.JSONDecodeError, OSError) as e:
-        logger.warning(
-            "Could not load app config from %s: %s; using defaults", config_path, e
-        )
-        return defaults
+    # (defaults = { ... } stays unchanged above this point)
+    baseline, merged = config_store.load_app_config(defaults)
+    _APP_CONFIG_BASELINE.clear()
+    _APP_CONFIG_BASELINE.update(baseline)
+    logger.info("Loaded app config (overrides from %s)", app_paths.local_config_path())
+    return merged
 
 
 def main():
@@ -211,7 +199,9 @@ def main():
     # Finder launch where cwd is "/").
     _data_dir = app_config.get("dataDirectory")
     if not _data_dir:
-        candidate = os.getcwd()
+        # Installed (frozen) build → ProgramData; dev run → cwd (unchanged),
+        # falling back to ~/Documents if cwd is not writable.
+        candidate = str(app_paths.writable_root()) if getattr(sys, "frozen", False) else os.getcwd()
         if os.access(candidate, os.W_OK):
             _data_dir = candidate
         else:
@@ -281,6 +271,7 @@ def main():
 
     connector = MotionConnector(
         motion_interface, app_config=app_config, data_dir=_data_dir,
+        baseline_config=_APP_CONFIG_BASELINE,
         app_version=APP_VERSION, log_path=logfile_path,
     )
     qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", connector)

--- a/main.py
+++ b/main.py
@@ -156,7 +156,9 @@ def _load_app_config() -> dict:
     baseline, merged = config_store.load_app_config(defaults)
     _APP_CONFIG_BASELINE.clear()
     _APP_CONFIG_BASELINE.update(baseline)
-    logger.info("Loaded app config (overrides from %s)", app_paths.local_config_path())
+    logger.info(
+        "Loaded app config (overrides from %s)", app_paths.local_config_path()
+    )
     return merged
 
 
@@ -201,7 +203,10 @@ def main():
     if not _data_dir:
         # Installed (frozen) build → ProgramData; dev run → cwd (unchanged),
         # falling back to ~/Documents if cwd is not writable.
-        candidate = str(app_paths.writable_root()) if getattr(sys, "frozen", False) else os.getcwd()
+        candidate = (
+            str(app_paths.writable_root()) if getattr(sys, "frozen", False)
+            else os.getcwd()
+        )
         if os.access(candidate, os.W_OK):
             _data_dir = candidate
         else:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -6,6 +6,7 @@ from PyQt6.QtCore import (
     QVariant,
     QTimer,
     QRecursiveMutex,
+    QCoreApplication,
 )
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -125,6 +126,20 @@ def _authenticode_status(path: str) -> str:
         return result.stdout.strip() or "Error"
     except Exception:
         return "Error"
+
+
+def _update_decision(status: str, require_signed: bool):
+    """Decide whether to launch the downloaded bundle given its signature status.
+
+    Returns (should_launch: bool, error_message: str | None).
+    """
+    if status == "Valid":
+        return True, None
+    if status == "NotSigned":
+        if require_signed:
+            return False, "Update is not signed; refusing to install."
+        return True, None  # transition period: allow with a warning logged by caller
+    return False, f"Update signature check failed: {status}"
 
 
 # Camera-mask → human config name, mirroring CameraSelectionModal's
@@ -4568,3 +4583,44 @@ class MotionConnector(QObject):
         """Open the download URL in the system browser."""
         import webbrowser
         webbrowser.open(url)
+
+    @pyqtSlot(str)
+    def applyUpdate(self, download_url: str):
+        """Download the update bundle, verify it, and launch the in-place upgrade."""
+        t = threading.Thread(
+            target=self._apply_update_worker, args=(download_url,), daemon=True
+        )
+        t.start()
+
+    def _apply_update_worker(self, download_url: str):
+        import urllib.request
+        import subprocess
+        from utils import app_paths
+
+        try:
+            updates_dir = app_paths.writable_root() / "updates"
+            updates_dir.mkdir(parents=True, exist_ok=True)
+            dest = updates_dir / download_url.rsplit("/", 1)[-1]
+            logger.info("Downloading update %s -> %s", download_url, dest)
+            urllib.request.urlretrieve(download_url, str(dest))
+
+            status = _authenticode_status(str(dest))
+            should_launch, error = _update_decision(status, _REQUIRE_SIGNED_UPDATES)
+            if not should_launch:
+                self.updateCheckFailed.emit(error)
+                return
+            if status == "NotSigned":
+                logger.warning("Update bundle is not signed (transition period) — proceeding")
+
+            # Launch the Burn bundle detached, then quit so our files unlock and
+            # the in-place major upgrade can replace them. Burn relaunches us.
+            logger.info("Launching installer; quitting app for in-place upgrade")
+            subprocess.Popen(
+                [str(dest)],
+                close_fds=True,
+                creationflags=getattr(subprocess, "DETACHED_PROCESS", 0),
+            )
+            QCoreApplication.quit()
+        except Exception as e:
+            logger.error("applyUpdate failed: %s", e)
+            self.updateCheckFailed.emit(str(e))

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -79,6 +79,28 @@ def developer_password_matches(pw) -> bool:
     return isinstance(pw, str) and pw == _DEVELOPER_PASSWORD
 
 
+# Flip to True once release builds are Authenticode-signed; until then an
+# unsigned (NotSigned) update bundle is allowed through with a logged warning.
+_REQUIRE_SIGNED_UPDATES = False
+
+
+def _select_update_asset(assets: list, is_ruo: bool):
+    """Return the download URL of the Setup bundle matching the running variant.
+
+    RUO builds match ``OpenWater-Setup-*_RUO.exe``; clinical builds match the
+    non-RUO ``OpenWater-Setup-*.exe``. Returns None if no matching .exe asset.
+    """
+    for asset in assets:
+        name = (asset.get("name") or "")
+        low = name.lower()
+        if not low.endswith(".exe"):
+            continue
+        asset_is_ruo = low.endswith("_ruo.exe")
+        if asset_is_ruo == is_ruo:
+            return asset.get("browser_download_url")
+    return None
+
+
 # Camera-mask → human config name, mirroring CameraSelectionModal's
 # pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
 # reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.
@@ -4461,12 +4483,12 @@ class MotionConnector(QObject):
                 self.updateCheckFailed.emit("Could not determine latest release tag.")
                 return
 
-            # Find the .zip asset download URL
-            download_url = data.get("html_url", "")
-            for asset in data.get("assets", []):
-                if asset["name"].endswith(".zip"):
-                    download_url = asset["browser_download_url"]
-                    break
+            # Find the Setup bundle matching this build's variant.
+            # reducedMode True = clinical build; False = RUO/full build.
+            is_ruo = not bool(self._app_config.get("reducedMode", False))
+            download_url = _select_update_asset(data.get("assets", []), is_ruo) or data.get(
+                "html_url", ""
+            )
 
             local_version = get_version()
             # Strip local metadata for comparison (e.g. "+3.gabc1234.dirty")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -142,6 +142,54 @@ def _update_decision(status: str, require_signed: bool):
     return False, f"Update signature check failed: {status}"
 
 
+def _is_bundle_url(url) -> bool:
+    """True if ``url`` is a Setup .exe bundle, not the release HTML page.
+
+    Guards against the GitHub ``html_url`` fallback: without this, a release
+    with no matching installer asset would make the updater download an HTML
+    page and try to execute it.
+    """
+    return isinstance(url, str) and url.lower().endswith(".exe")
+
+
+def _looks_like_pe(head: bytes) -> bool:
+    """True if the bytes start with the 'MZ' signature of a Windows executable.
+
+    A truncated download or an HTML error page will not start with 'MZ', so
+    this rejects corrupt downloads before they are launched.
+    """
+    return head[:2] == b"MZ"
+
+
+def _build_update_helper_script(
+    app_pid: int, installer: str, app_exe: str
+) -> str:
+    """Return a PowerShell script that performs the in-place upgrade handoff.
+
+    The running app cannot upgrade its own files while it holds them, and the
+    Burn bundle does not relaunch the app. So the app spawns this detached
+    helper and then exits; the helper (1) waits for the app to fully exit to
+    avoid a FilesInUse conflict, (2) runs the bundle non-interactively
+    (one UAC elevation, no bootstrapper UI), then (3) relaunches the app.
+    """
+    return (
+        "# OpenWater in-app update helper (auto-generated; do not edit)\n"
+        "$ErrorActionPreference = 'SilentlyContinue'\n"
+        f"# 1. Wait for the running app (PID {app_pid}) to exit so the\n"
+        "#    installer can replace its files without a FilesInUse conflict.\n"
+        "$deadline = (Get-Date).AddSeconds(60)\n"
+        f"while (Get-Process -Id {app_pid} -ErrorAction SilentlyContinue) {{\n"
+        "    if ((Get-Date) -gt $deadline) { break }\n"
+        "    Start-Sleep -Milliseconds 250\n"
+        "}\n"
+        "# 2. Run the upgrade non-interactively (one UAC elevation).\n"
+        f"Start-Process -FilePath \"{installer}\" "
+        "-ArgumentList '/passive','/norestart' -Wait\n"
+        "# 3. Relaunch the (now-updated) app.\n"
+        f"Start-Process -FilePath \"{app_exe}\"\n"
+    )
+
+
 # Camera-mask → human config name, mirroring CameraSelectionModal's
 # pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
 # reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.
@@ -723,6 +771,7 @@ class MotionConnector(QObject):
     updateAvailable = pyqtSignal(str, str)   # (latest_version, download_url)
     updateNotAvailable = pyqtSignal()
     updateCheckFailed = pyqtSignal(str)      # error message
+    updateProgress = pyqtSignal(str)         # human-readable progress status
 
     @staticmethod
     def _default_data_dir() -> str:
@@ -4527,20 +4576,30 @@ class MotionConnector(QObject):
             # Find the Setup bundle matching this build's variant.
             # reducedMode True = clinical build; False = RUO/full build.
             is_ruo = not bool(self._app_config.get("reducedMode", False))
-            download_url = _select_update_asset(data.get("assets", []), is_ruo) or data.get(
-                "html_url", ""
-            )
+            download_url = _select_update_asset(data.get("assets", []), is_ruo)
 
             local_version = get_version()
             # Strip local metadata for comparison (e.g. "+3.gabc1234.dirty")
             local_base = local_version.split("+")[0]
 
-            if self._version_newer(remote_tag, local_base):
-                logger.info(f"Update available: {remote_tag} (current: {local_base})")
-                self.updateAvailable.emit(remote_tag, download_url)
-            else:
+            if not self._version_newer(remote_tag, local_base):
                 logger.info(f"App is up to date ({local_base} >= {remote_tag})")
                 self.updateNotAvailable.emit()
+            elif not _is_bundle_url(download_url):
+                # Newer release exists but has no matching installer asset
+                # (e.g. assets still uploading) -- don't offer an in-place
+                # update we can't actually perform.
+                logger.warning(
+                    "Update %s available but no installer asset found",
+                    remote_tag,
+                )
+                self.updateNotAvailable.emit()
+            else:
+                logger.info(
+                    "Update available: %s (current: %s)",
+                    remote_tag, local_base,
+                )
+                self.updateAvailable.emit(remote_tag, download_url)
 
         except Exception as e:
             logger.warning(f"Update check failed: {e}")
@@ -4586,7 +4645,15 @@ class MotionConnector(QObject):
 
     @pyqtSlot(str)
     def applyUpdate(self, download_url: str):
-        """Download the update bundle, verify it, and launch the upgrade."""
+        """Download the update bundle, verify it, and launch the upgrade.
+
+        Guarded against re-entry so repeated clicks can't spawn racing
+        download threads against the same file.
+        """
+        if getattr(self, "_update_in_progress", False):
+            logger.info("Update already in progress; ignoring repeat request")
+            return
+        self._update_in_progress = True
         t = threading.Thread(
             target=self._apply_update_worker, args=(download_url,), daemon=True
         )
@@ -4595,14 +4662,36 @@ class MotionConnector(QObject):
     def _apply_update_worker(self, download_url: str):
         import urllib.request
         import subprocess
+        import sys
         from utils import app_paths
 
         try:
+            if not _is_bundle_url(download_url):
+                self.updateCheckFailed.emit("No installer for this update.")
+                return
+
             updates_dir = app_paths.writable_root() / "updates"
             updates_dir.mkdir(parents=True, exist_ok=True)
+            # Clear stale downloads so old installers don't accumulate.
+            for stale in updates_dir.glob("*"):
+                try:
+                    stale.unlink()
+                except OSError:
+                    pass
+
             dest = updates_dir / download_url.rsplit("/", 1)[-1]
+            self.updateProgress.emit("Downloading update…")
             logger.info("Downloading update %s -> %s", download_url, dest)
             urllib.request.urlretrieve(download_url, str(dest))
+
+            # Reject truncated / non-executable downloads before launching.
+            with open(dest, "rb") as f:
+                head = f.read(2)
+            if not _looks_like_pe(head):
+                self.updateCheckFailed.emit(
+                    "Downloaded update is not a valid installer."
+                )
+                return
 
             status = _authenticode_status(str(dest))
             should_launch, error = _update_decision(
@@ -4616,11 +4705,24 @@ class MotionConnector(QObject):
                     "Update bundle not signed (transition period) — proceeding"
                 )
 
-            # Launch the Burn bundle detached, then quit so our files unlock
-            # and the in-place major upgrade can replace them. Burn relaunches.
-            logger.info("Launching installer; quitting app for upgrade")
+            # The app cannot replace its own running files, and the Burn
+            # bundle does not relaunch the app. So write a detached helper
+            # that waits for us to exit, runs the bundle silently, then
+            # relaunches the (now-updated) app. Then quit.
+            helper = updates_dir / "update_helper.ps1"
+            helper.write_text(
+                _build_update_helper_script(
+                    os.getpid(), str(dest), sys.executable
+                ),
+                encoding="utf-8",
+            )
+            self.updateProgress.emit("Installing update…")
+            logger.info("Spawning update helper; quitting for upgrade")
             subprocess.Popen(
-                [str(dest)],
+                [
+                    "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+                    "-File", str(helper),
+                ],
                 close_fds=True,
                 creationflags=getattr(subprocess, "DETACHED_PROCESS", 0),
             )
@@ -4628,3 +4730,7 @@ class MotionConnector(QObject):
         except Exception as e:
             logger.error("applyUpdate failed: %s", e)
             self.updateCheckFailed.emit(str(e))
+        finally:
+            # Cleared so a failed attempt can be retried (on success the app
+            # is already quitting).
+            self._update_in_progress = False

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -42,6 +42,7 @@ import error_codes
 import bug_report
 from nan_gap_tracker import NanGapTracker, gap_note_line
 from utils.resource_path import resource_path
+from utils import config_store
 from data_sources import (
     LiveScanSource, PastScanSource, ScanDataSource, buffers_are_empty,
 )
@@ -680,6 +681,7 @@ class MotionConnector(QObject):
         self,
         interface: MotionInterface,
         app_config=None,
+        baseline_config=None,
         data_dir=None,
         config_dir="config",
         parent=None,
@@ -692,6 +694,7 @@ class MotionConnector(QObject):
 
         # Store the full config dict — exposed to QML as appConfig property
         self._app_config = dict(cfg)
+        self._baseline_config = dict(baseline_config or {})
 
         # Bug-report context (see sendBugReport). app_version + log_path come
         # from main.py; support_email / bug_report_smtp from app config.
@@ -2082,22 +2085,13 @@ class MotionConnector(QObject):
     def appConfig(self):
         return self._app_config
 
-    # Config keys that must always be stored as plain integers
-    _INT_CONFIG_KEYS = {"leftMask", "rightMask"}
-
     def _save_app_config(self):
-        """Write the in-memory config dict back to app_config.json."""
-        config_path = resource_path("config", "app_config.json")
-        # Coerce mask fields to int — QML passes JS numbers as Python float
-        out = dict(self._app_config)
-        for key in self._INT_CONFIG_KEYS:
-            if key in out and out[key] is not None:
-                out[key] = int(out[key])
-        try:
-            with open(config_path, "w", encoding="utf-8") as f:
-                json.dump(out, f, indent=2)
-        except OSError as e:
-            logger.warning(f"[Connector] Could not write app_config.json: {e}")
+        """Persist runtime config changes as a diff against the shipped baseline.
+
+        Writes only changed keys to %PROGRAMDATA%\\OpenWater\\app_config.local.json
+        — never the read-only bundled config under Program Files.
+        """
+        config_store.save_overrides(self._app_config, self._baseline_config)
 
     @pyqtSlot(str, result=bool)
     def checkDeveloperPassword(self, pw: str) -> bool:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -86,10 +86,10 @@ _REQUIRE_SIGNED_UPDATES = False
 
 
 def _select_update_asset(assets: list, is_ruo: bool):
-    """Return the download URL of the Setup bundle matching the running variant.
+    """Return download URL of the Setup bundle matching the running variant.
 
-    RUO builds match ``OpenWater-Setup-*_RUO.exe``; clinical builds match the
-    non-RUO ``OpenWater-Setup-*.exe``. Returns None if no matching .exe asset.
+    RUO builds match ``OpenWater-Setup-*_RUO.exe``; clinical builds match
+    the non-RUO ``OpenWater-Setup-*.exe``. Returns None if no match.
     """
     for asset in assets:
         name = (asset.get("name") or "")
@@ -129,7 +129,7 @@ def _authenticode_status(path: str) -> str:
 
 
 def _update_decision(status: str, require_signed: bool):
-    """Decide whether to launch the downloaded bundle given its signature status.
+    """Decide whether to launch the downloaded bundle given its signature.
 
     Returns (should_launch: bool, error_message: str | None).
     """
@@ -138,7 +138,7 @@ def _update_decision(status: str, require_signed: bool):
     if status == "NotSigned":
         if require_signed:
             return False, "Update is not signed; refusing to install."
-        return True, None  # transition period: allow with a warning logged by caller
+        return True, None  # transition period: allow with a warning logged
     return False, f"Update signature check failed: {status}"
 
 
@@ -4586,7 +4586,7 @@ class MotionConnector(QObject):
 
     @pyqtSlot(str)
     def applyUpdate(self, download_url: str):
-        """Download the update bundle, verify it, and launch the in-place upgrade."""
+        """Download the update bundle, verify it, and launch the upgrade."""
         t = threading.Thread(
             target=self._apply_update_worker, args=(download_url,), daemon=True
         )
@@ -4605,16 +4605,20 @@ class MotionConnector(QObject):
             urllib.request.urlretrieve(download_url, str(dest))
 
             status = _authenticode_status(str(dest))
-            should_launch, error = _update_decision(status, _REQUIRE_SIGNED_UPDATES)
+            should_launch, error = _update_decision(
+                status, _REQUIRE_SIGNED_UPDATES
+            )
             if not should_launch:
                 self.updateCheckFailed.emit(error)
                 return
             if status == "NotSigned":
-                logger.warning("Update bundle is not signed (transition period) — proceeding")
+                logger.warning(
+                    "Update bundle not signed (transition period) — proceeding"
+                )
 
-            # Launch the Burn bundle detached, then quit so our files unlock and
-            # the in-place major upgrade can replace them. Burn relaunches us.
-            logger.info("Launching installer; quitting app for in-place upgrade")
+            # Launch the Burn bundle detached, then quit so our files unlock
+            # and the in-place major upgrade can replace them. Burn relaunches.
+            logger.info("Launching installer; quitting app for upgrade")
             subprocess.Popen(
                 [str(dest)],
                 close_fds=True,

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -101,6 +101,32 @@ def _select_update_asset(assets: list, is_ruo: bool):
     return None
 
 
+def _authenticode_status(path: str) -> str:
+    """Return the Authenticode signature status of ``path``.
+
+    Uses PowerShell's Get-AuthenticodeSignature (always present on Windows).
+    Returns one of 'Valid', 'NotSigned', 'HashMismatch', 'UnknownError', ... or
+    'Error' if the check itself could not run.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                f"(Get-AuthenticodeSignature -LiteralPath '{path}').Status",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip() or "Error"
+    except Exception:
+        return "Error"
+
+
 # Camera-mask → human config name, mirroring CameraSelectionModal's
 # pattern table. Unmapped masks render as hex; -1 (unknown, e.g. a
 # reduced-mode scan whose meta lacks sdk_flags) renders as an em dash.

--- a/tests/test_app_paths.py
+++ b/tests/test_app_paths.py
@@ -1,6 +1,4 @@
-import os
 import pytest
-from pathlib import Path
 from utils import app_paths
 
 
@@ -13,11 +11,10 @@ def test_writable_root_honors_env_override(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
-def test_local_config_and_data_dir_under_root(tmp_path, monkeypatch):
+def test_local_config_path_under_root(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path / "ow"))
-    assert app_paths.local_config_path() == tmp_path / "ow" / "app_config.local.json"
-    assert app_paths.default_data_dir() == tmp_path / "ow" / "data"
-    assert (tmp_path / "ow" / "data").is_dir()
+    expected = tmp_path / "ow" / "app_config.local.json"
+    assert app_paths.local_config_path() == expected
 
 
 @pytest.mark.unit

--- a/tests/test_app_paths.py
+++ b/tests/test_app_paths.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from pathlib import Path
+from utils import app_paths
+
+
+@pytest.mark.unit
+def test_writable_root_honors_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path / "ow"))
+    root = app_paths.writable_root()
+    assert root == tmp_path / "ow"
+    assert root.is_dir()  # created on access
+
+
+@pytest.mark.unit
+def test_local_config_and_data_dir_under_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path / "ow"))
+    assert app_paths.local_config_path() == tmp_path / "ow" / "app_config.local.json"
+    assert app_paths.default_data_dir() == tmp_path / "ow" / "data"
+    assert (tmp_path / "ow" / "data").is_dir()
+
+
+@pytest.mark.unit
+def test_dev_root_is_cwd_when_not_frozen(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    # not frozen in test → root is cwd, behavior unchanged for local dev
+    assert app_paths.writable_root() == tmp_path

--- a/tests/test_apply_update.py
+++ b/tests/test_apply_update.py
@@ -1,0 +1,26 @@
+import pytest
+from motion_connector import _update_decision
+
+
+@pytest.mark.unit
+def test_valid_signature_launches():
+    assert _update_decision("Valid", require_signed=True) == (True, None)
+
+
+@pytest.mark.unit
+def test_invalid_signature_aborts_with_message():
+    launch, err = _update_decision("HashMismatch", require_signed=False)
+    assert launch is False
+    assert "HashMismatch" in err
+
+
+@pytest.mark.unit
+def test_unsigned_allowed_when_not_required():
+    assert _update_decision("NotSigned", require_signed=False) == (True, None)
+
+
+@pytest.mark.unit
+def test_unsigned_rejected_when_required():
+    launch, err = _update_decision("NotSigned", require_signed=True)
+    assert launch is False
+    assert "not signed" in err.lower()

--- a/tests/test_apply_update.py
+++ b/tests/test_apply_update.py
@@ -1,5 +1,10 @@
 import pytest
-from motion_connector import _update_decision
+from motion_connector import (
+    _update_decision,
+    _is_bundle_url,
+    _looks_like_pe,
+    _build_update_helper_script,
+)
 
 
 @pytest.mark.unit
@@ -24,3 +29,33 @@ def test_unsigned_rejected_when_required():
     launch, err = _update_decision("NotSigned", require_signed=True)
     assert launch is False
     assert "not signed" in err.lower()
+
+
+@pytest.mark.unit
+def test_is_bundle_url_accepts_only_exe():
+    assert _is_bundle_url("https://x/OpenWater-Setup-1.2.3.exe")
+    assert _is_bundle_url("https://x/OpenWater-Setup-1.2.3_RUO.EXE")
+    assert not _is_bundle_url("https://github.com/o/r/releases/tag/1.2.3")
+    assert not _is_bundle_url("")
+    assert not _is_bundle_url(None)
+
+
+@pytest.mark.unit
+def test_looks_like_pe_rejects_non_executables():
+    assert _looks_like_pe(b"MZ\x90\x00")
+    assert not _looks_like_pe(b"<!DOCTYPE html>")  # HTML error page
+    assert not _looks_like_pe(b"")                  # empty / truncated
+    assert not _looks_like_pe(b"M")                 # 1-byte truncation
+
+
+@pytest.mark.unit
+def test_helper_script_waits_installs_silently_and_relaunches():
+    s = _build_update_helper_script(
+        1234, r"C:\Users\u\updates\OpenWater-Setup-1.2.3.exe",
+        r"C:\Program Files\OpenWater\Bloodflow\OpenWaterApp.exe",
+    )
+    assert "1234" in s                              # waits for our PID
+    assert "Get-Process" in s
+    assert "/passive" in s                          # non-interactive install
+    assert "OpenWater-Setup-1.2.3.exe" in s         # runs the installer
+    assert "OpenWaterApp.exe" in s                  # relaunches the app

--- a/tests/test_authenticode_status.py
+++ b/tests/test_authenticode_status.py
@@ -1,0 +1,20 @@
+import subprocess
+import types
+import pytest
+import motion_connector
+
+
+@pytest.mark.unit
+def test_authenticode_status_parses_powershell_output(monkeypatch):
+    def fake_run(*a, **k):
+        return types.SimpleNamespace(stdout="Valid\n", returncode=0)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert motion_connector._authenticode_status("C:/x.exe") == "Valid"
+
+
+@pytest.mark.unit
+def test_authenticode_status_returns_error_on_exception(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no powershell")
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert motion_connector._authenticode_status("C:/x.exe") == "Error"

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -1,0 +1,35 @@
+import json
+import pytest
+from utils import config_store
+
+
+DEFAULTS = {"developerMode": False, "reducedMode": False, "leftMask": 0x66, "bfiMax": 10.0}
+
+
+@pytest.mark.unit
+def test_load_merges_overrides_over_baseline(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    (tmp_path / "app_config.local.json").write_text(
+        json.dumps({"developerMode": True}), encoding="utf-8"
+    )
+    baseline, merged = config_store.load_app_config(DEFAULTS)
+    assert baseline["developerMode"] is False      # baseline untouched
+    assert merged["developerMode"] is True          # override wins
+    assert merged["bfiMax"] == 10.0                 # untouched key flows through
+
+
+@pytest.mark.unit
+def test_save_writes_only_diff_against_baseline(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    baseline = dict(DEFAULTS)
+    current = {**DEFAULTS, "developerMode": True}
+    config_store.save_overrides(current, baseline)
+    written = json.loads((tmp_path / "app_config.local.json").read_text(encoding="utf-8"))
+    assert written == {"developerMode": True}       # only the changed key
+
+
+@pytest.mark.unit
+def test_load_with_no_override_file_returns_baseline(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    baseline, merged = config_store.load_app_config(DEFAULTS)
+    assert merged == baseline

--- a/tests/test_connector_save_overrides.py
+++ b/tests/test_connector_save_overrides.py
@@ -1,0 +1,30 @@
+import json
+import pytest
+import motion_connector
+from motion_connector import MotionConnector
+
+
+@pytest.mark.unit
+def test_save_app_config_delegates_diff_to_store(tmp_path, monkeypatch):
+    # Redirect resource_path("config", ...) to a throwaway dir so the pre-impl
+    # ("red") version of _save_app_config can't clobber the repo's real
+    # config/app_config.json when this test first runs.
+    (tmp_path / "app_config.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OPENWATER_CONFIG_DIR", str(tmp_path))
+
+    # MotionConnector.__init__ wires hardware/telemetry, so bypass it with
+    # __new__ and set only the attributes _save_app_config reads.
+    conn = MotionConnector.__new__(MotionConnector)
+    conn._app_config = {"developerMode": True, "reducedMode": False}
+    conn._baseline_config = {"developerMode": False, "reducedMode": False}
+
+    captured = {}
+    monkeypatch.setattr(
+        motion_connector.config_store,
+        "save_overrides",
+        lambda current, baseline: captured.update(current=current, baseline=baseline),
+    )
+    conn._save_app_config()
+
+    assert captured["current"] == conn._app_config
+    assert captured["baseline"] == conn._baseline_config

--- a/tests/test_main_config_wiring.py
+++ b/tests/test_main_config_wiring.py
@@ -1,0 +1,17 @@
+import json
+import importlib
+import pytest
+
+
+@pytest.mark.unit
+def test_load_app_config_applies_local_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    (tmp_path / "app_config.local.json").write_text(
+        json.dumps({"developerMode": True}), encoding="utf-8"
+    )
+    main = importlib.import_module("main")
+    cfg = main._load_app_config()
+    assert cfg["developerMode"] is True              # override applied over baseline
+    # baseline is stashed for the connector (value comes from the shipped
+    # config file, so assert presence, not a specific value).
+    assert "developerMode" in main._APP_CONFIG_BASELINE

--- a/tests/test_update_asset_select.py
+++ b/tests/test_update_asset_select.py
@@ -1,0 +1,22 @@
+import pytest
+from motion_connector import _select_update_asset
+
+
+CLINICAL = {"name": "OpenWater-Setup-1.2.3.exe", "browser_download_url": "u/clinical"}
+RUO = {"name": "OpenWater-Setup-1.2.3_RUO.exe", "browser_download_url": "u/ruo"}
+ZIP = {"name": "OpenMotionDriver-x64.zip", "browser_download_url": "u/zip"}
+
+
+@pytest.mark.unit
+def test_selects_ruo_bundle_for_ruo_variant():
+    assert _select_update_asset([CLINICAL, RUO, ZIP], is_ruo=True) == "u/ruo"
+
+
+@pytest.mark.unit
+def test_selects_clinical_bundle_for_clinical_variant():
+    assert _select_update_asset([CLINICAL, RUO, ZIP], is_ruo=False) == "u/clinical"
+
+
+@pytest.mark.unit
+def test_returns_none_when_no_matching_exe():
+    assert _select_update_asset([ZIP], is_ruo=True) is None

--- a/utils/app_paths.py
+++ b/utils/app_paths.py
@@ -33,10 +33,3 @@ def writable_root() -> Path:
 def local_config_path() -> Path:
     """Path to the writable config-overrides file."""
     return writable_root() / "app_config.local.json"
-
-
-def default_data_dir() -> Path:
-    """Default scan-data / logs root when dataDirectory is unset."""
-    d = writable_root() / "data"
-    d.mkdir(parents=True, exist_ok=True)
-    return d

--- a/utils/app_paths.py
+++ b/utils/app_paths.py
@@ -1,0 +1,42 @@
+"""Resolve writable, user-data locations outside the (read-only) install dir.
+
+When the app is installed to Program Files, its bundled files are read-only.
+Runtime-writable state (config overrides, logs, scan data) lives under
+%PROGRAMDATA%\\OpenWater\\ instead. In a dev (non-frozen) run, everything stays
+under the cwd so local development is unchanged.
+
+Override the root with the OPENWATER_DATA_ROOT env var (used by tests and as a
+power-user escape hatch).
+"""
+from pathlib import Path
+import os
+import sys
+
+_APP_DIRNAME = "OpenWater"
+
+
+def writable_root() -> Path:
+    """Return the writable data root, creating it if necessary."""
+    env = os.environ.get("OPENWATER_DATA_ROOT")
+    if env:
+        root = Path(env)
+    elif getattr(sys, "frozen", False):
+        base = os.environ.get("PROGRAMDATA", r"C:\ProgramData")
+        root = Path(base) / _APP_DIRNAME
+    else:
+        # dev: keep everything under the cwd, unchanged from before
+        root = Path.cwd()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def local_config_path() -> Path:
+    """Path to the writable config-overrides file."""
+    return writable_root() / "app_config.local.json"
+
+
+def default_data_dir() -> Path:
+    """Default scan-data / logs root when dataDirectory is unset."""
+    d = writable_root() / "data"
+    d.mkdir(parents=True, exist_ok=True)
+    return d

--- a/utils/config_store.py
+++ b/utils/config_store.py
@@ -10,6 +10,7 @@ shipped defaults still reach keys the operator never touched.
 """
 import json
 import logging
+import os
 
 from utils.resource_path import resource_path
 from utils import app_paths
@@ -67,13 +68,25 @@ def load_app_config(defaults: dict):
 
 
 def save_overrides(current: dict, baseline: dict) -> None:
-    """Persist only keys whose value differs from the baseline."""
+    """Persist only keys whose value differs from the baseline.
+
+    Written atomically (temp file + os.replace) so a crash mid-write can't
+    leave a truncated, unparseable overrides file that silently drops all
+    of the operator's settings on the next load.
+    """
     diff = _coerce_ints(
         {k: v for k, v in current.items() if baseline.get(k) != v}
     )
     path = app_paths.local_config_path()
+    tmp = path.with_name(path.name + ".tmp")
     try:
-        with open(path, "w", encoding="utf-8") as f:
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(diff, f, indent=2)
+        os.replace(tmp, path)
     except OSError as e:
         logger.warning("Could not write overrides %s: %s", path, e)
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass

--- a/utils/config_store.py
+++ b/utils/config_store.py
@@ -1,0 +1,75 @@
+"""Load app config from layered sources and persist runtime overrides.
+
+Layers (lowest to highest precedence):
+  1. code defaults (passed in by the caller)
+  2. shipped, read-only config/app_config.json (PyInstaller bundle)
+  3. writable overrides: %PROGRAMDATA%\\OpenWater\\app_config.local.json
+
+Runtime changes are written as a *diff* against layers 1+2 so future changes to
+shipped defaults still reach keys the operator never touched.
+"""
+import json
+import logging
+
+from utils.resource_path import resource_path
+from utils import app_paths
+
+logger = logging.getLogger(__name__)
+
+_INT_KEYS = ("leftMask", "rightMask", "reducedModeLeftMask", "reducedModeRightMask")
+
+
+def _coerce_ints(cfg: dict) -> dict:
+    for key in _INT_KEYS:
+        if cfg.get(key) is not None:
+            cfg[key] = int(cfg[key])
+    return cfg
+
+
+def shipped_baseline(defaults: dict) -> dict:
+    """defaults merged with the read-only bundled app_config.json."""
+    base = dict(defaults)
+    path = resource_path("config", "app_config.json")
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            base.update({k: v for k, v in loaded.items() if k in defaults})
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Could not load %s: %s; using defaults", path, e)
+    return _coerce_ints(base)
+
+
+def load_overrides() -> dict:
+    """Read the writable overrides file (empty dict if absent/invalid)."""
+    path = app_paths.local_config_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Could not load overrides %s: %s", path, e)
+        return {}
+
+
+def load_app_config(defaults: dict):
+    """Return (baseline, merged); merged = baseline + writable overrides."""
+    baseline = shipped_baseline(defaults)
+    overrides = load_overrides()
+    merged = {
+        **baseline,
+        **{k: v for k, v in overrides.items() if k in baseline},
+    }
+    return baseline, _coerce_ints(merged)
+
+
+def save_overrides(current: dict, baseline: dict) -> None:
+    """Persist only keys whose value differs from the baseline."""
+    diff = _coerce_ints({k: v for k, v in current.items() if baseline.get(k) != v})
+    path = app_paths.local_config_path()
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(diff, f, indent=2)
+    except OSError as e:
+        logger.warning("Could not write overrides %s: %s", path, e)

--- a/utils/config_store.py
+++ b/utils/config_store.py
@@ -16,7 +16,9 @@ from utils import app_paths
 
 logger = logging.getLogger(__name__)
 
-_INT_KEYS = ("leftMask", "rightMask", "reducedModeLeftMask", "reducedModeRightMask")
+_INT_KEYS = (
+    "leftMask", "rightMask", "reducedModeLeftMask", "reducedModeRightMask"
+)
 
 
 def _coerce_ints(cfg: dict) -> dict:
@@ -66,7 +68,9 @@ def load_app_config(defaults: dict):
 
 def save_overrides(current: dict, baseline: dict) -> None:
     """Persist only keys whose value differs from the baseline."""
-    diff = _coerce_ints({k: v for k, v in current.items() if baseline.get(k) != v})
+    diff = _coerce_ints(
+        {k: v for k, v in current.items() if baseline.get(k) != v}
+    )
     path = app_paths.local_config_path()
     try:
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Workstream #1 of three (cleanup #3 and tamper-resistance #2 run in parallel threads). Packages the app as a **WiX Burn bundle** that installs the WinUSB driver + the app into **Program Files** in one run, and adds a real **in-app in-place updater**. PyInstaller is unchanged — WiX wraps its `dist/` output.

Design: [`docs/superpowers/specs/2026-06-17-msi-installer-in-app-update-design.md`](docs/superpowers/specs/2026-06-17-msi-installer-in-app-update-design.md) · Plan: [`docs/superpowers/plans/2026-06-17-msi-installer-in-app-update.md`](docs/superpowers/plans/2026-06-17-msi-installer-in-app-update.md)

### What changed

**Writable-state relocation** (so a read-only Program Files install works)
- `utils/app_paths.py` — writable root `%PROGRAMDATA%\OpenWater\` when frozen, cwd in dev, `OPENWATER_DATA_ROOT` override for tests.
- `utils/config_store.py` — layered load (code defaults → read-only bundled `config/app_config.json` → writable `app_config.local.json`); saves are a **diff vs baseline** so future shipped-default changes still reach untouched keys.
- `main.py` delegates `_load_app_config` to the store, stashes the baseline, routes logs/scan-data to ProgramData when frozen; connector persists overrides via `config_store.save_overrides` instead of overwriting the bundled config.

**In-app updater**
- Variant-aware asset selection (`OpenWater-Setup-*.exe`, `*_RUO.exe` for RUO), Authenticode verification, and a new `applyUpdate` slot: download → verify signature → launch the bundle detached → quit for the in-place upgrade. `UpdateBanner.qml` now triggers `applyUpdate`.
- Signature enforcement is wired but lenient (`_REQUIRE_SIGNED_UPDATES = False`) until the cert lands.

**WiX installer** (`installer/`)
- `app.wxs` (app MSI → Program Files, major-upgrade), `bundle.wxs` (Burn: driver MSI → app MSI), `sign.ps1` (skippable signing), `build_installer.ps1` (both variants, constant per-variant GUIDs).

**CI** — `release-build.yml` builds both installers after PyInstaller and publishes the `OpenWater-Setup-*.exe` bundles (legacy zips kept one transition release).

### Decisions baked in
- WiX-over-PyInstaller (not Briefcase); Burn bundle; Program Files / ProgramData; one UAC prompt per update (no privileged service); RUO and clinical are **two distinct products** (distinct ProductName/UpgradeCode); signing wired-but-skippable until the EV cert arrives.
- Hardening of the overrides file (ACLs/signing) and dev-mode-persistence policy are **handed to workstream #2**.

## Test Plan

Automated (done): **17/17 unit tests pass** (`pytest -m unit` over the 7 new test files), flake8 clean on touched code, app imports clean.

Manual gate — **not yet run** (needs a clean Windows VM + WiX/dotnet toolchain + hardware):
- [ ] Install `.NET SDK` + WiX v5, `python -m PyInstaller -y openwater.spec`, then `installer\build_installer.ps1 -Variant clinical` / `-Variant ruo` produce the bundles.
- [ ] Fresh install on a clean VM: one UAC prompt, WinUSB driver present, app under `Program Files\OpenWater\Bloodflow\`, Start-menu shortcut.
- [ ] Settings persist to `%PROGRAMDATA%\OpenWater\app_config.local.json` (bundled config untouched); scan data + logs land under `%PROGRAMDATA%\OpenWater\`.
- [ ] In-app **Update** (RUO build): download → one UAC prompt → in-place upgrade → relaunch on new version.
- [ ] RUO and clinical installs coexist (distinct ProductCodes), no cross-upgrade.
- [ ] Once the EV cert exists: set `CODESIGN_THUMBPRINT`, flip `_REQUIRE_SIGNED_UPDATES = True`, confirm signed artifacts + update signature verification.

### Known minor (non-blocking)
- `app_paths.default_data_dir()` ended up unused (main routes via `writable_root()` directly).
- Connector's internal `_default_data_dir()` fallback still uses cwd — unreachable since `main.py` always passes `data_dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)