### PR TITLE
fix: replay past scans with their recorded camera config (#175)

### DIFF
--- a/data_sources.py
+++ b/data_sources.py
@@ -950,6 +950,48 @@ def _derive_reduced_from_buffers(buffers) -> int:
     return -1
 
 
+def _masks_from_flags(flags) -> Optional[tuple[int, int]]:
+    """Authoritative (left_mask, right_mask) from a scan's stored
+    ``session_meta.sdk_flags`` (written by the SDK's ScanDBSink at scan start),
+    or None when the flags don't carry a usable per-side mask pair.
+
+    This is the configuration the scan was actually RUN with — preferred over
+    _derive_masks_from_buffers, which only reconstructs the cameras that
+    happened to log data and so under-represents a config whose outer cameras
+    recorded nothing (issue #175 reopen). Returns None — caller falls back to
+    the derived heuristic — when ``flags`` isn't a dict, either mask key is
+    missing/non-int, or BOTH masks are 0 (no real scan configures zero
+    cameras; mirrors _derive_masks_from_buffers' both-zero "unknown")."""
+    if not isinstance(flags, dict):
+        return None
+    lm = flags.get("left_camera_mask")
+    rm = flags.get("right_camera_mask")
+    # bool is an int subclass; a mask is never a bool, so reject it explicitly.
+    if not isinstance(lm, int) or isinstance(lm, bool):
+        return None
+    if not isinstance(rm, int) or isinstance(rm, bool):
+        return None
+    lm &= 0xFF
+    rm &= 0xFF
+    if lm == 0 and rm == 0:
+        return None
+    return lm, rm
+
+
+def _reduced_from_flags(flags) -> Optional[int]:
+    """Recorded display mode (0 per-camera / 1 reduced) from a scan's stored
+    ``session_meta.sdk_flags.reduced_mode``, or None when absent. Preferred
+    over _derive_reduced_from_buffers for the same reason as _masks_from_flags
+    — it reflects how the scan was captured, not what its data happens to
+    contain (issue #175 reopen)."""
+    if not isinstance(flags, dict):
+        return None
+    rv = flags.get("reduced_mode")
+    if rv is None:
+        return None
+    return 1 if rv else 0
+
+
 def load_past_scan_buffers(
     scan_db,
     session_id: int,
@@ -994,6 +1036,7 @@ class PastScanSource(ScanDataSource):
         corrected_csv_path: Optional[str] = None,
         parent: Optional[QObject] = None,
         preloaded_buffers: Optional[dict] = None,
+        recorded_flags: Optional[dict] = None,
     ) -> None:
         # Unbounded buffers: a past scan is a finite, already-known result set
         # loaded in bulk (DB rows and/or the corrected CSV). With a finite
@@ -1014,8 +1057,21 @@ class PastScanSource(ScanDataSource):
             )
 
         # Lay the plot grid out from THIS scan's recorded cameras, not the
-        # operator's live selection (issue #175).
+        # operator's live selection (issue #175). Prefer the authoritative
+        # config the scan was RUN with — stored in session_meta.sdk_flags by
+        # the SDK's ScanDBSink and threaded in as recorded_flags — over the
+        # data-derived heuristic below. Deriving from data alone collapses a
+        # config whose outer cameras logged nothing: an All/All scan where only
+        # the middle cameras produced rows would render a Middle grid, hiding
+        # the configured-but-empty cameras (issue #175 reopen). Fall back to
+        # the heuristic for older scans whose meta predates these flags.
         self._left_mask, self._right_mask = _derive_masks_from_buffers(
             self.buffers
         )
         self._reduced_mode = _derive_reduced_from_buffers(self.buffers)
+        recorded_masks = _masks_from_flags(recorded_flags)
+        if recorded_masks is not None:
+            self._left_mask, self._right_mask = recorded_masks
+        recorded_reduced = _reduced_from_flags(recorded_flags)
+        if recorded_reduced is not None:
+            self._reduced_mode = recorded_reduced

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -99,6 +99,29 @@ def _config_name(mask) -> str:
     return _CONFIG_NAMES.get(m, f"0x{m:02X}")
 
 
+def _sdk_flags_from_session(session) -> Optional[dict]:
+    """Pull the ``sdk_flags`` block out of a ScanDatabase session dict's
+    ``session_meta`` (the camera config / reduced-mode the scan was RUN with,
+    written by the SDK's ScanDBSink). Returns None when absent or unparseable.
+
+    ScanDatabase already json-decodes session_meta into a dict, but tolerate a
+    raw JSON string too — the same defensive parse the History list uses
+    (_session_to_row). Used to lay a replayed scan's plot grid out from its
+    recorded config rather than only the cameras that logged data (#175)."""
+    if not isinstance(session, dict):
+        return None
+    meta = session.get("session_meta")
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except Exception:
+            return None
+    if not isinstance(meta, dict):
+        return None
+    flags = meta.get("sdk_flags")
+    return flags if isinstance(flags, dict) else None
+
+
 logger = logging.getLogger("openmotion.bloodflow-app.connector")
 
 # Define system states
@@ -607,8 +630,12 @@ class MotionConnector(QObject):
     # to clear its busy overlay and close only on success (issue #152).
     pastScanLoadFinished = pyqtSignal(str, bool)
     # Private worker→main marshalling for loadPastScan results:
-    # (seq, session_label, session_id, buffers-or-None, source_tag)
-    _pastScanBuffersReady = pyqtSignal(int, str, int, object, str)
+    # (seq, session_label, session_id, buffers-or-None, source_tag,
+    #  recorded_flags-or-None). recorded_flags is the scan's stored
+    # session_meta.sdk_flags so the PastScanSource lays its grid out from the
+    # config the scan was RUN with, not just the cameras that logged data
+    # (issue #175 reopen).
+    _pastScanBuffersReady = pyqtSignal(int, str, int, object, str, object)
     # Worker->main: interrupted/empty-scan outcome toast (message, severity).
     # Emitted from _on_pipeline_complete (pipeline worker thread); delivered
     # on the GUI thread via the auto-queued connection wired in connect_signals.
@@ -2418,10 +2445,16 @@ class MotionConnector(QObject):
                         session_label,
                     )
                     self._pastScanBuffersReady.emit(
-                        seq, session_label, -1, None, ""
+                        seq, session_label, -1, None, "", None
                     )
                     return
                 session_id = int(session["id"])
+                # The camera config the scan was RUN with lives in
+                # session_meta.sdk_flags (written by ScanDBSink). Thread it to
+                # the GUI thread so PastScanSource lays its grid out from the
+                # recorded config, not just the cameras that logged data
+                # (issue #175 reopen). Same parse the History list uses.
+                recorded_flags = _sdk_flags_from_session(session)
                 buffers, _ = load_past_scan_buffers(
                     db, session_id, corrected_csv
                 )
@@ -2436,11 +2469,14 @@ class MotionConnector(QObject):
                 else ("csv" if corrected_csv else "db-only-sentinel")
             )
             self._pastScanBuffersReady.emit(
-                seq, session_label, session_id, buffers, source_tag
+                seq, session_label, session_id, buffers, source_tag,
+                recorded_flags,
             )
         except Exception:
             logger.exception("loadPastScan failed for label %r", session_label)
-            self._pastScanBuffersReady.emit(seq, session_label, -1, None, "")
+            self._pastScanBuffersReady.emit(
+                seq, session_label, -1, None, "", None
+            )
 
     @pyqtSlot(str, str)
     def _on_scan_outcome_warning(self, message: str, severity: str) -> None:
@@ -2456,6 +2492,7 @@ class MotionConnector(QObject):
         session_id: int,
         buffers,
         source_tag: str,
+        recorded_flags=None,
     ) -> None:
         """GUI thread: bind a worker-loaded past scan to the viewer.
         Results from a superseded request (user clicked another scan
@@ -2491,6 +2528,7 @@ class MotionConnector(QObject):
                 session_id=session_id,
                 parent=self,
                 preloaded_buffers=buffers,
+                recorded_flags=recorded_flags,
             )
             self._set_current_scan_source(past)
             # Diagnostic — left in for now so we can spot regressions
@@ -2498,11 +2536,23 @@ class MotionConnector(QObject):
             n_buffers = len(past.buffers)
             n_samples = sum(b.n for b in past.buffers.values())
             sample_keys = sorted(past.buffers.keys())[:8]
+            # Grid masks are what the viewer actually lays out from; log them
+            # next to the data shape so a config/data mismatch (issue #175) is
+            # diagnosable from one line. flags=no means an older scan with no
+            # stored sdk_flags (masks derived from data instead). -1 prints as
+            # "unknown" (viewer falls back to the live selection).
+            def _mstr(v):
+                return f"0x{v & 0xFF:02X}" if v >= 0 else "unknown"
             logger.info(
                 "[Plot] loaded past scan %r (session_id=%d) source=%s: "
-                "buffers=%d samples=%d liveEdge=%.3f sample_keys=%s",
+                "buffers=%d samples=%d liveEdge=%.3f gridMasks=L%s/R%s "
+                "reduced=%d flags=%s sample_keys=%s",
                 session_label, session_id, source_tag,
-                n_buffers, n_samples, past.liveEdge, sample_keys,
+                n_buffers, n_samples, past.liveEdge,
+                _mstr(past.leftMask), _mstr(past.rightMask),
+                past.reducedMode,
+                "yes" if recorded_flags else "no",
+                sample_keys,
             )
             self.pastScanLoadFinished.emit(session_label, True)
         except Exception:

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -722,6 +722,128 @@ def test_live_scan_source_reduced_mode_unknown():
     assert src.reducedMode == -1
 
 
+# ── Issue #175 reopen — stored config wins over the data-derived heuristic ──
+# Deriving the replay grid from which cameras produced data under-represents a
+# scan whose outer cameras recorded nothing: an All/All scan where only the
+# middle four cameras logged rows collapses to a Middle grid. The camera config
+# the scan was actually RUN with is persisted in session_meta.sdk_flags
+# (left_camera_mask / right_camera_mask / reduced_mode) by the SDK's ScanDBSink
+# and already drives the History list. PastScanSource must prefer those stored
+# flags, falling back to the derive-from-buffers heuristic only for older scans
+# whose meta predates them.
+
+
+def _middle_four_buffers():
+    """Buffers for the middle-4 cams per side (camIds 1,2,5,6 → 0x66), the
+    data pattern an All/All scan logged when only the middle cameras had
+    usable data (the issue #175 reopen repro)."""
+    buffers = {}
+    for side in ("left", "right"):
+        for cam_id in (1, 2, 5, 6):
+            buf = _CameraBuffer(max_capacity=None)
+            buf.append(t=0.0, v=1.0, frame_id=0)
+            buffers[(side, cam_id, "bfi")] = buf
+    return buffers
+
+
+def test_recorded_flags_masks_override_derived_masks():
+    """The bug: middle-4 data but the scan ran All/All. The stored masks
+    (0xFF/0xFF) must win over the derived Middle masks (0x66)."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        recorded_flags={
+            "left_camera_mask": 0xFF,
+            "right_camera_mask": 0xFF,
+            "reduced_mode": False,
+        },
+    )
+    assert src.leftMask == 0xFF
+    assert src.rightMask == 0xFF
+
+
+def test_recorded_flags_honor_one_sided_config():
+    """A right-only scan (left mask 0) is preserved from the stored flags
+    even though both sides' data happens to be present."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        recorded_flags={
+            "left_camera_mask": 0x00,
+            "right_camera_mask": 0xFF,
+            "reduced_mode": False,
+        },
+    )
+    assert src.leftMask == 0x00
+    assert src.rightMask == 0xFF
+
+
+def test_recorded_flags_reduced_mode_overrides_derived():
+    """Stored reduced_mode=True yields reducedMode==1 even though the
+    per-camera buffers would derive 0 (per-camera)."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        recorded_flags={
+            "left_camera_mask": 0xFF,
+            "right_camera_mask": 0xFF,
+            "reduced_mode": True,
+        },
+    )
+    assert src.reducedMode == 1
+
+
+def test_missing_recorded_flags_falls_back_to_derived():
+    """Older scans pass no flags (None) — the derive-from-buffers heuristic
+    still applies, preserving backward compatibility."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        recorded_flags=None,
+    )
+    assert src.leftMask == 0x66
+    assert src.rightMask == 0x66
+    assert src.reducedMode == 0
+
+
+def test_partial_recorded_flags_derive_only_the_missing_field():
+    """Flags present but without mask keys → masks derive; a present
+    reduced_mode is still honored. Mixed-vintage / partially-written meta."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        recorded_flags={"reduced_mode": False},
+    )
+    # No mask keys → fall back to derived Middle.
+    assert src.leftMask == 0x66
+    assert src.rightMask == 0x66
+    # reduced_mode present → honored (0 = per-camera).
+    assert src.reducedMode == 0
+
+
+def test_recorded_flags_both_masks_zero_falls_back_to_derived():
+    """Degenerate stored masks (both 0 — no real scan configures zero
+    cameras) fall back to the derived config rather than render an empty
+    grid, mirroring _derive_masks_from_buffers' own both-zero convention."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        recorded_flags={
+            "left_camera_mask": 0,
+            "right_camera_mask": 0,
+            "reduced_mode": False,
+        },
+    )
+    assert src.leftMask == 0x66
+    assert src.rightMask == 0x66
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # currentScanSource holder pattern — verified via a parallel mini-class
 # (MotionConnector uses the same pattern; see motion_connector.py)

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from motion_connector import MotionConnector, _config_name
+from motion_connector import (
+    MotionConnector,
+    _config_name,
+    _sdk_flags_from_session,
+)
+from data_sources import _CameraBuffer
 from omotion.ScanDatabase import ScanDatabase
 
 pytestmark = pytest.mark.unit
@@ -161,3 +166,78 @@ def test_stats_and_delete_without_db_are_safe(tmp_path):
     c = _connector(tmp_path, None)
     assert c.get_session_stats(1) == {"sampleCount": 0}
     assert c.deleteScans([1, 2]) == 0
+
+
+# ── Issue #175 reopen — replay uses the recorded config, not the data shape ──
+# The History list already reads sdk_flags; the plot viewer must too. These
+# cover the connector wiring: extracting sdk_flags from the session row, then
+# threading it into the PastScanSource the viewer binds to.
+
+
+def test_sdk_flags_from_session_reads_meta_block(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260101_000000_subjA", 100.0, 110.0,
+                  left_mask=0xFF, right_mask=0xC3, reduced=False)
+    db = ScanDatabase(db_path=db_path)
+    try:
+        session = db.get_session_by_label("20260101_000000_subjA")
+    finally:
+        db.close()
+    flags = _sdk_flags_from_session(session)
+    assert flags["left_camera_mask"] == 0xFF
+    assert flags["right_camera_mask"] == 0xC3
+    assert flags["reduced_mode"] is False
+
+
+def test_sdk_flags_from_session_none_when_absent_or_unparseable():
+    import json as _json
+    assert _sdk_flags_from_session(None) is None
+    assert _sdk_flags_from_session({}) is None
+    assert _sdk_flags_from_session({"session_meta": {}}) is None
+    assert _sdk_flags_from_session({"session_meta": "not json"}) is None
+    # A raw JSON string for session_meta is tolerated and parsed.
+    raw = {"session_meta": _json.dumps(
+        {"sdk_flags": {"left_camera_mask": 0x09, "right_camera_mask": 0x09}})}
+    assert _sdk_flags_from_session(raw)["left_camera_mask"] == 0x09
+
+
+def _middle_four_buffers():
+    """middle-4 cams per side (camIds 1,2,5,6 → derived mask 0x66)."""
+    buffers = {}
+    for side in ("left", "right"):
+        for cam_id in (1, 2, 5, 6):
+            buf = _CameraBuffer(max_capacity=None)
+            buf.append(t=0.0, v=1.0, frame_id=0)
+            buffers[(side, cam_id, "bfi")] = buf
+    return buffers
+
+
+def test_load_past_scan_slot_lays_grid_from_recorded_config(tmp_path):
+    """The GUI-thread slot must thread the scan's recorded sdk_flags into the
+    PastScanSource so an All/All scan whose data is only middle-4 still reports
+    All/All masks — the viewer then renders all 16 configured cells."""
+    c = _connector(tmp_path, str(tmp_path / "scans.db"))
+    c._on_past_scan_buffers_ready(
+        c._past_scan_load_seq, "20260101_000000_subjA", 1,
+        _middle_four_buffers(), "db",
+        {"left_camera_mask": 0xFF, "right_camera_mask": 0xFF,
+         "reduced_mode": False},
+    )
+    src = c.currentScanSource
+    assert src is not None
+    assert src.leftMask == 0xFF
+    assert src.rightMask == 0xFF
+
+
+def test_load_past_scan_slot_without_flags_falls_back_to_derived(tmp_path):
+    """Older scans deliver no flags (None) — the slot still binds a source,
+    derived from the data (backward compatibility)."""
+    c = _connector(tmp_path, str(tmp_path / "scans.db"))
+    c._on_past_scan_buffers_ready(
+        c._past_scan_load_seq, "20260101_000000_subjA", 1,
+        _middle_four_buffers(), "db", None,
+    )
+    src = c.currentScanSource
+    assert src is not None
+    assert src.leftMask == 0x66
+    assert src.rightMask == 0x66


### PR DESCRIPTION
## Issue

Fixes the reopened [#175](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/issues/175): viewing a scan recorded with All/All only populates the Middle-camera plots.

## Root cause

`PastScanSource` laid the replay grid out by deriving its camera masks from **which cameras logged data** (`_derive_masks_from_buffers`). That under-represents a scan whose outer cameras recorded nothing: an All/All scan where only the middle four cameras produced rows collapses to a Middle grid.

The config the scan was actually **run** with is already persisted by the SDK's `ScanDBSink` in `session_meta.sdk_flags` (`left_camera_mask` / `right_camera_mask` / `reduced_mode`) — and the **History list already reads it**. So History showed All/All while the plot showed Middle. That inconsistency is the bug.

The reporter's log confirms it: `session_id=3` loaded `buffers=32` with cam_ids 1,2,5,6 per side (Middle pattern, `0x66`) for a scan History lists as All/All.

## Fix (app-only — the SDK already stores the data)

- `PastScanSource` now **prefers the stored `sdk_flags`** (`recorded_flags`) over the data-derived heuristic, falling back to derivation only for older scans whose meta predates the flags.
- The flags are threaded from the load worker (`_load_past_scan_worker`) through the `_pastScanBuffersReady` signal into the GUI-thread slot and on to `PastScanSource`.
- The past-scan load diagnostic now logs the resolved `gridMasks` + flag presence, so a future config/data mismatch is visible from one log line.

Net effect: an All/All scan renders all 16 configured cells, populated where data exists — matching the issue's expected behavior and the History list. No QML change needed (the viewer already prefers `scanSource` masks; covered by `test_plot_viewer_masks.py`).

## Tests

- `test_data_sources.py` — RED→GREEN: `PastScanSource` honors `recorded_flags` over derived masks (incl. one-sided, reduced-mode, partial/absent/degenerate-zero fallbacks).
- `test_history_sessions.py` — `_sdk_flags_from_session` extraction + the GUI-thread slot threading flags into the source (mutation-verified to catch a regression).
- **Full unit suite: 317 passed, 0 failed.**

## Hand-test to confirm

Load the All/All scan that reproduced the bug in a build with this change — it should now show all 16 cells (outer cells empty if they recorded no data). The new `[Plot] loaded past scan ... gridMasks=L0xFF/R0xFF ... flags=yes` log line confirms the resolved config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)