### PR TITLE
docs: retire the dead per-scan ft-test CSV export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ test_logs/
 
 # Runtime-writable app state (ProgramData/exe-folder in prod, cwd in dev):
 # app_config.local.json (config overrides) and data/ (scans, calibrations,
-# ft-test-csvs, debug-bundles, updates). logs/ isn't listed separately —
+# debug-bundles, updates). logs/ isn't listed separately —
 # the *.log glob above already covers the files inside it.
 app_config.local.json
 data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | `cq_dark_threshold_per_camera` | `[3.0,…]` | Contact-quality dark threshold. |
 | `bfiClampLow` / `bfiClampHigh` | `0.0` / `10.0` | Display clamps (values outside show `--`). |
 | `bviLowPassEnabled` | `true` | 1-pole LPF on BVI (cutoff 40 Hz). |
-| `dataDirectory` | `C:\Users\ethan\Projects\scan_data` | Single output root — `logs/` and `data/` (scan CSVs/DB, calibrations, ft-test-csvs) land under here. |
+| `dataDirectory` | `C:\Users\ethan\Projects\scan_data` | Single output root — `logs/` and `data/` (scan CSVs/DB, calibrations) land under here. |
 
 ## Reading the app log
 
@@ -117,7 +117,7 @@ Get-ChildItem C:\Users\ethan\Projects\scan_data\logs\open-motion-*.log |
 
 The `dataDirectory` config key controls the root (defaults to cwd if unset — falls back to `~/Documents/Open-Motion` on macOS). When unset on a frozen build, the default instead follows `portableMode`: next to the exe (portable zip) or `%PROGRAMDATA%\Openwater` (installer). Two fixed children live under that root:
 - `logs/` — app log files (one per launch)
-- `data/` — everything else: scan output files (raw / corrected / telemetry CSV + `scans.db`) land directly here; `data/calibrations/` holds saved calibration JSONs; `data/ft-test-csvs/` holds factory-test exports; `data/debug-bundles/` holds "Send Debug Logs" zips; `data/updates/` holds in-app-updater downloads. Scan notes live in `scans.db` (`sessions.session_notes`), not as files; `*_notes.txt` files are legacy read-only fallbacks.
+- `data/` — everything else: scan output files (raw / corrected / telemetry CSV + `scans.db`) land directly here; `data/calibrations/` holds saved calibration JSONs plus the SDK's per-camera PASS/FAIL CSVs (`calibration-<ts>.csv` / `test-<ts>.csv`); `data/debug-bundles/` holds "Send Debug Logs" zips; `data/updates/` holds in-app-updater downloads. Scan notes live in `scans.db` (`sessions.session_notes`), not as files; `*_notes.txt` files are legacy read-only fallbacks. (`data/ft-test-csvs/` was a legacy per-scan factory-test export — dead since May 2026 and retired; the Test/Calibrate flows' CSVs are its superset.)
 
 **Important:** the runner is fail-soft. `ScanRunner._safe_consume` catches sink exceptions and logs them as `sink %r raised on channel ...` at ERROR; `pipeline.process` exceptions log as `pipeline.process raised — resetting and continuing` at ERROR. **Neither aborts the scan**, so the app may report "complete" while every interval was actually broken. Always grep for `raised|exception` even on apparent successes when something downstream looks wrong.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The application creates two directories for output:
 | Directory | Contents |
 |-----------|----------|
 | `logs/` | Application log files (timestamped) |
-| `data/` | Scan CSVs, `scans.db`, calibrations, ft-test exports, debug bundles, in-app-updater downloads |
+| `data/` | Scan CSVs, `scans.db`, calibrations, debug bundles, in-app-updater downloads |
 
 **Where these are created:**
 

--- a/main.py
+++ b/main.py
@@ -247,7 +247,7 @@ def main():
     # ~/Documents fallback for an unwritable candidate — e.g. macOS Finder
     # launch where cwd is "/"). Two fixed children live under it: logs/
     # (this run's log file) and data/ (scans.db, scan CSVs, calibrations,
-    # ft-test-csvs, debug-bundles, downloaded updates).
+    # debug-bundles, downloaded updates).
     _data_dir = app_config.get("dataDirectory") or str(
         app_paths.writable_root(bool(app_config.get("portableMode", False)))
     )
@@ -279,7 +279,7 @@ def main():
     # Construct the MotionInterface and inject into the connector below.
     # data_dir + scan_db_path point the new pipeline's default CsvSink and
     # ScanDBSink at <_data_dir>/data — the same folder the connector uses
-    # for calibrations/ft-test-csvs/debug-bundles (self._data_root).
+    # for calibrations/debug-bundles (self._data_root).
     _scan_data_dir = os.path.join(_data_dir, app_paths.DATA_DIRNAME)
     os.makedirs(_scan_data_dir, exist_ok=True)
     _scan_db_path = os.path.join(_scan_data_dir, "scans.db")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -912,7 +912,7 @@ class MotionConnector(QObject):
         self._console_debug_logging       = bool(cfg.get("consoleDebugLogging", False))
         # Root directory: caller-supplied (from main.py) wins, else
         # dataDirectory from app config, else the resolved default (see
-        # app_paths.writable_root). Scan files, calibrations, ft-test-csvs,
+        # app_paths.writable_root). Scan files, calibrations,
         # debug-bundles, and scans.db all live under self._data_root
         # (self._directory/data — see that property).
         resolved_dir = (
@@ -2582,7 +2582,7 @@ class MotionConnector(QObject):
 
     @property
     def _data_root(self) -> str:
-        """Where scan files, calibrations, ft-test-csvs, debug-bundles, and
+        """Where scan files, calibrations, debug-bundles, and
         the scan DB live: self._directory/data. A sibling of the app-wide
         logs/ folder (main.py's concern only — the connector never touches
         it)."""

--- a/utils/app_paths.py
+++ b/utils/app_paths.py
@@ -10,7 +10,7 @@ Override the root with the OPENWATER_DATA_ROOT env var (used by tests and as a
 power-user escape hatch).
 
 Two fixed children live under the writable root: LOGS_DIRNAME (this run's log
-file) and DATA_DIRNAME (scans.db, scan CSVs, calibrations, ft-test-csvs,
+file) and DATA_DIRNAME (scans.db, scan CSVs, calibrations,
 debug-bundles, downloaded updates).
 """
 from pathlib import Path


### PR DESCRIPTION
## Decision record: retire, don't revive

The per-scan factory-test CSV export (`data/ft-test-csvs/ft-test-<ts>.csv`, per-camera mean/contrast PASS/FAIL against `ft_min_mean_per_camera` / `ft_min_contrast_per_camera`) has been **dead since 2877341** (May 22 2026): the sink-class refactor removed the only call to `MotionConnector._log_scan_image_stats`. #285 deletes the unreachable method itself; this PR retires the feature deliberately on the docs side.

### Why retire instead of rewiring it into the sink path

The Test / Calibrate flows fully supersede it:

- `runTestScan` / `runCalibration` pass the **same** `ft_*` thresholds to the SDK via `CalibrationThresholds` — plus bfi/bvi/dark thresholds the old export never evaluated.
- The SDK's `write_result_csv` output (`data/calibrations/test-<ts>.csv` / `calibration-<ts>.csv`) is a **strict column superset** of the old export: `camera_index, side, cam, mean, avg_contrast, bfi, bvi, dark, mean_test, contrast_test, bfi_test, bvi_test, dark_test, security_id, hwid` vs the old 9 columns.
- The UI already surfaces per-camera PASS/FAIL (test-scan rows → results window) and an overall ✅/❌ verdict in the capture log — replacing the old "FT criteria result" line.
- Six weeks dead with zero reports of missing `ft-test-csvs` output — nothing consumes it. Factory stations run the dedicated Test scan (feature #132), not clinical scans.

The only thing lost is an FT verdict computed from *clinical* scan data rather than a dedicated test scan — which was never the factory-test procedure anyway. If it's ever wanted again, the 166-line implementation is recoverable at `bdaa079^:motion_connector.py` (`_log_scan_image_stats`) and would slot into `_CompletionSink.on_complete`.

### Changes (docs/comments only, no behavior)

- CLAUDE.md + README.md: drop `ft-test-csvs` from the data-directory docs; document that `data/calibrations/` also holds the SDK's PASS/FAIL CSVs; leave a one-line legacy note in CLAUDE.md.
- `main.py`, `motion_connector.py`, `utils/app_paths.py`, `.gitignore`: scrub the stale directory-list comments.

Merges independently of #285 (touches different regions of `motion_connector.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)