### PR TITLE
fix: installed app data dir → %PROGRAMDATA%\Openwater + stage RUO config in installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Get-ChildItem C:\Users\ethan\Projects\scan_data\app-logs\ow-bloodflowapp-*.log |
   Get-Content | Select-String -Pattern "Calibration phase|procedure complete|samples captured"
 ```
 
-The `dataDirectory` config key controls the root (defaults to cwd if unset — falls back to `~/Documents/OpenWater Bloodflow` on macOS). Sibling output directories under the same root:
+The `dataDirectory` config key controls the root (defaults to cwd if unset — falls back to `~/Documents/Openwater Bloodflow` on macOS). Sibling output directories under the same root:
 - `app-logs/` — app log files (one per launch)
 - `app-logs/ft-test-csvs/` — factory-test CSVs
 - `calibrations/` — saved calibration JSONs (also written here)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Both directories live under a single root, chosen in this order:
 
 1. `dataDirectory` from `config/app_config.json` (also settable from the UI directory picker)
 2. The current working directory, when writable
-3. `~/Documents/OpenWater Bloodflow/` as a last-resort fallback (e.g. when the .app is launched from Finder on macOS and cwd is `/`)
+3. `~/Documents/Openwater Bloodflow/` as a last-resort fallback (e.g. when the .app is launched from Finder on macOS and cwd is `/`)
 
 ## Configuration
 

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -67,6 +67,25 @@ if (-not (Test-Path (Join-Path $DistAbs 'OpenWaterApp.exe'))) {
     throw "OpenWaterApp.exe not found under $DistAbs; PyInstaller build looks incomplete"
 }
 
+# -- stage the per-variant UI mode into the harvested config --
+# The MSI harvests dist\OpenWaterApp as-is, so clinical/RUO must be written
+# into the bundled config BEFORE wix runs. Mirrors build_and_zip.ps1's _RUO
+# flip: clinical keeps reducedMode=true (reduced clinical UI), RUO sets it
+# false (full research UI). We set it explicitly per variant so repeated
+# builds against one dist are always correct regardless of prior state.
+# Write UTF-8 *without* BOM — the app's json.load fails silently on a BOM and
+# falls back to defaults.
+$cfgPath = Join-Path $DistAbs "_internal\config\app_config.json"
+if (-not (Test-Path $cfgPath)) { throw "bundled config not found at $cfgPath" }
+$reduced = if ($Variant -eq "ruo") { "false" } else { "true" }
+$cfgText = [System.IO.File]::ReadAllText($cfgPath)
+if ($cfgText -notmatch '"reducedMode"\s*:\s*(true|false)') {
+    throw "reducedMode key not found in $cfgPath"
+}
+$cfgText = [regex]::Replace($cfgText, '("reducedMode"\s*:\s*)(true|false)', "`${1}$reduced")
+[System.IO.File]::WriteAllText($cfgPath, $cfgText, (New-Object System.Text.UTF8Encoding $false))
+Write-Host "Staged reducedMode=$reduced into bundled config" -ForegroundColor Green
+
 wix build installer\app.wxs -o $appMsi `
     -d "ProductName=$($g.ProductName)" `
     -d "Version=$version" `

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -19,6 +19,7 @@ import threading
 import json
 import csv
 import os
+import sys
 import datetime
 import time
 import random
@@ -807,16 +808,24 @@ class MotionConnector(QObject):
     def _default_data_dir() -> str:
         """Return a writable directory for logs and scan data.
 
-        Uses the current working directory when it is writable (typical
-        for development runs).  When cwd is read-only — e.g. ``/`` on
-        macOS when the .app bundle is launched from Finder — falls back
-        to ``~/Documents/OpenWater Bloodflow``.
+        Mirrors ``main.py``: an installed (frozen) build writes under
+        ``%PROGRAMDATA%\\Openwater`` via :func:`app_paths.writable_root` —
+        the same root ``main.py`` uses for logs — instead of the read-only
+        Program Files install dir.  A dev run uses the current working
+        directory when it is writable, falling back to
+        ``~/Documents/Openwater Bloodflow`` when it is not (e.g. ``/`` on a
+        macOS Finder launch).
         """
-        cwd = os.getcwd()
-        if os.access(cwd, os.W_OK):
-            return cwd
+        from utils import app_paths
+        candidate = (
+            str(app_paths.writable_root())
+            if getattr(sys, "frozen", False)
+            else os.getcwd()
+        )
+        if os.access(candidate, os.W_OK):
+            return candidate
         return os.path.join(
-            os.path.expanduser("~"), "Documents", "OpenWater Bloodflow"
+            os.path.expanduser("~"), "Documents", "Openwater Bloodflow"
         )
 
     def __init__(

--- a/tests/hil_helpers.py
+++ b/tests/hil_helpers.py
@@ -258,7 +258,7 @@ def find_app_log() -> Path | None:
     roots = [
         Path.cwd(),
         project_root,  # when launched via OPENWATER_FROM_SOURCE
-        home / "Documents" / "OpenWater Bloodflow",
+        home / "Documents" / "Openwater Bloodflow",
         home / "Documents" / "OpenMotion",
     ]
     candidates: list[Path] = []

--- a/tests/test_default_data_dir.py
+++ b/tests/test_default_data_dir.py
@@ -1,0 +1,54 @@
+"""Unit tests for MotionConnector._default_data_dir().
+
+The installed (frozen) build must write scan data + scans.db to the same
+writable %PROGRAMDATA%\\Openwater root that main.py uses for logs, instead of
+the (read-only) Program Files install dir. Dev runs stay on the cwd.
+"""
+import os
+
+import pytest
+
+from utils import app_paths
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def test_frozen_build_uses_writable_root(monkeypatch, tmp_path):
+    """An installed build resolves to app_paths.writable_root() (ProgramData),
+    not the cwd (the read-only Program Files install dir)."""
+    import sys
+    program_data = tmp_path / "ProgramData_Openwater"
+    program_data.mkdir()
+    install_dir = tmp_path / "install_dir"
+    install_dir.mkdir()
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(app_paths, "writable_root", lambda: program_data)
+    monkeypatch.chdir(install_dir)  # cwd is the install dir; must be ignored
+
+    assert MotionConnector._default_data_dir() == str(program_data)
+
+
+def test_dev_run_uses_cwd_when_writable(monkeypatch, tmp_path):
+    """A dev (non-frozen) run keeps everything under the writable cwd."""
+    import sys
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert MotionConnector._default_data_dir() == str(tmp_path)
+
+
+def test_falls_back_to_documents_when_cwd_unwritable(monkeypatch):
+    """When the cwd is read-only (e.g. "/" on a macOS Finder launch) the dev
+    fallback is ~/Documents/Openwater Bloodflow — note the "Openwater" casing."""
+    import sys
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setattr(os, "access", lambda path, mode: False)
+
+    result = MotionConnector._default_data_dir()
+
+    expected = os.path.join(
+        os.path.expanduser("~"), "Documents", "Openwater Bloodflow"
+    )
+    assert result == expected
+    assert "OpenWater" not in result  # casing must be "Openwater"


### PR DESCRIPTION
## What

Two related installer-correctness fixes.

### 1. Installed app writes data to `%PROGRAMDATA%\Openwater` (not Program Files)
`MotionConnector._default_data_dir()` returned the cwd, so a frozen/installed build wrote scan data + `scans.db` into the read-only Program Files install dir (admin) or `~/Documents/OpenWater Bloodflow` (standard user) — diverging from `main.py`, which already routed **logs** to `%PROGRAMDATA%\Openwater` via `app_paths.writable_root()`. Now logs and scan data share one writable root. Also fixes the `OpenWater` → `Openwater` casing in the dev fallback (+ `hil_helpers.py`, docs).

### 2. Installer stages `reducedMode` per variant
`build_installer.ps1` harvested `dist\OpenWaterApp` as-is, so `-Variant ruo` produced a relabeled *clinical* app (`reducedMode` still `true`). It now writes the per-variant UI mode into the bundled config before `wix` runs — clinical=`true`, RUO=`false` — mirroring `build_and_zip.ps1`'s `_RUO` flip. Written UTF-8 **without a BOM** (the app's `json.load` silently falls back to defaults on a BOM).

## Testing
- **Unit:** 3 new tests in `tests/test_default_data_dir.py` (frozen→ProgramData, dev→cwd, unwritable→`~/Documents/Openwater Bloodflow`) — green.
- **Installer:** built both variants via the script; verified the staging forces the correct `reducedMode` in **both** directions and writes no BOM.
- **End-to-end:** launched the frozen exe; the log confirmed `Data directory: C:\ProgramData\Openwater` and `[Connector] Directory initialized to: C:\ProgramData\Openwater`, with no writes to the install dir.

## Notes
- Installers built locally are **unsigned** (no `CODESIGN_THUMBPRINT`); the signing path is unchanged.
- Built against SDK `next-next` — the app imports `omotion.firmware_update`, which exists only on `next-next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)