### PR TITLE
feat: show device firmware versions in Settings → System Information

### DIFF
--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -1141,6 +1141,51 @@ Item {
                     }
                 }
 
+                // ── System Information ───────────────────────────────────────
+                // Firmware versions per device, cached on connect by the
+                // connector (_log_device_stats). Each row shows the live
+                // version when connected, or a muted "Not connected".
+                SectionCard {
+                    title: "System Information"
+
+                    FieldRow {
+                        label: "Console FW"
+                        Text {
+                            text: MotionInterface.consoleConnected
+                                  ? (MotionInterface.consoleFirmwareVersion || "—")
+                                  : "Not connected"
+                            color: MotionInterface.consoleConnected ? root.colTextPri : root.colTextMuted
+                            font.pixelSize: 13
+                            font.family: "Consolas"
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    FieldRow {
+                        label: "Left Sensor FW"
+                        Text {
+                            text: MotionInterface.leftSensorConnected
+                                  ? (MotionInterface.leftSensorFirmwareVersion || "—")
+                                  : "Not connected"
+                            color: MotionInterface.leftSensorConnected ? root.colTextPri : root.colTextMuted
+                            font.pixelSize: 13
+                            font.family: "Consolas"
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    FieldRow {
+                        label: "Right Sensor FW"
+                        Text {
+                            text: MotionInterface.rightSensorConnected
+                                  ? (MotionInterface.rightSensorFirmwareVersion || "—")
+                                  : "Not connected"
+                            color: MotionInterface.rightSensorConnected ? root.colTextPri : root.colTextMuted
+                            font.pixelSize: 13
+                            font.family: "Consolas"
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                }
+
                 // Bottom padding
                 Item { Layout.fillWidth: true; height: 20 }
             }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -659,6 +659,9 @@ class MotionConnector(QObject):
     tecDacChanged = pyqtSignal()
     appConfigChanged = pyqtSignal()
     consoleFanChanged = pyqtSignal()
+    # Per-device firmware versions, refreshed on every (dis)connect by
+    # _log_device_stats. Surfaced to Settings → System Information.
+    firmwareVersionsChanged = pyqtSignal()
 
     # App update signals
     updateAvailable = pyqtSignal(str, str)   # (latest_version, download_url)
@@ -801,6 +804,13 @@ class MotionConnector(QObject):
         # connect handler below). Surfaced to QML as ``consoleFanOn`` and
         # toggled via ``setConsoleFan``.
         self._console_fan_on: bool = True
+        # Per-device firmware version strings (e.g. "v1.2.3"), populated on
+        # connect by _log_device_stats and cleared on disconnect. Surfaced
+        # to QML as console/left/rightSensorFirmwareVersion for the Settings
+        # → System Information card.
+        self._firmware_versions: dict[str, str] = {
+            "console": "", "left": "", "right": "",
+        }
         # Track console connection time for safety grace period (issue #107 follow-up)
         self._console_connected_at: float | None = None
         # Real-time plot viewer source — assigned at scan start by startCapture.
@@ -1168,6 +1178,22 @@ class MotionConnector(QObject):
         """Expose Console connection status to QML."""
         return self._consoleConnected
 
+    @pyqtProperty(str, notify=firmwareVersionsChanged)
+    def consoleFirmwareVersion(self) -> str:
+        """Console firmware version cached at connect time (empty when
+        unknown / disconnected). Shown in Settings → System Information."""
+        return self._firmware_versions["console"]
+
+    @pyqtProperty(str, notify=firmwareVersionsChanged)
+    def leftSensorFirmwareVersion(self) -> str:
+        """Left sensor firmware version; see consoleFirmwareVersion."""
+        return self._firmware_versions["left"]
+
+    @pyqtProperty(str, notify=firmwareVersionsChanged)
+    def rightSensorFirmwareVersion(self) -> str:
+        """Right sensor firmware version; see consoleFirmwareVersion."""
+        return self._firmware_versions["right"]
+
     @pyqtProperty(bool, notify=consoleFanChanged)
     def consoleFanOn(self) -> bool:
         """Cached last-set console-fan state (True=on). Reflects the
@@ -1412,6 +1438,11 @@ class MotionConnector(QObject):
             self.signalDisconnected.emit(name, "")
             self._audit.log("device_disconnected",
                             {"device": name, "reason": str(reason)})
+            # Drop the cached firmware version so System Information no
+            # longer reports a stale value for the unplugged device.
+            if name in self._firmware_versions and self._firmware_versions[name]:
+                self._firmware_versions[name] = ""
+                self.firmwareVersionsChanged.emit()
             # Abort an in-flight FPGA flash / sensor-configure pipeline.
             # The SDK does not subscribe to disconnect events for the
             # configure-cameras flow (only start_scan does), so without
@@ -1459,6 +1490,12 @@ class MotionConnector(QObject):
         self._audit.log("device_stats", {
             "device": name, "hardware_id": hwid, "firmware_version": fw,
         })
+        # Cache for the Settings → System Information card. Fired from the
+        # SDK connection-monitor thread; the bound QML rows update via the
+        # queued firmwareVersionsChanged emit.
+        if name in self._firmware_versions:
+            self._firmware_versions[name] = fw
+            self.firmwareVersionsChanged.emit()
 
     def update_state(self):
         """Update system state based on connection and configuration."""

--- a/tests/test_firmware_versions.py
+++ b/tests/test_firmware_versions.py
@@ -1,0 +1,73 @@
+"""Unit tests for per-device firmware version caching in MotionConnector.
+
+The connector caches each device's firmware version on connect (via
+_log_device_stats) and clears it on disconnect, surfacing the values to the
+Settings -> System Information card. These tests mock the hardware seam.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = str(tmp_path / "scans.db")
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface,
+        app_config={"developerMode": False},
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+
+
+def _handle(name, version):
+    h = MagicMock()
+    h.name = name
+    h.get_hardware_id.return_value = "DEADBEEF"
+    h.get_version.return_value = version
+    return h
+
+
+def test_firmware_versions_empty_before_connect(tmp_path):
+    c = _connector(tmp_path)
+    assert c.consoleFirmwareVersion == ""
+    assert c.leftSensorFirmwareVersion == ""
+    assert c.rightSensorFirmwareVersion == ""
+
+
+def test_log_device_stats_caches_version_and_notifies(tmp_path):
+    c = _connector(tmp_path)
+    c._interface.left = _handle("left", "v2.3.4")
+    fired = []
+    c.firmwareVersionsChanged.connect(lambda: fired.append(True))
+
+    c._log_device_stats("left")
+
+    assert c.leftSensorFirmwareVersion == "v2.3.4"
+    assert fired, "firmwareVersionsChanged should fire so QML rebinds"
+
+
+def test_connect_caches_then_disconnect_clears(tmp_path):
+    from omotion import ConnectionState
+    c = _connector(tmp_path)
+    handle = _handle("console", "v1.0.0")
+    # _log_device_stats resolves the handle via getattr(self._interface, name).
+    c._interface.console = handle
+
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.DISCONNECTED, ConnectionState.CONNECTED, "found"
+    )
+    assert c.consoleFirmwareVersion == "v1.0.0"
+
+    c._on_handle_state_changed_impl(
+        handle, ConnectionState.CONNECTED, ConnectionState.DISCONNECTED, "lost"
+    )
+    assert c.consoleFirmwareVersion == ""


### PR DESCRIPTION
## What

Adds a **System Information** card to the bottom of the Settings modal showing the firmware version of each connected device — Console, Left Sensor, and Right Sensor. Each row displays the live `vX.Y.Z` when the device is connected, or a muted **Not connected** otherwise. It sits directly below the existing **About** card (Application / SDK versions).

## How

- **`motion_connector.py`** — caches per-device firmware versions and exposes them to QML:
  - New `firmwareVersionsChanged` signal + three `pyqtProperty` getters: `consoleFirmwareVersion`, `leftSensorFirmwareVersion`, `rightSensorFirmwareVersion`.
  - Populated in the existing `_log_device_stats()` hook, which already runs on every connect and already calls `get_version()` — so **no new device round-trips**. Cleared on disconnect.
- **`components/SettingsModal.qml`** — new `SectionCard` titled "System Information" after the "About" card, with three `FieldRow`s mirroring the existing About-card pattern.
- **`tests/test_firmware_versions.py`** — 3 `unit`-marked tests: empty-before-connect, connect→cache→notify, disconnect→clear.

## Testing

- `pytest tests/test_firmware_versions.py -m unit` → 3 passed.
- `pytest tests/test_audit_connector.py -m unit` (exercises the same `_log_device_stats` path) → 16 passed, no regression.
- Verified visually against live hardware (console + both sensors on FW 1.8.0): the card renders correctly under About, values populate on connect.

> Note: the live Settings UI is `components/SettingsModal.qml`; `pages/Settings.qml` is an unused stub and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)