### PR TITLE
Scan History: unify selection model + multi-scan CSV export

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -53,9 +53,8 @@ Item {
         try { scans = MotionInterface.get_scan_sessions() || [] }
         catch (e) { scans = [] }
         checked = ({}); checkedCount = 0
+        clearActive()
         rebuildView()
-        if (view.length > 0) focusRow(view[0].sessionId)
-        else { focusedSessionId = -1; focusedRow = null; focusedSampleCount = -1 }
     }
 
     function rebuildView() {
@@ -103,17 +102,51 @@ Item {
         }
     }
 
+    // Reset the active (detail-pane / Load + Export target) row.
+    function clearActive() {
+        focusedSessionId = -1; focusedRow = null; focusedSampleCount = -1
+    }
+
+    // Plain row-body click = standard single-select: replace the checked
+    // set with just this row and make it the active row.
+    function selectRow(sid) {
+        var c = {}; c[sid] = true
+        checked = c; checkedCount = 1
+        focusRow(sid)
+    }
+
+    // Keep the active row valid after a checkbox change: if it's no longer
+    // checked, move the highlight to the first checked row in view order,
+    // else clear it. (Invariant: the active row is always checked.)
+    function reconcileActive() {
+        if (focusedSessionId >= 0 && checked[focusedSessionId]) return
+        for (var i = 0; i < view.length; i++)
+            if (checked[view[i].sessionId]) { focusRow(view[i].sessionId); return }
+        clearActive()
+    }
+
+    // Every checked row, across the full list (ignores the search filter,
+    // matching Delete which also operates on all checked ids).
+    function checkedRows() {
+        var rows = []
+        for (var i = 0; i < scans.length; i++)
+            if (checked[scans[i].sessionId]) rows.push(scans[i])
+        return rows
+    }
+
     function toggleCheck(sid) {
         var c = Object.assign({}, checked)
         if (c[sid]) { delete c[sid]; checkedCount -= 1 }
         else { c[sid] = true; checkedCount += 1 }
         checked = c
+        reconcileActive()
     }
 
     function setAllChecked(on) {
         var c = {}, n = 0
         if (on) for (var i = 0; i < view.length; i++) { c[view[i].sessionId] = true; n++ }
         checked = c; checkedCount = n
+        reconcileActive()
     }
 
     function requestDelete() {
@@ -312,7 +345,7 @@ Item {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: root.focusRow(modelData.sessionId)
+                            onClicked: root.selectRow(modelData.sessionId)
                         }
 
                         RowLayout {

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -154,6 +154,39 @@ Item {
         deletePrompt.open()
     }
 
+    function requestExport() {
+        var rows = checkedRows()
+        if (rows.length === 0) return
+
+        if (rows.length === 1) {
+            // Single export keeps the Save As dialog (lets the user rename).
+            if (rows[0].interrupted) {
+                MotionInterface.notify("Interrupted scans can't be exported.", "warning")
+                return
+            }
+            exportDialog.selectedScanId = rows[0].label
+            exportDialog.selectedFile = "file:///" + MotionInterface.directory
+                                        + "/" + rows[0].label + "_export.csv"
+            exportDialog.open()
+            return
+        }
+
+        // 2+ checked -> pick a destination folder. Interrupted scans can't be
+        // exported, so drop them here and fold them into the skip count.
+        var labels = [], skipped = 0
+        for (var i = 0; i < rows.length; i++) {
+            if (rows[i].interrupted) { skipped += 1; continue }
+            labels.push(rows[i].label)
+        }
+        if (labels.length === 0) {
+            MotionInterface.notify("Interrupted scans can't be exported.", "warning")
+            return
+        }
+        exportFolderDialog.pendingLabels = labels
+        exportFolderDialog.pendingSkipped = skipped
+        exportFolderDialog.open()
+    }
+
     function doDelete() {
         var ids = []
         for (var k in checked) if (checked[k]) ids.push(parseInt(k))
@@ -497,9 +530,9 @@ Item {
 
                 Button {
                     id: exportBtn
-                    text: "Export CSV"
-                    Layout.preferredWidth: 112; Layout.preferredHeight: 36
-                    enabled: root.focusedRow !== null && !root.focusedRow.interrupted
+                    text: "Export CSV" + (root.checkedCount > 0 ? "  (" + root.checkedCount + ")" : "")
+                    Layout.preferredWidth: 128; Layout.preferredHeight: 36
+                    enabled: root.checkedCount > 0
                     hoverEnabled: enabled
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
@@ -512,12 +545,7 @@ Item {
                         border.color: exportBtn.enabled ? theme.borderStrong : theme.textTertiary
                         border.width: 1
                     }
-                    onClicked: {
-                        exportDialog.selectedScanId = root.focusedRow.label
-                        exportDialog.selectedFile = "file:///" + MotionInterface.directory
-                                                    + "/" + root.focusedRow.label + "_export.csv"
-                        exportDialog.open()
-                    }
+                    onClicked: root.requestExport()
                 }
                 Button {
                     id: loadBtn
@@ -581,6 +609,24 @@ Item {
             var path = selectedFile.toString().replace("file:///", "")
             var ok = MotionInterface.exportScanCsv(selectedScanId, path)
             if (ok) MotionInterface.notify("Exported to " + path, "success")
+        }
+    }
+
+    Dialogs.FolderDialog {
+        id: exportFolderDialog
+        title: "Export Scans to Folder"
+        currentFolder: MotionInterface.directory
+                       ? ("file:///" + MotionInterface.directory) : ""
+        property var pendingLabels: []
+        property int pendingSkipped: 0
+        onAccepted: {
+            var folder = selectedFolder.toString().replace("file:///", "")
+            var res = MotionInterface.exportScansToFolder(pendingLabels, folder)
+            var ok = (res && res.exported) ? res.exported : 0
+            var sk = pendingSkipped + ((res && res.skipped) ? res.skipped : 0)
+            var msg = "Exported " + ok + " scan(s) to " + folder
+            if (sk > 0) msg += " (" + sk + " skipped)"
+            MotionInterface.notify(msg, ok > 0 ? "success" : "warning")
         }
     }
 

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -204,6 +204,12 @@ Item {
         return m + ":" + (s < 10 ? "0" + s : s)
     }
 
+    // Trim a scan label for display on the fixed-width Load button.
+    function shortLabel(s) {
+        s = "" + (s || "")
+        return s.length > 16 ? (s.substring(0, 15) + "…") : s
+    }
+
     // Format an 8-bit mask as "0xNN", or "—" when unknown (< 0). Keeps the
     // detail pane consistent with the Config cell, which also shows "—" for
     // an unknown mask (a -1 rendered as 0xFF would misread as "All").
@@ -549,13 +555,17 @@ Item {
                 }
                 Button {
                     id: loadBtn
-                    text: "Load in viewer  →"
-                    Layout.preferredWidth: 156; Layout.preferredHeight: 36
+                    text: root.focusedRow
+                          ? ("Load “" + root.shortLabel(root.focusedRow.userLabel
+                                             || root.focusedRow.label || "scan") + "”  →")
+                          : "Load in viewer  →"
+                    Layout.preferredWidth: 200; Layout.preferredHeight: 36
                     enabled: root.focusedRow !== null && !root.focusedRow.interrupted
                     hoverEnabled: enabled
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13; font.weight: Font.DemiBold
                         color: loadBtn.enabled ? "#FFFFFF" : theme.textTertiary
+                        elide: Text.ElideRight
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -615,8 +615,7 @@ Item {
     Dialogs.FolderDialog {
         id: exportFolderDialog
         title: "Export Scans to Folder"
-        currentFolder: MotionInterface.directory
-                       ? ("file:///" + MotionInterface.directory) : ""
+        currentFolder: "file:///" + (MotionInterface.directory || "")
         property var pendingLabels: []
         property int pendingSkipped: 0
         onAccepted: {

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2637,7 +2637,6 @@ class MotionConnector(QObject):
         if not labels or not folder:
             return result
         try:
-            import os
             from omotion.ScanDatabase import ScanDatabase
             from omotion.SessionPlayback import materialize_corrected_csv
 
@@ -2645,29 +2644,29 @@ class MotionConnector(QObject):
             if not db_path:
                 self.errorOccurred.emit("No scan database available.")
                 return result
-            db = ScanDatabase(db_path)
-            for label in labels:
-                try:
-                    session = db.get_session_by_label(label)
-                    if not session:
+            with ScanDatabase(db_path) as db:
+                for label in labels:
+                    try:
+                        session = db.get_session_by_label(label)
+                        if not session:
+                            result["skipped"] += 1
+                            continue
+                        session_id = int(session["id"])
+                        out_path = os.path.join(
+                            folder, f"{label}_export.csv")
+                        materialize_corrected_csv(
+                            str(db_path), session_id, out_path,
+                            include_quality=True,
+                        )
+                        result["exported"] += 1
+                        logger.info(
+                            "exportScansToFolder: exported %r (sid=%d) -> %s",
+                            label, session_id, out_path,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "exportScansToFolder: failed for %r", label)
                         result["skipped"] += 1
-                        continue
-                    session_id = int(session["id"])
-                    out_path = os.path.join(
-                        folder, f"{label}_export.csv")
-                    materialize_corrected_csv(
-                        str(db_path), session_id, out_path,
-                        include_quality=True,
-                    )
-                    result["exported"] += 1
-                    logger.info(
-                        "exportScansToFolder: exported %r (sid=%d) -> %s",
-                        label, session_id, out_path,
-                    )
-                except Exception:
-                    logger.exception(
-                        "exportScansToFolder: failed for %r", label)
-                    result["skipped"] += 1
             return result
         except Exception as exc:
             logger.exception("exportScansToFolder failed")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2623,6 +2623,57 @@ class MotionConnector(QObject):
             self.errorOccurred.emit(f"Export failed:\n{exc}")
             return False
 
+    @pyqtSlot('QStringList', str, result='QVariantMap')
+    def exportScansToFolder(self, labels, folder) -> dict:
+        """Export several scans, one CSV each, into ``folder``.
+
+        Writes ``<folder>/<label>_export.csv`` for every label. Opens
+        the scan DB once for the whole batch. Missing or failing scans
+        are counted as skipped and never raise. Returns
+        ``{"exported": int, "skipped": int}``. (Callers pre-filter
+        interrupted scans, which can't be materialized.)
+        """
+        result = {"exported": 0, "skipped": 0}
+        if not labels or not folder:
+            return result
+        try:
+            import os
+            from omotion.ScanDatabase import ScanDatabase
+            from omotion.SessionPlayback import materialize_corrected_csv
+
+            db_path = getattr(self._interface, "scan_db_path", None)
+            if not db_path:
+                self.errorOccurred.emit("No scan database available.")
+                return result
+            db = ScanDatabase(db_path)
+            for label in labels:
+                try:
+                    session = db.get_session_by_label(label)
+                    if not session:
+                        result["skipped"] += 1
+                        continue
+                    session_id = int(session["id"])
+                    out_path = os.path.join(
+                        folder, f"{label}_export.csv")
+                    materialize_corrected_csv(
+                        str(db_path), session_id, out_path,
+                        include_quality=True,
+                    )
+                    result["exported"] += 1
+                    logger.info(
+                        "exportScansToFolder: exported %r (sid=%d) -> %s",
+                        label, session_id, out_path,
+                    )
+                except Exception:
+                    logger.exception(
+                        "exportScansToFolder: failed for %r", label)
+                    result["skipped"] += 1
+            return result
+        except Exception as exc:
+            logger.exception("exportScansToFolder failed")
+            self.errorOccurred.emit(f"Export failed:\n{exc}")
+            return result
+
     @pyqtSlot(str, result=int)
     @pyqtSlot(str, str, result=int)
     @pyqtSlot(str, str, int, result=int)

--- a/tests/test_history_export.py
+++ b/tests/test_history_export.py
@@ -63,3 +63,12 @@ def test_export_scans_to_folder_empty_inputs(tmp_path):
         "exported": 0, "skipped": 0}
     assert c.exportScansToFolder(["x"], "") == {
         "exported": 0, "skipped": 0}
+
+
+def test_export_scans_to_folder_no_db(tmp_path):
+    c = _connector(tmp_path, scan_db_path=None)
+    errors = []
+    c.errorOccurred.connect(errors.append)
+    res = c.exportScansToFolder(["scanA"], str(tmp_path))
+    assert res == {"exported": 0, "skipped": 0}
+    assert errors  # errorOccurred was emitted

--- a/tests/test_history_export.py
+++ b/tests/test_history_export.py
@@ -57,6 +57,33 @@ def test_export_scans_to_folder_writes_each_and_skips_missing(
     assert names == ["scanA_export.csv", "scanB_export.csv"]
 
 
+def test_export_scans_to_folder_isolates_per_label_failure(
+        tmp_path, monkeypatch):
+    """A scan whose materialize raises is counted skipped, and the batch
+    keeps going for the remaining scans."""
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, "scanA", 1.0)
+    _session(db_path, "scanB", 2.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    exported = []
+    import omotion.SessionPlayback as sp
+
+    def _materialize(*a, **k):
+        # a[2] == output_path, ends with "<label>_export.csv"
+        if os.path.basename(a[2]) == "scanA_export.csv":
+            raise RuntimeError("boom")
+        exported.append(a[2])
+
+    monkeypatch.setattr(sp, "materialize_corrected_csv", _materialize)
+
+    res = c.exportScansToFolder(["scanA", "scanB"], str(tmp_path))
+
+    assert res == {"exported": 1, "skipped": 1}
+    assert len(exported) == 1  # scanB still ran after scanA failed
+    assert os.path.basename(exported[0]) == "scanB_export.csv"
+
+
 def test_export_scans_to_folder_empty_inputs(tmp_path):
     c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
     assert c.exportScansToFolder([], str(tmp_path)) == {

--- a/tests/test_history_export.py
+++ b/tests/test_history_export.py
@@ -1,0 +1,65 @@
+"""exportScansToFolder — batch-export several scans into one folder."""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = scan_db_path  # MagicMock default would be truthy
+    return MotionConnector(
+        interface=iface, app_config={"developerMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _session(db_path, label, start):
+    db = ScanDatabase(db_path=db_path)
+    db.create_session(session_label=label, session_start=start,
+                      session_notes=None, session_meta={})
+    db.close()
+
+
+def test_export_scans_to_folder_writes_each_and_skips_missing(
+        tmp_path, monkeypatch):
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, "scanA", 1.0)
+    _session(db_path, "scanB", 2.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    # Mock the heavy materialize step; capture its output paths instead.
+    calls = []
+    import omotion.SessionPlayback as sp
+    monkeypatch.setattr(
+        sp, "materialize_corrected_csv",
+        lambda *a, **k: calls.append(a[2]),  # a[2] == output_path
+    )
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    res = c.exportScansToFolder(
+        ["scanA", "scanB", "missing"], str(out_dir))
+
+    assert res["exported"] == 2
+    assert res["skipped"] == 1            # 'missing' has no DB session
+    assert len(calls) == 2
+    names = sorted(os.path.basename(p) for p in calls)
+    assert names == ["scanA_export.csv", "scanB_export.csv"]
+
+
+def test_export_scans_to_folder_empty_inputs(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    assert c.exportScansToFolder([], str(tmp_path)) == {
+        "exported": 0, "skipped": 0}
+    assert c.exportScansToFolder(["x"], "") == {
+        "exported": 0, "skipped": 0}


### PR DESCRIPTION
## Summary

Two changes to the **Scan History** modal (`components/HistoryModal.qml`, plus one new `motion_connector.py` slot).

**1. Unified selection model — fixes the QA bug.**
Previously the modal had two independent selections: clicking a *row* set the "active" row (drives the detail pane, Export, and Load), while ticking a *checkbox* drove Delete. They could disagree — so clicking scan A, then ticking scan B's checkbox, then "Load in viewer" loaded **A**, not B. Now there's one model:
- A plain row-click is a single-select: it replaces the checked set with that one row and makes it the active row.
- A checkbox click is additive (multi-select for Delete/Export), and never changes which row is active.
- Invariant: the highlighted (active) row is always a member of the checked set — so Load/Export can never disagree with the highlight. Unchecking the active row moves the highlight to the next checked row (or clears it).
- The modal now opens with **nothing** selected (previously auto-focused the newest scan).

**2. Multi-scan CSV export.**
Export CSV now acts on the checked set, mirroring Delete:
- 1 scan checked → the familiar Save-As dialog (rename allowed).
- 2+ scans checked → a folder picker that writes one `<label>_export.csv` per non-interrupted scan, then shows a summary toast (`Exported N scan(s) to <folder>`, with a skipped count when applicable).
- Backed by a new `exportScansToFolder` slot that opens the scan DB once for the batch, isolates per-scan failures (counted as skipped, never aborts the batch), and returns `{exported, skipped}`.

**3. Polish:** the Load button now names its target, e.g. `Load "Patient 12"  →`.

## Test plan

- [x] Unit suite green — 331 unit tests pass, incl. 4 new in `tests/test_history_export.py` (batch export + filename layout, missing-scan skip, **per-label failure isolation**, empty-input guard, no-DB guard).
- [ ] **Hand-test the interactive selection** (no automated QML harness):
  - [ ] QA repro: click scan A → tick scan B's checkbox → Load loads the highlighted scan A; highlight & Load target never disagree.
  - [ ] Plain row-click replaces selection (click A then B → only B ticked + highlighted).
  - [ ] Checkbox clicks are additive; `Delete (N)` / `Export CSV (N)` counts track.
  - [ ] Unchecking the active row moves the highlight to the next checked row; unchecking the last clears it and disables the buttons.
  - [ ] Select-all checks everything and leaves a usable active row; toggling off clears.
  - [ ] Open state shows nothing selected.
- [ ] **Hand-test export:** 1 checked → Save-As; 2+ checked → folder picker writes one CSV each; interrupted scans skipped and reported.
- [ ] **Visual:** Load button label and `Export CSV (N)` badge don't overflow at the default window width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)