### PR TITLE
fix: patch config_store.resource_path in app-config default tests

### DIFF
--- a/tests/test_app_config_defaults.py
+++ b/tests/test_app_config_defaults.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 import main as app_main
+from utils import config_store
 
 pytestmark = pytest.mark.unit
 
@@ -22,15 +23,24 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _patch_config_path(monkeypatch, path):
-    """Point main._load_app_config at ``path`` for config/app_config.json."""
-    real_resource_path = app_main.resource_path
+    """Point config_store.shipped_baseline at ``path`` for config/app_config.json.
+
+    _load_app_config() delegates to config_store.load_app_config(), which has
+    its own `from utils.resource_path import resource_path` binding separate
+    from main's — patching main.resource_path is a no-op here. Also pin
+    OPENWATER_DATA_ROOT to path's tmp dir so the writable-overrides layer
+    (app_paths.writable_root(), cwd in dev mode) can't pick up a real
+    app_config.local.json left over from running the app locally.
+    """
+    real_resource_path = config_store.resource_path
 
     def fake_resource_path(*parts):
         if parts == ("config", "app_config.json"):
             return path
         return real_resource_path(*parts)
 
-    monkeypatch.setattr(app_main, "resource_path", fake_resource_path)
+    monkeypatch.setattr(config_store, "resource_path", fake_resource_path)
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(path.parent))
 
 
 def test_missing_config_falls_back_to_defaults(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- `_patch_config_path()` in `tests/test_app_config_defaults.py` patched `main.resource_path`, but `_load_app_config()` delegates to `config_store.load_app_config()`, which holds its own independent `resource_path` binding (`from utils.resource_path import resource_path`). Patching `main`'s copy was a no-op for the config-loading path, so `shipped_baseline()` always read the real shipped `config/app_config.json` instead of the test fixture.
- 3 of the 7 tests only passed by coincidence, because the shipped config's values for the keys they checked happened to match the in-code defaults. The other 3 (`test_unknown_keys_are_dropped`, `test_critical_error_config_keys_preserved`, `test_tec_trip_temp_default_is_registered`) failed for real once the mismatch was exposed.
- Fixed by patching `config_store.resource_path` instead (and dropped the now-dead `main.resource_path` patch — nothing else in the file relies on it being patched).
- Also pinned `OPENWATER_DATA_ROOT` to the same tmp dir used for the fixture file. This closes a second, related isolation gap: the writable-overrides layer (`app_paths.writable_root()`, which is `cwd` in dev mode) was unmocked, so a real `app_config.local.json` left over from running the app locally could leak into the merged config and cause machine-dependent failures. This mirrors the isolation pattern already used in `test_config_store.py` and `test_main_config_wiring.py`.

## Test plan
- [x] `pytest tests/test_app_config_defaults.py -v` — all 7 pass (previously 3-4 failed depending on local machine state)
- [x] `pytest -m unit -q` — full unit suite (375 tests) passes, no regressions
- [x] Re-verified against latest `origin/next` (local `next` was 2 commits behind; `config_store.py`/`app_paths.py`/`main.py` had upstream changes for a `portableMode` build flag) — fix still applies cleanly since `OPENWATER_DATA_ROOT` is checked before the `portable`/`frozen` branching in `writable_root()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)