### PR TITLE
fix: stop test collection from dirtying tracked config/app_config.json

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,13 @@ def pytest_configure(config):
     # _from_source_mode() helper picks it up without further plumbing.
     if config.getoption("--from-source"):
         os.environ["OPENWATER_FROM_SOURCE"] = "1"
+    # Snapshot the tracked repo config before collection imports any test
+    # module, so pytest_collection_finish can detect import-time writes.
+    global _repo_app_config_snapshot
+    try:
+        _repo_app_config_snapshot = _REPO_APP_CONFIG.read_bytes()
+    except OSError:
+        _repo_app_config_snapshot = None
 
 
 _class_failures = {}
@@ -126,6 +133,141 @@ def pytest_runtest_setup(item):
 # App discovery
 # ─────────────────────────────────────────────
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ─────────────────────────────────────────────
+# app_config.json hygiene + FORCE_APP_CONFIG
+# ─────────────────────────────────────────────
+# pytest imports EVERY test module during collection, even when `-m unit`
+# deselects all of a module's tests — so module-level code that writes
+# app_config.json fires on every run, and a module-scoped restore fixture
+# never runs for a fully-deselected module. That combination used to leave
+# the tracked config/app_config.json dirty (clinicalMode/engineeringMode
+# flipped, file re-serialized) after plain `pytest -m unit` runs.
+#
+# The sanctioned replacement: a module that needs an app-config value forced
+# on disk before the session `app` fixture launches declares
+#
+#     FORCE_APP_CONFIG = {"clinicalMode": False}
+#
+# at module level (a plain dict — no side effect at import). After
+# collection and `-m` deselection, pytest_collection_finish applies the
+# declarations of modules that actually have selected tests, targeting the
+# same file hil_helpers._resolve_app_config_path() resolves (repo config in
+# from-source mode, the exe's bundled copy otherwise). The file's original
+# bytes are restored at session end, so even the json.dump re-serialization
+# is undone.
+_REPO_APP_CONFIG = PROJECT_ROOT / "config" / "app_config.json"
+_repo_app_config_snapshot: bytes | None = None
+_forced_config_target: Path | None = None
+_forced_config_snapshot: bytes | None = None
+
+
+def _read_repo_app_config() -> bytes | None:
+    try:
+        return _REPO_APP_CONFIG.read_bytes()
+    except OSError:
+        return None
+
+
+def pytest_collection_finish(session):
+    """Guard the tracked repo config, then apply FORCE_APP_CONFIG.
+
+    Runs after collection + ``-m`` deselection but before any fixture, so
+    forced values are on disk before the session ``app`` fixture launches
+    the bloodflow app.
+    """
+    global _forced_config_target, _forced_config_snapshot
+
+    # 1. Fail loudly if merely importing the test modules dirtied the
+    #    tracked repo config — that's a module-level write sneaking back in.
+    if _repo_app_config_snapshot is not None:
+        current = _read_repo_app_config()
+        if current != _repo_app_config_snapshot:
+            _REPO_APP_CONFIG.write_bytes(_repo_app_config_snapshot)
+            raise pytest.UsageError(
+                "config/app_config.json was modified while importing test "
+                "modules. A test module writes the app config at import time "
+                "(e.g. a module-level force_app_config_value(...) call). That "
+                "fires during collection of every run — including `-m unit` "
+                "runs that never execute the module — and leaves the tracked "
+                "file dirty. Declare FORCE_APP_CONFIG = {...} at module level "
+                "instead; conftest applies it only when the module has "
+                "selected tests. (Original file contents were restored.)"
+            )
+
+    if session.config.option.collectonly:
+        return
+
+    # 2. Gather FORCE_APP_CONFIG from modules with selected tests.
+    forced: dict = {}
+    forced_by: dict = {}
+    for item in session.items:
+        module = getattr(item, "module", None)
+        declared = getattr(module, "FORCE_APP_CONFIG", None) or {}
+        for key, value in declared.items():
+            if key in forced and forced[key] != value:
+                log.warning(
+                    f"FORCE_APP_CONFIG conflict on {key!r}: "
+                    f"{forced_by[key]} wants {forced[key]!r}, "
+                    f"{module.__name__} wants {value!r}; using {value!r}"
+                )
+            forced[key] = value
+            forced_by[key] = module.__name__
+    if not forced:
+        return
+
+    # Deferred import — hil_helpers imports conftest, so importing it at
+    # module level here would be circular.
+    from hil_helpers import _resolve_app_config_path, force_app_config_value
+
+    target = _resolve_app_config_path()
+    try:
+        _forced_config_snapshot = target.read_bytes()
+    except OSError:
+        _forced_config_snapshot = None
+    _forced_config_target = target
+    for key, value in forced.items():
+        force_app_config_value(key, value)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Byte-exact restore of the app config we force-wrote at collection."""
+    if _forced_config_target is not None and _forced_config_snapshot is not None:
+        try:
+            _forced_config_target.write_bytes(_forced_config_snapshot)
+        except OSError as e:
+            log.warning(
+                f"could not restore {_forced_config_target} after forcing "
+                f"app-config values: {e}"
+            )
+
+
+@pytest.fixture(autouse=True)
+def _guard_tracked_app_config(request):
+    """Fail loudly if a unit test dirties the tracked config/app_config.json.
+
+    Unit tests must point config IO at tmp_path (monkeypatch
+    OPENWATER_DATA_ROOT / config_store.resource_path — see the pattern in
+    tests/test_app_config_defaults.py). HIL tests are exempt: several
+    legitimately write the on-disk config mid-session and restore it
+    themselves.
+    """
+    if request.node.get_closest_marker("unit") is None:
+        yield
+        return
+    before = _read_repo_app_config()
+    yield
+    after = _read_repo_app_config()
+    if before != after:
+        if before is not None:
+            _REPO_APP_CONFIG.write_bytes(before)
+        pytest.fail(
+            "this test modified the tracked config/app_config.json — unit "
+            "tests must redirect config reads/writes to tmp_path "
+            "(monkeypatch OPENWATER_DATA_ROOT / config_store.resource_path). "
+            "The original file contents were restored."
+        )
 
 
 def _from_source_mode() -> bool:

--- a/tests/hil_helpers.py
+++ b/tests/hil_helpers.py
@@ -183,21 +183,25 @@ def _resolve_app_config_path() -> Path:
 #
 # Test modules that need to pin a specific app_config.json value before
 # the bloodflow app launches (e.g. clinicalMode=false, so the modal
-# layout matches what tab walks expect) can:
+# layout matches what tab walks expect) declare it at module level:
 #
-#     from hil_helpers import force_app_config_value, write_app_config_value
+#     FORCE_APP_CONFIG = {"clinicalMode": False}
 #
-#     _INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
+# conftest's pytest_collection_finish applies the declarations (via
+# ``force_app_config_value``) after collection + ``-m`` deselection —
+# only for modules that actually have selected tests — and restores the
+# file byte-exact at session end.
 #
-#     @pytest.fixture(scope="module", autouse=True)
-#     def _restore_clinical_mode():
-#         yield
-#         write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# NEVER call ``force_app_config_value`` at module level yourself: pytest
+# imports every test module during collection, so the write would fire
+# on every run (including ``-m unit`` runs that never execute the
+# module) and leave the tracked config dirty, with no fixture teardown
+# to restore it. conftest fails the run loudly if it detects that.
 #
 # Caveat: the connector caches its config at startup, so writes only
-# affect the *next* app launch. Force calls happen at module-import
-# time (before the session-scoped ``app`` fixture runs) precisely so
-# any fresh launch in this session boots with the desired value. If
+# affect the *next* app launch. Declarations are applied before any
+# fixture runs (so before the session-scoped ``app`` fixture) precisely
+# so any fresh launch in this session boots with the desired value. If
 # the app was already running before pytest started, see
 # ``force_app_config_value``'s warning log.
 

--- a/tests/test_calibration_target_isolation.py
+++ b/tests/test_calibration_target_isolation.py
@@ -68,25 +68,18 @@ from hil_helpers import (
     RE_CONNECTED,
     click_panel,
     find_app_log,
-    force_app_config_value,
     recalibrate_panel_buttons,
     wait_for_pattern,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
 
 # Calibration controls live in the engineeringMode-gated "Engineering" card
 # of the Settings modal. The app ships with engineeringMode=false, so force
-# it true on disk before the test's app relaunches read the config;
-# restore the original value when the module finishes.
-_INITIAL_ENGINEERING_MODE = force_app_config_value("engineeringMode", True)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_engineering_mode():
-    yield
-    write_app_config_value("engineeringMode", _INITIAL_ENGINEERING_MODE)
+# it true on disk before the test's app relaunches read the config.
+# Applied by conftest's pytest_collection_finish only when this module has
+# selected tests; restored byte-exact at session end.
+FORCE_APP_CONFIG = {"engineeringMode": True}
 
 # Calibration on real hardware: phase-0 flash (~5–15 s) + 2 sub-scans
 # of ~6 s each + compute + write + validation. Field runs settle

--- a/tests/test_calibration_ui.py
+++ b/tests/test_calibration_ui.py
@@ -43,20 +43,16 @@ import pytest
 from pywinauto import findwindows
 
 from conftest import SLEEP, ensure_visible, log, uia_window
-from hil_helpers import click_panel, force_app_config_value, write_app_config_value
+from hil_helpers import click_panel
 
 pytestmark = pytest.mark.dev
 
 # Calibration controls live in the engineeringMode-gated "Engineering" card
 # of the Settings modal. The app ships with engineeringMode=false, so force
-# it true before the session ``app`` fixture launches; restore afterward.
-_INITIAL_ENGINEERING_MODE = force_app_config_value("engineeringMode", True)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_engineering_mode():
-    yield
-    write_app_config_value("engineeringMode", _INITIAL_ENGINEERING_MODE)
+# it true before the session ``app`` fixture launches. Applied by conftest's
+# pytest_collection_finish only when this module has selected tests;
+# restored byte-exact at session end.
+FORCE_APP_CONFIG = {"engineeringMode": True}
 
 # Calibration on real hardware: phase-0 flash (~5-15 s) + 2 sub-scans
 # of ~6 s each + compute + write_calibration. Field runs settle around

--- a/tests/test_clinicalmode.py
+++ b/tests/test_clinicalmode.py
@@ -38,30 +38,24 @@ from conftest import (
 )
 from hil_helpers import (
     click_panel,
-    force_app_config_value,
     move_window_on_screen,
     selected_scan_text,
     visible_modals,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
 
-# Force ``clinicalMode = true`` on disk at module-import time so any
-# fresh launch in this session boots directly into Clinical Mode.
-# Restored on module teardown via the autouse fixture below.
+# Force ``clinicalMode = true`` on disk so any fresh launch in this
+# session boots directly into Clinical Mode. Applied by conftest's
+# pytest_collection_finish only when this module has selected tests
+# (never a module-level write — that fires during collection of every
+# run, including `-m unit`); restored byte-exact at session end.
 #
-# Caveat (see utils.force_app_config_value): the app caches its
+# Caveat (see hil_helpers.force_app_config_value): the app caches its
 # config at startup, so if the app was already running with
-# clinicalMode=false when this module is imported, the running
-# instance will stay in non-clinical mode until it is relaunched.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", True)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# clinicalMode=false, the running instance will stay in non-clinical
+# mode until it is relaunched.
+FORCE_APP_CONFIG = {"clinicalMode": True}
 
 
 SCAN_WAIT       = 200   # seconds to run the long scan (3 min 20 s)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -26,24 +26,16 @@ from hil_helpers import (
     SENSOR_OPTIONS,
     click_element_center,
     click_panel,
-    force_app_config_value,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.dev
 
 # Same rationale as test_scan_settings: this module's seed scan opens
-# Scan Settings, which is hidden in clinical mode. Snapshot at module
-# import (before the session-scoped ``app`` fixture spins up the app)
-# so any fresh launch in this session boots in non-clinical mode;
-# restore on teardown via the autouse fixture below.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# Scan Settings, which is hidden in clinical mode. Applied by conftest's
+# pytest_collection_finish only when this module has selected tests
+# (before the session-scoped ``app`` fixture spins up the app);
+# restored byte-exact at session end.
+FORCE_APP_CONFIG = {"clinicalMode": False}
 
 # How long to seed the history with at the start. Short to keep
 # the dev-tier suite snappy, but long enough that the SDK actually

--- a/tests/test_scan_auto_stop_bug.py
+++ b/tests/test_scan_auto_stop_bug.py
@@ -61,29 +61,21 @@ from hil_helpers import (
     click_panel_button,
     dismiss_signal_quality_modal,
     find_app_log,
-    force_app_config_value,
     is_app_alive,
     log_size,
     move_window_on_screen,
     wait_for_pattern,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
 
 # Each iteration opens Scan Settings to set sensor masks + duration.
 # Scan Settings is hidden in clinical mode, so force the on-disk flag
-# false at module-import time (before the session-scoped ``app``
-# fixture launches the app); a module-scoped autouse fixture restores
-# the original value on teardown. Same pattern as the rest of the
-# release-tier scan-flow tests.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# false before the session-scoped ``app`` fixture launches the app.
+# Applied by conftest's pytest_collection_finish only when this module
+# has selected tests; restored byte-exact at session end. Same pattern
+# as the rest of the release-tier scan-flow tests.
+FORCE_APP_CONFIG = {"clinicalMode": False}
 
 # ─────────────────────────────────────────────
 # Configuration

--- a/tests/test_scan_auto_stop_bug_abbreviated.py
+++ b/tests/test_scan_auto_stop_bug_abbreviated.py
@@ -35,29 +35,22 @@ from hil_helpers import (
     click_panel_button,
     dismiss_signal_quality_modal,
     find_app_log,
-    force_app_config_value,
     is_app_alive,
     log_size,
     move_window_on_screen,
     wait_for_pattern,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
 
 # Each iteration opens Scan Settings to set sensor masks + duration.
 # Scan Settings is hidden in clinical mode, so force the on-disk flag
-# false at module-import time (before the session-scoped ``app``
-# fixture launches the app); a module-scoped autouse fixture restores
-# the original value on teardown. Same pattern as test_history /
-# test_scan_settings / test_usb_disconnect_freeze / test_scan_flow.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# false before the session-scoped ``app`` fixture launches the app.
+# Applied by conftest's pytest_collection_finish only when this module
+# has selected tests; restored byte-exact at session end. Same pattern
+# as test_history / test_scan_settings / test_usb_disconnect_freeze /
+# test_scan_flow.
+FORCE_APP_CONFIG = {"clinicalMode": False}
 
 # ─────────────────────────────────────────────
 # Configuration

--- a/tests/test_scan_flow.py
+++ b/tests/test_scan_flow.py
@@ -50,25 +50,17 @@ from conftest import (
 from hil_helpers import (
     click_panel,
     dismiss_signal_quality_modal,
-    force_app_config_value,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
 
 # This test opens Scan Settings (test_01) to set the 2-min duration.
 # Scan Settings is hidden in clinical mode, so force the on-disk flag
-# false at module-import time (before the session-scoped ``app``
-# fixture launches the app); a module-scoped autouse fixture restores
-# the original value on teardown. Same pattern as test_history /
-# test_scan_settings / test_usb_disconnect_freeze.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# false before the session-scoped ``app`` fixture launches the app.
+# Applied by conftest's pytest_collection_finish only when this module
+# has selected tests; restored byte-exact at session end. Same pattern
+# as test_history / test_scan_settings / test_usb_disconnect_freeze.
+FORCE_APP_CONFIG = {"clinicalMode": False}
 
 SCAN_DURATION_MIN = 2
 WAIT_AFTER_SCAN = SCAN_DURATION_MIN * 60 + 180  # scan + 3-min buffer

--- a/tests/test_scan_settings.py
+++ b/tests/test_scan_settings.py
@@ -31,8 +31,6 @@ from hil_helpers import (
     SENSOR_OPTIONS,
     click_panel,
     focus_combobox_by_label,
-    force_app_config_value,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.dev
@@ -44,16 +42,11 @@ SCAN_MODAL_CLOSE = (0.360, 0.119)
 # Every test in this module assumes clinicalMode is off — in clinical
 # mode the BloodFlow page forces freeRun + a 12-hour duration and the
 # Clinical Mode toggle in Settings hides itself, so the modal layout
-# the tab walks rely on isn't there. Snapshot at module import (before
-# the session-scoped ``app`` fixture spins up the app) and restore on
-# teardown via the autouse fixture below.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# the tab walks rely on isn't there. Applied by conftest's
+# pytest_collection_finish only when this module has selected tests
+# (before the session-scoped ``app`` fixture spins up the app);
+# restored byte-exact at session end.
+FORCE_APP_CONFIG = {"clinicalMode": False}
 
 
 # ─────────────────────────────────────────────

--- a/tests/test_usb_disconnect_freeze.py
+++ b/tests/test_usb_disconnect_freeze.py
@@ -52,29 +52,22 @@ from hil_helpers import (
     click_panel_button,
     dismiss_signal_quality_modal,
     find_app_log,
-    force_app_config_value,
     is_app_alive,
     log_size,
     move_window_on_screen,
     wait_for_pattern,
-    write_app_config_value,
 )
 
 pytestmark = pytest.mark.release
 
 # This test opens Scan Settings to configure the sensor masks +
 # duration before each iteration. Scan Settings is hidden in clinical
-# mode, so force the on-disk flag false at module-import time
-# (before the session-scoped ``app`` fixture launches the app); a
-# module-scoped autouse fixture restores the original value on
-# teardown. Same pattern as test_history / test_scan_settings.
-_INITIAL_CLINICAL_MODE = force_app_config_value("clinicalMode", False)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _restore_clinical_mode_on_module_teardown():
-    yield
-    write_app_config_value("clinicalMode", _INITIAL_CLINICAL_MODE)
+# mode, so force the on-disk flag false before the session-scoped
+# ``app`` fixture launches the app. Applied by conftest's
+# pytest_collection_finish only when this module has selected tests;
+# restored byte-exact at session end. Same pattern as test_history /
+# test_scan_settings.
+FORCE_APP_CONFIG = {"clinicalMode": False}
 
 # ─────────────────────────────────────────────
 # Configuration


### PR DESCRIPTION
## What

Running the unit suite (`python -m pytest tests/ -m unit`) — or even just `pytest --collect-only` — left the tracked `config/app_config.json` modified: `clinicalMode` flipped true→false, `engineeringMode` flipped false→true, and the whole file re-serialized by `json.dump(indent=2)`. The `engineeringMode` flip also made `tests/test_config_store.py::test_load_merges_overrides_over_baseline` fail order-dependently in full runs (it asserts the shipped baseline against the real repo config) while passing in isolation.

## Why

Nine HIL modules called `force_app_config_value(...)` at **module level**. pytest imports every test module during collection, even when `-m unit` deselects all of a module's tests — so the writes fired on every run, and the paired module-scoped restore fixtures never ran for a fully-deselected module.

## How

- HIL modules now declare `FORCE_APP_CONFIG = {"clinicalMode": False}` — a plain dict, no import side effect. All nine converted (`test_clinicalmode`, `test_calibration_ui`, `test_calibration_target_isolation`, `test_history`, `test_scan_flow`, `test_scan_settings`, `test_usb_disconnect_freeze`, both `test_scan_auto_stop_bug` variants).
- `conftest.pytest_collection_finish` applies the declarations after collection + `-m` deselection — still before the session `app` fixture launches the app — **only for modules that actually have selected tests**, targeting the same file `hil_helpers._resolve_app_config_path()` resolves (repo config from-source, the exe's bundled copy otherwise). The file's original bytes are restored at session end, so even the re-serialization churn is undone (the old value-level restore never did that).
- Two loud guards against regressions:
  - `pytest_collection_finish` raises `UsageError` (and restores the file) if merely importing test modules dirtied the tracked config.
  - An autouse fixture fails any **unit-marked** test that modifies it, pointing at the tmp_path/monkeypatch pattern (prior art: #279). HIL tests that legitimately write mid-session (e.g. `test_force_laser_fail`, `test_raw_csv_save`) are exempt.

## Reviewer notes

- Side benefit for full HIL runs: previously all module-level forces fired at import in file order, so with conflicting values (e.g. `test_clinicalmode` wants true, the scan-flow modules want false) the last import silently won for the whole session. Conflicts are now applied per-selection and logged as warnings.
- Verified: guard catches the pre-fix offenders (red), `--collect-only` and two full unit runs (378 passed, `test_config_store` included) leave the tree clean (green), plus probe tests exercising both the per-test guard and the FORCE_APP_CONFIG apply/byte-restore path via `OPENWATER_APP_CONFIG`.
- Not verified on hardware: the converted dev/release modules' end-to-end behavior (forced value on disk before app launch) — worth a glance on the next HIL run. Timing is equivalent: collection finishes before any fixture runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)