### PR TITLE
fix: single trigger-ON clock for notes duration + header counter (#201)

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -565,31 +565,11 @@ class _TriggerStateSink:
         c = self._connector
         if payload.state == "ON":
             c._trigger_state = "ON"
-            if c._trigger_on_mono is None:
-                c._trigger_on_mono = time.monotonic()
-                c._trigger_on_ts = payload.timestamp_s
+            c._trigger_clock_open(payload.timestamp_s)
             c.triggerStateChanged.emit()
         elif payload.state == "OFF":
             c._trigger_state = "OFF"
-            if c._trigger_on_mono is not None:
-                # Prefer the SDK-stamped, scan-relative timestamps: the OFF
-                # event can sit queued behind histogram batches in the runner's
-                # diagnostics channel and be consumed ~1 s after it was emitted,
-                # which inflates a receive-time measurement (a 16:00 scan shows
-                # as 16:01 — issue #201). Fall back to host receive-time only
-                # if the timestamps are unusable (e.g. the SDK's t0-None path
-                # emits 0.0 for both edges, giving a non-positive delta).
-                ts_delta = (
-                    payload.timestamp_s - c._trigger_on_ts
-                    if c._trigger_on_ts is not None
-                    else 0.0
-                )
-                if ts_delta > 0:
-                    c._trigger_cumulative_s += ts_delta
-                else:
-                    c._trigger_cumulative_s += time.monotonic() - c._trigger_on_mono
-                c._trigger_on_mono = None
-                c._trigger_on_ts = None
+            c._trigger_clock_close(payload.timestamp_s)
             c.triggerStateChanged.emit()
 
     def on_complete(self) -> None:
@@ -907,8 +887,11 @@ class MotionConnector(QObject):
         self._dropout_timer.timeout.connect(self._on_dropout_check)
         self._plot_t0: float = 0.0  # set at scan start; consumed by _on_dropout_check
 
-        # Trigger-ON elapsed mirrors — populated from start_capture locals so
-        # _on_dropout_check / _scan_elapsed_str can read them off the instance.
+        # Trigger-ON clock (issue #201) — the single scan-time source of
+        # truth for the notes duration line, the header elapsed counter and
+        # the dropout log timestamps. Managed exclusively through the
+        # _trigger_clock_reset/_open/_close helpers; read via
+        # _trigger_elapsed_s / scanElapsedSec / scanElapsedStr.
         self._trigger_cumulative_s: float = 0.0
         self._trigger_on_mono: float | None = None
         # Scan-relative timestamp (from the SDK's TriggerStateEvent) of the
@@ -1693,6 +1676,20 @@ class MotionConnector(QObject):
             elif is_now_lost:
                 # Clear connection timestamp on disconnect
                 self._console_connected_at = None
+                # A dead console can't be driving the laser trigger, and it
+                # can't deliver the SDK's trigger-OFF event either (its
+                # stop_trigger raises during teardown). Close the trigger
+                # clock at detection time so the notes duration line and the
+                # header counter stop here instead of counting several more
+                # seconds of scan teardown (issue #201).
+                if self._trigger_state == "ON" or self._trigger_on_mono is not None:
+                    logger.warning(
+                        "Console lost while trigger ON — closing the trigger "
+                        "clock at disconnect detection (%s)", reason,
+                    )
+                    self._trigger_clock_close()
+                    self._trigger_state = "OFF"
+                    self.triggerStateChanged.emit()
         elif name == "left":
             if is_now_connected:
                 self._leftSensorConnected = True
@@ -3268,10 +3265,8 @@ class MotionConnector(QObject):
         # instance (same pattern as nan_gap_tracker above).
         outcome_sink = _ScanOutcomeSink()
 
-        # Reset trigger ON-time mirrors so _scan_elapsed_str starts from zero.
-        self._trigger_cumulative_s = 0.0
-        self._trigger_on_mono = None
-        self._trigger_on_ts = None
+        # Reset the trigger-ON clock so _scan_elapsed_str starts from zero.
+        self._trigger_clock_reset()
 
         # _CompletionSink calls this from its on_complete() method once the
         # ScanRunner finishes.
@@ -3290,9 +3285,17 @@ class MotionConnector(QObject):
             # pre-scan setup + post-scan USB drain). Falls back to wall-clock
             # if the sink never saw a TriggerStateEvent (e.g. cancel before
             # trigger fired).
-            trigger_elapsed = self._trigger_cumulative_s
             if self._trigger_on_mono is not None:
-                trigger_elapsed += time.monotonic() - self._trigger_on_mono
+                # No OFF event and no disconnect-close reached us before
+                # completion — close here as a last resort, knowing the
+                # measurement now includes scan-teardown time.
+                logger.warning(
+                    "Scan completed with the trigger clock still open "
+                    "(no TriggerStateEvent OFF received); duration may "
+                    "include teardown time."
+                )
+                self._trigger_clock_close()
+            trigger_elapsed = self._trigger_cumulative_s
             if trigger_elapsed > 0:
                 elapsed = trigger_elapsed
             else:
@@ -4279,6 +4282,70 @@ class MotionConnector(QObject):
                 if src is not None and getattr(src, "live", False):
                     src.mark_dropped(side=side, cam_id=cam_id, t=now - self._plot_t0)
 
+    # --- TRIGGER-ON CLOCK (issue #201) ---
+    # Single scan-time clock backing the notes duration line, the header
+    # elapsed counter (scanElapsedSec) and dropout log timestamps. Opened /
+    # closed by _TriggerStateSink from SDK TriggerStateEvents; also closed
+    # by the console-disconnect handler because a dead console can't deliver
+    # its OFF event (stop_trigger raises before _emit_trigger_event runs).
+
+    def _trigger_clock_reset(self) -> None:
+        """Zero the clock. Called once per scan from startCapture."""
+        self._trigger_cumulative_s = 0.0
+        self._trigger_on_mono = None
+        self._trigger_on_ts = None
+
+    def _trigger_clock_open(self, ts_s: float | None) -> None:
+        """Start an ON interval. No-op if one is already open."""
+        if self._trigger_on_mono is None:
+            self._trigger_on_mono = time.monotonic()
+            self._trigger_on_ts = ts_s
+
+    def _trigger_clock_close(self, ts_s: float | None = None) -> None:
+        """Bank the open ON interval into the cumulative total.
+
+        Prefers the SDK-stamped, scan-relative timestamp pair: the OFF event
+        can sit queued behind histogram batches in the runner's diagnostics
+        channel and be consumed ~1 s after it was emitted, which inflates a
+        receive-time measurement (a 16:00 scan shows as 16:01 — issue #201).
+        Falls back to host receive-time when the timestamps are unusable
+        (the SDK's t0-None path emits 0.0 for both edges, giving a
+        non-positive delta) or when closing without an event (console lost).
+        No-op when the clock is already closed, so a late OFF event after a
+        disconnect-close can't double-count.
+        """
+        if self._trigger_on_mono is None:
+            return
+        ts_delta = (
+            ts_s - self._trigger_on_ts
+            if ts_s is not None and self._trigger_on_ts is not None
+            else 0.0
+        )
+        if ts_delta > 0:
+            self._trigger_cumulative_s += ts_delta
+        else:
+            self._trigger_cumulative_s += time.monotonic() - self._trigger_on_mono
+        self._trigger_on_mono = None
+        self._trigger_on_ts = None
+
+    def _trigger_elapsed_s(self) -> float:
+        """Trigger-ON seconds so far this scan, including any open interval."""
+        elapsed = self._trigger_cumulative_s
+        if self._trigger_on_mono is not None:
+            elapsed += time.monotonic() - self._trigger_on_mono
+        return elapsed
+
+    @pyqtSlot(result=int)
+    def scanElapsedSec(self) -> int:
+        """QML-facing accessor for trigger-ON elapsed whole seconds.
+
+        The header counter polls this once a second instead of counting its
+        own Timer ticks — a QML Timer fires late under GUI load and a
+        tick-counting clock drifts behind real time, disagreeing with the
+        notes duration line written from this same clock.
+        """
+        return int(self._trigger_elapsed_s())
+
     @pyqtSlot(result=str)
     def scanElapsedStr(self) -> str:
         """QML-facing accessor for trigger-ON elapsed time (HH:MM:SS)."""
@@ -4286,10 +4353,7 @@ class MotionConnector(QObject):
 
     def _scan_elapsed_str(self) -> str:
         """Return current scan elapsed trigger-ON time as HH:MM:SS."""
-        elapsed = self._trigger_cumulative_s
-        if self._trigger_on_mono is not None:
-            elapsed += time.monotonic() - self._trigger_on_mono
-        total_s = int(elapsed)
+        total_s = int(self._trigger_elapsed_s())
         h = total_s // 3600
         m = (total_s % 3600) // 60
         s = total_s % 60

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -72,12 +72,17 @@ Rectangle {
     // instant triggerState flips to "OFF" (top of the SDK teardown, right
     // after stop_trigger) rather than when captureFinished arrives 2-4s later
     // after all the camera-disable / USB-drain / writer-join work is done.
+    //
+    // Each tick PULLS the connector's trigger-ON clock rather than counting
+    // ticks (issue #201): a QML Timer fires late under GUI load and never
+    // catches up, so a += 1 counter drifts behind real time and disagrees
+    // with the notes duration line written from the connector's clock.
     Timer {
         id: scanTimer
         interval: 1000
         repeat: true
         running: bloodFlow.scanning && MotionInterface.triggerState === "ON"
-        onTriggered: bloodFlow.elapsedSec += 1
+        onTriggered: bloodFlow.elapsedSec = MotionInterface.scanElapsedSec()
     }
 
     // Convert mask to active array for camera selection modal
@@ -327,6 +332,16 @@ Rectangle {
     Connections {
         target: MotionInterface
         function onScanNotesReady() { notesModal.open() }
+        // Snap the header counter to the authoritative value on every
+        // trigger edge. The OFF edge matters most: it carries the SDK
+        // timestamp correction, so the final displayed value lands on
+        // exactly the duration the notes line will report — without this,
+        // the counter keeps the value of its last 1 s tick, which can sit
+        // a second high while the queued OFF event was in flight.
+        function onTriggerStateChanged() {
+            if (bloodFlow.scanning)
+                bloodFlow.elapsedSec = MotionInterface.scanElapsedSec()
+        }
     }
 
     HistoryModal {

--- a/tests/test_trigger_duration.py
+++ b/tests/test_trigger_duration.py
@@ -6,8 +6,16 @@ actually ran, derived from the SDK's scan-relative TriggerStateEvent
 sit queued behind histogram batches in the runner's diagnostics channel and be
 consumed ~1 s after it was emitted; measuring receive-time inflated a 960 s
 (16:00) scan to 16:01.
+
+Second failure mode (issue #201 follow-up): if the console powers off
+mid-scan, the SDK's stop_trigger() raises on the dead device and its OFF
+event is never emitted. The connector must close the trigger clock itself at
+disconnect-detection time — otherwise the still-open interval keeps counting
+through the multi-second scan teardown (a 10 s scan cut at ~9 s reported
+12 s), and the green header counter drifts the same way.
 """
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -83,3 +91,66 @@ def test_falls_back_to_monotonic_when_timestamps_unavailable(tmp_path):
     sink.consume("diagnostics", TriggerStateEvent(state="OFF", timestamp_s=0.0))
 
     assert c._trigger_cumulative_s >= 0.0
+
+
+def test_console_disconnect_mid_scan_closes_trigger_clock(tmp_path):
+    """Console power-off mid-scan: the SDK's stop_trigger() raises on the
+    dead console, so no OFF event ever reaches the sink. The connector must
+    close the trigger clock the moment the console handle reports
+    DISCONNECTED — not let it run on through scan teardown."""
+    from omotion import ConnectionState
+
+    c = _connector(tmp_path)
+    _reset_trigger_state(c)
+    sink = _TriggerStateSink(c)
+    sink.consume("diagnostics", TriggerStateEvent(state="ON", timestamp_s=1.0))
+    assert c._trigger_state == "ON"
+
+    handle = MagicMock()
+    handle.name = "console"
+    c._on_handle_state_changed_impl(
+        handle,
+        ConnectionState.CONNECTED,
+        ConnectionState.DISCONNECTED,
+        "usb gone",
+    )
+
+    # Clock closed at detection time: interval banked, state OFF.
+    assert c._trigger_on_mono is None
+    assert c._trigger_state == "OFF"
+    closed = c._trigger_cumulative_s
+    assert closed >= 0.0
+    # Teardown time after the disconnect must not extend the measurement.
+    time.sleep(0.05)
+    assert c._trigger_cumulative_s == closed
+    assert c._trigger_elapsed_s() == pytest.approx(closed, abs=1e-9)
+
+
+def test_trigger_clock_close_is_idempotent(tmp_path):
+    """A late OFF event arriving after a disconnect-close (e.g. an SDK that
+    emits OFF despite the failed stop_trigger) must not add time twice."""
+    c = _connector(tmp_path)
+    _reset_trigger_state(c)
+    sink = _TriggerStateSink(c)
+
+    sink.consume("diagnostics", TriggerStateEvent(state="ON", timestamp_s=1.0))
+    c._trigger_clock_close()  # disconnect-detection close (receive-time)
+    closed = c._trigger_cumulative_s
+
+    sink.consume("diagnostics", TriggerStateEvent(state="OFF", timestamp_s=12.0))
+    assert c._trigger_cumulative_s == closed
+
+
+def test_scan_elapsed_sec_reports_whole_trigger_on_seconds(tmp_path):
+    """The QML header counter pulls this accessor once a second instead of
+    counting its own ticks (which drift under GUI load), so it must be the
+    same clock the notes duration line is written from."""
+    c = _connector(tmp_path)
+    _reset_trigger_state(c)
+
+    c._trigger_cumulative_s = 95.7
+    assert c.scanElapsedSec() == 95
+
+    # A still-open interval is included.
+    c._trigger_on_mono = time.monotonic() - 4.0
+    assert c.scanElapsedSec() in (99, 100)  # 99.7 + scheduling jitter


### PR DESCRIPTION
Fixes the two remaining clock defects from #201 (the SDK-timestamp fix in ad599c3 covered the original +1s report; this covers the June 25 power-off comment and the drifting green header counter).

## Power-off mid-scan (10 s scan cut at ~9 s reported 12 s)

When the console dies, the SDK's `stop_trigger()` raises on the dead device before `_emit_trigger_event("OFF")` runs, so the OFF `TriggerStateEvent` never reaches `_TriggerStateSink` — the trigger clock stays open and keeps counting through the multi-second scan teardown. The connector now:

- closes the trigger clock the moment the console handle reports DISCONNECTED (a dead console can't be firing the laser), flipping `triggerState` to OFF so the header counter stops at the same instant, and
- warns + closes in `_on_pipeline_complete` as a last resort if the clock is somehow still open at completion, instead of silently folding teardown time into the notes duration.

An SDK-side defense-in-depth follow-up (emit OFF in a `finally`) is being done separately in openmotion-sdk.

## Green header counter drift

The counter was an independent tick-counting clock (`elapsedSec += 1` in a QML `Timer`). QML timers fire late under GUI load and lost ticks never catch up, and the counter kept ticking during the ~1 s queued delivery of the OFF event — so it could disagree with the notes duration line. Each tick now pulls the connector's clock via a new `scanElapsedSec()` slot, and the counter snaps to the authoritative final value on the OFF edge.

## Cleanup

The scattered `_trigger_cumulative_s` / `_trigger_on_mono` / `_trigger_on_ts` mirror-fiddling is consolidated into `_trigger_clock_reset/_open/_close` + `_trigger_elapsed_s` — one clock backing the notes duration line, header counter, spacebar note timestamps and dropout logs. Close is idempotent, so a late OFF event after a disconnect-close cannot double-count (this also makes the pending SDK change safe to land in either order).

## Testing

- 3 new failing-first unit tests in `tests/test_trigger_duration.py` (disconnect-close at detection time, idempotent close, `scanElapsedSec`); all 6 pass.
- Full unit suite: 377 passed; the 1 failure (`test_config_store::test_load_merges_overrides_over_baseline`) reproduces on clean `next` @ c6d72f2 — pre-existing order-dependent config pollution, tracked separately.
- App booted from source against bench hardware: no QML errors, page loads, console + sensor connect.

Draft pending bench hand-test of the repro steps:
1. 10 s scan, power off the console at ~9 s → notes duration should read ~00:00:09–10, not 12.
2. Timed scan run to completion → header counter's final value matches the notes duration line exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)