### PR TITLE
fix: modal backdrops capture scroll/hover so they don't reach the plot (#214)

### DIFF
--- a/components/CameraSelectionModal.qml
+++ b/components/CameraSelectionModal.qml
@@ -79,7 +79,15 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
-        MouseArea { anchors.fill: parent; onClicked: {} }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214). This
+        // backdrop intentionally does NOT close on click.
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: {}
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     // Dialog panel

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -234,9 +234,13 @@ Item {
         // Click-outside dismisses, but only when the modal opted in via
         // the `dismissable` property (false during checking / pre-scan
         // gating / live-scan warnings — see `dismissable` binding above).
+        // hoverEnabled + onWheel capture ALL pointer input so scroll/hover
+        // can't fall through to the plot viewer behind the modal (#214).
         MouseArea {
             anchors.fill: parent
+            hoverEnabled: true
             onClicked: { if (root.dismissable) root.close() }
+            onWheel: function(wheel) { wheel.accepted = true }
         }
     }
 

--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -83,7 +83,14 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000C0"
-        MouseArea { anchors.fill: parent; onClicked: root.dismiss() }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214).
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.dismiss()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     // Panel

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -153,7 +153,16 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
+        // Capture ALL pointer input so it can't fall through to the
+        // interactive plot viewer behind the modal (issue #214): without
+        // hoverEnabled the plot's crosshair tracks the cursor, and without
+        // an onWheel handler the scroll wheel zooms/pans the plot.
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.close()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     // Shared column widths (header + rows stay aligned).

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -41,7 +41,14 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214).
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.close()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     Rectangle {

--- a/components/NotesModal.qml
+++ b/components/NotesModal.qml
@@ -49,7 +49,14 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214).
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.close()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     Rectangle {

--- a/components/PasswordPromptModal.qml
+++ b/components/PasswordPromptModal.qml
@@ -45,7 +45,14 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000B0"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214).
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.close()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     // Panel

--- a/components/ScanSettingsModal.qml
+++ b/components/ScanSettingsModal.qml
@@ -143,7 +143,14 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214).
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.close()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     Rectangle {

--- a/components/ScanTimeModal.qml
+++ b/components/ScanTimeModal.qml
@@ -30,7 +30,15 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000AA"
-        MouseArea { anchors.fill: parent; onClicked: {} }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214). This
+        // backdrop intentionally does NOT close on click.
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: {}
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     Rectangle {

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -371,7 +371,14 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#000000B0"
-        MouseArea { anchors.fill: parent; onClicked: root.close() }
+        // Capture ALL pointer input so scroll/hover can't fall through to
+        // the interactive plot viewer behind the modal (issue #214).
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: root.close()
+            onWheel: function(wheel) { wheel.accepted = true }
+        }
     }
 
     // ── Modal panel ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Closes #214.

When a modal is open over the BloodFlow page, scrolling or moving the cursor over the modal also affected the **plot viewer behind it** — the wheel zoomed/panned the plot and the cursor dragged its crosshair.

## Root cause

Every modal's dimmed backdrop used the same pattern:

```qml
Rectangle { anchors.fill: parent; color: "#000000AA"
    MouseArea { anchors.fill: parent; onClicked: root.close() }
}
```

The backdrop `MouseArea` caught **clicks** but had no `hoverEnabled` and no `onWheel` handler. In Qt Quick, a `MouseArea` without those is transparent to hover and wheel events, so they fell through to `PlotCell.panZoomArea` behind the modal — which has `hoverEnabled: true`, an `onWheel` zoom handler, and drag-pan. History was the modal in the report (it opens over a loaded scan), but **all ten modal overlays shared the identical defect**.

## Fix

Make each modal backdrop a full pointer sink:

- `hoverEnabled: true` — swallows hover so the plot's crosshair stops tracking through the modal.
- `onWheel: function(wheel) { wheel.accepted = true }` — swallows scroll so the plot stops zooming/panning.

The backdrop spans the whole window beneath each modal's card, so it also catches events that fall through the card's empty areas. Existing click/dismiss behavior is unchanged.

Fixed in: `HistoryModal`, `SettingsModal`, `NotesModal`, `ScanSettingsModal`, `LogsModal`, `ContactQualityModal`, `CameraSelectionModal`, `CriticalErrorModal`, `PasswordPromptModal`, `ScanTimeModal`.

## Verification

- **Event-injection harness** (standalone PyQt6 + QQuickView, real Qt router): a background "plot" `MouseArea` (mirroring `panZoomArea`) under a modal backdrop. Injected 3 wheel notches + 4 hover moves:

  | backdrop | plot saw (wheel, hover) |
  |---|---|
  | none (sanity) | (3, 3) — plot is live |
  | current/buggy | (3, 4) — **leaks through** |
  | fixed | (0, 0) — **blocked** |

- `pyside6-qmllint` on all 10 files: no new syntax/structural errors (only pre-existing unresolved-import warnings).
- App boots from source with **zero QML errors**; all edited components load.

## Hand-testing

1. Run a scan (or History → Load in viewer on a past scan) so the plot is populated.
2. Open History (and each other modal).
3. Scroll and move the cursor over the modal → the background plot must not zoom/pan and its crosshair must not move.