### PR TITLE
feat: add Developer toggles for sensor debug flags (histoCmp + sensor logging)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | `forceLaserFail` | `false` | Debug: simulate a laser safety trip. |
 | `cameraFakeData` | `false` | **Broken — do not use.** Was meant to request firmware fake histograms; see "Working without hardware". |
 | `histoThrottle` | `false` | Drop histograms to reduce log spam. |
-| `histoCmp` | `true` | Compare received vs expected histogram frame counts. |
+| `histoCmp` | `true` | Histogram compression (firmware `DEBUG_FLAG_HISTO_CMP`, bit `0x40` — firmware logs it as "histo compress"). Toggle live from Settings → Developer → "Histogram compression". |
 | `tecTripTempC` | `40` | Console over-temp trip (°C) pushed to the console user config on connect via `motion_config.ensure_tec_trip` (read-modify-write, preserves calibration + OPT/EE keys). Validated to 1–60 °C; absent/invalid values leave the device's existing trip untouched (never writes `0`, which would disable the firmware trip). |
 | `ft_min_mean_per_camera` | `[40,40,…]` | Calibration pass threshold — min pixel mean per camera (8-element array). |
 | `calibration_scan_duration_sec` | `15` | Calibration runtime. |

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -852,6 +852,38 @@ Item {
                         Item { Layout.fillWidth: true }
                     }
 
+                    // Sensor firmware debug flags — persisted to config AND
+                    // pushed live to connected sensors via setSensorDebugFlag.
+                    // onToggled (not onCheckedChanged) so the appConfig rebind
+                    // after appConfigChanged can't feed back into the slot.
+                    FieldRow {
+                        label: "Histogram compression"
+                        PillSwitch {
+                            checked: MotionInterface.appConfig.histoCmp === true
+                            onToggled: MotionInterface.setSensorDebugFlag("histoCmp", checked)
+                        }
+                        Text {
+                            text: MotionInterface.appConfig.histoCmp === true ? "On" : "Off"
+                            color: MotionInterface.appConfig.histoCmp === true ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    FieldRow {
+                        label: "Sensor debug log"
+                        PillSwitch {
+                            checked: MotionInterface.appConfig.sensorDebugLogging === true
+                            onToggled: MotionInterface.setSensorDebugFlag("sensorDebugLogging", checked)
+                        }
+                        Text {
+                            text: MotionInterface.appConfig.sensorDebugLogging === true ? "On" : "Off"
+                            color: MotionInterface.appConfig.sensorDebugLogging === true ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
                     FieldRow {
                         label: "Save raw CSV"
                         PillSwitch {

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -963,6 +963,29 @@ class MotionConnector(QObject):
             flags |= DEBUG_FLAG_HISTO_CMP
         return flags
 
+    def _apply_sensor_debug_flags(self) -> None:
+        """Re-push the recomputed debug-flag bitmask to every connected sensor.
+
+        Unlike ``_run_sensor_init``, this writes even when ``flags == 0`` so
+        that turning the last flag off actually clears it on the firmware.
+        Used by the live Settings → Developer toggles (``setSensorDebugFlag``)
+        so no reconnect/restart is needed.
+        """
+        flags = self._compute_sensor_debug_flags()
+        for side in ("left", "right"):
+            try:
+                sensor = (
+                    getattr(self._interface, side, None)
+                    if self._interface else None
+                )
+            except Exception:
+                sensor = None
+            if sensor is None or not sensor.is_connected():
+                continue
+            logger.info("Re-applying debug flags 0x%x on %s sensor", flags, side)
+            if not sensor.set_debug_flags(flags):
+                logger.warning("Failed to set debug flags on %s sensor", side)
+
     def _schedule_sensor_init(self, side: str):
         """Delay initial sensor commands to allow USB settle."""
         QTimer.singleShot(1000, lambda: self._run_sensor_init(side))
@@ -2151,6 +2174,39 @@ class MotionConnector(QObject):
         logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
         if changes:
             self._audit.log("settings_changed", {"changes": changes})
+
+    # Sensor debug-flag config keys surfaced as live Settings → Developer
+    # toggles, mapped to the runtime cache attribute that
+    # _compute_sensor_debug_flags() reads.
+    _SENSOR_DEBUG_FLAG_ATTRS = {
+        "histoCmp": "_histo_cmp",
+        "sensorDebugLogging": "_sensor_debug_logging",
+    }
+
+    @pyqtSlot(str, bool)
+    def setSensorDebugFlag(self, key: str, enabled: bool) -> None:
+        """Toggle a sensor debug-flag config key, persist it, and re-push the
+        recomputed debug-flag bitmask to every connected sensor immediately.
+
+        Mirrors the live ``setConsoleFan`` developer toggle — no app restart
+        or reconnect needed. Unknown keys are ignored. When no sensor is
+        connected the value is still persisted and applies on the next
+        connect via ``_run_sensor_init``.
+        """
+        attr = self._SENSOR_DEBUG_FLAG_ATTRS.get(key)
+        if attr is None:
+            logger.warning("setSensorDebugFlag: unknown key %r", key)
+            return
+        enabled = bool(enabled)
+        old = self._app_config.get(key)
+        setattr(self, attr, enabled)
+        self._app_config[key] = enabled
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        if old != enabled:
+            self._audit.log("settings_changed",
+                            {"changes": {key: {"old": old, "new": enabled}}})
+        self._apply_sensor_debug_flags()
 
     @pyqtSlot(bool)
     def setWriteRawCsv(self, enabled: bool) -> None:

--- a/tests/test_sensor_debug_flags.py
+++ b/tests/test_sensor_debug_flags.py
@@ -1,0 +1,93 @@
+"""Settings → Developer switches for the sensor debug flags.
+
+``setSensorDebugFlag`` toggles ``histoCmp`` / ``sensorDebugLogging`` in the
+runtime cache and persisted config, then re-pushes the recomputed firmware
+debug-flag bitmask to every connected sensor immediately (no restart) —
+mirroring the live ``setConsoleFan`` developer toggle.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+from omotion.config import DEBUG_FLAG_HISTO_CMP, DEBUG_FLAG_USB_PRINTF
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, app_config=None, left=True, right=True):
+    """Build a MotionConnector with a mocked sensor interface.
+
+    ``scan_db_path=None`` makes the audit log a no-op, and we stub
+    ``_save_app_config`` so a toggle never writes the real
+    ``config/app_config.json`` during tests.
+    """
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, left, right)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    iface.left.is_connected.return_value = left
+    iface.right.is_connected.return_value = right
+    iface.left.set_debug_flags.return_value = True
+    iface.right.set_debug_flags.return_value = True
+    c = MotionConnector(
+        interface=iface, app_config=app_config or {},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+    c._save_app_config = MagicMock()
+    return c, iface
+
+
+def test_enable_histo_cmp_sets_cache_config_and_pushes_bit(tmp_path):
+    c, iface = _connector(tmp_path, {"histoCmp": False})
+
+    c.setSensorDebugFlag("histoCmp", True)
+
+    assert c._histo_cmp is True
+    assert c._app_config["histoCmp"] is True
+    c._save_app_config.assert_called_once()
+    iface.left.set_debug_flags.assert_called_once_with(DEBUG_FLAG_HISTO_CMP)
+    iface.right.set_debug_flags.assert_called_once_with(DEBUG_FLAG_HISTO_CMP)
+
+
+def test_enable_sensor_debug_logging_preserves_other_bits(tmp_path):
+    c, iface = _connector(tmp_path, {"histoCmp": True, "sensorDebugLogging": False})
+
+    c.setSensorDebugFlag("sensorDebugLogging", True)
+
+    expected = DEBUG_FLAG_HISTO_CMP | DEBUG_FLAG_USB_PRINTF
+    assert c._sensor_debug_logging is True
+    assert c._app_config["sensorDebugLogging"] is True
+    iface.left.set_debug_flags.assert_called_once_with(expected)
+
+
+def test_disabling_last_flag_pushes_zero(tmp_path):
+    # No != 0 guard on the live path: clearing the last flag must actually
+    # write 0 so the firmware turns the bit off.
+    c, iface = _connector(tmp_path, {"histoCmp": True})
+
+    c.setSensorDebugFlag("histoCmp", False)
+
+    assert c._histo_cmp is False
+    iface.left.set_debug_flags.assert_called_once_with(0)
+
+
+def test_only_connected_sensors_receive_push(tmp_path):
+    c, iface = _connector(tmp_path, {"histoCmp": False}, left=True, right=False)
+
+    c.setSensorDebugFlag("histoCmp", True)
+
+    iface.left.set_debug_flags.assert_called_once_with(DEBUG_FLAG_HISTO_CMP)
+    iface.right.set_debug_flags.assert_not_called()
+
+
+def test_unknown_key_is_noop(tmp_path):
+    c, iface = _connector(tmp_path, {"histoCmp": False})
+
+    c.setSensorDebugFlag("bogusKey", True)
+
+    assert "bogusKey" not in c._app_config
+    c._save_app_config.assert_not_called()
+    iface.left.set_debug_flags.assert_not_called()


### PR DESCRIPTION
## What

Adds two switches to the **Settings → Developer** pane to toggle sensor firmware debug flags live, without hand-editing `config/app_config.json` and restarting:

- **Histogram compression** → `histoCmp` (`DEBUG_FLAG_HISTO_CMP`, bit `0x40`)
- **Sensor debug log** → `sensorDebugLogging` (`DEBUG_FLAG_USB_PRINTF`, firmware printf over USB)

## How

- New connector slot `setSensorDebugFlag(key, enabled)` updates the runtime cache, persists the config key, and calls `_apply_sensor_debug_flags()`.
- `_apply_sensor_debug_flags()` recomputes the full debug-flag bitmask (`_compute_sensor_debug_flags()`) and re-pushes it to **every connected sensor** — mirroring the existing live `setConsoleFan` toggle, so no restart/reconnect is needed.
- Unlike the connect-time `_run_sensor_init` path, the live apply has **no `!= 0` guard**, so clearing the last flag actually writes `0` and turns the bit off on the firmware.
- Two `FieldRow`s in the developer-gated card, using `onToggled` (not `onCheckedChanged`) to avoid a feedback loop with the `appConfig` rebind. No new config keys.
- Also corrects the `histoCmp` description in `CLAUDE.md` — it's histogram compression, not frame-count comparison (firmware logs it as `histo compress`).

## Testing

- **5 new `@pytest.mark.unit` tests** (`tests/test_sensor_debug_flags.py`) mocking the sensor seam: cache + config update, mask bits track the toggle, other bits preserved, clear-to-zero pushes `0`, only connected sensors get the push, unknown keys are a no-op. All 304 unit tests pass; flake8 clean on changed Python.
- **Verified live on hardware** (both sensors connected). Toggling in the UI produced, in the app log:
  - `Re-applying debug flags 0x0` — histoCmp off (clear-to-zero path)
  - `Debug flags changed: 0x0 -> 0x1 (USB printf ON)` — sensor logging on
  - `Debug flags changed: 0x1 -> 0x41 (USB printf ON) (histo compress ON)` — histoCmp on, printf bit preserved
  - Both left + right sensors acked each change; values persisted to config.

> Note: QML has no hot-reload — restart the app to see the new rows/labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)