### PR TITLE
feat: console debug logging toggle in developer panel

### DIFF
--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -884,6 +884,25 @@ Item {
                         Item { Layout.fillWidth: true }
                     }
 
+                    // Console USB-printf debug log — persisted to config AND
+                    // pushed live to a connected console via
+                    // setConsoleDebugLogging. Re-applied on connect (RAM-only
+                    // firmware flag). onToggled (not onCheckedChanged) so the
+                    // appConfig rebind can't feed back into the slot.
+                    FieldRow {
+                        label: "Console debug log"
+                        PillSwitch {
+                            checked: MotionInterface.appConfig.consoleDebugLogging === true
+                            onToggled: MotionInterface.setConsoleDebugLogging(checked)
+                        }
+                        Text {
+                            text: MotionInterface.appConfig.consoleDebugLogging === true ? "On" : "Off"
+                            color: MotionInterface.appConfig.consoleDebugLogging === true ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
                     FieldRow {
                         label: "Save raw CSV"
                         PillSwitch {

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -58,6 +58,7 @@
   "tecTripTempC": 40,
   "powerOffUnusedCameras": true,
   "sensorDebugLogging": false,
+  "consoleDebugLogging": false,
   "histoThrottle": false,
   "histoCmp": true,
   "commVerbose": false,

--- a/main.py
+++ b/main.py
@@ -79,6 +79,7 @@ def _load_app_config() -> dict:
         # (1-60 °C) before any write; see motion_config.ensure_tec_trip.
         "tecTripTempC": 40,
         "sensorDebugLogging": False,
+        "consoleDebugLogging": False,
         "cameraFakeData": False,
         "histoThrottle": False,
         "histoCmp": False,

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -771,6 +771,10 @@ class MotionConnector(QObject):
         self._histo_cmp                   = bool(cfg.get("histoCmp", False))
         self._comm_verbose                = bool(cfg.get("commVerbose", False))
         self._verbose_command_handling    = bool(cfg.get("verboseCommandHandling", False))
+        # Console USB-printf mirror (DEBUG_FLAG_USB_PRINTF). Separate from the
+        # sensor debug flags above — applied to self._interface.console, not the
+        # left/right sensors. See setConsoleDebugLogging.
+        self._console_debug_logging       = bool(cfg.get("consoleDebugLogging", False))
         # Single output root: caller-supplied (from main.py) wins, else
         # dataDirectory from app config, else default (cwd or ~/Documents).
         # All sub-paths (app-logs, scan files, scans.db,
@@ -1257,6 +1261,39 @@ class MotionConnector(QObject):
             logger.error("Error setting console fan: %s", e)
             return False
 
+    @pyqtSlot(bool)
+    def setConsoleDebugLogging(self, on: bool) -> None:
+        """Toggle the console USB-printf debug log (DEBUG_FLAG_USB_PRINTF).
+
+        Persists ``consoleDebugLogging`` and, when the console is connected,
+        pushes the bit live via ``console.enable_usb_printf`` (no restart) —
+        the console analogue of the sensor ``setSensorDebugFlag`` toggles. The
+        firmware flag is RAM-only, so it is also re-applied on every console
+        connect (see the connect handler). When no console is connected the
+        value is still persisted and applies on the next connect. Guarded like
+        ``setConsoleFan`` so a mid-flight disconnect can't raise out of the
+        slot.
+        """
+        on = bool(on)
+        old = self._app_config.get("consoleDebugLogging")
+        self._console_debug_logging = on
+        self._app_config["consoleDebugLogging"] = on
+        self._save_app_config()
+        self.appConfigChanged.emit()
+        if old != on:
+            self._audit.log("settings_changed",
+                            {"changes": {"consoleDebugLogging":
+                                         {"old": old, "new": on}}})
+        if not self._consoleConnected:
+            return
+        try:
+            logger.info("Setting console debug logging %s",
+                        "ON" if on else "OFF")
+            if not self._interface.console.enable_usb_printf(on):
+                logger.warning("Failed to set console debug logging")
+        except Exception as e:  # noqa: BLE001 — slot must not raise
+            logger.error("Error setting console debug logging: %s", e)
+
     @pyqtProperty(bool, notify=laserStateChanged)
     def laserOn(self):
         """Expose Console connection status to QML."""
@@ -1403,6 +1440,14 @@ class MotionConnector(QObject):
                         self.consoleFanChanged.emit()
                     else:
                         logger.error("Failed to set console fan speed")
+                    # Re-apply the console debug-log flag — it is RAM-only on
+                    # the MCU, so it resets across reconnects/power-cycles.
+                    # Default-off needs no action (firmware default is off).
+                    if self._console_debug_logging:
+                        if self._interface.console.enable_usb_printf(True):
+                            logger.info("Console debug logging re-enabled")
+                        else:
+                            logger.error("Failed to re-enable console debug logging")
                     # Apply laser-power params once per console connect —
                     # the FPGA registers are volatile across power cycles,
                     # so every (re)connect needs them. Scans no longer

--- a/tests/test_console_debug_flags.py
+++ b/tests/test_console_debug_flags.py
@@ -1,0 +1,72 @@
+"""Settings → Developer switch for the console debug-logging flag.
+
+``setConsoleDebugLogging`` toggles ``consoleDebugLogging`` in the runtime cache
+and persisted config, then — when the console is connected — pushes the
+``DEBUG_FLAG_USB_PRINTF`` bit live via ``console.enable_usb_printf`` (no
+restart). Mirrors the sensor ``setSensorDebugFlag`` toggles and the live
+``setConsoleFan`` developer toggle.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, app_config=None, console=True):
+    """Build a MotionConnector with a mocked interface.
+
+    ``scan_db_path=None`` makes the audit log a no-op, and we stub
+    ``_save_app_config`` so a toggle never writes the real
+    ``config/app_config.json`` during tests. ``console`` controls whether
+    ``is_device_connected`` reports the console as present.
+    """
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (console, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    iface.console.enable_usb_printf.return_value = True
+    c = MotionConnector(
+        interface=iface, app_config=app_config or {},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+    c._save_app_config = MagicMock()
+    return c, iface
+
+
+def test_enable_persists_cache_config_and_pushes_printf(tmp_path):
+    c, iface = _connector(tmp_path, {"consoleDebugLogging": False})
+
+    c.setConsoleDebugLogging(True)
+
+    assert c._console_debug_logging is True
+    assert c._app_config["consoleDebugLogging"] is True
+    c._save_app_config.assert_called_once()
+    iface.console.enable_usb_printf.assert_called_once_with(True)
+
+
+def test_disable_pushes_printf_false(tmp_path):
+    c, iface = _connector(tmp_path, {"consoleDebugLogging": True})
+
+    c.setConsoleDebugLogging(False)
+
+    assert c._console_debug_logging is False
+    assert c._app_config["consoleDebugLogging"] is False
+    iface.console.enable_usb_printf.assert_called_once_with(False)
+
+
+def test_disconnected_console_persists_without_hardware_call(tmp_path):
+    c, iface = _connector(tmp_path, {"consoleDebugLogging": False}, console=False)
+
+    c.setConsoleDebugLogging(True)
+
+    # Value still persists for the next connect...
+    assert c._console_debug_logging is True
+    assert c._app_config["consoleDebugLogging"] is True
+    c._save_app_config.assert_called_once()
+    # ...but no live push is attempted when the console is absent.
+    iface.console.enable_usb_printf.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a **"Console debug log"** switch to **Settings → Developer** that enables the console's USB-printf logging (`DEBUG_FLAG_USB_PRINTF`), mirroring the existing **"Sensor debug log"** toggle. When on, the console firmware's `printf()` output streams over the USB CDC command link and the SDK surfaces those lines into the app log (same place the sensor debug output lands).

The SDK already supported this end-to-end (`MotionConsole.enable_usb_printf`), so this is purely app-side wiring — no firmware or SDK changes.

## Changes

- **config** — new `consoleDebugLogging` key in `config/app_config.json` **and** `main.py` defaults. The latter is required: `shipped_baseline` filters `app_config.json` to keys present in `defaults`, so a missing default would silently drop the key from the loaded config (binding reads `undefined`).
- **motion_connector.py** — `setConsoleDebugLogging(bool)` slot persists the flag and, when the console is connected, applies it live via `console.enable_usb_printf` (guarded like `setConsoleFan` so a mid-flight disconnect can't raise out of the slot). Re-applied on every console connect, since the RAM-only firmware flag resets across reconnects/power-cycles.
- **components/SettingsModal.qml** — `PillSwitch` row placed directly next to "Sensor debug log". Persists while offline and applies on connect (not gated on connection), matching the sensor toggle.
- **tests/test_console_debug_flags.py** — unit coverage for the enable / disable / disconnected-persist paths (mirrors `test_sensor_debug_flags.py`).

## Behavior

Flip it on → console `printf()` mirrors into `<dataDirectory>/app-logs/ow-bloodflowapp-*.log` live, no restart. Flip it off → it stops. Persists to config and re-applies on the next console reconnect.

## Testing

- TDD (RED→GREEN) on the slot; full `-m unit` suite passes (315 passed; the only 2 failures are pre-existing in `test_app_config_defaults.py`, unrelated — confirmed by stashing this change).
- Launched from source against live hardware: app starts clean with no QML errors, Developer panel renders the new toggle next to "Sensor debug log".

## Base branch

Targets `next-next` (this branch was cut from it; a clean single-commit diff). Retarget to `next` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)