### PR TITLE
feat: show a "Viewing" badge naming the replayed scan in the plot viewer

### DIFF
--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -966,6 +966,67 @@ Rectangle {
         }
     }
 
+    // ── Top-center overlay: "Viewing" scan badge (issue #245) ──────────
+    // Names the replayed past scan so it's always clear which scan the plots
+    // show. Past-scan only — hidden during live monitoring (live is the
+    // implied default) and when nothing is loaded. The source carries the
+    // identity (userLabel/dateTime), derived from the same session row the
+    // History list renders, so the badge can't disagree with the clicked row.
+    readonly property string _scanBadgeLabel:
+        (viewer.scanSource && viewer.scanSource.userLabel) || ""
+    readonly property string _scanBadgeDate: {
+        var d = (viewer.scanSource && viewer.scanSource.dateTime) || ""
+        // Trim "YYYY-MM-DD HH:MM:SS" → "YYYY-MM-DD HH:MM" for a tighter badge.
+        return d.length >= 16 ? d.substring(0, 16) : d
+    }
+    readonly property string _scanBadgeText:
+        viewer._scanBadgeLabel.length > 0
+            ? (viewer._scanBadgeLabel + " · " + viewer._scanBadgeDate)
+            : viewer._scanBadgeDate
+    readonly property bool _showScanBadge:
+        viewer.scanSource !== null
+        && viewer.scanSource.live === false
+        && viewer._scanBadgeText.length > 0
+
+    Rectangle {
+        id: scanBadge
+        // No MouseArea: a bare Rectangle doesn't consume pointer events, so
+        // plot interaction beneath the badge passes straight through (same
+        // as the profiler HUD overlay).
+        visible: viewer._showScanBadge
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: viewer._overlayEdgeMarginPx
+        z: 6
+        width: scanBadgeRow.implicitWidth + 28
+        height: 36
+        radius: 18
+        color: theme.overlayBg
+        border.color: theme.borderSubtle
+        border.width: 1
+
+        Row {
+            id: scanBadgeRow
+            anchors.centerIn: parent
+            spacing: 8
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: "Viewing"
+                color: theme.textTertiary
+                font.pixelSize: 12
+                font.family: "Roboto Mono"
+            }
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: viewer._scanBadgeText
+                color: theme.textPrimary
+                font.pixelSize: 13
+                font.weight: Font.DemiBold
+                font.family: "Roboto Mono"
+            }
+        }
+    }
+
     // ── Bottom-right overlay: window-seconds pill + three-dot menu ────
     // Window-seconds pill shows the current zoom and opens a dropdown
     // menu of the canonical zoom options when clicked. The three-dot

--- a/data_sources.py
+++ b/data_sources.py
@@ -273,6 +273,12 @@ class ScanDataSource(QObject):
         # reduced. -1 for live sources (viewer follows the live config);
         # PastScanSource derives the real value from its buffer layout.
         self._reduced_mode: int = -1
+        # Human-readable identity for the viewer's "Viewing" badge (issue
+        # #245): the operator's user label and the scan's date/time. Empty
+        # on live sources — the badge is past-scan only. PastScanSource sets
+        # these from the same session row the History list shows.
+        self._user_label: str = ""
+        self._date_time: str = ""
         self.buffers: dict[tuple[str, int, str], _CameraBuffer] = {}
         # Ring-trim threshold for buffers this source creates. Live sources
         # pass a finite value (config) to bound memory; past sources pass None
@@ -327,6 +333,21 @@ class ScanDataSource(QObject):
         so a replayed scan renders in its own mode rather than the live config.
         See ``leftMask`` for why this must be a pyqtProperty."""
         return self._reduced_mode
+
+    @pyqtProperty(str, constant=True)
+    def userLabel(self) -> str:
+        """Operator-entered label for the viewer's "Viewing" badge (issue
+        #245), or "" when none (live sources, unlabeled scans). Exposed as a
+        ``pyqtProperty`` so QML can read it; ``constant=True`` since it's set
+        once at construction. See ``leftMask`` for the plain-attribute caveat."""
+        return self._user_label
+
+    @pyqtProperty(str, constant=True)
+    def dateTime(self) -> str:
+        """The scan's date/time for the viewer badge (issue #245), formatted
+        as ``YYYY-MM-DD HH:MM:SS`` like the History list; "" when unknown. The
+        viewer trims it to minutes for display. See ``userLabel``."""
+        return self._date_time
 
     @pyqtProperty(float)
     def liveEdge(self) -> float:
@@ -1037,6 +1058,8 @@ class PastScanSource(ScanDataSource):
         parent: Optional[QObject] = None,
         preloaded_buffers: Optional[dict] = None,
         recorded_flags: Optional[dict] = None,
+        user_label: str = "",
+        date_time: str = "",
     ) -> None:
         # Unbounded buffers: a past scan is a finite, already-known result set
         # loaded in bulk (DB rows and/or the corrected CSV). With a finite
@@ -1045,6 +1068,10 @@ class PastScanSource(ScanDataSource):
         super().__init__(plot_t0=0.0, parent=parent, buffer_max_capacity=None)
         self._live = False
         self.session_id = int(session_id)
+        # Viewer "Viewing" badge identity (issue #245). Coerced to str so a
+        # stray None from the meta lookup can't reach QML as `undefined`.
+        self._user_label = str(user_label or "")
+        self._date_time = str(date_time or "")
 
         if preloaded_buffers is not None:
             # Already bulk-loaded on a worker thread — adopt as-is.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -631,11 +631,14 @@ class MotionConnector(QObject):
     pastScanLoadFinished = pyqtSignal(str, bool)
     # Private worker→main marshalling for loadPastScan results:
     # (seq, session_label, session_id, buffers-or-None, source_tag,
-    #  recorded_flags-or-None). recorded_flags is the scan's stored
-    # session_meta.sdk_flags so the PastScanSource lays its grid out from the
-    # config the scan was RUN with, not just the cameras that logged data
-    # (issue #175 reopen).
-    _pastScanBuffersReady = pyqtSignal(int, str, int, object, str, object)
+    #  recorded_flags-or-None, display_meta-or-None). recorded_flags is the
+    # scan's stored session_meta.sdk_flags so the PastScanSource lays its grid
+    # out from the config the scan was RUN with, not just the cameras that
+    # logged data (issue #175 reopen). display_meta is {userLabel, dateTime}
+    # for the viewer's "Viewing" badge (issue #245), derived from the same
+    # session row the History list shows.
+    _pastScanBuffersReady = pyqtSignal(
+        int, str, int, object, str, object, object)
     # Worker->main: interrupted/empty-scan outcome toast (message, severity).
     # Emitted from _on_pipeline_complete (pipeline worker thread); delivered
     # on the GUI thread via the auto-queued connection wired in connect_signals.
@@ -2445,7 +2448,7 @@ class MotionConnector(QObject):
                         session_label,
                     )
                     self._pastScanBuffersReady.emit(
-                        seq, session_label, -1, None, "", None
+                        seq, session_label, -1, None, "", None, None
                     )
                     return
                 session_id = int(session["id"])
@@ -2455,6 +2458,24 @@ class MotionConnector(QObject):
                 # recorded config, not just the cameras that logged data
                 # (issue #175 reopen). Same parse the History list uses.
                 recorded_flags = _sdk_flags_from_session(session)
+                # The viewer's "Viewing" badge (issue #245) names the scan with
+                # the user label + date/time. Derive them from the SAME row the
+                # History list renders (_session_to_row prefers subject_id over
+                # the label suffix) so the badge can't disagree with the row the
+                # user clicked. Best-effort: a parse failure just hides the
+                # badge — it must never block the load.
+                display_meta = None
+                try:
+                    row = self._session_to_row(session)
+                    display_meta = {
+                        "userLabel": row["userLabel"],
+                        "dateTime": row["dateTime"],
+                    }
+                except Exception:
+                    logger.warning(
+                        "loadPastScan: could not derive badge meta for %r",
+                        session_label, exc_info=True,
+                    )
                 buffers, _ = load_past_scan_buffers(
                     db, session_id, corrected_csv
                 )
@@ -2470,12 +2491,12 @@ class MotionConnector(QObject):
             )
             self._pastScanBuffersReady.emit(
                 seq, session_label, session_id, buffers, source_tag,
-                recorded_flags,
+                recorded_flags, display_meta,
             )
         except Exception:
             logger.exception("loadPastScan failed for label %r", session_label)
             self._pastScanBuffersReady.emit(
-                seq, session_label, -1, None, "", None
+                seq, session_label, -1, None, "", None, None
             )
 
     @pyqtSlot(str, str)
@@ -2493,6 +2514,7 @@ class MotionConnector(QObject):
         buffers,
         source_tag: str,
         recorded_flags=None,
+        display_meta=None,
     ) -> None:
         """GUI thread: bind a worker-loaded past scan to the viewer.
         Results from a superseded request (user clicked another scan
@@ -2523,12 +2545,15 @@ class MotionConnector(QObject):
             self.pastScanLoadFinished.emit(session_label, False)
             return
         try:
+            dm = display_meta or {}
             past = PastScanSource(
                 scan_db=None,
                 session_id=session_id,
                 parent=self,
                 preloaded_buffers=buffers,
                 recorded_flags=recorded_flags,
+                user_label=dm.get("userLabel", ""),
+                date_time=dm.get("dateTime", ""),
             )
             self._set_current_scan_source(past)
             # Diagnostic — left in for now so we can spot regressions

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -844,6 +844,45 @@ def test_recorded_flags_both_masks_zero_falls_back_to_derived():
     assert src.rightMask == 0x66
 
 
+# ── Issue #245 — viewer "Viewing" badge: the source names the replayed scan ──
+# The PlotViewer shows a top-center badge identifying the loaded past scan. The
+# source carries the operator's user label and the scan's date/time so the
+# viewer can render the badge without re-querying the DB. Base/live sources have
+# no viewing label and read blank — the badge is hidden during live monitoring.
+
+
+def test_past_scan_source_exposes_user_label_and_date_time():
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+        user_label="Patient A",
+        date_time="2026-06-23 11:19:35",
+    )
+    assert src.userLabel == "Patient A"
+    assert src.dateTime == "2026-06-23 11:19:35"
+
+
+def test_past_scan_source_label_fields_default_blank():
+    """Omitting the kwargs (unlabeled scans / older call sites) yields empty
+    strings, never None — the viewer treats blank as 'nothing to show'."""
+    src = PastScanSource(
+        scan_db=None,
+        session_id=1,
+        preloaded_buffers=_middle_four_buffers(),
+    )
+    assert src.userLabel == ""
+    assert src.dateTime == ""
+
+
+def test_live_scan_source_has_blank_label_fields():
+    """Live sources never carry a viewing label — the badge is past-scan only,
+    so the viewer can gate on `live === false` and a non-empty label."""
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.userLabel == ""
+    assert src.dateTime == ""
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # currentScanSource holder pattern — verified via a parallel mini-class
 # (MotionConnector uses the same pattern; see motion_connector.py)

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -241,3 +241,64 @@ def test_load_past_scan_slot_without_flags_falls_back_to_derived(tmp_path):
     assert src is not None
     assert src.leftMask == 0x66
     assert src.rightMask == 0x66
+
+
+# ── Issue #245 — viewer "Viewing" badge: thread the scan's identity to source ──
+# The viewer reads userLabel/dateTime off the bound source to render its badge.
+# The connector must (a) compute those in the worker from the same session row
+# the History list shows, and (b) thread them through the GUI-thread slot into
+# the PastScanSource.
+
+
+def test_load_past_scan_slot_threads_display_meta_to_source(tmp_path):
+    """The GUI-thread slot must pass the worker's display_meta into the
+    PastScanSource so the viewer badge can name the scan (issue #245)."""
+    c = _connector(tmp_path, str(tmp_path / "scans.db"))
+    c._on_past_scan_buffers_ready(
+        c._past_scan_load_seq, "20260623_111935_PatientA", 1,
+        _middle_four_buffers(), "db", None,
+        {"userLabel": "Patient A", "dateTime": "2026-06-23 11:19:35"},
+    )
+    src = c.currentScanSource
+    assert src is not None
+    assert src.userLabel == "Patient A"
+    assert src.dateTime == "2026-06-23 11:19:35"
+
+
+def test_load_past_scan_slot_missing_display_meta_leaves_label_blank(tmp_path):
+    """No display_meta (older worker path / failed lookup) → source label is
+    blank, so the viewer simply hides the badge. Backward compatible with the
+    existing 6-arg slot calls."""
+    c = _connector(tmp_path, str(tmp_path / "scans.db"))
+    c._on_past_scan_buffers_ready(
+        c._past_scan_load_seq, "20260101_000000_subjA", 1,
+        _middle_four_buffers(), "db", None,
+    )
+    src = c.currentScanSource
+    assert src is not None
+    assert src.userLabel == ""
+    assert src.dateTime == ""
+
+
+def test_load_past_scan_worker_emits_display_meta_from_session(tmp_path):
+    """The worker derives the badge's userLabel/dateTime from the same session
+    row the History list renders (prefers session_meta.subject_id over the label
+    suffix), so the badge can never disagree with the clicked row."""
+    db_path = str(tmp_path / "scans.db")
+    sid = _make_session(
+        db_path, "20260623_111935_PatientA", 100.0, 110.0,
+        left_mask=0xFF, right_mask=0xFF, reduced=False,
+        subject="Patient A",   # subject_id differs from the label suffix
+    )
+    _insert_rows(db_path, sid, 3)
+    c = _connector(tmp_path, db_path)
+
+    captured = []
+    c._pastScanBuffersReady.connect(lambda *a: captured.append(a))
+    c._load_past_scan_worker(
+        c._past_scan_load_seq, "20260623_111935_PatientA", db_path, None)
+
+    assert captured, "worker did not emit _pastScanBuffersReady"
+    display_meta = captured[-1][-1]
+    assert display_meta["userLabel"] == "Patient A"
+    assert display_meta["dateTime"] == "2026-06-23 11:19:35"

--- a/tests/test_plot_viewer_masks.py
+++ b/tests/test_plot_viewer_masks.py
@@ -74,18 +74,25 @@ FAR_MASK = 0xC3  # cams 1,2,7,8 (1-based) → camIds 0,1,6,7
 class _StubPastScanSource(QObject):
     """Minimal past-scan source exposing the camera-config masks the way
     data_sources.PastScanSource does. live=False marks it as a replayed
-    scan; leftMask/rightMask carry the configuration that scan recorded."""
+    scan; leftMask/rightMask carry the configuration that scan recorded.
+    user_label/date_time back the viewer's "Viewing" badge (issue #245);
+    pass live=True to stand in for a live source (badge hidden)."""
 
     _neverEmitted = pyqtSignal()
 
-    def __init__(self, left_mask: int, right_mask: int, parent=None):
+    def __init__(self, left_mask: int, right_mask: int, parent=None,
+                 user_label: str = "", date_time: str = "",
+                 live: bool = False):
         super().__init__(parent)
         self._left = int(left_mask)
         self._right = int(right_mask)
+        self._user_label = str(user_label)
+        self._date_time = str(date_time)
+        self._live = bool(live)
 
     @pyqtProperty(bool, notify=_neverEmitted)
     def live(self):
-        return False
+        return self._live
 
     @pyqtProperty(int, notify=_neverEmitted)
     def leftMask(self):
@@ -94,6 +101,14 @@ class _StubPastScanSource(QObject):
     @pyqtProperty(int, notify=_neverEmitted)
     def rightMask(self):
         return self._right
+
+    @pyqtProperty(str, notify=_neverEmitted)
+    def userLabel(self):
+        return self._user_label
+
+    @pyqtProperty(str, notify=_neverEmitted)
+    def dateTime(self):
+        return self._date_time
 
     @pyqtProperty(float, notify=_neverEmitted)
     def liveEdge(self):
@@ -303,6 +318,56 @@ def test_past_scan_config_overrides_live_mask_selection(viewer_factory):
         assert len(cells) == 8
     finally:
         viewer_factory.stub.setScanSource(None)
+
+
+# ── Issue #245 — "Viewing" badge names the replayed scan ───────────────
+# The viewer shows a top-center badge identifying the loaded past scan
+# (user label · date trimmed to minutes). It is hidden during live
+# monitoring and when no scan is loaded.
+
+
+def test_viewing_badge_names_loaded_past_scan(viewer_factory):
+    viewer = viewer_factory()
+    try:
+        past = _StubPastScanSource(
+            FAR_MASK, FAR_MASK,
+            user_label="Patient A", date_time="2026-06-23 11:19:35")
+        viewer_factory.stub.setScanSource(past)
+        assert viewer.property("_showScanBadge") is True
+        assert viewer.property("_scanBadgeText") == "Patient A · 2026-06-23 11:19"
+    finally:
+        viewer_factory.stub.setScanSource(None)
+
+
+def test_viewing_badge_collapses_to_date_when_unlabeled(viewer_factory):
+    viewer = viewer_factory()
+    try:
+        past = _StubPastScanSource(
+            FAR_MASK, FAR_MASK,
+            user_label="", date_time="2026-06-23 11:19:35")
+        viewer_factory.stub.setScanSource(past)
+        assert viewer.property("_showScanBadge") is True
+        assert viewer.property("_scanBadgeText") == "2026-06-23 11:19"
+    finally:
+        viewer_factory.stub.setScanSource(None)
+
+
+def test_viewing_badge_hidden_during_live(viewer_factory):
+    viewer = viewer_factory()
+    try:
+        live = _StubPastScanSource(
+            ALL_MASK, ALL_MASK,
+            user_label="ignored", date_time="2026-06-23 11:19:35", live=True)
+        viewer_factory.stub.setScanSource(live)
+        assert viewer.property("_showScanBadge") is False
+    finally:
+        viewer_factory.stub.setScanSource(None)
+
+
+def test_viewing_badge_hidden_without_source(viewer_factory):
+    viewer = viewer_factory()
+    viewer_factory.stub.setScanSource(None)
+    assert viewer.property("_showScanBadge") is False
 
 
 def test_unknown_source_masks_fall_back_to_live_selection(viewer_factory):


### PR DESCRIPTION
## What

Resolves #245. Loading a past scan from History gave no on-screen indication of **which** scan the plots showed, and the History checkboxes (which only drive bulk delete) looked like a viewing selection.

This adds a persistent **top-center badge** in the `PlotViewer` naming the replayed scan — `Viewing  <user label> · <date · trimmed to minutes>`. It collapses to just the date when a scan has no user label, and is **hidden during live monitoring** (live is the implied default). History-modal selection visuals are unchanged (scoped that way deliberately).

## How

Three thin layers — no new files:

- **`data_sources.py`** — `userLabel`/`dateTime` `pyqtProperty`s on the base `ScanDataSource` (blank by default, so `LiveScanSource` is naturally empty); `PastScanSource` takes them as kwargs.
- **`motion_connector.py`** — the load worker derives the two strings from the **same** session row the History list renders (`_session_to_row`, which prefers `session_meta.subject_id` over the label suffix), so the badge can never disagree with the row the user clicked. Threaded to the GUI thread via `_pastScanBuffersReady`'s new `display_meta` payload (follows the existing `recorded_flags` precedent). Best-effort — a lookup failure just hides the badge, never blocks the load.
- **`components/PlotViewer.qml`** — a top-center pill matching the existing overlay styling, **no `MouseArea`** so plot interaction passes through beneath it. Gated on `scanSource.live === false` and a non-empty label.

## Test plan

Automated (all green, TDD — each test watched fail first):
- `pytest -m unit` → **327 passed**, no regressions.
- 9 new tests: source properties + blank defaults (`test_data_sources.py`); worker `display_meta` derivation incl. the `subject_id`-wins case + slot threading + 6-arg backward-compat (`test_history_sessions.py`); badge text/visibility for labeled, unlabeled, live-hidden, and no-source cases (`test_plot_viewer_masks.py`).
- Offscreen render of the real `PlotViewer.qml` confirmed badge placement/sizing/styling.

Hand-test (please verify):
1. Run a scan (or use existing history), open **History**, select a scan, **Load in viewer**.
2. Confirm the top-center badge shows `Viewing  <label> · <date>` and identifies the right scan.
3. Load a scan with **no** user label → badge shows just the date.
4. Select multiple scans via checkboxes, load one → badge unambiguously names the loaded one.
5. During a **live** scan → no badge.
6. Check **reduced/clinical** mode — badge clears the large side metric panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)