### PR TITLE
fix: CQ check must not require cameras set to "None"

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -4066,8 +4066,8 @@ class MotionConnector(QObject):
         return self._ensure_idle() is None
 
     # ──────────────────────────────────────────────────────────────────
-    @pyqtSlot()
-    def runContactQualityCheck(self):
+    @pyqtSlot(int, int)
+    def runContactQualityCheck(self, left_camera_mask: int, right_camera_mask: int):
         """Run the contact-quality check via the SDK's ContactQualityWorkflow.
 
         Delegates to interface.contact_quality_workflow.check(), which runs
@@ -4075,6 +4075,13 @@ class MotionConnector(QObject):
         per-camera BFI statistics. The SDK call is synchronous/blocking, so
         we run it in a background thread and marshal results back via a
         private signal.
+
+        left_camera_mask / right_camera_mask: the *configured scan* mask
+        (bloodFlow.leftMask/rightMask — cameras the user actually selected,
+        with any camera set to "None" cleared). Only these cameras are
+        evaluated; a camera excluded from the scan must not be required to
+        pass contact quality. Still AND-gated on sensor-connected state
+        below, matching the pre-existing safety check.
         """
         err = self._ensure_idle()
         if err is not None:
@@ -4099,8 +4106,8 @@ class MotionConnector(QObject):
         self.contactQualityScanInProgress.emit(True)
         self.contactQualityCheckStarted.emit(int(round(duration_s + 3)))
 
-        left_mask = 0xFF if self._leftSensorConnected else 0x00
-        right_mask = 0xFF if self._rightSensorConnected else 0x00
+        left_mask = int(left_camera_mask) if self._leftSensorConnected else 0x00
+        right_mask = int(right_camera_mask) if self._rightSensorConnected else 0x00
 
         self._cq_t0 = time.monotonic()
         logger.info(

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -443,14 +443,20 @@ Rectangle {
     // ===== SCAN RUNNER (check mode) =====
     // Shares flash + trigger/laser plumbing with scanRunner; final stage is
     // the contact-quality check instead of capture. Always flashes 0xFF so
-    // every physically-present camera participates — absent cameras are
-    // skipped by the configure workflow.
+    // every physically-present camera participates (lets the live CQ view
+    // show a dot for every camera) — absent cameras are skipped by the
+    // configure workflow. The pass/fail *evaluation* is narrower: only the
+    // user's currently configured scan mask (evalLeftMask/evalRightMask)
+    // is required to pass — a camera set to "None" in scan settings is
+    // flashed/shown but never blocks the check.
     ScanRunner {
         id: qualityCheckRunner
         mode: "check"
         connector: MotionInterface
         leftMask: MotionInterface.leftSensorConnected  ? 0xFF : 0x00
         rightMask: MotionInterface.rightSensorConnected ? 0xFF : 0x00
+        evalLeftMask: bloodFlow.leftMask
+        evalRightMask: bloodFlow.rightMask
         laserOn: true
         laserPower: 50
         // See note on the scanRunner triggerConfig above — same here.

--- a/pages/scan/ContactQualityCheckTask.qml
+++ b/pages/scan/ContactQualityCheckTask.qml
@@ -10,6 +10,11 @@ import QtQuick 6.5
 QtObject {
     id: task
     property var connector
+    // Configured scan mask (cameras the user actually selected — a camera
+    // set to "None" is cleared here) so the CQ pass/fail verdict only
+    // requires contact on cameras that will actually be used.
+    property int leftCameraMask: 0
+    property int rightCameraMask: 0
 
     signal started()
     signal progress(int pct)
@@ -43,7 +48,7 @@ QtObject {
         connector.contactQualityCheckFinished.connect(_onDone)
 
         try {
-            connector.runContactQualityCheck()
+            connector.runContactQualityCheck(task.leftCameraMask, task.rightCameraMask)
         } catch (e) {
             try { connector.contactQualityCheckFinished.disconnect(_onDone) } catch(e2) {}
             finished(false, "runContactQualityCheck exception: " + e)

--- a/pages/scan/ScanRunner.qml
+++ b/pages/scan/ScanRunner.qml
@@ -23,6 +23,16 @@ QtObject {
     property int leftMask: 0x5A
     property int rightMask: 0x5A
 
+    // "check" mode only: the mask actually evaluated for contact-quality
+    // pass/fail. Defaults to leftMask/rightMask (the flash mask) so
+    // existing callers are unaffected; a caller that flashes every
+    // physically-present camera (leftMask/rightMask = 0xFF) but only
+    // wants to require contact on the user's *configured* scan cameras
+    // sets these explicitly — a camera the user set to "None" then never
+    // needs to pass contact quality.
+    property int evalLeftMask: leftMask
+    property int evalRightMask: rightMask
+
     property int durationSec: 60
     property string subjectId: ""
     property string dataDir: ""
@@ -173,6 +183,8 @@ QtObject {
 
     property ContactQualityCheckTask checkTask: ContactQualityCheckTask {
         connector: runner.connector
+        leftCameraMask: runner.evalLeftMask
+        rightCameraMask: runner.evalRightMask
 
         onStarted: {
             runner._stage = "check"

--- a/tests/test_contact_quality_mask.py
+++ b/tests/test_contact_quality_mask.py
@@ -1,0 +1,93 @@
+"""Unit tests for issue: cameras set to "None" (deselected from the
+configured scan mask) must not be required to pass the contact-quality
+check. No hardware — fakes the interface and runs the CQ worker thread
+synchronously so we can assert on the exact mask handed to the SDK."""
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+pytestmark = pytest.mark.unit
+
+
+class _SyncThread:
+    """Stand-in for threading.Thread that runs the target synchronously on
+    start(), so the CQ worker's SDK call can be asserted on without racing
+    a real background thread."""
+
+    def __init__(self, target=None, args=(), kwargs=None, **_kw):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        self._target(*self._args, **self._kwargs)
+
+    def join(self, *a, **kw):
+        pass
+
+
+@pytest.fixture
+def connector(monkeypatch):
+    from motion_connector import MotionConnector
+
+    fake_iface = MagicMock()
+    fake_iface.console = MagicMock()
+    fake_iface.left = MagicMock()
+    fake_iface.right = MagicMock()
+    fake_iface.is_device_connected.return_value = (True, True, True)
+    fake_iface.scan_workflow = MagicMock()
+    fake_iface.scan_workflow.running = False
+    fake_iface.scan_workflow.config_running = False
+    fake_iface.contact_quality_workflow = MagicMock()
+    # A bare MagicMock result crashes _on_cq_result_ready's per-camera loop
+    # (result.per_camera.get(...) returns a truthy Mock instead of None, so
+    # every unset field then hits real arithmetic/formatting against a
+    # Mock). _SyncThread runs the CQ worker (and its signal emit) inline
+    # on the test thread, so give it a minimal real-shaped result instead.
+    fake_iface.contact_quality_workflow.check.return_value = SimpleNamespace(
+        per_camera={}, passed=True,
+    )
+
+    c = MotionConnector(
+        interface=fake_iface,
+        app_config={"developerMode": False},
+        data_dir=".",
+        config_dir="config",
+    )
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._rightSensorConnected = True
+
+    monkeypatch.setattr("motion_connector.threading.Thread", _SyncThread)
+    return c
+
+
+def test_run_contact_quality_check_uses_configured_mask_not_all_cameras(connector):
+    """A camera the user set to "None" (bit cleared in the configured scan
+    mask) must be excluded from the SDK's evaluation, not silently probed
+    against all 8 cameras regardless of the user's selection."""
+    # 0x99 = "Outer" pattern: cameras 1,2,7,8 selected, 3-6 set to "None".
+    connector.runContactQualityCheck(0x99, 0x00)
+
+    connector._interface.contact_quality_workflow.check.assert_called_once()
+    _, kwargs = connector._interface.contact_quality_workflow.check.call_args
+    assert kwargs["left_camera_mask"] == 0x99
+    assert kwargs["right_camera_mask"] == 0x00
+
+
+def test_run_contact_quality_check_still_excludes_disconnected_side(connector):
+    """A requested mask on a side whose sensor isn't connected must not
+    reach the SDK — connection state still wins over the requested mask."""
+    connector._rightSensorConnected = False
+
+    connector.runContactQualityCheck(0xFF, 0xFF)
+
+    _, kwargs = connector._interface.contact_quality_workflow.check.call_args
+    assert kwargs["left_camera_mask"] == 0xFF
+    assert kwargs["right_camera_mask"] == 0x00


### PR DESCRIPTION
## Summary
- `runContactQualityCheck()` always evaluated **all 8 cameras** per connected side (hardcoded `0xFF`/`0xFF`), completely ignoring the user's configured scan mask (`bloodFlow.leftMask`/`rightMask`). A camera the user deselected ("None" in Scan Settings) still had to pass contact quality — showing spurious `no_signal`/`poor_contact` warnings, and contributing to the overall pass/fail verdict, for a camera that was never going to be used in the real scan.
- Fix threads the *configured* scan mask through the CQ pipeline:
  - `runContactQualityCheck(left_camera_mask, right_camera_mask)` now takes the mask as an argument (matching the existing `startCapture`/`startConfigureCameraSensors` pattern) instead of hardcoding it.
  - `ContactQualityCheckTask.qml` gained `leftCameraMask`/`rightCameraMask` properties, forwarded to the connector call.
  - `ScanRunner.qml` gained `evalLeftMask`/`evalRightMask` — separate from `leftMask`/`rightMask` (which still flash `0xFF` so the live CQ view keeps showing a dot for every physically-present camera).
  - `BloodFlow.qml`'s `qualityCheckRunner` binds `evalLeftMask`/`evalRightMask` to `bloodFlow.leftMask`/`rightMask` (the user's actual scan selection).
- The SDK side already supported this correctly (`ContactQualityWorkflow.check`'s mask already excludes unset camera bits from evaluation) — the bug was entirely on the app side always sending `0xFF`.

(Replaces #276, which was accidentally cut from `main` instead of `next` and picked up 182 unrelated commits in the diff.)

## Test plan
- [x] Added `tests/test_contact_quality_mask.py` — asserts the SDK call receives the configured mask (not `0xFF`), and that a disconnected side still zeroes out regardless of the requested mask.
- [x] `pytest tests/ -m unit` — 372 passed (3 pre-existing, unrelated failures in `test_app_config_defaults.py` from a local `app_config.local.json` override in this environment — reproduce identically on bare `next`).