### PR TITLE
feat: add deferHistoSend flag -> sensor DEBUG_FLAG_SEND_DEFER (bit 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | `cameraFakeData` | `false` | **Broken — do not use.** Was meant to request firmware fake histograms; see "Working without hardware". |
 | `histoThrottle` | `false` | Drop histograms to reduce log spam. |
 | `histoCmp` | `true` | Histogram compression (firmware `DEBUG_FLAG_HISTO_CMP`, bit `0x40` — firmware logs it as "histo compress"). Toggle live from Settings → Developer → "Histogram compression". |
+| `deferHistoSend` | `true` | Defer the per-frame histogram send out of the FSIN ISR into the firmware main loop (firmware `DEBUG_FLAG_SEND_DEFER`, bit `0x80`; sensor-fw#68). Config-only (no Settings UI); pushed to connected sensors at connect via `_compute_sensor_debug_flags`. Requires the PR-branch sensor firmware — stock firmware ignores bit 7. |
 | `tecTripTempC` | `40` | Console over-temp trip (°C) pushed to the console user config on connect via `motion_config.ensure_tec_trip` (read-modify-write, preserves calibration + OPT/EE keys). Validated to 1–60 °C; absent/invalid values leave the device's existing trip untouched (never writes `0`, which would disable the firmware trip). |
 | `ft_min_mean_per_camera` | `[40,40,…]` | Calibration pass threshold — min pixel mean per camera (8-element array). |
 | `calibration_scan_duration_sec` | `15` | Calibration runtime. |

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -62,6 +62,7 @@
   "consoleDebugLogging": false,
   "histoThrottle": false,
   "histoCmp": true,
+  "deferHistoSend": true,
   "commVerbose": false,
   "verboseCommandHandling": false,
   "support_email": "support@openwater.health",

--- a/main.py
+++ b/main.py
@@ -88,6 +88,7 @@ def _load_app_config() -> dict:
         "cameraFakeData": False,
         "histoThrottle": False,
         "histoCmp": False,
+        "deferHistoSend": False,
         "powerOffUnusedCameras": False,
         "commVerbose": False,  # Enable cmd id and "." prints from MCU
         "verboseCommandHandling": False,  # Enable printf in MCU command handlers

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -40,6 +40,7 @@ from omotion.config import (
     DEBUG_FLAG_HISTO_CMP,
     DEBUG_FLAG_COMM_VERBOSE,
     DEBUG_FLAG_CMD_VERBOSE,
+    DEBUG_FLAG_SEND_DEFER,
 )
 from omotion.MotionProcessing import process_bin_file
 from omotion.ScanWorkflow import ConfigureRequest, ScanRequest
@@ -912,6 +913,7 @@ class MotionConnector(QObject):
         self._camera_fake_data            = bool(cfg.get("cameraFakeData", False))
         self._histo_throttle              = bool(cfg.get("histoThrottle", False))
         self._histo_cmp                   = bool(cfg.get("histoCmp", False))
+        self._send_data_defer             = bool(cfg.get("deferHistoSend", False))
         self._comm_verbose                = bool(cfg.get("commVerbose", False))
         self._verbose_command_handling    = bool(cfg.get("verboseCommandHandling", False))
         # Console USB-printf mirror (DEBUG_FLAG_USB_PRINTF). Separate from the
@@ -1133,6 +1135,8 @@ class MotionConnector(QObject):
             flags |= DEBUG_FLAG_CMD_VERBOSE
         if self._histo_cmp:
             flags |= DEBUG_FLAG_HISTO_CMP
+        if self._send_data_defer:
+            flags |= DEBUG_FLAG_SEND_DEFER
         return flags
 
     def _apply_sensor_debug_flags(self) -> None:
@@ -1178,13 +1182,14 @@ class MotionConnector(QObject):
             logger.info(
                 "Setting debug flags 0x%x on %s sensor "
                 "(debug_logging=%s, fake_data=%s, histoThrottle=%s, histoCmp=%s, "
-                "commVerbose=%s, verboseCommand=%s)",
+                "deferHistoSend=%s, commVerbose=%s, verboseCommand=%s)",
                 flags,
                 side,
                 self._sensor_debug_logging,
                 self._camera_fake_data,
                 getattr(self, "_histo_throttle", False),
                 getattr(self, "_histo_cmp", False),
+                getattr(self, "_send_data_defer", False),
                 getattr(self, "_comm_verbose", False),
                 getattr(self, "_verbose_command_handling", False),
             )

--- a/tests/test_send_defer_flag.py
+++ b/tests/test_send_defer_flag.py
@@ -1,0 +1,69 @@
+"""``deferHistoSend`` config flag -> firmware ``DEBUG_FLAG_SEND_DEFER`` (bit 7).
+
+Unlike ``histoCmp``/``sensorDebugLogging`` (live Settings -> Developer
+toggles), ``deferHistoSend`` is config-only: it is read from the app config at
+construction into ``_send_data_defer`` and folded into the sensor debug-flag
+bitmask by ``_compute_sensor_debug_flags``, which is pushed to each sensor at
+connect via ``_run_sensor_init``. The firmware bit moves the per-frame
+histogram send out of the FSIN ISR into the main loop (sensor-fw#68).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+from omotion.config import DEBUG_FLAG_HISTO_CMP, DEBUG_FLAG_SEND_DEFER
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, app_config=None, left=True, right=True):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, left, right)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    iface.left.is_connected.return_value = left
+    iface.right.is_connected.return_value = right
+    iface.left.set_debug_flags.return_value = True
+    iface.right.set_debug_flags.return_value = True
+    c = MotionConnector(
+        interface=iface, app_config=app_config or {},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+    c._save_app_config = MagicMock()
+    return c, iface
+
+
+def test_defaults_off_when_absent(tmp_path):
+    c, _ = _connector(tmp_path, {})
+
+    assert c._send_data_defer is False
+    assert c._compute_sensor_debug_flags() & DEBUG_FLAG_SEND_DEFER == 0
+
+
+def test_enabled_sets_bit(tmp_path):
+    c, _ = _connector(tmp_path, {"deferHistoSend": True})
+
+    assert c._send_data_defer is True
+    assert c._compute_sensor_debug_flags() == DEBUG_FLAG_SEND_DEFER
+
+
+def test_combines_with_histo_cmp(tmp_path):
+    c, _ = _connector(tmp_path, {"deferHistoSend": True, "histoCmp": True})
+
+    assert c._compute_sensor_debug_flags() == (
+        DEBUG_FLAG_SEND_DEFER | DEBUG_FLAG_HISTO_CMP
+    )
+
+
+def test_pushed_to_connected_sensor_at_init(tmp_path):
+    # Config-only flags have no live-toggle path: they reach the firmware via
+    # the connect-time _run_sensor_init push, so that is what we exercise here.
+    c, iface = _connector(tmp_path, {"deferHistoSend": True})
+    c._leftSensorConnected = True
+
+    c._run_sensor_init("left")
+
+    iface.left.set_debug_flags.assert_called_once_with(DEBUG_FLAG_SEND_DEFER)


### PR DESCRIPTION
Adds a new **config-only** sensor debug flag, `deferHistoSend`, that sets firmware **bit 7 (`DEBUG_FLAG_SEND_DEFER`, `0x80`)** — moving the per-frame histogram send out of the FSIN ISR into the firmware main loop. Under investigation for the RIGHT-module intermittent 15–30 s histogram stall under laser-on (sensor-fw#68).

## Wiring (mirrors `histoCmp`)
- `motion_connector.py`: import `DEBUG_FLAG_SEND_DEFER`; read `cfg.get("deferHistoSend", False)` into `self._send_data_defer`; OR the bit in `_compute_sensor_debug_flags`; add it to the connect-time diagnostic log line.
- `config/app_config.json`: `"deferHistoSend": true` (shipped default), `main.py` in-code fallback `False` (matches the `histoCmp` precedent).
- Pushed to each connected sensor at connect via `_run_sensor_init` → `_compute_sensor_debug_flags`. **No Settings UI** (config-only); change the JSON + restart to flip it.
- `CLAUDE.md`: documented in the config-flag table.

## Default-true is safe
Stock firmware ignores bit 7; only the sensor-fw PR-branch firmware (sensor-fw#69) acts on it.

## Tests
New `tests/test_send_defer_flag.py` (unit): default-off, bit set when enabled, combines with `histoCmp`, and pushed to a connected sensor at init. All pass (4/4); existing `test_sensor_debug_flags` regression green (5/5).

## Requires
omotion with `DEBUG_FLAG_SEND_DEFER` — openmotion-sdk#104 (base next-next). Merge that first / together.

> Note: 4 failures in `tests/test_app_config_defaults.py` are **pre-existing on next-next** (tests monkeypatch the old `main.resource_path` seam; the loader now uses `config_store`) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)