### PR TITLE
fix: RUO reduced-mode Settings lockout + add portableMode build flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 |---|---|---|
 | `developerMode` | `true` | Show debug telemetry, per-camera CQ dots, test buttons. |
 | `reducedMode` | `true` | Clinical UI: hide settings, large BFI/BVI panels. |
+| `clinicalLock` | `true` | Build-time flag (not user-facing): gates the Settings "Reduced Mode" toggle behind the developer password. Only the Clinical variant ships this `true` — RUO always ships `false` so a stray `reducedMode:true` can be self-service undone. Flipped alongside `reducedMode` in `Set-ReducedMode` (`scripts/build_common.ps1`). |
+| `portableMode` | `false` | Build-time flag: `true` keeps all writable state (config overrides, logs, scan data/db) next to the exe (old un-installed layout); `false` scatters it to `%PROGRAMDATA%\Openwater`. Portable zips ship `true`, installers force `false` — see `Set-PortableMode` (`scripts/build_common.ps1`) and `utils/app_paths.py:writable_root`. |
 | `forceLaserFail` | `false` | Debug: simulate a laser safety trip. |
 | `cameraFakeData` | `false` | **Broken — do not use.** Was meant to request firmware fake histograms; see "Working without hardware". |
 | `histoThrottle` | `false` | Drop histograms to reduce log spam. |
@@ -114,7 +116,7 @@ Get-ChildItem C:\Users\ethan\Projects\scan_data\app-logs\ow-bloodflowapp-*.log |
   Get-Content | Select-String -Pattern "Calibration phase|procedure complete|samples captured"
 ```
 
-The `dataDirectory` config key controls the root (defaults to cwd if unset — falls back to `~/Documents/Openwater Bloodflow` on macOS). Sibling output directories under the same root:
+The `dataDirectory` config key controls the root (defaults to cwd if unset — falls back to `~/Documents/Openwater Bloodflow` on macOS). When unset on a frozen build, the default instead follows `portableMode`: next to the exe (portable zip) or `%PROGRAMDATA%\Openwater` (installer). Sibling output directories under the same root:
 - `app-logs/` — app log files (one per launch)
 - `app-logs/ft-test-csvs/` — factory-test CSVs
 - `calibrations/` — saved calibration JSONs (also written here)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | Flag | Default | Purpose |
 |---|---|---|
 | `developerMode` | `true` | Show debug telemetry, per-camera CQ dots, test buttons. |
-| `reducedMode` | `true` | Clinical UI: hide settings, large BFI/BVI panels. |
-| `clinicalLock` | `true` | Build-time flag (not user-facing): gates the Settings "Reduced Mode" toggle behind the developer password. Only the Clinical variant ships this `true` — RUO always ships `false` so a stray `reducedMode:true` can be self-service undone. Flipped alongside `reducedMode` in `Set-ReducedMode` (`scripts/build_common.ps1`). |
+| `reducedMode` | `true` | Clinical UI: hide settings, large BFI/BVI panels. Build-time only — there is no Settings toggle for it (removed; config-only now). |
 | `portableMode` | `false` | Build-time flag: `true` keeps all writable state (config overrides, logs, scan data/db) next to the exe (old un-installed layout); `false` scatters it to `%PROGRAMDATA%\Openwater`. Portable zips ship `true`, installers force `false` — see `Set-PortableMode` (`scripts/build_common.ps1`) and `utils/app_paths.py:writable_root`. |
 | `forceLaserFail` | `false` | Debug: simulate a laser safety trip. |
 | `cameraFakeData` | `false` | **Broken — do not use.** Was meant to request firmware fake histograms; see "Working without hardware". |

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -759,9 +759,15 @@ Item {
                 }
 
                 // ── Reduced Mode ─────────────────────────────────────────────
+                // Gated on clinicalLock (a build-time flag, true only for the
+                // Clinical variant), not on reducedMode itself — otherwise a
+                // Research/RUO build that ever ends up with reducedMode:true
+                // (e.g. a stale %PROGRAMDATA% override) hides the only way to
+                // turn it back off, trapping the user without the developer
+                // password.
                 SectionCard {
                     title: "Reduced Mode"
-                    visible: !root.reducedMode || (MotionInterface.appConfig.developerMode ? true : false)
+                    visible: !MotionInterface.appConfig.clinicalLock || (MotionInterface.appConfig.developerMode ? true : false)
 
                     FieldRow {
                         label: "Enable"

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -758,34 +758,6 @@ Item {
                     }
                 }
 
-                // ── Reduced Mode ─────────────────────────────────────────────
-                // Gated on clinicalLock (a build-time flag, true only for the
-                // Clinical variant), not on reducedMode itself — otherwise a
-                // Research/RUO build that ever ends up with reducedMode:true
-                // (e.g. a stale %PROGRAMDATA% override) hides the only way to
-                // turn it back off, trapping the user without the developer
-                // password.
-                SectionCard {
-                    title: "Reduced Mode"
-                    visible: !MotionInterface.appConfig.clinicalLock || (MotionInterface.appConfig.developerMode ? true : false)
-
-                    FieldRow {
-                        label: "Enable"
-                        PillSwitch {
-                            checked: root.reducedMode
-                            onCheckedChanged: root.reducedMode = checked
-                        }
-                        Item { Layout.fillWidth: true }
-                    }
-                    Text {
-                        text: "Simplified clinical view: forces Far camera configuration, enables free run mode, hides scan settings, and shows large left/right BFI and BVI panels."
-                        color: root.colTextMuted
-                        font.pixelSize: 11
-                        wrapMode: Text.WordWrap
-                        Layout.fillWidth: true
-                    }
-                }
-
                 // ── Appearance ───────────────────────────────────────────────
                 SectionCard {
                     title: "Appearance"

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -7,7 +7,6 @@
   "leftMask": 102,
   "rightMask": 102,
   "reducedMode": true,
-  "clinicalLock": true,
   "reducedModeLeftMask": 195,
   "reducedModeRightMask": 195,
   "uncorrectedOnly": true,

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -1,4 +1,5 @@
 {
+  "portableMode": false,
   "dataDirectory": null,
   "writeRawCsv": false,
   "rawCsvDurationSec": null,
@@ -6,6 +7,7 @@
   "leftMask": 102,
   "rightMask": 102,
   "reducedMode": true,
+  "clinicalLock": true,
   "reducedModeLeftMask": 195,
   "reducedModeRightMask": 195,
   "uncorrectedOnly": true,

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -84,6 +84,12 @@ $reduced = ($Variant -ne "ruo")   # clinical => reducedMode true; ruo => false
 [void](Set-ReducedMode -ConfigPath $cfgPath -Reduced $reduced)
 Write-Host "Staged reducedMode=$reduced into bundled config" -ForegroundColor Green
 
+# Installed (MSI) apps always scatter writable state to %PROGRAMDATA% —
+# portableMode is a portable-zip-only concept. Force it off here too so this
+# script stays correct when run standalone, not just via package_artifacts.ps1.
+[void](Set-PortableMode -ConfigPath $cfgPath -Portable $false)
+Write-Host "Staged portableMode=false into bundled config" -ForegroundColor Green
+
 wix build installer\app.wxs -o $appMsi `
     -d "ProductName=$($g.ProductName)" `
     -d "Version=$version" `

--- a/main.py
+++ b/main.py
@@ -134,7 +134,19 @@ def _load_app_config() -> dict:
         "autoScalePerPlot": False,
         # Y-axis tick labels on plot cells; runtime toggle in the ⋯ popup.
         "showAxisLabels": True,
+        # Build-time flag: true keeps ALL writable state (config overrides,
+        # logs, scan data/db) next to the exe, like the old un-installed
+        # layout; false scatters it to %PROGRAMDATA%\Openwater (the
+        # installed/MSI layout). Set by the build system per artifact type
+        # (portable zip vs installer) — see scripts/build_common.ps1.
+        "portableMode": False,
         "reducedMode": False,
+        # Gates the Settings "Reduced Mode" toggle behind the developer
+        # password (only the Clinical build ships this true). Without it,
+        # a Research/RUO build that ever picks up a stray reducedMode:true
+        # (e.g. a leftover %PROGRAMDATA% override) has no way for the user
+        # to self-service turn it back off.
+        "clinicalLock": False,
         "reducedModeLeftMask": 0xC3,
         "reducedModeRightMask": 0xC3,
         "plotWindowSec": 15,
@@ -168,7 +180,8 @@ def _load_app_config() -> dict:
     _APP_CONFIG_BASELINE.clear()
     _APP_CONFIG_BASELINE.update(baseline)
     logger.info(
-        "Loaded app config (overrides from %s)", app_paths.local_config_path()
+        "Loaded app config (overrides from %s)",
+        app_paths.local_config_path(bool(baseline.get("portableMode", False))),
     )
     return merged
 
@@ -228,10 +241,11 @@ def main():
     # Finder launch where cwd is "/").
     _data_dir = app_config.get("dataDirectory")
     if not _data_dir:
-        # Frozen (installed) build uses ProgramData; dev run uses cwd,
-        # falling back to ~/Documents if cwd is not writable.
+        # Frozen + non-portable uses ProgramData; frozen + portable (or a
+        # dev run) keeps everything next to the exe / cwd, falling back to
+        # ~/Documents if that's not writable.
         candidate = (
-            str(app_paths.writable_root())
+            str(app_paths.writable_root(bool(app_config.get("portableMode", False))))
             if getattr(sys, "frozen", False)
             else os.getcwd()
         )

--- a/main.py
+++ b/main.py
@@ -141,12 +141,6 @@ def _load_app_config() -> dict:
         # (portable zip vs installer) — see scripts/build_common.ps1.
         "portableMode": False,
         "reducedMode": False,
-        # Gates the Settings "Reduced Mode" toggle behind the developer
-        # password (only the Clinical build ships this true). Without it,
-        # a Research/RUO build that ever picks up a stray reducedMode:true
-        # (e.g. a leftover %PROGRAMDATA% override) has no way for the user
-        # to self-service turn it back off.
-        "clinicalLock": False,
         "reducedModeLeftMask": 0xC3,
         "reducedModeRightMask": 0xC3,
         "plotWindowSec": 15,

--- a/scripts/build_common.ps1
+++ b/scripts/build_common.ps1
@@ -30,15 +30,9 @@ function Get-BuildVersion {
 }
 
 function Set-ReducedMode {
-    # BOM-safe flip of "reducedMode" (and the paired "clinicalLock" build flag)
-    # in a bundled app_config.json. Returns the ORIGINAL file text so the
-    # caller can restore it. Writes UTF-8 WITHOUT BOM — the app's json.load
-    # fails silently on a BOM (memory: config_edit_bom_breaks_load).
-    #
-    # clinicalLock mirrors $Reduced: it's what gates the "Reduced Mode" toggle
-    # in Settings behind the developer password, so only the Clinical variant
-    # (Reduced=true) is locked — Research/RUO users can always self-service
-    # flip a stray reducedMode:true back off (see #<lockout fix>).
+    # BOM-safe flip of "reducedMode" in a bundled app_config.json. Returns the
+    # ORIGINAL file text so the caller can restore it. Writes UTF-8 WITHOUT BOM —
+    # the app's json.load fails silently on a BOM (memory: config_edit_bom_breaks_load).
     param(
         [Parameter(Mandatory)][string]$ConfigPath,
         [Parameter(Mandatory)][bool]$Reduced
@@ -50,9 +44,6 @@ function Set-ReducedMode {
     }
     $val = if ($Reduced) { "true" } else { "false" }
     $new = [regex]::Replace($orig, '("reducedMode"\s*:\s*)(true|false)', "`${1}$val")
-    if ($new -match '"clinicalLock"\s*:\s*(true|false)') {
-        $new = [regex]::Replace($new, '("clinicalLock"\s*:\s*)(true|false)', "`${1}$val")
-    }
     [System.IO.File]::WriteAllText($ConfigPath, $new, (New-Object System.Text.UTF8Encoding $false))
     return $orig
 }

--- a/scripts/build_common.ps1
+++ b/scripts/build_common.ps1
@@ -30,9 +30,15 @@ function Get-BuildVersion {
 }
 
 function Set-ReducedMode {
-    # BOM-safe flip of "reducedMode" in a bundled app_config.json. Returns the
-    # ORIGINAL file text so the caller can restore it. Writes UTF-8 WITHOUT BOM —
-    # the app's json.load fails silently on a BOM (memory: config_edit_bom_breaks_load).
+    # BOM-safe flip of "reducedMode" (and the paired "clinicalLock" build flag)
+    # in a bundled app_config.json. Returns the ORIGINAL file text so the
+    # caller can restore it. Writes UTF-8 WITHOUT BOM — the app's json.load
+    # fails silently on a BOM (memory: config_edit_bom_breaks_load).
+    #
+    # clinicalLock mirrors $Reduced: it's what gates the "Reduced Mode" toggle
+    # in Settings behind the developer password, so only the Clinical variant
+    # (Reduced=true) is locked — Research/RUO users can always self-service
+    # flip a stray reducedMode:true back off (see #<lockout fix>).
     param(
         [Parameter(Mandatory)][string]$ConfigPath,
         [Parameter(Mandatory)][bool]$Reduced
@@ -44,6 +50,32 @@ function Set-ReducedMode {
     }
     $val = if ($Reduced) { "true" } else { "false" }
     $new = [regex]::Replace($orig, '("reducedMode"\s*:\s*)(true|false)', "`${1}$val")
+    if ($new -match '"clinicalLock"\s*:\s*(true|false)') {
+        $new = [regex]::Replace($new, '("clinicalLock"\s*:\s*)(true|false)', "`${1}$val")
+    }
+    [System.IO.File]::WriteAllText($ConfigPath, $new, (New-Object System.Text.UTF8Encoding $false))
+    return $orig
+}
+
+function Set-PortableMode {
+    # BOM-safe flip of "portableMode" in a bundled app_config.json. Portable
+    # zips keep all writable state (config overrides, logs, scan data) next
+    # to the exe; installers scatter it to %PROGRAMDATA% instead — see
+    # utils/app_paths.py:writable_root. Does NOT return the original text —
+    # callers should already hold that from an earlier Set-ReducedMode call
+    # (or capture it themselves) since Restore-ConfigText only needs to run
+    # once per artifact regardless of how many flags got flipped.
+    param(
+        [Parameter(Mandatory)][string]$ConfigPath,
+        [Parameter(Mandatory)][bool]$Portable
+    )
+    if (-not (Test-Path $ConfigPath)) { throw "config not found at $ConfigPath" }
+    $orig = [System.IO.File]::ReadAllText($ConfigPath)
+    if ($orig -notmatch '"portableMode"\s*:\s*(true|false)') {
+        throw "portableMode key not found in $ConfigPath"
+    }
+    $val = if ($Portable) { "true" } else { "false" }
+    $new = [regex]::Replace($orig, '("portableMode"\s*:\s*)(true|false)', "`${1}$val")
     [System.IO.File]::WriteAllText($ConfigPath, $new, (New-Object System.Text.UTF8Encoding $false))
     return $orig
 }

--- a/scripts/package_artifacts.ps1
+++ b/scripts/package_artifacts.ps1
@@ -57,7 +57,11 @@ foreach ($variant in $Variants) {
 
     $orig = Set-ReducedMode -ConfigPath $cfgPath -Reduced $m.Reduced
     try {
-        # portable zip (full version)
+        # portable zip (full version) — portableMode:true so it keeps all
+        # writable state next to the exe, matching the old un-installed layout.
+        # build_installer.ps1 below independently forces portableMode:false
+        # onto the same file before harvesting it for the MSI.
+        [void](Set-PortableMode -ConfigPath $cfgPath -Portable $true)
         $zip = Join-Path $OutDir "OpenMotion-Bloodflow-$verFull$($m.Suffix).zip"
         Write-Host "=== Portable ($variant): $zip ===" -ForegroundColor Cyan
         New-PortableZip -DistDir $DistDir -OutZip $zip

--- a/utils/app_paths.py
+++ b/utils/app_paths.py
@@ -15,14 +15,22 @@ import sys
 _APP_DIRNAME = "Openwater"
 
 
-def writable_root() -> Path:
-    """Return the writable data root, creating it if necessary."""
+def writable_root(portable: bool = False) -> Path:
+    """Return the writable data root, creating it if necessary.
+
+    ``portable`` mirrors the shipped ``portableMode`` config flag: when set,
+    a frozen build keeps everything next to the exe (the old un-installed
+    behavior) instead of scattering it to %PROGRAMDATA%.
+    """
     env = os.environ.get("OPENWATER_DATA_ROOT")
     if env:
         root = Path(env)
     elif getattr(sys, "frozen", False):
-        base = os.environ.get("PROGRAMDATA", r"C:\ProgramData")
-        root = Path(base) / _APP_DIRNAME
+        if portable:
+            root = Path(sys.executable).resolve().parent
+        else:
+            base = os.environ.get("PROGRAMDATA", r"C:\ProgramData")
+            root = Path(base) / _APP_DIRNAME
     else:
         # dev: keep everything under the cwd, unchanged from before
         root = Path.cwd()
@@ -30,6 +38,6 @@ def writable_root() -> Path:
     return root
 
 
-def local_config_path() -> Path:
+def local_config_path(portable: bool = False) -> Path:
     """Path to the writable config-overrides file."""
-    return writable_root() / "app_config.local.json"
+    return writable_root(portable) / "app_config.local.json"

--- a/utils/config_store.py
+++ b/utils/config_store.py
@@ -43,9 +43,9 @@ def shipped_baseline(defaults: dict) -> dict:
     return _coerce_ints(base)
 
 
-def load_overrides() -> dict:
+def load_overrides(portable: bool = False) -> dict:
     """Read the writable overrides file (empty dict if absent/invalid)."""
-    path = app_paths.local_config_path()
+    path = app_paths.local_config_path(portable)
     if not path.exists():
         return {}
     try:
@@ -57,9 +57,15 @@ def load_overrides() -> dict:
 
 
 def load_app_config(defaults: dict):
-    """Return (baseline, merged); merged = baseline + writable overrides."""
+    """Return (baseline, merged); merged = baseline + writable overrides.
+
+    ``portableMode`` is read off the shipped baseline itself (it's a
+    build-time flag, never a runtime override) to decide where the writable
+    overrides file lives before we go looking for it.
+    """
     baseline = shipped_baseline(defaults)
-    overrides = load_overrides()
+    portable = bool(baseline.get("portableMode", False))
+    overrides = load_overrides(portable)
     merged = {
         **baseline,
         **{k: v for k, v in overrides.items() if k in baseline},
@@ -77,7 +83,7 @@ def save_overrides(current: dict, baseline: dict) -> None:
     diff = _coerce_ints(
         {k: v for k, v in current.items() if baseline.get(k) != v}
     )
-    path = app_paths.local_config_path()
+    path = app_paths.local_config_path(bool(baseline.get("portableMode", False)))
     tmp = path.with_name(path.name + ".tmp")
     try:
         with open(tmp, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Users got stuck in Reduced Mode with no way back: the Settings "Reduced Mode" toggle was hidden whenever `reducedMode` was `true` unless `developerMode` was already unlocked. Any build — including RUO/research — that ever ended up with a stray `reducedMode:true` (e.g. a leftover `%PROGRAMDATA%\Openwater\app_config.local.json` override from a prior install/variant on the same machine) had no self-service way to turn it back off, since the toggle to fix it was the thing hidden.
- Fix: remove the "Reduced Mode" toggle from Settings entirely, for all users/variants. `reducedMode` itself is unchanged — it's still what actually drives the simplified clinical UI (`BloodFlow.qml`, `ButtonPanel.qml`, `motion_connector.py`, etc.) — it's just no longer user-editable from Settings, so there's nothing left to get stuck toggling.
- Also adds `portableMode`, a build-time flag set per artifact type: `true` for portable zips (keeps config overrides, logs, and scan data next to the exe — the old un-installed layout) and `false` for installers (scatters state to `%PROGRAMDATA%\Openwater`, unchanged from current installed behavior). New `Set-PortableMode` helper mirrors `Set-ReducedMode`; `build_installer.ps1` force-sets it `false` standalone (self-contained, same pattern as its existing `reducedMode` flip).

(An earlier version of this PR added a `clinicalLock` flag to gate the toggle instead of removing it — dropped once we decided to just remove the toggle for everyone, since a flag that only gates a now-deleted toggle has no purpose.)

## Test plan
- [x] `pytest tests/test_app_paths.py tests/test_config_store.py tests/test_connector_save_overrides.py tests/test_main_config_wiring.py` — 8 passed
- [x] `pytest tests/test_app_config_defaults.py` — 3 pre-existing failures unrelated to this change (verified identical failures with these changes stashed out, caused by a stray local `app_config.local.json` in this worktree, not this PR)
- [x] PowerShell syntax-checked `scripts/build_common.ps1`, `scripts/package_artifacts.ps1`, `installer/build_installer.ps1` via the `System.Management.Automation.Language.Parser`
- [ ] Manual: run `build_and_zip.ps1`, confirm the RUO portable zip's bundled config has `reducedMode:false`, `portableMode:true`, and the Clinical installer's has `reducedMode:true`, `portableMode:false`; confirm the Settings modal no longer shows a "Reduced Mode" card in either build
- [ ] HIL: `tests/test_reducedmode.py` needs a running app window on real hardware — not runnable in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)