### PR TITLE
feat: in-app in-place updater [Phase 1.5, stacked on #224]

### DIFF
--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -23,6 +23,10 @@ Rectangle {
 
     property string latestVersion: ""
     property string downloadUrl: ""
+    // True from the moment Update is clicked until the download/install
+    // either fails or the app quits for the in-place upgrade.
+    property bool updating: false
+    property string statusText: "Update"
 
     color: theme.accentBlue
     radius: 0
@@ -58,7 +62,7 @@ Rectangle {
             Text {
                 id: downloadBtn
                 anchors.centerIn: parent
-                text: "Download"
+                text: banner.updating ? banner.statusText : "Update"
                 color: theme.accentBlue
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
@@ -66,10 +70,18 @@ Rectangle {
 
             MouseArea {
                 anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
+                enabled: !banner.updating
+                cursorShape: banner.updating ? Qt.ArrowCursor : Qt.PointingHandCursor
                 hoverEnabled: true
-                onClicked: MotionInterface.openDownloadUrl(banner.downloadUrl)
-                onContainsMouseChanged: parent.color = containsMouse ? "#E0E0E0" : "#FFFFFF"
+                // Guard against double-clicks spawning racing downloads; the
+                // connector also guards re-entry, this just reflects it in UI.
+                onClicked: {
+                    banner.updating = true
+                    banner.statusText = "Starting…"
+                    MotionInterface.applyUpdate(banner.downloadUrl)
+                }
+                onContainsMouseChanged: parent.color =
+                    (containsMouse && !banner.updating) ? "#E0E0E0" : "#FFFFFF"
             }
         }
 
@@ -108,6 +120,15 @@ Rectangle {
             banner.latestVersion = version
             banner.downloadUrl = url
             banner.shown = true
+        }
+        // Reflect download/install progress on the button.
+        function onUpdateProgress(message) {
+            banner.statusText = message
+        }
+        // Re-enable the button so a failed update can be retried.
+        function onUpdateCheckFailed(error) {
+            banner.updating = false
+            banner.statusText = "Update"
         }
     }
 

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -1,7 +1,8 @@
 # installer/build_installer.ps1 - build the app MSI + Burn bundle for one variant.
 param(
     [ValidateSet("clinical", "ruo")][string]$Variant = "clinical",
-    [string]$DistDir = "dist\OpenWaterApp"
+    [string]$DistDir = "dist\OpenWaterApp",
+    [string]$Version = ""   # override the numeric X.Y.Z (else derived from git)
 )
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
@@ -25,14 +26,18 @@ $guids = @{
 }
 $g = $guids[$Variant]
 
-# -- numeric X.Y.Z from the git tag/describe (drop any -dev/-rc suffix) --
-try {
-    $desc = (git describe --tags --always 2>$null).Trim()
-} catch { $desc = "" }
-if ($desc -match '(\d+)\.(\d+)\.(\d+)') {
-    $version = "$($matches[1]).$($matches[2]).$($matches[3])"
+# -- numeric X.Y.Z: explicit -Version override, else from the git tag/describe --
+if ($Version) {
+    $version = $Version
 } else {
-    $version = "0.0.0"
+    try {
+        $desc = (git describe --tags --always 2>$null).Trim()
+    } catch { $desc = "" }
+    if ($desc -match '(\d+)\.(\d+)\.(\d+)') {
+        $version = "$($matches[1]).$($matches[2]).$($matches[3])"
+    } else {
+        $version = "0.0.0"
+    }
 }
 Write-Host "Variant=$Variant  Version=$version  Product='$($g.ProductName)'" -ForegroundColor Green
 

--- a/main.py
+++ b/main.py
@@ -73,6 +73,11 @@ def _load_app_config() -> dict:
     """Load application config from config/app_config.json. Returns defaults if missing or invalid."""
     defaults = {
         "forceLaserFail": False,
+        # In-app updater source overrides (default None => production GitHub
+        # repo). updateRepo swaps the owner/repo; updateApiUrl fully overrides
+        # the releases-latest endpoint (used by the local update-test server).
+        "updateRepo": None,
+        "updateApiUrl": None,
         "cameraTempAlertThresholdC": 105,
         # Console over-temp trip (°C) pushed to the console user config on
         # connect. 0/missing disables the firmware trip, so this is validated

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -4675,11 +4675,14 @@ class MotionConnector(QObject):
         import urllib.request
         from version import get_version
 
-        # ``updateRepo`` config key lets a build point its update check at a
-        # staging/mirror repo (used for end-to-end update testing); absent =>
-        # the production repo.
+        # ``updateRepo`` points the check at a staging/mirror repo; the broader
+        # ``updateApiUrl`` fully overrides the releases-latest endpoint (used by
+        # the local fake-releases server for offline end-to-end update testing).
+        # Both absent => the production GitHub repo.
         repo = self._app_config.get("updateRepo") or self._GITHUB_REPO
-        api_url = f"https://api.github.com/repos/{repo}/releases/latest"
+        api_url = self._app_config.get("updateApiUrl") or (
+            f"https://api.github.com/repos/{repo}/releases/latest"
+        )
         try:
             req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github+json"})
             with urllib.request.urlopen(req, timeout=10) as resp:

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -7,6 +7,8 @@ from PyQt6.QtCore import (
     QTimer,
     QRecursiveMutex,
     QCoreApplication,
+    QMetaObject,
+    Qt,
 )
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -173,17 +175,27 @@ def _build_update_helper_script(
     The running app cannot upgrade its own files while it holds them, and the
     Burn bundle does not relaunch the app. So the app spawns this detached
     helper and then exits; the helper (1) waits for the app to fully exit to
-    avoid a FilesInUse conflict, (2) runs the bundle non-interactively
-    (one UAC elevation, no bootstrapper UI), then (3) relaunches the app.
+    avoid a FilesInUse conflict — and force-kills it if it doesn't exit in
+    time, since a wedged GUI thread (e.g. a synchronous SDK/USB call blocking
+    the event loop) can otherwise leave the app alive and stall the whole
+    upgrade, (2) runs the bundle non-interactively (one UAC elevation, no
+    bootstrapper UI), then (3) relaunches the app.
     """
     return (
         "# OpenWater in-app update helper (auto-generated; do not edit)\n"
         "$ErrorActionPreference = 'SilentlyContinue'\n"
         f"# 1. Wait for the running app (PID {app_pid}) to exit so the\n"
         "#    installer can replace its files without a FilesInUse conflict.\n"
-        "$deadline = (Get-Date).AddSeconds(60)\n"
+        "#    If it doesn't exit in time (the app may not self-exit under\n"
+        "#    qasync), force-kill it - installing over a live app fails the\n"
+        "#    in-place file swap.\n"
+        "$deadline = (Get-Date).AddSeconds(10)\n"
         f"while (Get-Process -Id {app_pid} -ErrorAction SilentlyContinue) {{\n"
-        "    if ((Get-Date) -gt $deadline) { break }\n"
+        "    if ((Get-Date) -gt $deadline) {\n"
+        f"        Stop-Process -Id {app_pid} -Force -ErrorAction SilentlyContinue\n"
+        "        Start-Sleep -Milliseconds 500\n"
+        "        break\n"
+        "    }\n"
         "    Start-Sleep -Milliseconds 250\n"
         "}\n"
         "# 2. Run the upgrade non-interactively (one UAC elevation).\n"
@@ -4838,15 +4850,40 @@ class MotionConnector(QObject):
             )
             self.updateProgress.emit("Installing update…")
             logger.info("Spawning update helper; quitting for upgrade")
+            # NB: DETACHED_PROCESS leaves powershell with no console and no std
+            # handles, so it dies instantly WITHOUT running the script (verified
+            # in isolation — the helper never executed, which is why earlier
+            # upgrades silently never installed). CREATE_NO_WINDOW gives it a
+            # hidden console and DEVNULL std handles, so the detached helper
+            # actually runs.
             subprocess.Popen(
                 [
                     "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
                     "-File", str(helper),
                 ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 close_fds=True,
-                creationflags=getattr(subprocess, "DETACHED_PROCESS", 0),
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
-            QCoreApplication.quit()
+            # Ask Qt to shut down gracefully (aboutToQuit -> handle_exit stops
+            # the hardware monitor, releases the USB transport, flushes the
+            # audit log). This runs on a worker thread, so DO NOT call
+            # QCoreApplication.quit() directly: under qasync a cross-thread
+            # quit() blocks inside the C++ call while HOLDING the GIL, which
+            # freezes the whole process — every thread, including any hard-exit
+            # backstop, starves (confirmed via py-spy). Post the quit to the
+            # main thread instead; QueuedConnection just enqueues an event and
+            # returns immediately, so this worker never blocks. If graceful
+            # teardown stalls or qasync ignores the quit, the detached helper
+            # force-kills us after its grace window and the upgrade proceeds
+            # regardless — so we don't rely on the app exiting itself.
+            QMetaObject.invokeMethod(
+                QCoreApplication.instance(),
+                "quit",
+                Qt.ConnectionType.QueuedConnection,
+            )
         except Exception as e:
             logger.error("applyUpdate failed: %s", e)
             self.updateCheckFailed.emit(str(e))

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -6,6 +6,7 @@ from PyQt6.QtCore import (
     QVariant,
     QTimer,
     QRecursiveMutex,
+    QCoreApplication,
 )
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -81,6 +82,116 @@ _DEVELOPER_PASSWORD = "OpenwaterHealth"
 def developer_password_matches(pw) -> bool:
     """Return True iff ``pw`` equals the developer-mode password."""
     return isinstance(pw, str) and pw == _DEVELOPER_PASSWORD
+
+
+# Flip to True once release builds are Authenticode-signed; until then an
+# unsigned (NotSigned) update bundle is allowed through with a logged warning.
+_REQUIRE_SIGNED_UPDATES = False
+
+
+def _select_update_asset(assets: list, is_ruo: bool):
+    """Return download URL of the Setup bundle matching the running variant.
+
+    RUO builds match ``Openwater-Setup-*_RUO.exe``; clinical builds match
+    the non-RUO ``Openwater-Setup-*.exe``. Returns None if no match.
+    """
+    for asset in assets:
+        name = (asset.get("name") or "")
+        low = name.lower()
+        if not low.endswith(".exe"):
+            continue
+        asset_is_ruo = low.endswith("_ruo.exe")
+        if asset_is_ruo == is_ruo:
+            return asset.get("browser_download_url")
+    return None
+
+
+def _authenticode_status(path: str) -> str:
+    """Return the Authenticode signature status of ``path``.
+
+    Uses PowerShell's Get-AuthenticodeSignature (always present on Windows).
+    Returns one of 'Valid', 'NotSigned', 'HashMismatch', 'UnknownError', ... or
+    'Error' if the check itself could not run.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                f"(Get-AuthenticodeSignature -LiteralPath '{path}').Status",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip() or "Error"
+    except Exception:
+        return "Error"
+
+
+def _update_decision(status: str, require_signed: bool):
+    """Decide whether to launch the downloaded bundle given its signature.
+
+    Returns (should_launch: bool, error_message: str | None).
+    """
+    if status == "Valid":
+        return True, None
+    if status == "NotSigned":
+        if require_signed:
+            return False, "Update is not signed; refusing to install."
+        return True, None  # transition period: allow with a warning logged
+    return False, f"Update signature check failed: {status}"
+
+
+def _is_bundle_url(url) -> bool:
+    """True if ``url`` is a Setup .exe bundle, not the release HTML page.
+
+    Guards against the GitHub ``html_url`` fallback: without this, a release
+    with no matching installer asset would make the updater download an HTML
+    page and try to execute it.
+    """
+    return isinstance(url, str) and url.lower().endswith(".exe")
+
+
+def _looks_like_pe(head: bytes) -> bool:
+    """True if the bytes start with the 'MZ' signature of a Windows executable.
+
+    A truncated download or an HTML error page will not start with 'MZ', so
+    this rejects corrupt downloads before they are launched.
+    """
+    return head[:2] == b"MZ"
+
+
+def _build_update_helper_script(
+    app_pid: int, installer: str, app_exe: str
+) -> str:
+    """Return a PowerShell script that performs the in-place upgrade handoff.
+
+    The running app cannot upgrade its own files while it holds them, and the
+    Burn bundle does not relaunch the app. So the app spawns this detached
+    helper and then exits; the helper (1) waits for the app to fully exit to
+    avoid a FilesInUse conflict, (2) runs the bundle non-interactively
+    (one UAC elevation, no bootstrapper UI), then (3) relaunches the app.
+    """
+    return (
+        "# OpenWater in-app update helper (auto-generated; do not edit)\n"
+        "$ErrorActionPreference = 'SilentlyContinue'\n"
+        f"# 1. Wait for the running app (PID {app_pid}) to exit so the\n"
+        "#    installer can replace its files without a FilesInUse conflict.\n"
+        "$deadline = (Get-Date).AddSeconds(60)\n"
+        f"while (Get-Process -Id {app_pid} -ErrorAction SilentlyContinue) {{\n"
+        "    if ((Get-Date) -gt $deadline) { break }\n"
+        "    Start-Sleep -Milliseconds 250\n"
+        "}\n"
+        "# 2. Run the upgrade non-interactively (one UAC elevation).\n"
+        f"Start-Process -FilePath \"{installer}\" "
+        "-ArgumentList '/passive','/norestart' -Wait\n"
+        "# 3. Relaunch the (now-updated) app.\n"
+        f"Start-Process -FilePath \"{app_exe}\"\n"
+    )
 
 
 # Camera-mask → human config name, mirroring CameraSelectionModal's
@@ -668,6 +779,7 @@ class MotionConnector(QObject):
     updateAvailable = pyqtSignal(str, str)   # (latest_version, download_url)
     updateNotAvailable = pyqtSignal()
     updateCheckFailed = pyqtSignal(str)      # error message
+    updateProgress = pyqtSignal(str)         # human-readable progress status
 
     @staticmethod
     def _default_data_dir() -> str:
@@ -4574,23 +4686,33 @@ class MotionConnector(QObject):
                 self.updateCheckFailed.emit("Could not determine latest release tag.")
                 return
 
-            # Find the .zip asset download URL
-            download_url = data.get("html_url", "")
-            for asset in data.get("assets", []):
-                if asset["name"].endswith(".zip"):
-                    download_url = asset["browser_download_url"]
-                    break
+            # Find the Setup bundle matching this build's variant.
+            # reducedMode True = clinical build; False = RUO/full build.
+            is_ruo = not bool(self._app_config.get("reducedMode", False))
+            download_url = _select_update_asset(data.get("assets", []), is_ruo)
 
             local_version = get_version()
             # Strip local metadata for comparison (e.g. "+3.gabc1234.dirty")
             local_base = local_version.split("+")[0]
 
-            if self._version_newer(remote_tag, local_base):
-                logger.info(f"Update available: {remote_tag} (current: {local_base})")
-                self.updateAvailable.emit(remote_tag, download_url)
-            else:
+            if not self._version_newer(remote_tag, local_base):
                 logger.info(f"App is up to date ({local_base} >= {remote_tag})")
                 self.updateNotAvailable.emit()
+            elif not _is_bundle_url(download_url):
+                # Newer release exists but has no matching installer asset
+                # (e.g. assets still uploading) -- don't offer an in-place
+                # update we can't actually perform.
+                logger.warning(
+                    "Update %s available but no installer asset found",
+                    remote_tag,
+                )
+                self.updateNotAvailable.emit()
+            else:
+                logger.info(
+                    "Update available: %s (current: %s)",
+                    remote_tag, local_base,
+                )
+                self.updateAvailable.emit(remote_tag, download_url)
 
         except Exception as e:
             logger.warning(f"Update check failed: {e}")
@@ -4633,3 +4755,95 @@ class MotionConnector(QObject):
         """Open the download URL in the system browser."""
         import webbrowser
         webbrowser.open(url)
+
+    @pyqtSlot(str)
+    def applyUpdate(self, download_url: str):
+        """Download the update bundle, verify it, and launch the upgrade.
+
+        Guarded against re-entry so repeated clicks can't spawn racing
+        download threads against the same file.
+        """
+        if getattr(self, "_update_in_progress", False):
+            logger.info("Update already in progress; ignoring repeat request")
+            return
+        self._update_in_progress = True
+        t = threading.Thread(
+            target=self._apply_update_worker, args=(download_url,), daemon=True
+        )
+        t.start()
+
+    def _apply_update_worker(self, download_url: str):
+        import urllib.request
+        import subprocess
+        import sys
+        from utils import app_paths
+
+        try:
+            if not _is_bundle_url(download_url):
+                self.updateCheckFailed.emit("No installer for this update.")
+                return
+
+            updates_dir = app_paths.writable_root() / "updates"
+            updates_dir.mkdir(parents=True, exist_ok=True)
+            # Clear stale downloads so old installers don't accumulate.
+            for stale in updates_dir.glob("*"):
+                try:
+                    stale.unlink()
+                except OSError:
+                    pass
+
+            dest = updates_dir / download_url.rsplit("/", 1)[-1]
+            self.updateProgress.emit("Downloading update…")
+            logger.info("Downloading update %s -> %s", download_url, dest)
+            urllib.request.urlretrieve(download_url, str(dest))
+
+            # Reject truncated / non-executable downloads before launching.
+            with open(dest, "rb") as f:
+                head = f.read(2)
+            if not _looks_like_pe(head):
+                self.updateCheckFailed.emit(
+                    "Downloaded update is not a valid installer."
+                )
+                return
+
+            status = _authenticode_status(str(dest))
+            should_launch, error = _update_decision(
+                status, _REQUIRE_SIGNED_UPDATES
+            )
+            if not should_launch:
+                self.updateCheckFailed.emit(error)
+                return
+            if status == "NotSigned":
+                logger.warning(
+                    "Update bundle not signed (transition); proceeding"
+                )
+
+            # The app cannot replace its own running files, and the Burn
+            # bundle does not relaunch the app. So write a detached helper
+            # that waits for us to exit, runs the bundle silently, then
+            # relaunches the (now-updated) app. Then quit.
+            helper = updates_dir / "update_helper.ps1"
+            helper.write_text(
+                _build_update_helper_script(
+                    os.getpid(), str(dest), sys.executable
+                ),
+                encoding="utf-8",
+            )
+            self.updateProgress.emit("Installing update…")
+            logger.info("Spawning update helper; quitting for upgrade")
+            subprocess.Popen(
+                [
+                    "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+                    "-File", str(helper),
+                ],
+                close_fds=True,
+                creationflags=getattr(subprocess, "DETACHED_PROCESS", 0),
+            )
+            QCoreApplication.quit()
+        except Exception as e:
+            logger.error("applyUpdate failed: %s", e)
+            self.updateCheckFailed.emit(str(e))
+        finally:
+            # Cleared so a failed attempt can be retried (on success the app
+            # is already quitting).
+            self._update_in_progress = False

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -4675,7 +4675,11 @@ class MotionConnector(QObject):
         import urllib.request
         from version import get_version
 
-        api_url = f"https://api.github.com/repos/{self._GITHUB_REPO}/releases/latest"
+        # ``updateRepo`` config key lets a build point its update check at a
+        # staging/mirror repo (used for end-to-end update testing); absent =>
+        # the production repo.
+        repo = self._app_config.get("updateRepo") or self._GITHUB_REPO
+        api_url = f"https://api.github.com/repos/{repo}/releases/latest"
         try:
             req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github+json"})
             with urllib.request.urlopen(req, timeout=10) as resp:

--- a/scripts/UPDATE_E2E_TEST.md
+++ b/scripts/UPDATE_E2E_TEST.md
@@ -1,0 +1,77 @@
+# In-app updater — end-to-end test runbook
+
+Exercises the full in-place update flow **entirely on one machine over
+loopback** — no public hosting of the (proprietary) installer. An "old" build
+detects a "newer" release from a local fake-releases server, downloads it,
+verifies it, and performs the in-place upgrade + relaunch.
+
+What it covers: release detection → variant asset selection → version compare →
+download → PE/signature verification → wait-for-exit helper → `/passive`
+in-place upgrade → relaunch on the new version.
+
+## Prerequisites
+
+- A machine with **Python 3** (to run the server) — the **dev box is easiest**
+  (it also has the console for the bonus hardware test).
+- To *build* the bundles: the WiX 5.0.2 + .NET 8 toolchain and a conda env with
+  PyQt6 + **a clean-`next` `omotion` SDK** + PyInstaller (`pylib` here). See
+  `installer/` and the build script. **Bundles whatever `omotion` resolves to —
+  make sure it's clean.**
+- The server + the installed app must be the **same machine** (the old build is
+  pointed at `127.0.0.1:8077`; pass `-ServerUrl` to the build script to change).
+
+## 1. Build the two test bundles
+
+```powershell
+powershell -File scripts\build_update_test_bundles.ps1
+```
+
+Produces (in `build\installer\`):
+
+- `Openwater-Setup-1.3.0_RUO.exe` — **OLD**, the build under test (its update
+  check points at `http://127.0.0.1:8077/releases/latest`).
+- `Openwater-Setup-1.3.1_RUO.exe` — **NEW**, the upgrade target.
+
+The script prints the SDK path it built against — confirm it's a clean `next`.
+
+## 2. Start the fake-releases server (leave running)
+
+```powershell
+conda run -n pylib python scripts\fake_release_server.py `
+    --bundle build\installer\Openwater-Setup-1.3.1_RUO.exe --tag 1.3.1 --port 8077
+```
+
+It serves `releases/latest` (advertising 1.3.1) and the bundle file. Watch its
+log — you'll see the app's requests, confirming nothing goes to the internet.
+
+## 3. Install the OLD bundle + run the test
+
+1. Double-click `Openwater-Setup-1.3.0_RUO.exe` → SmartScreen "More info → Run
+   anyway" + UAC. Installs to `C:\Program Files\Openwater\Bloodflow\`.
+2. Launch **Openwater Bloodflow (RUO)** from the Start menu.
+3. Within ~3 s the banner appears: *"A new version is available: 1.3.1."*
+   (the server log shows `GET /releases/latest`).
+4. Click **Update**. Expect: button → "Downloading…" → "Installing…", the app
+   **quits**, **one UAC** prompt (the bundle self-elevates), a `/passive`
+   progress install, then the app **relaunches**.
+5. **Verify:** the relaunched app reports **1.3.1** (Settings/About), and the
+   banner does **not** reappear (1.3.1 == latest).
+6. **State preserved:** settings / scan data still under `C:\ProgramData\Openwater\`.
+
+## 4. Bonus (dev box + hardware)
+
+Repeat with a **console connected and streaming** → confirm no FilesInUse hang
+during the in-place file swap (the scenario the relaunch-helper was built for).
+
+## Cleanup
+
+- Uninstall via Apps & Features (single RUO entry).
+- Stop the server (Ctrl+C).
+
+## Notes
+
+- The download is allowed despite being **unsigned** because
+  `_REQUIRE_SIGNED_UPDATES = False` (transition period until the EV cert lands);
+  the PE-header (`MZ`) check still rejects truncated/HTML downloads.
+- `updateRepo` / `updateApiUrl` config keys default to `None` → production
+  GitHub repo. They exist only to point a build at a staging/local source.

--- a/scripts/build_update_test_bundles.ps1
+++ b/scripts/build_update_test_bundles.ps1
@@ -1,0 +1,59 @@
+# scripts/build_update_test_bundles.ps1
+# Build the two RUO bundles for the in-app-update end-to-end test:
+#   OLD 1.3.0 -> the build under test; its update check points at -ServerUrl
+#   NEW 1.3.1 -> the upgrade target the fake-release server hands out
+#
+# Prereqs (see docs / memory project_local_build_test_env):
+#   * conda env with PyQt6 + omotion (clean SDK!) + PyInstaller  (default: pylib)
+#   * WiX 5.0.2 + .NET 8 (the script wires DOTNET_ROOT if installed user-scope)
+#   * a CLEAN SDK: this bundles whatever `omotion` resolves to — the script
+#     prints which SDK it built against; make sure it's a clean next.
+#
+# Usage:
+#   powershell -File scripts\build_update_test_bundles.ps1
+#   powershell -File scripts\build_update_test_bundles.ps1 -ServerUrl http://127.0.0.1:8077/releases/latest
+param(
+    [string]$ServerUrl = "http://127.0.0.1:8077/releases/latest",
+    [string]$CondaEnv  = "pylib"
+)
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
+Set-Location $root
+
+# WiX/.NET toolchain (user-scope install location)
+$dotnetDir = "$env:LOCALAPPDATA\Microsoft\dotnet"
+if (Test-Path $dotnetDir) {
+    $env:DOTNET_ROOT = $dotnetDir
+    $env:Path = "$dotnetDir;$env:USERPROFILE\.dotnet\tools;$env:Path"
+}
+
+$sdk = (& conda run -n $CondaEnv python -c "import omotion; print(omotion.__file__)").Trim()
+Write-Host "Building against SDK: $sdk" -ForegroundColor Cyan
+
+function Build-RuoBundle([string]$ver, [string]$apiUrl) {
+    (Get-Content version.py) -replace '^_FALLBACK_VERSION = .*', "_FALLBACK_VERSION = `"$ver`"" |
+        Set-Content version.py -Encoding UTF8
+    try {
+        & conda run -n $CondaEnv python -m PyInstaller -y openwater.spec
+        if (-not (Test-Path "dist\OpenWaterApp\OpenWaterApp.exe")) { throw "dist missing after PyInstaller" }
+        # RUO (reducedMode:false) + optional updateApiUrl injection, via JSON (no BOM)
+        $py = "import json; p='dist/OpenWaterApp/_internal/config/app_config.json'; " +
+              "d=json.load(open(p,encoding='utf-8')); d['reducedMode']=False; "
+        if ($apiUrl) { $py += "d['updateApiUrl']='$apiUrl'; " }
+        $py += "json.dump(d, open(p,'w',encoding='utf-8'), indent=2)"
+        & conda run -n $CondaEnv python -c $py
+        & powershell -NoProfile -ExecutionPolicy Bypass -File installer\build_installer.ps1 -Variant ruo -Version $ver
+        if ($LASTEXITCODE -ne 0) { throw "build_installer failed for $ver" }
+    } finally {
+        git checkout -- version.py
+    }
+}
+
+Write-Host "=== OLD 1.3.0  (update check -> $ServerUrl) ===" -ForegroundColor Green
+Build-RuoBundle "1.3.0" $ServerUrl
+Write-Host "=== NEW 1.3.1  (upgrade target) ===" -ForegroundColor Green
+Build-RuoBundle "1.3.1" ""
+
+Write-Host "=== Artifacts (build\installer) ===" -ForegroundColor Green
+Get-ChildItem "build\installer\Openwater-Setup-1.3.*_RUO.exe" |
+    Select-Object Name, @{N='MB';E={[math]::Round($_.Length/1MB,1)}} | Format-Table -AutoSize

--- a/scripts/fake_release_server.py
+++ b/scripts/fake_release_server.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Local fake GitHub-releases server for end-to-end in-app-update testing.
+
+Serves a ``releases/latest`` JSON that advertises a newer version and points
+its asset ``browser_download_url`` back at this server, plus the bundle file
+itself. Nothing leaves the machine — point an old build's ``updateApiUrl``
+config at ``http://127.0.0.1:<port>/releases/latest`` and the whole
+detect -> download -> verify -> install -> relaunch flow runs over loopback.
+
+Usage:
+    python scripts/fake_release_server.py \
+        --bundle build/installer/Openwater-Setup-1.3.1_RUO.exe \
+        --tag 1.3.1 --port 8077
+
+Then the old build's bundled config/app_config.json must contain:
+    "updateApiUrl": "http://127.0.0.1:8077/releases/latest"
+"""
+import argparse
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def build_handler(bundle_path: str, tag: str, host_port: str):
+    asset_name = os.path.basename(bundle_path)
+    download_url = f"http://{host_port}/{asset_name}"
+    latest_json = json.dumps(
+        {
+            "tag_name": tag,
+            "name": tag,
+            "html_url": f"http://{host_port}/",
+            "assets": [
+                {
+                    "name": asset_name,
+                    "browser_download_url": download_url,
+                }
+            ],
+        }
+    ).encode()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            print(f"[fake-release] {self.address_string()} {fmt % args}")
+
+        def do_GET(self):
+            path = self.path.split("?", 1)[0]
+            if path.endswith("/releases/latest"):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(latest_json)))
+                self.end_headers()
+                self.wfile.write(latest_json)
+            elif path == f"/{asset_name}":
+                size = os.path.getsize(bundle_path)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(size))
+                self.end_headers()
+                with open(bundle_path, "rb") as f:
+                    while True:
+                        chunk = f.read(1 << 20)
+                        if not chunk:
+                            break
+                        self.wfile.write(chunk)
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+    return Handler
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bundle", required=True, help="path to the .exe bundle to serve")
+    ap.add_argument("--tag", default="1.3.1", help="release tag to advertise")
+    ap.add_argument("--port", type=int, default=8077)
+    ap.add_argument("--host", default="127.0.0.1", help="bind/advertise host")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.bundle):
+        raise SystemExit(f"bundle not found: {args.bundle}")
+
+    host_port = f"{args.host}:{args.port}"
+    handler = build_handler(args.bundle, args.tag, host_port)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"[fake-release] serving tag {args.tag} ({os.path.basename(args.bundle)})")
+    print(f"[fake-release]   releases/latest -> http://{host_port}/releases/latest")
+    print(f"[fake-release]   set the old build's updateApiUrl to that URL")
+    print("[fake-release] Ctrl+C to stop")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[fake-release] stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_apply_update.py
+++ b/tests/test_apply_update.py
@@ -1,0 +1,61 @@
+import pytest
+from motion_connector import (
+    _update_decision,
+    _is_bundle_url,
+    _looks_like_pe,
+    _build_update_helper_script,
+)
+
+
+@pytest.mark.unit
+def test_valid_signature_launches():
+    assert _update_decision("Valid", require_signed=True) == (True, None)
+
+
+@pytest.mark.unit
+def test_invalid_signature_aborts_with_message():
+    launch, err = _update_decision("HashMismatch", require_signed=False)
+    assert launch is False
+    assert "HashMismatch" in err
+
+
+@pytest.mark.unit
+def test_unsigned_allowed_when_not_required():
+    assert _update_decision("NotSigned", require_signed=False) == (True, None)
+
+
+@pytest.mark.unit
+def test_unsigned_rejected_when_required():
+    launch, err = _update_decision("NotSigned", require_signed=True)
+    assert launch is False
+    assert "not signed" in err.lower()
+
+
+@pytest.mark.unit
+def test_is_bundle_url_accepts_only_exe():
+    assert _is_bundle_url("https://x/OpenWater-Setup-1.2.3.exe")
+    assert _is_bundle_url("https://x/OpenWater-Setup-1.2.3_RUO.EXE")
+    assert not _is_bundle_url("https://github.com/o/r/releases/tag/1.2.3")
+    assert not _is_bundle_url("")
+    assert not _is_bundle_url(None)
+
+
+@pytest.mark.unit
+def test_looks_like_pe_rejects_non_executables():
+    assert _looks_like_pe(b"MZ\x90\x00")
+    assert not _looks_like_pe(b"<!DOCTYPE html>")  # HTML error page
+    assert not _looks_like_pe(b"")                  # empty / truncated
+    assert not _looks_like_pe(b"M")                 # 1-byte truncation
+
+
+@pytest.mark.unit
+def test_helper_script_waits_installs_silently_and_relaunches():
+    s = _build_update_helper_script(
+        1234, r"C:\Users\u\updates\OpenWater-Setup-1.2.3.exe",
+        r"C:\Program Files\OpenWater\Bloodflow\OpenWaterApp.exe",
+    )
+    assert "1234" in s                              # waits for our PID
+    assert "Get-Process" in s
+    assert "/passive" in s                          # non-interactive install
+    assert "OpenWater-Setup-1.2.3.exe" in s         # runs the installer
+    assert "OpenWaterApp.exe" in s                  # relaunches the app

--- a/tests/test_authenticode_status.py
+++ b/tests/test_authenticode_status.py
@@ -1,0 +1,20 @@
+import subprocess
+import types
+import pytest
+import motion_connector
+
+
+@pytest.mark.unit
+def test_authenticode_status_parses_powershell_output(monkeypatch):
+    def fake_run(*a, **k):
+        return types.SimpleNamespace(stdout="Valid\n", returncode=0)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert motion_connector._authenticode_status("C:/x.exe") == "Valid"
+
+
+@pytest.mark.unit
+def test_authenticode_status_returns_error_on_exception(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no powershell")
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert motion_connector._authenticode_status("C:/x.exe") == "Error"

--- a/tests/test_update_asset_select.py
+++ b/tests/test_update_asset_select.py
@@ -1,0 +1,22 @@
+import pytest
+from motion_connector import _select_update_asset
+
+
+CLINICAL = {"name": "OpenWater-Setup-1.2.3.exe", "browser_download_url": "u/clinical"}
+RUO = {"name": "OpenWater-Setup-1.2.3_RUO.exe", "browser_download_url": "u/ruo"}
+ZIP = {"name": "OpenMotionDriver-x64.zip", "browser_download_url": "u/zip"}
+
+
+@pytest.mark.unit
+def test_selects_ruo_bundle_for_ruo_variant():
+    assert _select_update_asset([CLINICAL, RUO, ZIP], is_ruo=True) == "u/ruo"
+
+
+@pytest.mark.unit
+def test_selects_clinical_bundle_for_clinical_variant():
+    assert _select_update_asset([CLINICAL, RUO, ZIP], is_ruo=False) == "u/clinical"
+
+
+@pytest.mark.unit
+def test_returns_none_when_no_matching_exe():
+    assert _select_update_asset([ZIP], is_ruo=True) is None


### PR DESCRIPTION
**Phase 1.5 of 3** — stacked on the MSI installer ([#224]). Review/merge #224 first; this PR's base is `feature/msi-installer`, so its own diff is just the updater.

## What this does
Turns the existing "update available" banner into a real **in-place updater**:
- Downloads the **variant-matched `OpenWater-Setup-*.exe`** from the GitHub release (RUO build → `*_RUO.exe`).
- **Verifies** it: Authenticode status + a PE-header (`MZ`) check; rejects non-`.exe` URLs (no more `html_url`-launch) and truncated/HTML downloads.
- **In-place upgrade via a detached helper**: the app can't replace its own running files and Burn doesn't relaunch it, so the app writes a PowerShell helper that **waits for the app to exit → runs the bundle `/passive /norestart` (one UAC, no bootstrapper UI) → relaunches the updated app**.
- **Re-entrancy guard** + Downloading/Installing feedback on the banner.
- Signing enforcement wired but lenient (`_REQUIRE_SIGNED_UPDATES=False`) until the cert lands.

By existing design (issue #96) clinical builds suppress the updater; it runs on **RUO** builds.

## Provenance
This is the updater portion split out of the original combined #215, **with the adversarial-audit hardening already applied** (relaunch handoff, FilesInUse sequencing, integrity guards, re-entrancy). 12 updater unit tests green.

## Manual gate (needs a clean VM + a published newer release)
- [ ] Click **Update** on an RUO install → download → one UAC → in-place upgrade → app **relaunches** on the new version.
- [ ] Verify no FilesInUse failure while a device is connected/streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)