### PR TITLE
build: unified 4-artifact build (Clinical/Research × Portable/Installer)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -109,29 +109,6 @@ jobs:
           wix extension add -g WixToolset.BootstrapperApplications.wixext/5.0.2
           echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: Build clinical installer
-        shell: pwsh
-        env:
-          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
-        run: |
-          powershell -NoProfile -File installer\build_installer.ps1 -Variant clinical
-
-      - name: Build RUO installer
-        shell: pwsh
-        env:
-          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
-        run: |
-          $cfg = "dist\OpenWaterApp\_internal\config\app_config.json"
-          $orig = Get-Content -Raw $cfg
-          $ruo = $orig -replace '"reducedMode"\s*:\s*true', '"reducedMode": false'
-          if ($ruo -eq $orig) { throw "RUO build: did not find reducedMode: true to flip" }
-          Set-Content -Path $cfg -Value $ruo -Encoding UTF8 -NoNewline
-          try {
-            powershell -NoProfile -File installer\build_installer.ps1 -Variant ruo
-          } finally {
-            Set-Content -Path $cfg -Value $orig -Encoding UTF8 -NoNewline
-          }
-
       # ── package ──────────────────────────────────────────────────
       - name: Determine version tag
         id: meta
@@ -158,30 +135,12 @@ jobs:
 
           echo "::notice ::Version tag resolved to: ${TAG}"
 
-      - name: Zip build output
+      - name: Package all artifacts (zips + installers, clinical + RUO)
         shell: pwsh
+        env:
+          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
         run: |
-          Compress-Archive -Path dist\* -DestinationPath "${{ steps.meta.outputs.ARTIFACT_ZIP }}"
-
-      # ── RUO variant: same bits with reducedMode flipped to false ─
-      - name: Zip RUO build output
-        shell: pwsh
-        run: |
-          $configPath = "dist\OpenWaterApp\_internal\config\app_config.json"
-          if (-not (Test-Path $configPath)) {
-              throw "RUO build failed: bundled config not found at $configPath."
-          }
-          $orig = Get-Content -Raw $configPath
-          $ruo = $orig -replace '"reducedMode"\s*:\s*true', '"reducedMode": false'
-          if ($ruo -eq $orig) {
-              throw "RUO build failed: did not find 'reducedMode: true' in $configPath to flip."
-          }
-          Set-Content -Path $configPath -Value $ruo -Encoding UTF8 -NoNewline
-          try {
-              Compress-Archive -Path dist\* -DestinationPath "${{ steps.meta.outputs.ARTIFACT_ZIP_RUO }}"
-          } finally {
-              Set-Content -Path $configPath -Value $orig -Encoding UTF8 -NoNewline
-          }
+          powershell -NoProfile -File scripts\package_artifacts.ps1 -Version "${{ steps.meta.outputs.TAG }}"
 
       # ── always upload workflow artifact ──────────────────────────
       - name: Upload workflow artifact

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ junit/
 local_notes.md
 /scan_data/
 OpenWaterApp*.zip
+OpenMotion-Bloodflow*.zip
 /run-logs/
 
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,16 @@ pip install -e ../openmotion-sdk
 python main.py                          # run the app
 
 python -m PyInstaller -y openwater.spec # package .exe → dist/OpenWaterApp/
-.\build_and_zip.ps1                     # CI packaging wrapper
+.\build_and_zip.ps1                     # build + package all 4 artifacts
+
+# 4 artifacts: Clinical/Research × Portable/Installer
+#   OpenMotion-Bloodflow-<ver>.zip      (Clinical portable)
+#   OpenMotion-Bloodflow-<ver>_RUO.zip  (Research portable)
+#   build/installer/Openwater-Setup-<ver>.exe      (Clinical installer)
+#   build/installer/Openwater-Setup-<ver>_RUO.exe  (Research installer)
+# build_and_zip.ps1 runs PyInstaller once, then scripts/package_artifacts.ps1
+# loops the variants. Installers are skipped with a warning if WiX isn't found;
+# scripts/package_artifacts.ps1 -SkipInstaller forces portable-only.
 ```
 
 - Tested on **Python 3.13.5**; `requirements.txt` pins PyQt6 6.8.0, qasync 0.27.1, pandas, numpy, matplotlib, pyusb, libusb1, PyInstaller 6.11.1, flake8 7.1.1.

--- a/build_and_zip.ps1
+++ b/build_and_zip.ps1
@@ -51,13 +51,9 @@ if (-not (Test-Path $SpecFile)) {
 
 Write-Host "=== Building with PyInstaller ===" -ForegroundColor Cyan
 
-# Determine version from git tags
-try {
-    $GitVersion = (git describe --tags --dirty --always --long 2>$null).Trim()
-    if (-not $GitVersion) { throw "empty" }
-} catch {
-    $GitVersion = "dev-$(Get-Date -Format 'yyyyMMdd_HHmmss')"
-}
+# Determine version from git tags (shared helper)
+. (Join-Path $PSScriptRoot "scripts\build_common.ps1")
+$GitVersion = (Get-BuildVersion).Full
 Write-Host "Version: $GitVersion" -ForegroundColor Yellow
 
 # Stamp _FALLBACK_VERSION in version.py so the frozen exe uses the right version
@@ -74,35 +70,13 @@ if (-not (Test-Path "dist\$AppName")) {
     throw "Build failed: dist\$AppName not found. Check your spec name and exe name."
 }
 
-$ZipName = "$AppName-$GitVersion.zip"
-
-Write-Host "=== Creating zip: $ZipName ===" -ForegroundColor Cyan
-Compress-Archive -Path "dist\$AppName\*" -DestinationPath $ZipName -Force
-
-# Build a second artifact with reducedMode flipped to false, for RUO distribution
-$RuoZipName = "$AppName-${GitVersion}_RUO.zip"
-$configPath = "dist\$AppName\_internal\config\app_config.json"
-if (-not (Test-Path $configPath)) {
-    throw "RUO build failed: bundled config not found at $configPath."
-}
-
-Write-Host "=== Creating RUO zip: $RuoZipName ===" -ForegroundColor Cyan
-$origConfig = Get-Content -Raw $configPath
-$ruoConfig = $origConfig -replace '"reducedMode"\s*:\s*true', '"reducedMode": false'
-if ($ruoConfig -eq $origConfig) {
-    throw "RUO build failed: did not find 'reducedMode: true' in $configPath to flip."
-}
-Set-Content -Path $configPath -Value $ruoConfig -Encoding UTF8 -NoNewline
-try {
-    Compress-Archive -Path "dist\$AppName\*" -DestinationPath $RuoZipName -Force
-} finally {
-    Set-Content -Path $configPath -Value $origConfig -Encoding UTF8 -NoNewline
-}
+# Package all 4 artifacts (Clinical/Research x Portable/Installer) via the shared
+# orchestrator. Installers are skipped with a warning if WiX isn't installed.
+& (Join-Path $PSScriptRoot "scripts\package_artifacts.ps1") -DistDir "dist\$AppName" -Version $GitVersion
+if ($LASTEXITCODE -ne 0) { throw "package_artifacts failed" }
 
 Write-Host "=== Build complete ===" -ForegroundColor Green
-Write-Host "ZIP file: $ZipName" -ForegroundColor Green
-Write-Host "RUO ZIP file: $RuoZipName" -ForegroundColor Green
 
 if ($OpenFolder) {
-    Start-Process explorer.exe "/select,$(Resolve-Path $ZipName)"
+    Start-Process explorer.exe (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 }

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -76,14 +76,9 @@ if (-not (Test-Path (Join-Path $DistAbs 'OpenWaterApp.exe'))) {
 # Write UTF-8 *without* BOM — the app's json.load fails silently on a BOM and
 # falls back to defaults.
 $cfgPath = Join-Path $DistAbs "_internal\config\app_config.json"
-if (-not (Test-Path $cfgPath)) { throw "bundled config not found at $cfgPath" }
-$reduced = if ($Variant -eq "ruo") { "false" } else { "true" }
-$cfgText = [System.IO.File]::ReadAllText($cfgPath)
-if ($cfgText -notmatch '"reducedMode"\s*:\s*(true|false)') {
-    throw "reducedMode key not found in $cfgPath"
-}
-$cfgText = [regex]::Replace($cfgText, '("reducedMode"\s*:\s*)(true|false)', "`${1}$reduced")
-[System.IO.File]::WriteAllText($cfgPath, $cfgText, (New-Object System.Text.UTF8Encoding $false))
+. (Join-Path $root "scripts\build_common.ps1")
+$reduced = ($Variant -ne "ruo")   # clinical => reducedMode true; ruo => false
+[void](Set-ReducedMode -ConfigPath $cfgPath -Reduced $reduced)
 Write-Host "Staged reducedMode=$reduced into bundled config" -ForegroundColor Green
 
 wix build installer\app.wxs -o $appMsi `

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -72,9 +72,12 @@ if (-not (Test-Path (Join-Path $DistAbs 'OpenWaterApp.exe'))) {
 # into the bundled config BEFORE wix runs. Mirrors build_and_zip.ps1's _RUO
 # flip: clinical keeps reducedMode=true (reduced clinical UI), RUO sets it
 # false (full research UI). We set it explicitly per variant so repeated
-# builds against one dist are always correct regardless of prior state.
-# Write UTF-8 *without* BOM — the app's json.load fails silently on a BOM and
-# falls back to defaults.
+# builds against one dist are always correct regardless of prior state —
+# including when scripts/package_artifacts.ps1 already staged the same value
+# before invoking us (the re-apply is an idempotent no-op, not a bug). This
+# self-contained flip is also what lets build_installer.ps1 be run standalone.
+# Set-ReducedMode writes UTF-8 *without* BOM — the app's json.load fails
+# silently on a BOM and falls back to defaults.
 $cfgPath = Join-Path $DistAbs "_internal\config\app_config.json"
 . (Join-Path $root "scripts\build_common.ps1")
 $reduced = ($Variant -ne "ruo")   # clinical => reducedMode true; ruo => false

--- a/scripts/build_common.ps1
+++ b/scripts/build_common.ps1
@@ -1,0 +1,74 @@
+# scripts/build_common.ps1
+# Shared helpers for the unified build/packaging path. Dot-source this:
+#   . (Join-Path $PSScriptRoot build_common.ps1)
+# Single source of truth for the reducedMode flip + version derivation + zip,
+# so the logic isn't copy-pasted across build_and_zip.ps1, package_artifacts.ps1,
+# installer/build_installer.ps1, and scripts/build_update_test_bundles.ps1.
+
+function Get-NumericVersion {
+    # Extract numeric X.Y.Z from any version string (the MSI requires numeric).
+    param([Parameter(Mandatory)][string]$Version)
+    if ($Version -match '(\d+)\.(\d+)\.(\d+)') {
+        return "$($matches[1]).$($matches[2]).$($matches[3])"
+    }
+    return "0.0.0"
+}
+
+function Get-BuildVersion {
+    # Full version string from git, with a dev-timestamp fallback (matches the
+    # prior inline behavior in build_and_zip.ps1). .Full names the zips; .Numeric
+    # feeds the MSI.
+    param()
+    $full = $null
+    try {
+        $full = (git describe --tags --dirty --always --long 2>$null).Trim()
+        if (-not $full) { throw "empty" }
+    } catch {
+        $full = "dev-$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+    }
+    return [pscustomobject]@{ Full = $full; Numeric = (Get-NumericVersion -Version $full) }
+}
+
+function Set-ReducedMode {
+    # BOM-safe flip of "reducedMode" in a bundled app_config.json. Returns the
+    # ORIGINAL file text so the caller can restore it. Writes UTF-8 WITHOUT BOM —
+    # the app's json.load fails silently on a BOM (memory: config_edit_bom_breaks_load).
+    param(
+        [Parameter(Mandatory)][string]$ConfigPath,
+        [Parameter(Mandatory)][bool]$Reduced
+    )
+    if (-not (Test-Path $ConfigPath)) { throw "config not found at $ConfigPath" }
+    $orig = [System.IO.File]::ReadAllText($ConfigPath)
+    if ($orig -notmatch '"reducedMode"\s*:\s*(true|false)') {
+        throw "reducedMode key not found in $ConfigPath"
+    }
+    $val = if ($Reduced) { "true" } else { "false" }
+    $new = [regex]::Replace($orig, '("reducedMode"\s*:\s*)(true|false)', "`${1}$val")
+    [System.IO.File]::WriteAllText($ConfigPath, $new, (New-Object System.Text.UTF8Encoding $false))
+    return $orig
+}
+
+function Restore-ConfigText {
+    # Write back the original text captured by Set-ReducedMode (no BOM).
+    param(
+        [Parameter(Mandatory)][string]$ConfigPath,
+        [Parameter(Mandatory)][string]$Text
+    )
+    [System.IO.File]::WriteAllText($ConfigPath, $Text, (New-Object System.Text.UTF8Encoding $false))
+}
+
+function New-PortableZip {
+    # Zip the whole dist tree so the archive contains a top-level OpenWaterApp\
+    # folder (the released structure — matches CI's `Compress-Archive dist\*`).
+    # $DistDir is dist\OpenWaterApp; zip its PARENT's contents.
+    param(
+        [Parameter(Mandatory)][string]$DistDir,
+        [Parameter(Mandatory)][string]$OutZip
+    )
+    $parent = Split-Path -Parent $DistDir
+    Compress-Archive -Path (Join-Path $parent '*') -DestinationPath $OutZip -Force
+}
+
+function Test-WixAvailable {
+    return [bool](Get-Command wix -ErrorAction SilentlyContinue)
+}

--- a/scripts/build_update_test_bundles.ps1
+++ b/scripts/build_update_test_bundles.ps1
@@ -36,12 +36,17 @@ function Build-RuoBundle([string]$ver, [string]$apiUrl) {
     try {
         & conda run -n $CondaEnv python -m PyInstaller -y openwater.spec
         if (-not (Test-Path "dist\OpenWaterApp\OpenWaterApp.exe")) { throw "dist missing after PyInstaller" }
-        # RUO (reducedMode:false) + optional updateApiUrl injection, via JSON (no BOM)
-        $py = "import json; p='dist/OpenWaterApp/_internal/config/app_config.json'; " +
-              "d=json.load(open(p,encoding='utf-8')); d['reducedMode']=False; "
-        if ($apiUrl) { $py += "d['updateApiUrl']='$apiUrl'; " }
-        $py += "json.dump(d, open(p,'w',encoding='utf-8'), indent=2)"
-        & conda run -n $CondaEnv python -c $py
+        # RUO (reducedMode:false) via the shared helper; optional updateApiUrl
+        # injection stays a JSON round-trip (no BOM, preserves the false above).
+        $cfgPath = "dist\OpenWaterApp\_internal\config\app_config.json"
+        . (Join-Path $PSScriptRoot "build_common.ps1")
+        [void](Set-ReducedMode -ConfigPath $cfgPath -Reduced $false)
+        if ($apiUrl) {
+            $py = "import json; p='dist/OpenWaterApp/_internal/config/app_config.json'; " +
+                  "d=json.load(open(p,encoding='utf-8')); d['updateApiUrl']='$apiUrl'; " +
+                  "json.dump(d, open(p,'w',encoding='utf-8'), indent=2)"
+            & conda run -n $CondaEnv python -c $py
+        }
         & powershell -NoProfile -ExecutionPolicy Bypass -File installer\build_installer.ps1 -Variant ruo -Version $ver
         if ($LASTEXITCODE -ne 0) { throw "build_installer failed for $ver" }
     } finally {

--- a/scripts/package_artifacts.ps1
+++ b/scripts/package_artifacts.ps1
@@ -1,0 +1,88 @@
+﻿# scripts/package_artifacts.ps1
+# Produce the 4 release artifacts (Clinical/Research x Portable/Installer) from a
+# single already-built PyInstaller dist. PyInstaller is NOT run here — the caller
+# (build_and_zip.ps1 or CI) runs it once; this packages it.
+#
+#   powershell -File scripts\package_artifacts.ps1                 # all 4 (needs WiX)
+#   powershell -File scripts\package_artifacts.ps1 -SkipInstaller  # 2 portable zips
+#   powershell -File scripts\package_artifacts.ps1 -Version 1.4.0-dev.0
+param(
+    [string]$DistDir    = "dist\OpenWaterApp",
+    [string]$Version    = "",
+    [string[]]$Variants = @("clinical", "ruo"),
+    [switch]$SkipInstaller,
+    [string]$OutDir     = ""
+)
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "build_common.ps1")
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+if (-not $OutDir) { $OutDir = $root }
+
+# -- resolve version (Full for zips, Numeric for the MSI) --
+if ($Version) {
+    $verFull    = $Version
+    $verNumeric = Get-NumericVersion -Version $Version
+} else {
+    $v = Get-BuildVersion
+    $verFull    = $v.Full
+    $verNumeric = $v.Numeric
+}
+Write-Host "Packaging version: Full=$verFull Numeric=$verNumeric" -ForegroundColor Yellow
+
+# -- validate the dist --
+if (-not (Test-Path $DistDir)) { throw "PyInstaller output '$DistDir' not found; run PyInstaller first" }
+if (-not (Test-Path (Join-Path $DistDir 'OpenWaterApp.exe'))) {
+    throw "OpenWaterApp.exe not found under $DistDir; PyInstaller build looks incomplete"
+}
+$cfgPath = Join-Path $DistDir "_internal\config\app_config.json"
+
+# -- WiX gate: skip installers (zips still build) when the toolchain is absent --
+$buildInstallers = -not $SkipInstaller
+if ($buildInstallers -and -not (Test-WixAvailable)) {
+    Write-Host "installers skipped — WiX not found (install WiX 5.0.2 or pass -SkipInstaller to silence)" -ForegroundColor Yellow
+    $buildInstallers = $false
+}
+
+# -- per-variant suffix + reducedMode value --
+$variantMap = @{
+    clinical = @{ Suffix = "";     Reduced = $true  }
+    ruo      = @{ Suffix = "_RUO";  Reduced = $false }
+}
+
+$produced = @()
+foreach ($variant in $Variants) {
+    if (-not $variantMap.ContainsKey($variant)) { throw "unknown variant '$variant' (expected clinical|ruo)" }
+    $m = $variantMap[$variant]
+
+    $orig = Set-ReducedMode -ConfigPath $cfgPath -Reduced $m.Reduced
+    try {
+        # portable zip (full version)
+        $zip = Join-Path $OutDir "OpenMotion-Bloodflow-$verFull$($m.Suffix).zip"
+        Write-Host "=== Portable ($variant): $zip ===" -ForegroundColor Cyan
+        New-PortableZip -DistDir $DistDir -OutZip $zip
+        $produced += $zip
+
+        # installer (numeric version)
+        if ($buildInstallers) {
+            Write-Host "=== Installer ($variant) ===" -ForegroundColor Cyan
+            & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $root "installer\build_installer.ps1") `
+                -Variant $variant -DistDir $DistDir -Version $verNumeric
+            if ($LASTEXITCODE -ne 0) { throw "build_installer failed for $variant" }
+            $produced += (Join-Path $root "build\installer\Openwater-Setup-$verNumeric$($m.Suffix).exe")
+        }
+    } finally {
+        Restore-ConfigText -ConfigPath $cfgPath -Text $orig
+    }
+}
+
+# -- post-build assertions --
+foreach ($a in $produced) {
+    if (-not (Test-Path $a)) { throw "expected artifact missing: $a" }
+    if ($a.EndsWith(".zip") -and (Get-Item $a).Length -lt 5MB) {
+        throw "portable zip suspiciously small (<5MB): $a"
+    }
+}
+
+Write-Host "=== Packaging complete — $($produced.Count) artifact(s) ===" -ForegroundColor Green
+$produced | ForEach-Object { Write-Host "  $_" -ForegroundColor Green }


### PR DESCRIPTION
## Summary

Unifies the build so a single shared packaging core produces all **4 release artifacts** — Clinical/Research × Portable/Installer — called by both the local `build_and_zip.ps1` and CI. Eliminates the `reducedMode`-flip + zip + installer logic that was copy-pasted across four files.

- **`scripts/build_common.ps1`** (new) — single source of truth: `Get-BuildVersion`/`Get-NumericVersion`, BOM-safe `Set-ReducedMode`/`Restore-ConfigText`, `New-PortableZip`, `Test-WixAvailable`.
- **`scripts/package_artifacts.ps1`** (new) — orchestrator. Loops `{clinical, ruo} × {portable, installer}` over one PyInstaller dist, flipping `reducedMode` per variant and restoring it in a `finally`. Skips installers with a warning when WiX is absent.
- **`build_and_zip.ps1`** — runs PyInstaller once, then delegates all packaging to the orchestrator (was: 2 inline zips, no installers).
- **`installer/build_installer.ps1`** & **`scripts/build_update_test_bundles.ps1`** — route their flip through `Set-ReducedMode` (dedup).
- **`.github/workflows/release-build.yml`** — replaces 4 inline steps (each repeating the flip) with one orchestrator call; same 4 artifacts attached to the release. (The whole-file diff is a one-time CRLF→LF normalization under `autocrlf=true`; inert on the runner.)
- Portable zips standardized onto the public name `OpenMotion-Bloodflow-<ver>[_RUO].zip` (+ `.gitignore` updated to match); installers unchanged (`Openwater-Setup-<ver>[_RUO].exe`).

## Test Plan

- [x] Parse-checks pass on every modified/new `.ps1`
- [x] Full local build (`build_and_zip.ps1`, pylib env, WiX 5.0.2) produced all 4 artifacts
- [x] Clinical zip has `reducedMode: true`; RUO zip has `reducedMode: false` (verified inside the archives)
- [x] Tracked `config/app_config.json` clean after build (per-variant restore works); only `version.py` stamped (pre-existing behavior)
- [x] WiX-absent path skips installers with a warning, still emits the 2 portable zips
- [ ] CI dry-run on a `*-dev.N` tag to confirm release attaches all 4 (zips + installers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)