### PR TITLE
feat: add "Create a desktop shortcut" checkbox to the installer

### DIFF
--- a/installer/app.wxs
+++ b/installer/app.wxs
@@ -21,9 +21,16 @@
       <Directory Id="AppShortcutFolder" Name="$(var.ProductName)" />
     </StandardDirectory>
 
+    <StandardDirectory Id="DesktopFolder" />
+
+    <!-- Desktop-shortcut opt-in. Set by the bundle's checkbox (default 1); the
+         default here also makes a direct MSI install create the shortcut. -->
+    <Property Id="INSTALLDESKTOPSHORTCUT" Value="1" />
+
     <Feature Id="Main" Title="$(var.ProductName)" Level="1">
       <ComponentGroupRef Id="AppFiles" />
       <ComponentRef Id="AppShortcut" />
+      <ComponentRef Id="DesktopShortcut" />
     </Feature>
 
     <!-- Harvest the entire PyInstaller one-folder output. -->
@@ -39,6 +46,18 @@
       <RemoveFolder Id="RemoveAppShortcutFolder" On="uninstall" />
       <RegistryValue Root="HKLM" Key="Software\Openwater\Bloodflow"
                      Name="installed" Type="integer" Value="1" KeyPath="yes" />
+    </Component>
+
+    <!-- Optional desktop shortcut (All Users desktop, since perMachine). Only
+         installed when the bundle checkbox / INSTALLDESKTOPSHORTCUT is set. -->
+    <Component Id="DesktopShortcut" Directory="DesktopFolder" Guid="*"
+               Condition="INSTALLDESKTOPSHORTCUT = &quot;1&quot;">
+      <Shortcut Id="DesktopShortcutLink"
+                Name="$(var.ProductName)"
+                Target="[APPFOLDER]OpenWaterApp.exe"
+                WorkingDirectory="APPFOLDER" />
+      <RegistryValue Root="HKLM" Key="Software\Openwater\Bloodflow"
+                     Name="desktopShortcut" Type="integer" Value="1" KeyPath="yes" />
     </Component>
   </Package>
 </Wix>

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -101,7 +101,11 @@ if ((Get-Item $appMsi).Length -lt 1MB) {
 powershell -NoProfile -File installer\sign.ps1 -Files $appMsi
 
 # -- build the Burn bundle --
+# -bindpath installer so the custom BA ThemeFile/LocalizationFile payloads
+# (bundle-theme.xml/.wxl) resolve; WiX searches bind paths (default cwd=repo
+# root), NOT the .wxs directory, for payload source files.
 wix build installer\bundle.wxs -o $bundleExe -ext WixToolset.BootstrapperApplications.wixext `
+    -bindpath installer `
     -d "ProductName=$($g.ProductName)" `
     -d "Version=$version" `
     -d "BundleUpgradeCode=$($g.BundleUpgradeCode)" `

--- a/installer/bundle-theme.wxl
+++ b/installer/bundle-theme.wxl
@@ -1,0 +1,69 @@
+<!-- installer/bundle-theme.wxl — localization for bundle-theme.xml. Stock WiX
+     5.0.2 HyperlinkTheme.wxl plus the DesktopShortcutCheckbox string. -->
+<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] Setup" />
+  <String Id="Title" Value="[WixBundleName]" />
+  <String Id="CheckingForUpdatesLabel" Value="Checking for updates" />
+  <String Id="UpdateButton" Value="&amp;Update to version [WixStdBAUpdateAvailable]" />
+  <String Id="InstallHeader" Value="Welcome" />
+  <String Id="InstallMessage" Value="Setup will install [WixBundleName] on your computer. Click Install to continue or Cancel to exit." />
+  <String Id="InstallMessageOptions" Value="Setup will install [WixBundleName] on your computer. Click Install to continue, Options to set installation options, or Cancel to exit." />
+  <String Id="InstallVersion" Value="Version [WixBundleVersion]" />
+  <String Id="ConfirmCancelMessage" Value="Are you sure you want to cancel?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Previous version" />
+  <String Id="HelpHeader" Value="Setup Help" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or&#xA;   creates a complete local copy of the bundle in directory. Install is the default.&#xA;&#xA;/passive | /quiet -  displays minimal UI with no prompts or displays no UI and&#xA;   no prompts. By default UI and all prompts are displayed.&#xA;&#xA;/norestart   - suppress any attempts to restart. By default UI will prompt before restart.&#xA;/log log.txt - logs to a specific file. By default a log file is created in %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Close" />
+  <String Id="InstallLicenseLinkText" Value="[WixBundleName] &lt;a href=&quot;#&quot;&gt;license terms&lt;/a&gt;." />
+  <String Id="InstallAcceptCheckbox" Value="I &amp;agree to the license terms and conditions" />
+  <String Id="DesktopShortcutCheckbox" Value="Create a &amp;desktop shortcut" />
+  <String Id="InstallOptionsButton" Value="&amp;Options" />
+  <String Id="InstallInstallButton" Value="&amp;Install" />
+  <String Id="InstallCancelButton" Value="&amp;Cancel" />
+  <String Id="OptionsHeader" Value="Setup Options" />
+  <String Id="OptionsLocationLabel" Value="Install location:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Browse" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Cancel" />
+  <String Id="ProgressHeader" Value="Setup Progress" />
+  <String Id="ProgressLabel" Value="Processing:" />
+  <String Id="OverallProgressPackageText" Value="Initializing..." />
+  <String Id="ProgressCancelButton" Value="&amp;Cancel" />
+  <String Id="ModifyHeader" Value="Modify Setup" />
+  <String Id="ModifyRepairButton" Value="&amp;Repair" />
+  <String Id="ModifyUninstallButton" Value="&amp;Uninstall" />
+  <String Id="ModifyCancelButton" Value="&amp;Cancel" />
+  <String Id="SuccessHeader" Value="Setup Successful" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Installation Successfully Completed" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Repair Successfully Completed" />
+  <String Id="SuccessUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessLaunchButton" Value="&amp;Launch" />
+  <String Id="SuccessRestartText" Value="You must restart your computer before you can use the software." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Restart" />
+  <String Id="SuccessCloseButton" Value="&amp;Close" />
+  <String Id="FailureHeader" Value="Setup Failed" />
+  <String Id="FailureCacheHeader" Value="Cache Failed" />
+  <String Id="FailureInstallHeader" Value="Setup Failed" />
+  <String Id="FailureLayoutHeader" Value="Layout Failed" />
+  <String Id="FailureModifyHeader" Value="Modify Failed" />
+  <String Id="FailureRepairHeader" Value="Repair Failed" />
+  <String Id="FailureUninstallHeader" Value="Uninstall Failed" />
+  <String Id="FailureUnsafeUninstallHeader" Value="Uninstall Failed" />
+  <String Id="FailureHyperlinkLogText" Value="One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href=&quot;#&quot;&gt;log file&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="You must restart your computer to complete the rollback of the software." />
+  <String Id="FailureRestartButton" Value="&amp;Restart" />
+  <String Id="FailureCloseButton" Value="&amp;Close" />
+  <String Id="FilesInUseTitle" Value="Files In Use" />
+  <String Id="FilesInUseLabel" Value="The following applications are using files that need to be updated:" />
+  <String Id="FilesInUseNetfxCloseRadioButton" Value="Close the &amp;applications." />
+  <String Id="FilesInUseCloseRadioButton" Value="Close the &amp;applications and attempt to restart them." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Do not close applications. A reboot will be required." />
+  <String Id="FilesInUseRetryButton" Value="&amp;Retry" />
+  <String Id="FilesInUseIgnoreButton" Value="&amp;Ignore" />
+  <String Id="FilesInUseExitButton" Value="E&amp;xit" />
+</WixLocalization>

--- a/installer/bundle-theme.xml
+++ b/installer/bundle-theme.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- installer/bundle-theme.xml — custom WixStdBA theme: stock WiX 5.0.2
+     hyperlinkLicense theme (src/ext/Bal/stdbas/Resources/HyperlinkTheme.xml)
+     plus a "Create a desktop shortcut" checkbox on the Install page. The
+     checkbox's Name two-way-binds to the InstallDesktopShortcut bundle
+     variable (default 1); see bundle.wxs. -->
+<Theme xmlns="http://wixtoolset.org/schemas/v4/thmutil">
+    <Font Id="0" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
+    <Font Id="1" Height="-24" Weight="500" Foreground="windowtext">Segoe UI</Font>
+    <Font Id="2" Height="-22" Weight="500" Foreground="graytext">Segoe UI</Font>
+    <Font Id="3" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
+
+    <Window Width="485" Height="300" HexStyle="100a0000" FontId="0" Caption="#(loc.Caption)">
+        <ImageControl X="11" Y="11" Width="64" Height="64" ImageFile="logo.png" Visible="yes"/>
+        <Label X="80" Y="11" Width="-11" Height="64" FontId="1" Visible="yes" DisablePrefix="yes">#(loc.Title)</Label>
+
+        <Page Name="Help">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Label>
+            <Label X="11" Y="112" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Label>
+            <Button Name="HelpCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.HelpCloseButton)</Text>
+                <CloseWindowAction />
+            </Button>
+        </Page>
+        <Page Name="Loading">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes" Visible="no" Name="CheckingForUpdatesLabel" />
+        </Page>
+        <Page Name="Install">
+            <Hypertext Name="EulaHyperlink" X="11" Y="121" Width="-11" Height="51" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
+            <Checkbox Name="InstallDesktopShortcut" X="11" Y="-41" Width="300" Height="17" TabStop="yes" FontId="3">#(loc.DesktopShortcutCheckbox)</Checkbox>
+            <Checkbox Name="EulaAcceptCheckbox" X="-11" Y="-41" Width="260" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
+            <Button Name="InstallUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
+            <Button Name="OptionsButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" VisibleCondition="NOT WixStdBASuppressOptionsUI">
+                <Text>#(loc.InstallOptionsButton)</Text>
+                <ChangePageAction Page="Options" />
+            </Button>
+            <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
+            <Button Name="InstallCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.InstallCancelButton)</Text>
+                <CloseWindowAction />
+            </Button>
+        </Page>
+        <Page Name="Options">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsHeader)</Label>
+            <Label X="11" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Label>
+            <Editbox Name="InstallFolder" X="11" Y="143" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
+            <Button Name="BrowseButton" X="-11" Y="142" Width="75" Height="23" TabStop="yes" FontId="3">
+                <Text>#(loc.OptionsBrowseButton)</Text>
+                <BrowseDirectoryAction VariableName="InstallFolder" />
+            </Button>
+            <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.OptionsOkButton)</Text>
+                <ChangePageAction Page="Install" />
+            </Button>
+            <Button Name="OptionsCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.OptionsCancelButton)</Text>
+                <ChangePageAction Page="Install" Cancel="yes" />
+            </Button>
+        </Page>
+        <Page Name="Progress">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
+            <Label X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Label>
+            <Label Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
+            <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
+            <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
+        </Page>
+        <Page Name="Modify">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Label>
+            <Button Name="ModifyUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
+            <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
+            <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
+            <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.ModifyCancelButton)</Text>
+                <CloseWindowAction />
+            </Button>
+        </Page>
+        <Page Name="Success">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
+                <Text>#(loc.SuccessHeader)</Text>
+                <Text Condition="WixBundleAction = 2">#(loc.SuccessLayoutHeader)</Text>
+                <Text Condition="WixBundleAction = 3">#(loc.SuccessUnsafeUninstallHeader)</Text>
+                <Text Condition="WixBundleAction = 4">#(loc.SuccessUninstallHeader)</Text>
+                <Text Condition="WixBundleAction = 5">#(loc.SuccessCacheHeader)</Text>
+                <Text Condition="WixBundleAction = 6">#(loc.SuccessInstallHeader)</Text>
+                <Text Condition="WixBundleAction = 7">#(loc.SuccessModifyHeader)</Text>
+                <Text Condition="WixBundleAction = 8">#(loc.SuccessRepairHeader)</Text>
+            </Label>
+            <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
+            <Label X="-11" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
+                <Text>#(loc.SuccessRestartText)</Text>
+                <Text Condition="WixBundleAction = 3">#(loc.SuccessUninstallRestartText)</Text>
+            </Label>
+            <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
+            <Button Name="SuccessCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.SuccessCloseButton)</Text>
+                <CloseWindowAction />
+            </Button>
+        </Page>
+        <Page Name="Failure">
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">
+                <Text>#(loc.FailureHeader)</Text>
+                <Text Condition="WixBundleAction = 2">#(loc.FailureLayoutHeader)</Text>
+                <Text Condition="WixBundleAction = 3">#(loc.FailureUnsafeUninstallHeader)</Text>
+                <Text Condition="WixBundleAction = 4">#(loc.FailureUninstallHeader)</Text>
+                <Text Condition="WixBundleAction = 5">#(loc.FailureCacheHeader)</Text>
+                <Text Condition="WixBundleAction = 6">#(loc.FailureInstallHeader)</Text>
+                <Text Condition="WixBundleAction = 7">#(loc.FailureModifyHeader)</Text>
+                <Text Condition="WixBundleAction = 8">#(loc.FailureRepairHeader)</Text>
+            </Label>
+            <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
+            <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
+            <Label X="-11" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
+            <Button Name="FailureRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
+            <Button Name="FailureCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
+                <Text>#(loc.FailureCloseButton)</Text>
+                <CloseWindowAction />
+            </Button>
+        </Page>
+    </Window>
+</Theme>

--- a/installer/bundle.wxs
+++ b/installer/bundle.wxs
@@ -7,9 +7,20 @@
           UpgradeCode="$(var.BundleUpgradeCode)">
 
     <BootstrapperApplication>
+      <!-- Custom theme = stock hyperlinkLicense + a "Create a desktop shortcut"
+           checkbox. Theme="hyperlinkLicense" is kept so the standard payload
+           group (logo.png etc.) is still provided; ThemeFile/LocalizationFile
+           override only the layout + strings. -->
       <bal:WixStandardBootstrapperApplication Theme="hyperlinkLicense"
+                                              ThemeFile="bundle-theme.xml"
+                                              LocalizationFile="bundle-theme.wxl"
                                               LicenseUrl="" />
     </BootstrapperApplication>
+
+    <!-- Desktop-shortcut checkbox state. Default 1 = checked; the theme
+         checkbox two-way-binds to this by name, and it is handed to the app
+         MSI below. -->
+    <Variable Name="InstallDesktopShortcut" Type="numeric" Value="1" />
 
     <Chain>
       <!-- WinUSB driver. Vital but its absence on uninstall is fine (Permanent). -->
@@ -18,10 +29,13 @@
                   Vital="yes"
                   Permanent="yes"
                   Visible="no" />
-      <!-- The app itself. -->
+      <!-- The app itself. Pass the checkbox state through as a public MSI
+           property so the desktop-shortcut component installs conditionally. -->
       <MsiPackage Id="AppMsi"
                   SourceFile="$(var.AppMsi)"
-                  Vital="yes" />
+                  Vital="yes">
+        <MsiProperty Name="INSTALLDESKTOPSHORTCUT" Value="[InstallDesktopShortcut]" />
+      </MsiPackage>
     </Chain>
   </Bundle>
 </Wix>


### PR DESCRIPTION
## What

Adds a **"Create a desktop shortcut"** checkbox to the installer's main install page, **checked by default**, letting the user opt out of the desktop icon. The Start Menu shortcut is unchanged.

## How

Standard Burn pattern — checkbox → bundle variable → MSI property → conditional component:

- **`installer/bundle-theme.xml` / `.wxl`** (new) — a custom `WixStandardBootstrapperApplication` theme: exact copies of WiX 5.0.2's stock `hyperlinkLicense` theme/localization plus one `InstallDesktopShortcut` checkbox + its string. `Theme="hyperlinkLicense"` is kept on the BA so the stock `logo.png` payload group is still provided; the `ThemeFile`/`LocalizationFile` override only the layout and strings.
- **`installer/bundle.wxs`** — points the BA at the custom theme, declares `<Variable Name="InstallDesktopShortcut" Value="1">` (default checked; thmutil two-way-binds the checkbox by name), and passes it to the app MSI as `INSTALLDESKTOPSHORTCUT`.
- **`installer/app.wxs`** — adds `DesktopFolder`, a default `INSTALLDESKTOPSHORTCUT=1` property (so a direct MSI install also creates it), and a `DesktopShortcut` component conditioned on `INSTALLDESKTOPSHORTCUT = "1"`.
- **`installer/build_installer.ps1`** — adds `-bindpath installer` so the theme payloads resolve (WiX searches bind paths, not the `.wxs` dir).

Because the install is `perMachine`, the icon lands on the **All Users** desktop, consistent with the Start Menu shortcut. Applies to both the **clinical** and **RUO** variants (shared `.wxs` files).

## Verification done

- Both `.wxs` compile; the **full bundle builds clean** (`setup.exe`, ~930 KB) with the theme payloads resolving.
- **Built MSI tables confirmed**: `DesktopShortcut` carries `Condition = INSTALLDESKTOPSHORTCUT = "1"`, targets `OpenWaterApp.exe` under `DesktopFolder`, is mapped to the `Main` feature, default property `= 1`.
- Theme files are well-formed XML.

## Needs hand-test

WiX embeds the theme as a runtime payload and doesn't validate it at build time, so the install-time behavior needs a real install to confirm:

- [ ] Checkbox renders on the install page, checked by default
- [ ] Default install → desktop icon present
- [ ] Uncheck → no icon
- [ ] Uninstall → icon removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)