### PR TITLE
feat: Download Beta Firmware toggle (Settings -> Developer)

### DIFF
--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -903,6 +903,24 @@ Item {
                         Item { Layout.fillWidth: true }
                     }
 
+                    // Beta firmware: when on, the autoupdater targets the
+                    // most-recently-published release (incl. dev/rc), not just
+                    // full releases. Plain config flag — the connector re-runs
+                    // the firmware check when it toggles (setConfig hook).
+                    FieldRow {
+                        label: "Download beta firmware"
+                        PillSwitch {
+                            checked: MotionInterface.appConfig.downloadBetaFirmware === true
+                            onToggled: MotionInterface.setConfig("downloadBetaFirmware", checked)
+                        }
+                        Text {
+                            text: MotionInterface.appConfig.downloadBetaFirmware === true ? "On" : "Off"
+                            color: MotionInterface.appConfig.downloadBetaFirmware === true ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
                     FieldRow {
                         label: "Save raw CSV"
                         PillSwitch {

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -52,6 +52,7 @@
   "cq_light_threshold_per_camera": [15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0],
 
   "developerMode": false,
+  "downloadBetaFirmware": false,
   "forceLaserFail": false,
   "cameraFakeData": false,
   "cameraTempAlertThresholdC": 110,

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1662,7 +1662,8 @@ class MotionConnector(QObject):
 
     def _firmware_check_worker(self, kind: FirmwareKind) -> None:
         try:
-            info = check_latest(kind)
+            beta = self._app_config.get("downloadBetaFirmware", False)
+            info = check_latest(kind, include_prerelease=beta)
         except Exception:                           # defensive; check_latest is fail-soft
             info = None
         finally:
@@ -1679,7 +1680,9 @@ class MotionConnector(QObject):
         kind = self._kind_for_device(name)
         installed = self._firmware_versions.get(name, "")
         latest = self._firmware_latest_by_kind.get(kind.value, "")
-        avail = bool(installed) and bool(latest) and is_update_available(installed, latest)
+        beta = self._app_config.get("downloadBetaFirmware", False)
+        avail = (bool(installed) and bool(latest)
+                 and is_update_available(installed, latest, prerelease=beta))
         self._firmware_latest[name] = latest
         self._firmware_update_available[name] = avail
         self.firmwareUpdateInfoChanged.emit()
@@ -1687,6 +1690,20 @@ class MotionConnector(QObject):
             logger.info("Firmware update available for %s: %s -> %s",
                         name, installed, latest)
             self.firmwareUpdateAvailable.emit(name, installed, latest)
+
+    def _refresh_firmware_update_check(self) -> None:
+        """Invalidate the firmware-latest caches and re-run detection for every
+        connected device — called when downloadBetaFirmware toggles so the
+        banner/Settings card reflect the new release pool immediately."""
+        self._firmware_latest_by_kind.clear()
+        self._firmware_checking_kinds.clear()
+        for name in ("console", "left", "right"):
+            self._firmware_latest[name] = ""
+            self._firmware_update_available[name] = False
+        self.firmwareUpdateInfoChanged.emit()
+        for name in ("console", "left", "right"):
+            if self._firmware_versions.get(name):
+                self._maybe_check_firmware_update(name)
 
     @pyqtSlot(str, result=bool)
     def startFirmwareUpdate(self, device_key: str) -> bool:
@@ -1723,7 +1740,8 @@ class MotionConnector(QObject):
             kind = self._kind_for_device(device_key)
             self.firmwareUpdateProgress.emit(
                 device_key, "check", -1, "Checking latest release…")
-            info = check_latest(kind)
+            beta = self._app_config.get("downloadBetaFirmware", False)
+            info = check_latest(kind, include_prerelease=beta)
             if info is None:
                 raise RuntimeError("Could not reach GitHub to fetch firmware.")
             self.firmwareUpdateProgress.emit(
@@ -2433,6 +2451,8 @@ class MotionConnector(QObject):
         if old != value:
             self._audit.log("settings_changed",
                             {"changes": {key: {"old": old, "new": value}}})
+        if key == "downloadBetaFirmware" and old != value:
+            self._refresh_firmware_update_check()
 
     @pyqtSlot('QVariantMap')
     def saveConfigs(self, configs: dict):

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -838,6 +838,7 @@ class MotionConnector(QObject):
         self._firmware_latest_by_kind: dict[str, str] = {}   # "console"/"sensor" -> tag
         self._firmware_checking_kinds: set = set()           # in-flight network checks
         self._firmware_check_lock = threading.Lock()         # guards check-then-add on _firmware_checking_kinds
+        self._firmware_check_generation: int = 0
         self._firmware_update_in_progress: str | None = None # deviceKey being flashed
         # Track console connection time for safety grace period (issue #107 follow-up)
         self._console_connected_at: float | None = None
@@ -1657,10 +1658,12 @@ class MotionConnector(QObject):
                 return                              # a check is already in flight
             self._firmware_checking_kinds.add(kind)
         threading.Thread(
-            target=self._firmware_check_worker, args=(kind,), daemon=True
+            target=self._firmware_check_worker,
+            args=(kind, self._firmware_check_generation),
+            daemon=True,
         ).start()
 
-    def _firmware_check_worker(self, kind: FirmwareKind) -> None:
+    def _firmware_check_worker(self, kind: FirmwareKind, generation: int | None = None) -> None:
         try:
             beta = self._app_config.get("downloadBetaFirmware", False)
             info = check_latest(kind, include_prerelease=beta)
@@ -1670,6 +1673,11 @@ class MotionConnector(QObject):
             self._firmware_checking_kinds.discard(kind)
         if info is None:
             return                                  # leave kind unchecked so it retries
+        # A beta toggle (or other refresh) bumps the generation; a worker that
+        # started under an older generation captured a now-stale beta flag, so
+        # discard its result rather than clobber the fresh one.
+        if generation is not None and generation != self._firmware_check_generation:
+            return
         self._firmware_latest_by_kind[kind.value] = info.tag
         for dev in self._devices_for_kind(kind):
             self._recompute_firmware_update(dev)
@@ -1697,6 +1705,7 @@ class MotionConnector(QObject):
         banner/Settings card reflect the new release pool immediately."""
         self._firmware_latest_by_kind.clear()
         self._firmware_checking_kinds.clear()
+        self._firmware_check_generation += 1
         for name in ("console", "left", "right"):
             self._firmware_latest[name] = ""
             self._firmware_update_available[name] = False
@@ -2468,6 +2477,8 @@ class MotionConnector(QObject):
         logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
         if changes:
             self._audit.log("settings_changed", {"changes": changes})
+        if "downloadBetaFirmware" in changes:
+            self._refresh_firmware_update_check()
 
     # Sensor debug-flag config keys surfaced as live Settings → Developer
     # toggles, mapped to the runtime cache attribute that

--- a/tests/test_firmware_update_beta.py
+++ b/tests/test_firmware_update_beta.py
@@ -63,3 +63,16 @@ def test_toggle_invalidates_and_rechecks(tmp_path):
 
     assert c._firmware_latest_by_kind == {}      # cache invalidated
     assert "left" in called                      # re-check for the connected device
+    assert c._firmware_update_available["left"] is False
+
+
+def test_check_worker_discards_superseded_generation(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        motion_connector, "check_latest",
+        lambda kind, **_: LatestInfo(FirmwareKind.SENSOR, "1.8.1-dev.5", "motion-sensor-fw.bin"),
+    )
+    c = _connector(tmp_path, beta=True)
+    c._firmware_versions["left"] = "1.8.0"
+    c._firmware_check_generation = 5
+    c._firmware_check_worker(FirmwareKind.SENSOR, generation=4)   # stale generation
+    assert c._firmware_latest_by_kind == {}                       # result discarded

--- a/tests/test_firmware_update_beta.py
+++ b/tests/test_firmware_update_beta.py
@@ -1,0 +1,65 @@
+"""downloadBetaFirmware flows into the SDK check + a toggle re-checks."""
+from unittest.mock import MagicMock
+
+import pytest
+
+import motion_connector
+from motion_connector import MotionConnector
+from omotion.firmware_update import FirmwareKind, LatestInfo
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, dev_mode=True, beta=False):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = str(tmp_path / "scans.db")
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface,
+        app_config={"developerMode": dev_mode, "downloadBetaFirmware": beta},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def test_beta_flag_passed_to_check_latest(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_check(kind, *, include_prerelease=False):
+        seen["beta"] = include_prerelease
+        return None
+
+    monkeypatch.setattr(motion_connector, "check_latest", fake_check)
+    c = _connector(tmp_path, beta=True)
+    c._firmware_versions["left"] = "1.8.0"
+    c._firmware_check_worker(FirmwareKind.SENSOR)
+    assert seen["beta"] is True
+
+
+def test_beta_uses_release_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        motion_connector, "check_latest",
+        lambda kind, *, include_prerelease=False:
+            LatestInfo(FirmwareKind.SENSOR, "1.8.1-dev.5", "motion-sensor-fw.bin"),
+    )
+    c = _connector(tmp_path, beta=True)
+    # base tag 1.8.1-rc.0 differs from latest 1.8.1-dev.5 -> available
+    c._firmware_versions["left"] = "1.8.1-rc.0-2-gf09e8dc-dirty"
+    c._firmware_check_worker(FirmwareKind.SENSOR)
+    assert c._firmware_update_available["left"] is True
+
+
+def test_toggle_invalidates_and_rechecks(tmp_path):
+    c = _connector(tmp_path, beta=False)
+    c._firmware_versions["left"] = "1.8.0"
+    c._firmware_latest_by_kind["sensor"] = "1.8.0"
+    c._firmware_update_available["left"] = True
+    called = []
+    c._maybe_check_firmware_update = lambda name: called.append(name)
+
+    c.setConfig("downloadBetaFirmware", True)
+
+    assert c._firmware_latest_by_kind == {}      # cache invalidated
+    assert "left" in called                      # re-check for the connected device

--- a/tests/test_firmware_update_detection.py
+++ b/tests/test_firmware_update_detection.py
@@ -37,7 +37,7 @@ def test_no_check_when_developer_mode_off(tmp_path, monkeypatch):
 def test_worker_flags_update_and_emits(tmp_path, monkeypatch):
     monkeypatch.setattr(
         motion_connector, "check_latest",
-        lambda k: LatestInfo(FirmwareKind.SENSOR, "1.5.0", "motion-sensor-fw.bin"),
+        lambda k, **_: LatestInfo(FirmwareKind.SENSOR, "1.5.0", "motion-sensor-fw.bin"),
     )
     c = _connector(tmp_path, dev_mode=True)
     c._firmware_versions["left"] = "v1.0.0"
@@ -54,7 +54,7 @@ def test_worker_flags_update_and_emits(tmp_path, monkeypatch):
 
 
 def test_worker_none_result_is_soft(tmp_path, monkeypatch):
-    monkeypatch.setattr(motion_connector, "check_latest", lambda k: None)
+    monkeypatch.setattr(motion_connector, "check_latest", lambda k, **_: None)
     c = _connector(tmp_path, dev_mode=True)
     c._firmware_versions["console"] = "v1.0.0"
     c._firmware_check_worker(FirmwareKind.CONSOLE)

--- a/tests/test_firmware_update_orchestration.py
+++ b/tests/test_firmware_update_orchestration.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unit
 def _no_network_check(monkeypatch):
     # Unit tests must not hit GitHub. _maybe_check_firmware_update may spawn a
     # background thread; stub check_latest so it returns immediately with no emit.
-    monkeypatch.setattr(motion_connector, "check_latest", lambda kind: None)
+    monkeypatch.setattr(motion_connector, "check_latest", lambda kind, **_: None)
 
 
 def _connector(tmp_path, dev_mode=True):


### PR DESCRIPTION
# Download Beta Firmware toggle (Settings → Developer)

A developerMode-gated **"Download beta firmware"** toggle that makes the firmware autoupdater target the **most-recently-published** release — including dev/rc — instead of only full releases.

## Depends on
**OpenwaterHealth/openmotion-sdk#102** (the prerelease-aware `check_latest` / `is_update_available`). Must be on `next-next` for this to work.

## Behavior
- **off** (default): newest **stable**, M.M.P compare — today's behavior, unchanged.
- **on**: the release with the **max `published_at`** (incl. dev/rc); "update available" iff the device's base release tag differs from it. So a dev published *after* an rc wins (timestamp, not semver), and the device's git-describe tail (`-N-gSHA-dirty`) is reduced to its base tag for the comparison.

## What it adds
- `config/app_config.json`: `"downloadBetaFirmware": false`.
- `motion_connector.py`: the flag flows into both `check_latest` calls (`include_prerelease=`) and the comparison (`is_update_available(..., prerelease=)`); `_refresh_firmware_update_check()` invalidates the caches + re-checks connected devices when the toggle changes (wired in `setConfig` and `saveConfigs`); a **generation guard** so a stale in-flight check from before a toggle can't clobber the fresh result.
- `components/SettingsModal.qml`: the toggle row in the Developer card (mirrors "Histogram compression").

## Tests
4 new unit tests in `tests/test_firmware_update_beta.py` (flag flows to the SDK; release-identity compare picks the newer dev; toggle invalidates + re-checks; generation guard discards a superseded result). Two pre-existing `check_latest` stubs widened to accept the new keyword. All firmware suites green (15 app + 48 SDK).

## Validated live (hand-test)
Toggling beta **on** with the sensors on `1.8.0-rc.3-1-gedfdc8c` flipped the banner to target `1.8.1-rc.0` (`Firmware update available for left/right: 1.8.0-rc.3-… → 1.8.1-rc.0`); off → cleared. Confirms the release-identity compare on a real git-describe version string.

Draft for hand-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
