### PR TITLE
Audit follow-ups: GUI-thread freezes (sensor init, exports, debug bundle) + AppTheme singleton

### DIFF
--- a/components/AppTheme.qml
+++ b/components/AppTheme.qml
@@ -1,11 +1,15 @@
+pragma Singleton
 import QtQuick 6.0
 import OpenMotion 1.0
 
-/*  AppTheme — lightweight colour-token provider.
+/*  AppTheme — colour-token provider, registered as a QML SINGLETON
+ *  (main.py: qmlRegisterSingletonType into the OpenMotion module).
  *
- *  Instantiate once per file that needs themed colours:
- *      AppTheme { id: theme }
- *  Then reference: theme.bgBase, theme.textPrimary, etc.
+ *  Do NOT instantiate — `import OpenMotion 1.0` and reference the
+ *  tokens directly: AppTheme.bgBase, AppTheme.textPrimary, etc.
+ *  One instance serves the whole UI; the old per-file
+ *  `AppTheme { id: theme }` pattern re-evaluated every token binding
+ *  once per instantiating file on each darkMode flip.
  *
  *  All tokens react to MotionInterface.appConfig.darkMode so the
  *  entire UI flips live when the toggle is changed.

--- a/components/ButtonPanel.qml
+++ b/components/ButtonPanel.qml
@@ -6,12 +6,11 @@ import OpenMotion 1.0
 Rectangle {
     id: panel
 
-    AppTheme { id: theme }
 
     width: 80
-    color: theme.bgPanel
+    color: AppTheme.bgPanel
     radius: 12
-    border.color: theme.borderStrong
+    border.color: AppTheme.borderStrong
     border.width: 1
 
     property bool scanning: false
@@ -58,7 +57,7 @@ Rectangle {
                     id: startStopCircle
                     Layout.alignment: Qt.AlignHCenter
                     width: 36; height: 36; radius: 18
-                    color: !panel.allConnected ? theme.textDisabled
+                    color: !panel.allConnected ? AppTheme.textDisabled
                          : panel.waiting  ? "#F1C40F"
                          : panel.scanning ? "#E74C3C"
                          :                  "#2ECC71"
@@ -101,7 +100,7 @@ Rectangle {
                 Text {
                     text: !panel.allConnected ? "Disconnected" : panel.scanning ? "Stop" : "Start"
                     font.pixelSize: 10
-                    color: (panel.camerasReady && panel.allConnected) ? theme.textSecondary : theme.textDisabled
+                    color: (panel.camerasReady && panel.allConnected) ? AppTheme.textSecondary : AppTheme.textDisabled
                     horizontalAlignment: Text.AlignHCenter
                     Layout.alignment: Qt.AlignHCenter
                 }
@@ -111,8 +110,8 @@ Rectangle {
             Rectangle {
                 anchors.fill: parent
                 radius: 10
-                color: ssArea.containsMouse ? theme.bgHover : "transparent"
-                border.color: ssArea.containsMouse ? theme.borderHover : "transparent"
+                color: ssArea.containsMouse ? AppTheme.bgHover : "transparent"
+                border.color: ssArea.containsMouse ? AppTheme.borderHover : "transparent"
                 border.width: 1
                 z: -1
                 Behavior on color { ColorAnimation { duration: 150 } }
@@ -133,7 +132,7 @@ Rectangle {
         Rectangle {
             Layout.preferredWidth: 52; Layout.preferredHeight: 1
             Layout.topMargin: 4; Layout.bottomMargin: 4
-            Layout.alignment: Qt.AlignHCenter; color: theme.borderSubtle
+            Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle
         }
 
         // Scan Settings (camera + duration)
@@ -151,7 +150,7 @@ Rectangle {
             visible: !panel.clinicalMode
             Layout.preferredWidth: 52; Layout.preferredHeight: 1
             Layout.topMargin: 4; Layout.bottomMargin: 4
-            Layout.alignment: Qt.AlignHCenter; color: theme.borderSubtle
+            Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle
         }
 
         // Notes
@@ -165,7 +164,7 @@ Rectangle {
             visible: !panel.clinicalMode
             Layout.preferredWidth: 52; Layout.preferredHeight: 1
             Layout.topMargin: 4; Layout.bottomMargin: 4
-            Layout.alignment: Qt.AlignHCenter; color: theme.borderSubtle
+            Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle
         }
 
         // Check (contact quality quick-check)
@@ -188,7 +187,7 @@ Rectangle {
             onClicked: panel.historyClicked()
         }
 
-        Rectangle { Layout.preferredWidth: 52; Layout.preferredHeight: 1; Layout.topMargin: 4; Layout.bottomMargin: 4; Layout.alignment: Qt.AlignHCenter; color: theme.borderSubtle }
+        Rectangle { Layout.preferredWidth: 52; Layout.preferredHeight: 1; Layout.topMargin: 4; Layout.bottomMargin: 4; Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle }
 
         // Settings
         PanelButton {
@@ -216,9 +215,9 @@ Rectangle {
             anchors.fill: parent
             radius: 10
             color: btnMouseArea.containsMouse
-                ? (btnItem.highlighted ? Qt.lighter(btnItem.highlightColor, 1.2) : theme.bgHover)
+                ? (btnItem.highlighted ? Qt.lighter(btnItem.highlightColor, 1.2) : AppTheme.bgHover)
                 : (btnItem.highlighted ? btnItem.highlightColor : "transparent")
-            border.color: btnMouseArea.containsMouse ? theme.borderHover : "transparent"
+            border.color: btnMouseArea.containsMouse ? AppTheme.borderHover : "transparent"
             border.width: 1
 
             Behavior on color { ColorAnimation { duration: 150 } }
@@ -232,7 +231,7 @@ Rectangle {
                 text: btnItem.iconText
                 font.family: iconFont.name
                 font.pixelSize: 26
-                color: btnItem.enabled ? (btnItem.highlighted ? "white" : theme.textSecondary) : theme.textDisabled
+                color: btnItem.enabled ? (btnItem.highlighted ? "white" : AppTheme.textSecondary) : AppTheme.textDisabled
                 horizontalAlignment: Text.AlignHCenter
                 Layout.alignment: Qt.AlignHCenter
             }
@@ -240,7 +239,7 @@ Rectangle {
             Text {
                 text: btnItem.label
                 font.pixelSize: 10
-                color: btnItem.enabled ? (btnItem.highlighted ? "white" : theme.textTertiary) : theme.textDisabled
+                color: btnItem.enabled ? (btnItem.highlighted ? "white" : AppTheme.textTertiary) : AppTheme.textDisabled
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
                 Layout.preferredWidth: 64

--- a/components/CameraDot.qml
+++ b/components/CameraDot.qml
@@ -1,5 +1,6 @@
 import QtQuick 6.0
 import QtQuick.Controls as Controls
+import OpenMotion 1.0
 
 /*  CameraDot — single per-camera contact-quality indicator.
  *
@@ -27,7 +28,6 @@ Item {
     width: size
     height: size
 
-    AppTheme { id: theme }
 
     readonly property string status: modal.cameraStatus(side, camIndex1)
     readonly property var    types: status === "bad" && modal.engineeringMode
@@ -43,12 +43,12 @@ Item {
         if (status === "inactive") return "#666666"
         // status === "bad" past this point
         if (!modal.engineeringMode)  return "#E67E22"
-        if (isSplit)                return theme.accentOrangeAmbient  // unused at render time (splitFrame handles it); kept so singleColor is never undefined
-        if (hasAmbient)             return theme.accentOrangeAmbient
-        if (hasContact)             return theme.accentOrangeContact
+        if (isSplit)                return AppTheme.accentOrangeAmbient  // unused at render time (splitFrame handles it); kept so singleColor is never undefined
+        if (hasAmbient)             return AppTheme.accentOrangeAmbient
+        if (hasContact)             return AppTheme.accentOrangeContact
         // Unknown / future typeKey — fall back to dark orange and warn.
         console.warn("CameraDot: unknown typeKey(s)", types, "for", side, camIndex1)
-        return theme.accentOrangeAmbient
+        return AppTheme.accentOrangeAmbient
     }
 
     // Solid case (no split) — single coloured circle.
@@ -75,10 +75,10 @@ Item {
         border.width: 1
         gradient: Gradient {
             orientation: Gradient.Horizontal
-            GradientStop { position: 0.0;    color: theme.accentOrangeAmbient }
-            GradientStop { position: 0.4999; color: theme.accentOrangeAmbient }
-            GradientStop { position: 0.5001; color: theme.accentOrangeContact }
-            GradientStop { position: 1.0;    color: theme.accentOrangeContact }
+            GradientStop { position: 0.0;    color: AppTheme.accentOrangeAmbient }
+            GradientStop { position: 0.4999; color: AppTheme.accentOrangeAmbient }
+            GradientStop { position: 0.5001; color: AppTheme.accentOrangeContact }
+            GradientStop { position: 1.0;    color: AppTheme.accentOrangeContact }
         }
     }
 

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -34,7 +34,6 @@ Item {
     visible: false
     z: 9999
 
-    AppTheme { id: theme }
 
     // ── state ────────────────────────────────────────────────────────────
     // One of: "checking" | "ok" | "warnings" | "error"
@@ -250,12 +249,12 @@ Item {
         width: 520
         height: 480
         radius: 10
-        color: theme.bgContainer
+        color: AppTheme.bgContainer
         border.width: 2
-        border.color: root.state_ === "ok" ? theme.accentGreen
+        border.color: root.state_ === "ok" ? AppTheme.accentGreen
                     : (root.state_ === "warnings"
-                       ? ((root.liveScan && root.liveScanDismissable) ? theme.accentGreen : theme.accentOrange)
-                       : (root.state_ === "error" ? theme.accentRed : theme.borderSubtle))
+                       ? ((root.liveScan && root.liveScanDismissable) ? AppTheme.accentGreen : AppTheme.accentOrange)
+                       : (root.state_ === "error" ? AppTheme.accentRed : AppTheme.borderSubtle))
         anchors.centerIn: parent
         focus: true
 
@@ -275,7 +274,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 font.pixelSize: 20
                 font.bold: true
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 wrapMode: Text.WordWrap
                 text: root.label
             }
@@ -296,7 +295,7 @@ Item {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 14
                 text: "All cameras are reporting acceptable ambient light and contact levels."
             }
@@ -307,7 +306,7 @@ Item {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 14
                 text: (root.entries.length > 0)
                       ? "Hover over orange cameras for details."
@@ -320,7 +319,7 @@ Item {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
-                color: theme.accentRed
+                color: AppTheme.accentRed
                 font.pixelSize: 14
                 text: root.errorText
             }
@@ -336,15 +335,15 @@ Item {
                 Rectangle {
                     visible: MotionInterface.leftSensorConnected
                     width: 180; height: 210; radius: 22
-                    color: theme.bgCard
-                    border.color: theme.borderSubtle; border.width: 2
+                    color: AppTheme.bgCard
+                    border.color: AppTheme.borderSubtle; border.width: 2
 
                     ColumnLayout {
                         anchors.fill: parent; anchors.margins: 8; spacing: 6
 
                         Text {
                             text: "Left Sensor"
-                            font.pixelSize: 14; color: theme.textSecondary
+                            font.pixelSize: 14; color: AppTheme.textSecondary
                             horizontalAlignment: Text.AlignHCenter
                             Layout.alignment: Qt.AlignHCenter
                         }
@@ -382,15 +381,15 @@ Item {
                 Rectangle {
                     visible: MotionInterface.rightSensorConnected
                     width: 180; height: 210; radius: 22
-                    color: theme.bgCard
-                    border.color: theme.borderSubtle; border.width: 2
+                    color: AppTheme.bgCard
+                    border.color: AppTheme.borderSubtle; border.width: 2
 
                     ColumnLayout {
                         anchors.fill: parent; anchors.margins: 8; spacing: 6
 
                         Text {
                             text: "Right Sensor"
-                            font.pixelSize: 14; color: theme.textSecondary
+                            font.pixelSize: 14; color: AppTheme.textSecondary
                             horizontalAlignment: Text.AlignHCenter
                             Layout.alignment: Qt.AlignHCenter
                         }
@@ -436,16 +435,16 @@ Item {
                 RowLayout {
                     spacing: 6
                     Rectangle { width: 10; height: 10; radius: 5
-                        color: theme.accentOrangeAmbient
+                        color: AppTheme.accentOrangeAmbient
                         border.color: "black"; border.width: 1 }
-                    Text { text: "ambient"; color: theme.textSecondary; font.pixelSize: 11 }
+                    Text { text: "ambient"; color: AppTheme.textSecondary; font.pixelSize: 11 }
                 }
                 RowLayout {
                     spacing: 6
                     Rectangle { width: 10; height: 10; radius: 5
-                        color: theme.accentOrangeContact
+                        color: AppTheme.accentOrangeContact
                         border.color: "black"; border.width: 1 }
-                    Text { text: "contact"; color: theme.textSecondary; font.pixelSize: 11 }
+                    Text { text: "contact"; color: AppTheme.textSecondary; font.pixelSize: 11 }
                 }
                 RowLayout {
                     spacing: 6
@@ -454,13 +453,13 @@ Item {
                         border.color: "black"; border.width: 1
                         gradient: Gradient {
                             orientation: Gradient.Horizontal
-                            GradientStop { position: 0.0;    color: theme.accentOrangeAmbient }
-                            GradientStop { position: 0.4999; color: theme.accentOrangeAmbient }
-                            GradientStop { position: 0.5001; color: theme.accentOrangeContact }
-                            GradientStop { position: 1.0;    color: theme.accentOrangeContact }
+                            GradientStop { position: 0.0;    color: AppTheme.accentOrangeAmbient }
+                            GradientStop { position: 0.4999; color: AppTheme.accentOrangeAmbient }
+                            GradientStop { position: 0.5001; color: AppTheme.accentOrangeContact }
+                            GradientStop { position: 1.0;    color: AppTheme.accentOrangeContact }
                         }
                     }
-                    Text { text: "both"; color: theme.textSecondary; font.pixelSize: 11 }
+                    Text { text: "both"; color: AppTheme.textSecondary; font.pixelSize: 11 }
                 }
             }
 
@@ -484,12 +483,12 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : theme.textSecondary
+                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        radius: 4; border.color: parent.hovered ? theme.accentBlue : theme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.dismissed() }
                 }
@@ -500,12 +499,12 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : theme.textSecondary
+                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        radius: 4; border.color: parent.hovered ? theme.accentBlue : theme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.retestRequested() }
                 }
@@ -516,12 +515,12 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : theme.textSecondary
+                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentGreen : theme.bgInput
-                        radius: 4; border.color: parent.hovered ? theme.accentGreen : theme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentGreen : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentGreen : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.continueRequested(); root.close(); root.dismissed() }
                 }
@@ -534,12 +533,12 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : theme.textSecondary
+                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentRed : theme.bgInput
-                        radius: 4; border.color: parent.hovered ? theme.accentRed : theme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentRed : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentRed : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.stopScanRequested(); root.close(); root.dismissed() }
                 }
@@ -551,16 +550,16 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: !parent.enabled ? theme.textDisabled
-                              : (parent.hovered ? "#FFFFFF" : theme.textSecondary)
+                        color: !parent.enabled ? AppTheme.textDisabled
+                              : (parent.hovered ? "#FFFFFF" : AppTheme.textSecondary)
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: !parent.enabled ? theme.bgCard
-                              : (parent.hovered ? theme.accentBlue : theme.bgInput)
+                        color: !parent.enabled ? AppTheme.bgCard
+                              : (parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput)
                         radius: 4
-                        border.color: !parent.enabled ? theme.borderSubtle
-                                    : (parent.hovered ? theme.accentBlue : theme.borderSoft)
+                        border.color: !parent.enabled ? AppTheme.borderSubtle
+                                    : (parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft)
                         border.width: 1
                     }
                     onClicked: { root.continueRequested(); root.close(); root.dismissed() }
@@ -574,12 +573,12 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : theme.textSecondary
+                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        radius: 4; border.color: parent.hovered ? theme.accentBlue : theme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.dismissed() }
                 }
@@ -590,12 +589,12 @@ Item {
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : theme.textSecondary
+                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        radius: 4; border.color: parent.hovered ? theme.accentBlue : theme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.retestRequested() }
                 }
@@ -612,7 +611,7 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? "#B8740F" : theme.bgInput
+                        color: parent.hovered ? "#B8740F" : AppTheme.bgInput
                         radius: 4
                         border.color: parent.hovered ? "#E8A020" : "#E8A020"
                         border.width: 1

--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -21,7 +21,6 @@ Item {
     visible: false
     z: 100000
 
-    AppTheme { id: theme }
 
     // Current error fields (bound into the panel).
     property string code: ""
@@ -98,8 +97,8 @@ Item {
         width: 520
         height: contentCol.implicitHeight + headerBar.height + 16 + 20
         radius: 14
-        color: theme.bgContainer
-        border.color: theme.accentRed
+        color: AppTheme.bgContainer
+        border.color: AppTheme.accentRed
         border.width: 1
         anchors.centerIn: parent
 
@@ -114,14 +113,14 @@ Item {
             anchors.right: parent.right
             height: 44
             radius: 14
-            color: theme.accentRed
+            color: AppTheme.accentRed
             // square off the bottom corners so only the top is rounded
             Rectangle {
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
                 height: parent.radius
-                color: theme.accentRed
+                color: AppTheme.accentRed
             }
 
             RowLayout {
@@ -139,7 +138,7 @@ Item {
                         id: codeText
                         anchors.centerIn: parent
                         text: root.code
-                        color: theme.accentRed
+                        color: AppTheme.accentRed
                         font.pixelSize: 13
                         font.weight: Font.Bold
                         font.family: "Consolas, monospace"
@@ -175,7 +174,7 @@ Item {
 
             Text {
                 text: root.title
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 17
                 font.weight: Font.DemiBold
                 wrapMode: Text.WordWrap
@@ -184,7 +183,7 @@ Item {
 
             Text {
                 text: root.message
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 13
                 wrapMode: Text.WordWrap
                 Layout.fillWidth: true
@@ -195,7 +194,7 @@ Item {
                 visible: root.suggestedAction !== ""
                 Layout.fillWidth: true
                 radius: 6
-                color: theme.bgInput
+                color: AppTheme.bgInput
                 Layout.preferredHeight: actionRow.implicitHeight + 16
                 RowLayout {
                     id: actionRow
@@ -204,13 +203,13 @@ Item {
                     spacing: 8
                     Text {
                         text: "→"
-                        color: theme.accentBlue
+                        color: AppTheme.accentBlue
                         font.pixelSize: 14
                         font.weight: Font.Bold
                     }
                     Text {
                         text: root.suggestedAction
-                        color: theme.textPrimary
+                        color: AppTheme.textPrimary
                         font.pixelSize: 13
                         wrapMode: Text.WordWrap
                         Layout.fillWidth: true
@@ -222,7 +221,7 @@ Item {
             Text {
                 visible: root.detail !== ""
                 text: (root._detailExpanded ? "▼ " : "▶ ") + "Details"
-                color: theme.textTertiary
+                color: AppTheme.textTertiary
                 font.pixelSize: 12
                 MouseArea {
                     anchors.fill: parent
@@ -233,7 +232,7 @@ Item {
             Text {
                 visible: root.detail !== "" && root._detailExpanded
                 text: root.detail
-                color: theme.textTertiary
+                color: AppTheme.textTertiary
                 font.pixelSize: 12
                 font.family: "Consolas, monospace"
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -252,14 +251,14 @@ Item {
                     onClicked: MotionInterface.copyToClipboard(root._reportText())
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
-                        color: theme.textSecondary
+                        color: AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        color: parent.hovered ? AppTheme.bgHover : AppTheme.bgInput
                         radius: 4
-                        border.color: theme.borderSoft; border.width: 1
+                        border.color: AppTheme.borderSoft; border.width: 1
                     }
                 }
 
@@ -269,14 +268,14 @@ Item {
                     onClicked: MotionInterface.sendBugReport(root.code)
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
-                        color: theme.textPrimary
+                        color: AppTheme.textPrimary
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        color: parent.hovered ? AppTheme.bgHover : AppTheme.bgInput
                         radius: 4
-                        border.color: theme.borderSubtle; border.width: 1
+                        border.color: AppTheme.borderSubtle; border.width: 1
                     }
                 }
 
@@ -293,7 +292,7 @@ Item {
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? Qt.lighter(theme.accentRed, 1.1) : theme.accentRed
+                        color: parent.hovered ? Qt.lighter(AppTheme.accentRed, 1.1) : AppTheme.accentRed
                         radius: 4
                     }
                 }

--- a/components/FirmwareUpdateBanner.qml
+++ b/components/FirmwareUpdateBanner.qml
@@ -13,7 +13,6 @@ Rectangle {
     height: visible ? 36 : 0
     clip: true
 
-    AppTheme { id: theme }
 
     signal viewRequested()
 
@@ -21,7 +20,7 @@ Rectangle {
     property bool _dismissed: false
     visible: _devMode && MotionInterface.anyFirmwareUpdateAvailable && !_dismissed
 
-    color: theme.accentBlue
+    color: AppTheme.accentBlue
     radius: 0
     Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
 
@@ -46,7 +45,7 @@ Rectangle {
                 id: viewBtn
                 anchors.centerIn: parent
                 text: "View"
-                color: theme.accentBlue
+                color: AppTheme.accentBlue
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
             }

--- a/components/HistoryHeaderCell.qml
+++ b/components/HistoryHeaderCell.qml
@@ -1,5 +1,6 @@
 import QtQuick 6.0
 import QtQuick.Layouts 6.0
+import OpenMotion 1.0
 
 // One clickable, sort-aware column header in the History table.
 Item {
@@ -12,20 +13,19 @@ Item {
 
     Layout.preferredHeight: 30
 
-    AppTheme { id: theme }
 
     Row {
         anchors.verticalCenter: parent.verticalCenter
         spacing: 4
         Text {
             text: cell.text
-            color: theme.textSecondary
+            color: AppTheme.textSecondary
             font.pixelSize: 12; font.weight: Font.DemiBold
         }
         Text {
             visible: cell.activeSort === cell.sortName
             text: cell.ascending ? "▲" : "▼"
-            color: theme.textSecondary; font.pixelSize: 9
+            color: AppTheme.textSecondary; font.pixelSize: 9
             anchors.verticalCenter: parent.verticalCenter
         }
     }

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -10,7 +10,6 @@ Item {
     visible: false
     z: 9998
 
-    AppTheme { id: theme }
 
     // Modal interface label (single source of truth — see ModalManager).
     readonly property string label: "Scan History"
@@ -252,8 +251,8 @@ Item {
         width: Math.min(parent.width - root.iconBarInset - 40, 1040)
         height: Math.min(parent.height - 60, 680)
         radius: 12
-        color: theme.bgContainer
-        border.color: theme.borderSubtle
+        color: AppTheme.bgContainer
+        border.color: AppTheme.borderSubtle
         border.width: 2
         // Center within [iconBarInset, parent.width] so the card clears the
         // icon bar instead of bleeding under it. horizontalCenterOffset
@@ -278,7 +277,7 @@ Item {
                 Text {
                     text: root.label
                     font.pixelSize: 20; font.weight: Font.Bold
-                    color: theme.textPrimary
+                    color: AppTheme.textPrimary
                 }
                 Item { Layout.fillWidth: true }
 
@@ -287,14 +286,14 @@ Item {
                     Layout.preferredWidth: 240
                     Layout.preferredHeight: 34
                     placeholderText: "Search label…"
-                    color: theme.textPrimary
-                    placeholderTextColor: theme.textSecondary
+                    color: AppTheme.textPrimary
+                    placeholderTextColor: AppTheme.textSecondary
                     font.pixelSize: 13
                     leftPadding: 12; rightPadding: 12
                     verticalAlignment: TextInput.AlignVCenter
                     background: Rectangle {
-                        color: theme.bgInput; radius: 6
-                        border.color: searchField.activeFocus ? theme.accentBlue : theme.borderSubtle
+                        color: AppTheme.bgInput; radius: 6
+                        border.color: searchField.activeFocus ? AppTheme.accentBlue : AppTheme.borderSubtle
                         border.width: 1
                     }
                     onTextChanged: root.searchText = text
@@ -302,10 +301,10 @@ Item {
 
                 Rectangle {
                     width: 30; height: 30; radius: 15
-                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
-                    border.color: theme.borderHover; border.width: 1
+                    color: xArea.containsMouse ? "#C0392B" : AppTheme.borderStrong
+                    border.color: AppTheme.borderHover; border.width: 1
                     Behavior on color { ColorAnimation { duration: 120 } }
-                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    Text { anchors.centerIn: parent; text: "✕"; color: AppTheme.textPrimary; font.pixelSize: 13 }
                     MouseArea {
                         id: xArea; anchors.fill: parent; hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor; onClicked: root.close()
@@ -317,7 +316,7 @@ Item {
             Rectangle {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 30
-                color: theme.bgCardAlt; radius: 4
+                color: AppTheme.bgCardAlt; radius: 4
                 RowLayout {
                     anchors.fill: parent
                     anchors.leftMargin: 8; anchors.rightMargin: 8
@@ -327,7 +326,7 @@ Item {
                     Text {
                         Layout.preferredWidth: col.chk
                         text: (root.checkedCount > 0 && root.checkedCount === root.view.length) ? "☑" : "☐"
-                        color: theme.textSecondary; font.pixelSize: 15
+                        color: AppTheme.textSecondary; font.pixelSize: 15
                         horizontalAlignment: Text.AlignHCenter
                         MouseArea {
                             anchors.fill: parent; cursorShape: Qt.PointingHandCursor
@@ -362,8 +361,8 @@ Item {
             // ── table body ─────────────────────────────────────────
             Rectangle {
                 Layout.fillWidth: true; Layout.fillHeight: true
-                radius: 6; color: theme.bgCardAlt
-                border.color: theme.borderSubtle; border.width: 1
+                radius: 6; color: AppTheme.bgCardAlt
+                border.color: AppTheme.borderSubtle; border.width: 1
                 clip: true
 
                 ListView {
@@ -396,7 +395,7 @@ Item {
                             Text {
                                 Layout.preferredWidth: col.chk
                                 text: root.checked[modelData.sessionId] ? "☑" : "☐"
-                                color: theme.textPrimary; font.pixelSize: 15
+                                color: AppTheme.textPrimary; font.pixelSize: 15
                                 horizontalAlignment: Text.AlignHCenter
                                 MouseArea {
                                     anchors.fill: parent; cursorShape: Qt.PointingHandCursor
@@ -408,25 +407,25 @@ Item {
                             Text {
                                 Layout.fillWidth: true
                                 text: modelData.userLabel || "(unlabeled)"
-                                color: theme.textPrimary; font.pixelSize: 13
+                                color: AppTheme.textPrimary; font.pixelSize: 13
                                 elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
                             }
                             Text {
                                 Layout.preferredWidth: col.date
                                 text: modelData.dateTime || "-"
-                                color: theme.textSecondary; font.pixelSize: 13
+                                color: AppTheme.textSecondary; font.pixelSize: 13
                                 verticalAlignment: Text.AlignVCenter
                             }
                             Text {
                                 Layout.preferredWidth: col.config
                                 text: (modelData.configL || "—") + " / " + (modelData.configR || "—")
-                                color: theme.textSecondary; font.pixelSize: 13
+                                color: AppTheme.textSecondary; font.pixelSize: 13
                                 elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
                             }
                             Text {
                                 Layout.preferredWidth: col.dur
                                 text: root.formatDuration(modelData.durationSec)
-                                color: theme.textSecondary; font.pixelSize: 13
+                                color: AppTheme.textSecondary; font.pixelSize: 13
                                 verticalAlignment: Text.AlignVCenter
                             }
                             Text {
@@ -446,7 +445,7 @@ Item {
                         visible: root.view.length === 0
                         text: root.scans.length === 0 ? "No scans yet."
                                                       : "No scans match the filter."
-                        color: theme.textSecondary; font.pixelSize: 14
+                        color: AppTheme.textSecondary; font.pixelSize: 14
                     }
                 }
             }
@@ -455,8 +454,8 @@ Item {
             Rectangle {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 230
-                radius: 6; color: theme.bgCardAlt
-                border.color: theme.borderSubtle; border.width: 1
+                radius: 6; color: AppTheme.bgCardAlt
+                border.color: AppTheme.borderSubtle; border.width: 1
                 visible: root.focusedRow !== null
 
                 // Stacked: a compact metadata strip on top, then the notes box
@@ -468,36 +467,36 @@ Item {
                     GridLayout {
                         Layout.fillWidth: true
                         columns: 6; columnSpacing: 12; rowSpacing: 6
-                        Text { text: "Full label:"; color: theme.textSecondary; font.pixelSize: 12 }
-                        Text { text: root.focusedRow ? root.focusedRow.label : ""; color: theme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
-                        Text { text: "Operator:"; color: theme.textSecondary; font.pixelSize: 12 }
-                        Text { text: root.focusedRow ? (root.focusedRow.operator || "-") : ""; color: theme.textPrimary; font.pixelSize: 12 }
-                        Text { text: "Samples:"; color: theme.textSecondary; font.pixelSize: 12 }
-                        Text { text: root.focusedSampleCount < 0 ? "…" : root.focusedSampleCount.toLocaleString(); color: theme.textPrimary; font.pixelSize: 12; Layout.preferredWidth: 70 }
+                        Text { text: "Full label:"; color: AppTheme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? root.focusedRow.label : ""; color: AppTheme.textPrimary; font.pixelSize: 12; elide: Text.ElideRight; Layout.fillWidth: true }
+                        Text { text: "Operator:"; color: AppTheme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? (root.focusedRow.operator || "-") : ""; color: AppTheme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Samples:"; color: AppTheme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedSampleCount < 0 ? "…" : root.focusedSampleCount.toLocaleString(); color: AppTheme.textPrimary; font.pixelSize: 12; Layout.preferredWidth: 70 }
 
-                        Text { text: "Mask (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
+                        Text { text: "Mask (L / R):"; color: AppTheme.textSecondary; font.pixelSize: 12 }
                         Text {
-                            color: theme.textPrimary; font.pixelSize: 12
+                            color: AppTheme.textPrimary; font.pixelSize: 12
                             text: root.focusedRow
                                   ? (root.maskLabel(root.focusedRow.leftMask)
                                      + " / " + root.maskLabel(root.focusedRow.rightMask))
                                   : ""
                         }
-                        Text { text: "Config (L / R):"; color: theme.textSecondary; font.pixelSize: 12 }
-                        Text { text: root.focusedRow ? (root.focusedRow.configL + " / " + root.focusedRow.configR) : ""; color: theme.textPrimary; font.pixelSize: 12 }
+                        Text { text: "Config (L / R):"; color: AppTheme.textSecondary; font.pixelSize: 12 }
+                        Text { text: root.focusedRow ? (root.focusedRow.configL + " / " + root.focusedRow.configR) : ""; color: AppTheme.textPrimary; font.pixelSize: 12 }
                     }
 
-                    Text { text: "Notes (read-only):"; color: theme.textSecondary; font.pixelSize: 12 }
+                    Text { text: "Notes (read-only):"; color: AppTheme.textSecondary; font.pixelSize: 12 }
                     Rectangle {
                         Layout.fillWidth: true; Layout.fillHeight: true
-                        radius: 4; color: theme.bgInput
-                        border.color: theme.borderSubtle; border.width: 1
+                        radius: 4; color: AppTheme.bgInput
+                        border.color: AppTheme.borderSubtle; border.width: 1
                         ScrollView {
                             anchors.fill: parent; anchors.margins: 2
                             TextArea {
                                 readOnly: true; wrapMode: Text.Wrap; background: null
                                 text: root.focusedRow ? (root.focusedRow.notes || "") : ""
-                                color: theme.textPrimary; font.pixelSize: 12
+                                color: AppTheme.textPrimary; font.pixelSize: 12
                             }
                         }
                     }
@@ -520,14 +519,14 @@ Item {
                     hoverEnabled: enabled
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
-                        color: deleteBtn.enabled ? theme.accentRed : theme.textTertiary
+                        color: deleteBtn.enabled ? AppTheme.accentRed : AppTheme.textTertiary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
                         radius: 6
                         color: deleteBtn.hovered && deleteBtn.enabled
                                ? Qt.rgba(0.75, 0.22, 0.17, 0.16) : "transparent"
-                        border.color: deleteBtn.enabled ? theme.accentRed : theme.textTertiary
+                        border.color: deleteBtn.enabled ? AppTheme.accentRed : AppTheme.textTertiary
                         border.width: 1
                     }
                     onClicked: root.requestDelete()
@@ -543,13 +542,13 @@ Item {
                     hoverEnabled: enabled
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
-                        color: exportBtn.enabled ? theme.textSecondary : theme.textTertiary
+                        color: exportBtn.enabled ? AppTheme.textSecondary : AppTheme.textTertiary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
                         radius: 6
-                        color: exportBtn.hovered && exportBtn.enabled ? theme.bgHover : "transparent"
-                        border.color: exportBtn.enabled ? theme.borderStrong : theme.textTertiary
+                        color: exportBtn.hovered && exportBtn.enabled ? AppTheme.bgHover : "transparent"
+                        border.color: exportBtn.enabled ? AppTheme.borderStrong : AppTheme.textTertiary
                         border.width: 1
                     }
                     onClicked: root.requestExport()
@@ -565,15 +564,15 @@ Item {
                     hoverEnabled: enabled
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13; font.weight: Font.DemiBold
-                        color: loadBtn.enabled ? "#FFFFFF" : theme.textTertiary
+                        color: loadBtn.enabled ? "#FFFFFF" : AppTheme.textTertiary
                         elide: Text.ElideRight
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
                         radius: 6
-                        color: !loadBtn.enabled ? theme.bgInput
-                               : (loadBtn.hovered ? Qt.lighter(theme.accentBlue, 1.12)
-                                                  : theme.accentBlue)
+                        color: !loadBtn.enabled ? AppTheme.bgInput
+                               : (loadBtn.hovered ? Qt.lighter(AppTheme.accentBlue, 1.12)
+                                                  : AppTheme.accentBlue)
                     }
                     onClicked: {
                         root.loadingPlot = true
@@ -595,7 +594,7 @@ Item {
             Column {
                 anchors.centerIn: parent; spacing: 12
                 BusyIndicator { running: root.loadingPlot; width: 48; height: 48 }
-                Text { text: "Loading scan..."; color: theme.textPrimary; font.pixelSize: 14 }
+                Text { text: "Loading scan..."; color: AppTheme.textPrimary; font.pixelSize: 14 }
             }
         }
     }

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -618,8 +618,9 @@ Item {
         property string selectedScanId: ""
         onAccepted: {
             var path = selectedFile.toString().replace("file:///", "")
-            var ok = MotionInterface.exportScanCsv(selectedScanId, path)
-            if (ok) MotionInterface.notify("Exported to " + path, "success")
+            // Async: runs on a worker thread; the success toast fires
+            // from onScanCsvExportFinished below.
+            MotionInterface.exportScanCsv(selectedScanId, path)
         }
     }
 
@@ -631,12 +632,10 @@ Item {
         property int pendingSkipped: 0
         onAccepted: {
             var folder = selectedFolder.toString().replace("file:///", "")
-            var res = MotionInterface.exportScansToFolder(pendingLabels, folder)
-            var ok = (res && res.exported) ? res.exported : 0
-            var sk = pendingSkipped + ((res && res.skipped) ? res.skipped : 0)
-            var msg = "Exported " + ok + " scan(s) to " + folder
-            if (sk > 0) msg += " (" + sk + " skipped)"
-            MotionInterface.notify(msg, ok > 0 ? "success" : "warning")
+            // Async: the batch runs on a worker thread; the summary
+            // toast fires from onScansExportFinished below, which folds
+            // in pendingSkipped (interrupted scans filtered pre-dialog).
+            MotionInterface.exportScansToFolder(pendingLabels, folder)
         }
     }
 
@@ -649,6 +648,18 @@ Item {
             if (ok) root.close()
         }
         function onDirectoryChanged() { if (root.visible) root.refresh() }
+        function onScanCsvExportFinished(ok, path) {
+            if (ok) MotionInterface.notify("Exported to " + path, "success")
+            // Failure toast comes from errorOccurred (handler below).
+        }
+        function onScansExportFinished(exported, skipped, folder) {
+            var sk = exportFolderDialog.pendingSkipped + skipped
+            exportFolderDialog.pendingSkipped = 0
+            var msg = "Exported " + exported + " scan(s) to " + folder
+            if (sk > 0) msg += " (" + sk + " skipped)"
+            MotionInterface.notify(msg, exported > 0 ? "success" : "warning",
+                                   4000, true, "scan-export")
+        }
         // Re-apply the clinical-mode row filter if the app's mode changes
         // while History is open.
         function onAppConfigChanged() { if (root.visible) root.rebuildView() }

--- a/components/IconSmallButton.qml
+++ b/components/IconSmallButton.qml
@@ -1,6 +1,7 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
+import OpenMotion 1.0
 
 Item {
     id: iconSmallButton
@@ -11,15 +12,14 @@ Item {
     property string iconGlyph: "\ue900"       // Unicode glyph for the icon
     property string buttonText: "Action"      // Tooltip text
 
-    AppTheme { id: theme }
 
     // Colors
-    property color iconColor: theme.textSecondary
-    property color hoverColor: theme.textPrimary
-    property color backgroundColor: theme.bgInput
-    property color hoverBackgroundColor: theme.borderSubtle
+    property color iconColor: AppTheme.textSecondary
+    property color hoverColor: AppTheme.textPrimary
+    property color backgroundColor: AppTheme.bgInput
+    property color hoverBackgroundColor: AppTheme.borderSubtle
     property color borderColor: "transparent"
-    property color hoverBorderColor: theme.textSecondary
+    property color hoverBorderColor: AppTheme.textSecondary
 
     // Signals
     signal clicked()
@@ -56,7 +56,7 @@ Item {
         width: Math.max(80, buttonText.length * 8)
         height: 28
         radius: 4
-        color: theme.bgBase
+        color: AppTheme.bgBase
         border.color: "transparent"
         z: 10
 
@@ -70,7 +70,7 @@ Item {
             text: buttonText
             anchors.centerIn: parent
             font.pixelSize: 12
-            color: theme.textPrimary
+            color: AppTheme.textPrimary
         }
     }
 

--- a/components/IconWindowButton.qml
+++ b/components/IconWindowButton.qml
@@ -1,18 +1,18 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
+import OpenMotion 1.0
 
 Item {
     id: iconWindowButton
     width: 40
     height: 40
 
-    AppTheme { id: theme }
 
     // IconWindowButton properties
     property string buttonIcon: "\ue900"         // Icon Unicode
-    property color iconColor: theme.textSecondary         // Default icon color
-    property color hoverBackground: theme.bgHover   // Background color on hover
+    property color iconColor: AppTheme.textSecondary         // Default icon color
+    property color hoverBackground: AppTheme.bgHover   // Background color on hover
     property color hoverIconColor: "white"      // Icon color on hover
     property color backgroundColor: "transparent" // Default background color
     property color activeBackground: "#374774"      // Background color when clicked

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -13,7 +13,6 @@ Item {
     visible: false
     z: 9998
 
-    AppTheme { id: theme }
 
     readonly property string label: "Audit Log"
     property var entries: []
@@ -55,8 +54,8 @@ Item {
         width: Math.min(parent.width - 60, 980)
         height: Math.min(parent.height - 60, 700)
         radius: 12
-        color: theme.bgContainer
-        border.color: theme.borderSubtle
+        color: AppTheme.bgContainer
+        border.color: AppTheme.borderSubtle
         border.width: 2
         anchors.centerIn: parent
 
@@ -75,7 +74,7 @@ Item {
                 Text {
                     text: root.label
                     font.pixelSize: 20; font.weight: Font.Bold
-                    color: theme.textPrimary
+                    color: AppTheme.textPrimary
                 }
                 Item { Layout.fillWidth: true }
 
@@ -84,12 +83,12 @@ Item {
                     Layout.preferredWidth: 110; Layout.preferredHeight: 32
                     hoverEnabled: true
                     contentItem: Text {
-                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        text: parent.text; font.pixelSize: 13; color: AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        border.color: parent.hovered ? AppTheme.textPrimary : AppTheme.textSecondary; radius: 4
                     }
                     onClicked: {
                         exportDialog.selectedFile = "file:///" + MotionInterface.directory
@@ -102,21 +101,21 @@ Item {
                     Layout.preferredWidth: 80; Layout.preferredHeight: 32
                     hoverEnabled: true
                     contentItem: Text {
-                        text: parent.text; font.pixelSize: 13; color: theme.textSecondary
+                        text: parent.text; font.pixelSize: 13; color: AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.accentBlue : theme.bgInput
-                        border.color: parent.hovered ? theme.textPrimary : theme.textSecondary; radius: 4
+                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        border.color: parent.hovered ? AppTheme.textPrimary : AppTheme.textSecondary; radius: 4
                     }
                     onClicked: root.refresh()
                 }
                 Rectangle {
                     width: 28; height: 28; radius: 14
-                    color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
-                    border.color: theme.borderHover; border.width: 1
+                    color: xArea.containsMouse ? "#C0392B" : AppTheme.borderStrong
+                    border.color: AppTheme.borderHover; border.width: 1
                     Behavior on color { ColorAnimation { duration: 120 } }
-                    Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+                    Text { anchors.centerIn: parent; text: "✕"; color: AppTheme.textPrimary; font.pixelSize: 13 }
                     MouseArea {
                         id: xArea; anchors.fill: parent; hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor; onClicked: root.close()
@@ -128,25 +127,25 @@ Item {
             Rectangle {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 30
-                color: theme.bgCardAlt; radius: 4
+                color: AppTheme.bgCardAlt; radius: 4
                 RowLayout {
                     anchors.fill: parent
                     anchors.leftMargin: 8; anchors.rightMargin: 8
                     spacing: 8
                     Text { text: "Time"; Layout.preferredWidth: col.time
-                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                           color: AppTheme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
                     Text { text: "Event"; Layout.preferredWidth: col.event
-                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                           color: AppTheme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
                     Text { text: "Details"; Layout.fillWidth: true
-                           color: theme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
+                           color: AppTheme.textSecondary; font.pixelSize: 12; font.weight: Font.DemiBold }
                 }
             }
 
             // ── table body ─────────────────────────────────────────
             Rectangle {
                 Layout.fillWidth: true; Layout.fillHeight: true
-                radius: 6; color: theme.bgCardAlt
-                border.color: theme.borderSubtle; border.width: 1
+                radius: 6; color: AppTheme.bgCardAlt
+                border.color: AppTheme.borderSubtle; border.width: 1
                 clip: true
 
                 ListView {
@@ -168,19 +167,19 @@ Item {
                             Text {
                                 Layout.preferredWidth: col.time
                                 text: modelData.ts_iso || ""
-                                color: theme.textSecondary; font.pixelSize: 12
+                                color: AppTheme.textSecondary; font.pixelSize: 12
                                 font.family: "Consolas"; verticalAlignment: Text.AlignVCenter
                             }
                             Text {
                                 Layout.preferredWidth: col.event
                                 text: modelData.event_type || ""
-                                color: theme.textPrimary; font.pixelSize: 12
+                                color: AppTheme.textPrimary; font.pixelSize: 12
                                 verticalAlignment: Text.AlignVCenter
                             }
                             Text {
                                 Layout.fillWidth: true
                                 text: modelData.details || ""
-                                color: theme.textSecondary; font.pixelSize: 12
+                                color: AppTheme.textSecondary; font.pixelSize: 12
                                 font.family: "Consolas"
                                 elide: Text.ElideRight; verticalAlignment: Text.AlignVCenter
                             }
@@ -191,7 +190,7 @@ Item {
                         anchors.centerIn: parent
                         visible: root.entries.length === 0
                         text: "No audit entries yet."
-                        color: theme.textSecondary; font.pixelSize: 14
+                        color: AppTheme.textSecondary; font.pixelSize: 14
                     }
                 }
             }

--- a/components/NotesModal.qml
+++ b/components/NotesModal.qml
@@ -9,7 +9,6 @@ Item {
     visible: false
     z: 9998
 
-    AppTheme { id: theme }
 
     // Modal interface — see HistoryModal.qml for rationale.
     readonly property string label: "Session Notes"
@@ -63,8 +62,8 @@ Item {
         width: Math.min(parent.width - root.iconBarInset - 40, 600)
         height: 450
         radius: 12
-        color: theme.bgContainer
-        border.color: theme.borderSubtle
+        color: AppTheme.bgContainer
+        border.color: AppTheme.borderSubtle
         border.width: 2
         // Center within [iconBarInset, parent.width] so the card clears the
         // icon bar instead of bleeding under it. horizontalCenterOffset
@@ -80,13 +79,13 @@ Item {
         // X close button
         Rectangle {
             width: 28; height: 28; radius: 14
-            color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
-            border.color: theme.borderHover; border.width: 1
+            color: xArea.containsMouse ? "#C0392B" : AppTheme.borderStrong
+            border.color: AppTheme.borderHover; border.width: 1
             anchors.top: parent.top; anchors.right: parent.right
             anchors.topMargin: 10; anchors.rightMargin: 10
             z: 10
             Behavior on color { ColorAnimation { duration: 120 } }
-            Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+            Text { anchors.centerIn: parent; text: "✕"; color: AppTheme.textPrimary; font.pixelSize: 13 }
             MouseArea {
                 id: xArea; anchors.fill: parent; hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor; onClicked: root.close()
@@ -100,16 +99,16 @@ Item {
 
             Text {
                 text: root.label
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 20
                 font.weight: Font.Bold
                 Layout.alignment: Qt.AlignHCenter
             }
 
             Rectangle {
-                color: theme.bgInput
+                color: AppTheme.bgInput
                 radius: 6
-                border.color: theme.borderSubtle
+                border.color: AppTheme.borderSubtle
                 border.width: 1
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -121,10 +120,10 @@ Item {
                     TextArea {
                         id: notesArea
                         font.pixelSize: 14
-                        color: theme.textPrimary
+                        color: AppTheme.textPrimary
                         wrapMode: Text.Wrap
                         placeholderText: "Enter notes for this session..."
-                        placeholderTextColor: theme.textTertiary
+                        placeholderTextColor: AppTheme.textTertiary
                         background: null
                     }
                 }

--- a/components/NotificationCenter.qml
+++ b/components/NotificationCenter.qml
@@ -19,7 +19,6 @@ Item {
     // Visible only via its toasts; root itself is transparent and doesn't
     // capture mouse events on empty space.
 
-    AppTheme { id: theme }
 
     FontLoader {
         id: iconFont
@@ -35,11 +34,11 @@ Item {
 
     function _accentColor(type) {
         switch (type) {
-            case "success": return theme.accentGreen
-            case "warning": return theme.accentYellow
-            case "error":   return theme.accentRed
+            case "success": return AppTheme.accentGreen
+            case "warning": return AppTheme.accentYellow
+            case "error":   return AppTheme.accentRed
             case "info":
-            default:        return theme.accentBlue
+            default:        return AppTheme.accentBlue
         }
     }
 
@@ -249,8 +248,8 @@ Item {
                     implicitHeight: contentRow.implicitHeight + 24
                     height: implicitHeight
                     radius: 10
-                    color: theme.bgElevated
-                    border.color: theme.borderSubtle
+                    color: AppTheme.bgElevated
+                    border.color: AppTheme.borderSubtle
                     border.width: 1
 
                     // Hovering anywhere on the toast pauses the auto-dismiss timer.
@@ -295,7 +294,7 @@ Item {
 
                         Text {
                             text: model.text
-                            color: theme.textPrimary
+                            color: AppTheme.textPrimary
                             font.pixelSize: 13
                             wrapMode: Text.Wrap
                             Layout.fillWidth: true
@@ -312,7 +311,7 @@ Item {
                                 text: "\ue9b4"
                                 font.family: iconFont.name
                                 font.pixelSize: 14
-                                color: closeArea.containsMouse ? theme.textPrimary : theme.textTertiary
+                                color: closeArea.containsMouse ? AppTheme.textPrimary : AppTheme.textTertiary
                             }
                             MouseArea {
                                 id: closeArea

--- a/components/PasswordPromptModal.qml
+++ b/components/PasswordPromptModal.qml
@@ -12,7 +12,6 @@ Item {
     visible: false
     z: 10000
 
-    AppTheme { id: theme }
 
     property string title: "Password Required"
     property string description: "Enter the password to continue."
@@ -60,8 +59,8 @@ Item {
         width: 360
         height: contentCol.implicitHeight + 48
         radius: 14
-        color: theme.bgContainer
-        border.color: theme.borderStrong
+        color: AppTheme.bgContainer
+        border.color: AppTheme.borderStrong
         border.width: 1
         anchors.centerIn: parent
 
@@ -76,14 +75,14 @@ Item {
 
             Text {
                 text: root.title
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 18
                 font.weight: Font.DemiBold
             }
 
             Text {
                 text: root.description
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 13
                 wrapMode: Text.WordWrap
                 Layout.fillWidth: true
@@ -95,8 +94,8 @@ Item {
                 Layout.preferredHeight: 38
                 echoMode: TextInput.Password
                 placeholderText: ""
-                color: theme.textPrimary
-                placeholderTextColor: theme.textSecondary
+                color: AppTheme.textPrimary
+                placeholderTextColor: AppTheme.textSecondary
                 font.pixelSize: 14
                 verticalAlignment: TextInput.AlignVCenter
                 leftPadding: 10
@@ -104,9 +103,9 @@ Item {
                 topPadding: 0
                 bottomPadding: 0
                 background: Rectangle {
-                    color: theme.bgInput
+                    color: AppTheme.bgInput
                     radius: 4
-                    border.color: pwField.activeFocus ? theme.accentBlue : theme.borderSoft
+                    border.color: pwField.activeFocus ? AppTheme.accentBlue : AppTheme.borderSoft
                     border.width: 1
                 }
                 onAccepted: root._submit()
@@ -115,7 +114,7 @@ Item {
             Text {
                 id: errorLabel
                 text: "Incorrect password"
-                color: theme.accentRed
+                color: AppTheme.accentRed
                 font.pixelSize: 12
                 visible: false
             }
@@ -131,14 +130,14 @@ Item {
                     onClicked: root.close()
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
-                        color: theme.textSecondary
+                        color: AppTheme.textSecondary
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? theme.bgHover : theme.bgInput
+                        color: parent.hovered ? AppTheme.bgHover : AppTheme.bgInput
                         radius: 4
-                        border.color: theme.borderSoft; border.width: 1
+                        border.color: AppTheme.borderSoft; border.width: 1
                     }
                 }
 
@@ -153,7 +152,7 @@ Item {
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? Qt.lighter(theme.accentBlue, 1.1) : theme.accentBlue
+                        color: parent.hovered ? Qt.lighter(AppTheme.accentBlue, 1.1) : AppTheme.accentBlue
                         radius: 4
                     }
                 }

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -1,4 +1,5 @@
 import QtQuick 6.0
+import OpenMotion 1.0
 
 // Phase 2a — single-trace Canvas bound to one (side, cam_id, metric) key
 // on a ScanDataSource. The cell tracks the live edge of the source
@@ -26,7 +27,7 @@ Item {
     property string metric: "bfi"
     property real yMin: 0.0
     property real yMax: 10.0
-    property color traceColor: theme.statusBlue
+    property color traceColor: AppTheme.statusBlue
 
     // Secondary trace (optional) — set secondaryMetric to a non-empty
     // string to render a second overlaid trace with its own y-mapping.
@@ -34,11 +35,11 @@ Item {
     property string secondaryMetric: ""
     property real secondaryYMin: 0.0
     property real secondaryYMax: 10.0
-    property color secondaryColor: theme.statusBlue
+    property color secondaryColor: AppTheme.statusBlue
 
     // Visual — defaults pulled from AppTheme; can be overridden per-cell.
-    property color frameColor: theme.borderSubtle
-    property color bgColor: theme.plotCellBg
+    property color frameColor: AppTheme.borderSubtle
+    property color bgColor: AppTheme.plotCellBg
 
     // DVR target — set to PlotViewer; cell calls .setWindow(startT, sec)
     // on pan/zoom interactions. Cell itself owns no time-axis state;
@@ -62,7 +63,6 @@ Item {
     // binds this from appConfig.engineeringMode (issue #165).
     property bool showTemperature: false
 
-    AppTheme { id: theme }
 
     // ── Repaint plumbing ───────────────────────────────────────────────
     // Repaints are throttled by the parent PlotViewer: it owns a 33 ms
@@ -236,7 +236,7 @@ Item {
             var dropT = cell.source.dropped_at_for(cell.side, cell.camId)
             if (isFinite(dropT) && dropT >= tLo && dropT <= tHi) {
                 var dropX = ((dropT - tLo) / dt) * width
-                ctx.strokeStyle = theme.accentRed
+                ctx.strokeStyle = AppTheme.accentRed
                 ctx.lineWidth = 2
                 ctx.beginPath()
                 ctx.moveTo(Math.floor(dropX) + 0.5, 0)
@@ -248,7 +248,7 @@ Item {
             // viewer so every cell stays in sync on hover).
             if (isFinite(cell.cursorT) && cell.cursorT >= tLo && cell.cursorT <= tHi) {
                 var crossX = ((cell.cursorT - tLo) / dt) * width
-                ctx.strokeStyle = theme.textTertiary
+                ctx.strokeStyle = AppTheme.textTertiary
                 ctx.lineWidth = 1
                 ctx.beginPath()
                 ctx.moveTo(Math.floor(crossX) + 0.5, 0)
@@ -281,7 +281,7 @@ Item {
             // the large side panel next to the plot already names the side.
             visible: cell.camId !== -1
             text: cell.side.toUpperCase() + " " + (cell.camId + 1)
-            color: theme.textSecondary
+            color: AppTheme.textSecondary
             font.pixelSize: 11
             font.family: "Roboto Mono"
         }
@@ -342,7 +342,7 @@ Item {
         // but only when it's drawn; reclaim the space when axis labels are off.
         anchors.topMargin: cell.showAxisLabels ? 18 : 8
         text: isFinite(tempC) ? tempC.toFixed(1) + "°C" : ""
-        color: theme.readableInk(theme.accentOrange)
+        color: AppTheme.readableInk(AppTheme.accentOrange)
         font.pixelSize: 10
         font.family: "Roboto Mono"
     }

--- a/components/PlotScrubber.qml
+++ b/components/PlotScrubber.qml
@@ -1,4 +1,5 @@
 import QtQuick 6.0
+import OpenMotion 1.0
 
 // Bottom timeline showing the full scan extent (0 → liveEdge) with the
 // visible window highlighted as a draggable inset. Click outside the
@@ -11,7 +12,6 @@ import QtQuick 6.0
 Item {
     id: scrubber
 
-    AppTheme { id: theme }
 
     // ── Inputs ─────────────────────────────────────────────────────────
     property real fullScanDuration: 0      // = liveEdgeSnapshot
@@ -39,8 +39,8 @@ Item {
     // ── Background ─────────────────────────────────────────────────────
     Rectangle {
         anchors.fill: parent
-        color: theme.plotCellBg
-        border.color: theme.borderSubtle
+        color: AppTheme.plotCellBg
+        border.color: AppTheme.borderSubtle
         border.width: 1
         radius: 4
     }
@@ -56,7 +56,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.topMargin: 2
         anchors.bottomMargin: 2
-        color: scrubber.followLive ? theme.statusBlue : theme.accentOrange
+        color: scrubber.followLive ? AppTheme.statusBlue : AppTheme.accentOrange
         opacity: 0.35
         radius: 3
     }
@@ -70,7 +70,7 @@ Item {
         width: 2
         anchors.top: parent.top
         anchors.bottom: parent.bottom
-        color: theme.statusGreen
+        color: AppTheme.statusGreen
         visible: scrubber.fullScanDuration > 0
     }
 

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -13,9 +13,9 @@ import OpenMotion 1.0
 // inlined it overrode the caller's anchors and slid under the ButtonPanel.
 Rectangle {
     id: viewer
-    color: theme.bgPlot
+    color: AppTheme.bgPlot
     radius: 8
-    border.color: theme.borderSoft
+    border.color: AppTheme.borderSoft
     border.width: 1
 
     // Keyboard focus — viewer starts focused so spec keys (← → +/- 0
@@ -62,7 +62,6 @@ Rectangle {
         }
     }
 
-    AppTheme { id: theme }
 
     // ── Inputs ─────────────────────────────────────────────────────────
     property bool clinicalMode: false   // honored in Phase 2b-ii
@@ -359,14 +358,14 @@ Rectangle {
     // on dark) doesn't render invisible in the other.
     property color bfiColor: "#E74C3C"
     property color bviColor: "#3498DB"
-    readonly property color bfiInk: theme.readableInk(viewer.bfiColor)
-    readonly property color bviInk: theme.readableInk(viewer.bviColor)
+    readonly property color bfiInk: AppTheme.readableInk(viewer.bfiColor)
+    readonly property color bviInk: AppTheme.readableInk(viewer.bviColor)
 
     function _traceColorForMetric(m) {
         if (m === "bfi")      return viewer.bfiInk
         if (m === "bvi")      return viewer.bviInk
-        if (m === "mean")     return theme.readableInk("#2ECC71")  // green
-        if (m === "contrast") return theme.readableInk("#9B59B6")  // purple
+        if (m === "mean")     return AppTheme.readableInk("#2ECC71")  // green
+        if (m === "contrast") return AppTheme.readableInk("#9B59B6")  // purple
         return viewer.bviInk
     }
 
@@ -612,7 +611,7 @@ Rectangle {
 
             Text {
                 text: panel.panelSide.toUpperCase()
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 20
                 font.weight: Font.DemiBold
             }
@@ -627,7 +626,7 @@ Rectangle {
             }
             Text {
                 text: panel._displayText("bfi")
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 60
                 font.weight: Font.Bold
                 font.family: "Roboto Mono"
@@ -643,7 +642,7 @@ Rectangle {
             }
             Text {
                 text: panel._displayText("bvi")
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 60
                 font.weight: Font.Bold
                 font.family: "Roboto Mono"
@@ -754,7 +753,7 @@ Rectangle {
                 Text {
                     anchors.centerIn: parent
                     text: "No active cameras selected"
-                    color: theme.textTertiary
+                    color: AppTheme.textTertiary
                     font.pixelSize: 14
                     font.family: "Roboto Mono"
                 }
@@ -805,8 +804,8 @@ Rectangle {
                               ? backToLiveOverlay.height + viewer._overlayMarginPx
                               : 0)
         anchors.rightMargin: viewer._overlayEdgeMarginPx
-        color: theme.overlayBgSolid
-        border.color: theme.borderSubtle
+        color: AppTheme.overlayBgSolid
+        border.color: AppTheme.borderSubtle
         border.width: 1
         radius: 4
         width: tooltipColumn.implicitWidth + 16
@@ -860,7 +859,7 @@ Rectangle {
                     var secs = (t - mins * 60).toFixed(3)
                     return "t = " + mins + ":" + (secs < 10 ? "0" + secs : secs) + " s"
                 }
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 11
                 font.family: "Roboto Mono"
                 font.bold: true
@@ -872,7 +871,7 @@ Rectangle {
                     Text {
                         text: modelData.label
                         width: 30
-                        color: theme.textSecondary
+                        color: AppTheme.textSecondary
                         font.pixelSize: 10
                         font.family: "Roboto Mono"
                     }
@@ -942,8 +941,8 @@ Rectangle {
         anchors.topMargin: viewer._overlayEdgeMarginPx
         anchors.rightMargin: viewer._overlayEdgeMarginPx
         z: 6
-        color: theme.overlayBg
-        border.color: theme.accentRed
+        color: AppTheme.overlayBg
+        border.color: AppTheme.accentRed
         border.width: 1
 
         Text {
@@ -954,7 +953,7 @@ Rectangle {
                    && MotionInterface.liveSourceAvailable)
                   ? "← Back to live scan"
                   : "● Back to live"
-            color: theme.accentRed
+            color: AppTheme.accentRed
             font.pixelSize: 13
             font.family: "Roboto Mono"
         }
@@ -1001,8 +1000,8 @@ Rectangle {
         width: scanBadgeRow.implicitWidth + 28
         height: 36
         radius: 18
-        color: theme.overlayBg
-        border.color: theme.borderSubtle
+        color: AppTheme.overlayBg
+        border.color: AppTheme.borderSubtle
         border.width: 1
 
         Row {
@@ -1012,14 +1011,14 @@ Rectangle {
             Text {
                 anchors.verticalCenter: parent.verticalCenter
                 text: "Viewing"
-                color: theme.textTertiary
+                color: AppTheme.textTertiary
                 font.pixelSize: 12
                 font.family: "Roboto Mono"
             }
             Text {
                 anchors.verticalCenter: parent.verticalCenter
                 text: viewer._scanBadgeText
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 13
                 font.weight: Font.DemiBold
                 font.family: "Roboto Mono"
@@ -1047,8 +1046,8 @@ Rectangle {
             width: windowSecondsText.implicitWidth + 38
             height: 36
             radius: 18
-            color: theme.overlayBg
-            border.color: theme.borderSubtle
+            color: AppTheme.overlayBg
+            border.color: AppTheme.borderSubtle
             border.width: 1
 
             Text {
@@ -1057,7 +1056,7 @@ Rectangle {
                 anchors.leftMargin: 14
                 anchors.verticalCenter: parent.verticalCenter
                 text: viewer._labelForWindowSeconds(viewer.windowSeconds)
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 13
                 font.family: "Roboto Mono"
             }
@@ -1066,7 +1065,7 @@ Rectangle {
                 anchors.rightMargin: 12
                 anchors.verticalCenter: parent.verticalCenter
                 text: "▾"
-                color: theme.textTertiary
+                color: AppTheme.textTertiary
                 font.pixelSize: 12
             }
 
@@ -1089,8 +1088,8 @@ Rectangle {
                 padding: 6
                 implicitWidth: 120
                 background: Rectangle {
-                    color: theme.overlayBgSolid
-                    border.color: theme.borderSubtle
+                    color: AppTheme.overlayBgSolid
+                    border.color: AppTheme.borderSubtle
                     border.width: 1
                     radius: 8
                 }
@@ -1119,14 +1118,14 @@ Rectangle {
             radius: 18
             color: settingsPopup.opened
                    ? Qt.rgba(0.29, 0.56, 0.89, 0.85)
-                   : theme.overlayBg
-            border.color: settingsPopup.opened ? "#4A90E2" : theme.borderSubtle
+                   : AppTheme.overlayBg
+            border.color: settingsPopup.opened ? "#4A90E2" : AppTheme.borderSubtle
             border.width: 1
 
             Text {
                 anchors.centerIn: parent
                 text: "⋯"
-                color: settingsPopup.opened ? "white" : theme.textPrimary
+                color: settingsPopup.opened ? "white" : AppTheme.textPrimary
                 font.pixelSize: 20
                 font.bold: true
             }
@@ -1152,8 +1151,8 @@ Rectangle {
                 closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
                 background: Rectangle {
-                    color: theme.overlayBgSolid
-                    border.color: theme.borderSubtle
+                    color: AppTheme.overlayBgSolid
+                    border.color: AppTheme.borderSubtle
                     border.width: 1
                     radius: 8
                 }
@@ -1168,8 +1167,8 @@ Rectangle {
                         x:      psCtrl.leftPadding
                         y:      (psCtrl.height - height) / 2
                         width:  44; height: 24; radius: 12
-                        color:  psCtrl.checked ? theme.accentBlue : theme.bgInput
-                        border.color: psCtrl.checked ? theme.accentBlue : theme.borderSoft
+                        color:  psCtrl.checked ? AppTheme.accentBlue : AppTheme.bgInput
+                        border.color: psCtrl.checked ? AppTheme.accentBlue : AppTheme.borderSoft
                         border.width: 1
                         Behavior on color { ColorAnimation { duration: 120 } }
 
@@ -1201,7 +1200,7 @@ Rectangle {
                         Text {
                             anchors.verticalCenter: bfiBviSwitch.verticalCenter
                             text: bfiBviSwitch.checked ? "BFI / BVI" : "Mean / Contrast"
-                            color: theme.textPrimary
+                            color: AppTheme.textPrimary
                             font.pixelSize: 12
                             font.family: "Roboto Mono"
                         }
@@ -1220,7 +1219,7 @@ Rectangle {
                         Text {
                             anchors.verticalCenter: autoScaleSwitch.verticalCenter
                             text: "Autoscale"
-                            color: theme.textPrimary
+                            color: AppTheme.textPrimary
                             font.pixelSize: 12
                             font.family: "Roboto Mono"
                         }
@@ -1236,7 +1235,7 @@ Rectangle {
                         Text {
                             anchors.verticalCenter: axisLabelsSwitch.verticalCenter
                             text: "Axis labels"
-                            color: theme.textPrimary
+                            color: AppTheme.textPrimary
                             font.pixelSize: 12
                             font.family: "Roboto Mono"
                         }
@@ -1300,25 +1299,25 @@ Rectangle {
             }
             Text {
                 text: "rate    " + viewer.profSampleRateHz.toFixed(1) + " Hz"
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 10
                 font.family: "Roboto Mono"
             }
             Text {
                 text: "tick    " + viewer.profPaintTickMsAvg.toFixed(2) + " ms"
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 10
                 font.family: "Roboto Mono"
             }
             Text {
                 text: "canvas  " + viewer.profCanvasMsAvg.toFixed(2) + " ms avg"
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 10
                 font.family: "Roboto Mono"
             }
             Text {
                 text: "points  " + viewer.profPointsLastTick
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 10
                 font.family: "Roboto Mono"
             }

--- a/components/ScanSettingsModal.qml
+++ b/components/ScanSettingsModal.qml
@@ -9,7 +9,6 @@ Item {
     visible: false
     z: 9998
 
-    AppTheme { id: theme }
 
     // Modal interface — see HistoryModal.qml for rationale.
     readonly property string label: "Scan Settings"
@@ -157,8 +156,8 @@ Item {
         width: Math.min(parent.width - root.iconBarInset - 40, 520)
         height: Math.min(parent.height - 60, 640)
         radius: 14
-        color: theme.bgContainer
-        border.color: theme.borderSubtle
+        color: AppTheme.bgContainer
+        border.color: AppTheme.borderSubtle
         border.width: 2
         // Center within [iconBarInset, parent.width] so the card clears the
         // icon bar instead of bleeding under it. horizontalCenterOffset
@@ -177,13 +176,13 @@ Item {
         // X close button
         Rectangle {
             width: 28; height: 28; radius: 14
-            color: xArea.containsMouse ? "#C0392B" : theme.borderStrong
-            border.color: theme.borderHover; border.width: 1
+            color: xArea.containsMouse ? "#C0392B" : AppTheme.borderStrong
+            border.color: AppTheme.borderHover; border.width: 1
             anchors.top: parent.top; anchors.right: parent.right
             anchors.topMargin: 10; anchors.rightMargin: 10
             z: 10
             Behavior on color { ColorAnimation { duration: 120 } }
-            Text { anchors.centerIn: parent; text: "✕"; color: theme.textPrimary; font.pixelSize: 13 }
+            Text { anchors.centerIn: parent; text: "✕"; color: AppTheme.textPrimary; font.pixelSize: 13 }
             MouseArea {
                 id: xArea; anchors.fill: parent; hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor; onClicked: root.close()
@@ -198,18 +197,18 @@ Item {
             // Title
             Text {
                 text: root.label
-                color: theme.textPrimary
+                color: AppTheme.textPrimary
                 font.pixelSize: 20
                 font.weight: Font.Bold
                 Layout.alignment: Qt.AlignHCenter
             }
 
             // ── Session ──────────────────────────────────────────────────
-            Rectangle { Layout.fillWidth: true; height: 1; color: theme.borderSubtle }
+            Rectangle { Layout.fillWidth: true; height: 1; color: AppTheme.borderSubtle }
 
             Text {
                 text: "Session"
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 15
                 font.weight: Font.DemiBold
             }
@@ -228,7 +227,7 @@ Item {
                     activeFocusOnTab: false
                     background: null
                     padding: 0
-                    color: theme.textSecondary
+                    color: AppTheme.textSecondary
                     font.pixelSize: 14
                     Layout.alignment: Qt.AlignVCenter
                 }
@@ -238,10 +237,10 @@ Item {
                     Layout.fillWidth: true
                     Layout.preferredHeight: 30
                     font.pixelSize: 14
-                    color: theme.textPrimary
+                    color: AppTheme.textPrimary
                     background: Rectangle {
-                        color: theme.bgInput; radius: 4
-                        border.color: userLabelField.activeFocus ? theme.accentBlue : theme.borderSubtle
+                        color: AppTheme.bgInput; radius: 4
+                        border.color: userLabelField.activeFocus ? AppTheme.accentBlue : AppTheme.borderSubtle
                         border.width: 1
                     }
                     onEditingFinished: {
@@ -254,11 +253,11 @@ Item {
             }
 
             // ── Camera Configuration ──────────────────────────────────────
-            Rectangle { Layout.fillWidth: true; height: 1; color: theme.borderSubtle }
+            Rectangle { Layout.fillWidth: true; height: 1; color: AppTheme.borderSubtle }
 
             Text {
                 text: "Camera Configuration"
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 15
                 font.weight: Font.DemiBold
             }
@@ -294,20 +293,20 @@ Item {
                         onCurrentIndexChanged: applyPatternToSensor(currentIndex, "left")
                         contentItem: Text {
                             leftPadding: 10; text: leftSelector.displayText; font: leftSelector.font
-                            color: theme.textPrimary; verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
+                            color: AppTheme.textPrimary; verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
                         }
-                        background: Rectangle { color: theme.bgInput; radius: 4; border.color: theme.borderSubtle; border.width: 1 }
-                        indicator: Text { x: leftSelector.width - width - 10; y: (leftSelector.height - height) / 2; text: "\u25BE"; font.pixelSize: 14; color: theme.textSecondary }
+                        background: Rectangle { color: AppTheme.bgInput; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
+                        indicator: Text { x: leftSelector.width - width - 10; y: (leftSelector.height - height) / 2; text: "\u25BE"; font.pixelSize: 14; color: AppTheme.textSecondary }
                         delegate: ItemDelegate {
                             width: leftSelector.width; height: 32
-                            contentItem: Text { text: model.name; font.pixelSize: 13; color: theme.textPrimary; verticalAlignment: Text.AlignVCenter; leftPadding: 8 }
-                            background: Rectangle { color: highlighted ? theme.accentBlue : "transparent" }
+                            contentItem: Text { text: model.name; font.pixelSize: 13; color: AppTheme.textPrimary; verticalAlignment: Text.AlignVCenter; leftPadding: 8 }
+                            background: Rectangle { color: highlighted ? AppTheme.accentBlue : "transparent" }
                             highlighted: leftSelector.highlightedIndex === index
                         }
                         popup: Popup {
                             y: leftSelector.height; width: leftSelector.width; implicitHeight: contentItem.implicitHeight + 2; padding: 1
                             contentItem: ListView { clip: true; implicitHeight: contentHeight; model: leftSelector.delegateModel; ScrollIndicator.vertical: ScrollIndicator {} }
-                            background: Rectangle { color: theme.bgCard; radius: 4; border.color: theme.borderSubtle; border.width: 1 }
+                            background: Rectangle { color: AppTheme.bgCard; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
                         }
                         Component.onCompleted: {
                             var defMask = MotionInterface.appConfig.leftMask !== undefined
@@ -344,20 +343,20 @@ Item {
                         onCurrentIndexChanged: applyPatternToSensor(currentIndex, "right")
                         contentItem: Text {
                             leftPadding: 10; text: rightSelector.displayText; font: rightSelector.font
-                            color: theme.textPrimary; verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
+                            color: AppTheme.textPrimary; verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
                         }
-                        background: Rectangle { color: theme.bgInput; radius: 4; border.color: theme.borderSubtle; border.width: 1 }
-                        indicator: Text { x: rightSelector.width - width - 10; y: (rightSelector.height - height) / 2; text: "\u25BE"; font.pixelSize: 14; color: theme.textSecondary }
+                        background: Rectangle { color: AppTheme.bgInput; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
+                        indicator: Text { x: rightSelector.width - width - 10; y: (rightSelector.height - height) / 2; text: "\u25BE"; font.pixelSize: 14; color: AppTheme.textSecondary }
                         delegate: ItemDelegate {
                             width: rightSelector.width; height: 32
-                            contentItem: Text { text: model.name; font.pixelSize: 13; color: theme.textPrimary; verticalAlignment: Text.AlignVCenter; leftPadding: 8 }
-                            background: Rectangle { color: highlighted ? theme.accentBlue : "transparent" }
+                            contentItem: Text { text: model.name; font.pixelSize: 13; color: AppTheme.textPrimary; verticalAlignment: Text.AlignVCenter; leftPadding: 8 }
+                            background: Rectangle { color: highlighted ? AppTheme.accentBlue : "transparent" }
                             highlighted: rightSelector.highlightedIndex === index
                         }
                         popup: Popup {
                             y: rightSelector.height; width: rightSelector.width; implicitHeight: contentItem.implicitHeight + 2; padding: 1
                             contentItem: ListView { clip: true; implicitHeight: contentHeight; model: rightSelector.delegateModel; ScrollIndicator.vertical: ScrollIndicator {} }
-                            background: Rectangle { color: theme.bgCard; radius: 4; border.color: theme.borderSubtle; border.width: 1 }
+                            background: Rectangle { color: AppTheme.bgCard; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
                         }
                         Component.onCompleted: {
                             var defMask = MotionInterface.appConfig.rightMask !== undefined
@@ -370,11 +369,11 @@ Item {
             }
 
             // ── Scan Duration ─────────────────────────────────────────────
-            Rectangle { Layout.fillWidth: true; height: 1; color: theme.borderSubtle }
+            Rectangle { Layout.fillWidth: true; height: 1; color: AppTheme.borderSubtle }
 
             Text {
                 text: "Scan Duration"
-                color: theme.textSecondary
+                color: AppTheme.textSecondary
                 font.pixelSize: 15
                 font.weight: Font.DemiBold
             }
@@ -386,7 +385,7 @@ Item {
 
                 Text {
                     text: "Timed"
-                    color: !root.freeRun ? theme.accentBlue : theme.textSecondary
+                    color: !root.freeRun ? AppTheme.accentBlue : AppTheme.textSecondary
                     font.pixelSize: 14
                     font.weight: !root.freeRun ? Font.Bold : Font.Normal
                 }
@@ -398,8 +397,8 @@ Item {
                     indicator: Rectangle {
                         x: modeSwitch.leftPadding; y: (modeSwitch.height - height) / 2
                         width: 44; height: 24; radius: 12
-                        color: modeSwitch.checked ? theme.accentBlue : theme.bgInput
-                        border.color: modeSwitch.checked ? theme.accentBlue : theme.borderSubtle; border.width: 1
+                        color: modeSwitch.checked ? AppTheme.accentBlue : AppTheme.bgInput
+                        border.color: modeSwitch.checked ? AppTheme.accentBlue : AppTheme.borderSubtle; border.width: 1
                         Behavior on color { ColorAnimation { duration: 120 } }
                         Rectangle {
                             x: modeSwitch.checked ? parent.width - width - 3 : 3
@@ -411,7 +410,7 @@ Item {
 
                 Text {
                     text: "Continuous"
-                    color: root.freeRun ? theme.accentBlue : theme.textSecondary
+                    color: root.freeRun ? AppTheme.accentBlue : AppTheme.textSecondary
                     font.pixelSize: 14
                     font.weight: root.freeRun ? Font.Bold : Font.Normal
                 }
@@ -428,53 +427,53 @@ Item {
                     text: String(root.hours)
                     inputMethodHints: Qt.ImhDigitsOnly
                     validator: IntValidator { bottom: 0; top: 99 }
-                    font.pixelSize: 20; color: theme.textPrimary
+                    font.pixelSize: 20; color: AppTheme.textPrimary
                     horizontalAlignment: Text.AlignHCenter
                     Layout.preferredWidth: 54; Layout.preferredHeight: 40
-                    background: Rectangle { color: theme.bgInput; radius: 6; border.color: theme.borderSubtle; border.width: 1 }
+                    background: Rectangle { color: AppTheme.bgInput; radius: 6; border.color: AppTheme.borderSubtle; border.width: 1 }
                     onEditingFinished: {
                         var v = parseInt(text); if (isNaN(v)) v = 0
                         root.hours = Math.max(0, Math.min(99, v)); text = String(root.hours)
                     }
                 }
-                Text { text: ":"; color: theme.textSecondary; font.pixelSize: 22 }
+                Text { text: ":"; color: AppTheme.textSecondary; font.pixelSize: 22 }
                 TextField {
                     id: minutesField
                     text: String(root.minutes).padStart(2, '0')
                     inputMethodHints: Qt.ImhDigitsOnly
                     validator: IntValidator { bottom: 0; top: 59 }
-                    font.pixelSize: 20; color: theme.textPrimary
+                    font.pixelSize: 20; color: AppTheme.textPrimary
                     horizontalAlignment: Text.AlignHCenter
                     Layout.preferredWidth: 54; Layout.preferredHeight: 40
-                    background: Rectangle { color: theme.bgInput; radius: 6; border.color: theme.borderSubtle; border.width: 1 }
+                    background: Rectangle { color: AppTheme.bgInput; radius: 6; border.color: AppTheme.borderSubtle; border.width: 1 }
                     onEditingFinished: {
                         var v = parseInt(text); if (isNaN(v)) v = 0
                         root.minutes = Math.max(0, Math.min(59, v)); text = String(root.minutes).padStart(2, '0')
                     }
                 }
-                Text { text: ":"; color: theme.textSecondary; font.pixelSize: 22 }
+                Text { text: ":"; color: AppTheme.textSecondary; font.pixelSize: 22 }
                 TextField {
                     id: secondsField
                     text: String(root.seconds).padStart(2, '0')
                     inputMethodHints: Qt.ImhDigitsOnly
                     validator: IntValidator { bottom: 0; top: 59 }
-                    font.pixelSize: 20; color: theme.textPrimary
+                    font.pixelSize: 20; color: AppTheme.textPrimary
                     horizontalAlignment: Text.AlignHCenter
                     Layout.preferredWidth: 54; Layout.preferredHeight: 40
-                    background: Rectangle { color: theme.bgInput; radius: 6; border.color: theme.borderSubtle; border.width: 1 }
+                    background: Rectangle { color: AppTheme.bgInput; radius: 6; border.color: AppTheme.borderSubtle; border.width: 1 }
                     onEditingFinished: {
                         var v = parseInt(text); if (isNaN(v)) v = 0
                         root.seconds = Math.max(0, Math.min(59, v)); text = String(root.seconds).padStart(2, '0')
                     }
                 }
-                Text { text: "H : M : S"; color: theme.textTertiary; font.pixelSize: 11; Layout.alignment: Qt.AlignBottom }
+                Text { text: "H : M : S"; color: AppTheme.textTertiary; font.pixelSize: 11; Layout.alignment: Qt.AlignBottom }
             }
 
             // Free run hint
             Text {
                 visible: root.freeRun
                 text: "Scan will run indefinitely until stopped."
-                color: theme.textTertiary
+                color: AppTheme.textTertiary
                 font.pixelSize: 13
                 Layout.alignment: Qt.AlignHCenter
             }

--- a/components/SensorView.qml
+++ b/components/SensorView.qml
@@ -2,6 +2,7 @@ import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
 import QtQuick.Controls as Controls
+import OpenMotion 1.0
 
 Rectangle {
     id: root
@@ -13,13 +14,12 @@ Rectangle {
     property string sensorSide: "left"  // "left" or "right"
     property var connector
 
-    AppTheme { id: theme }
 
     width: 150
     height: 195
     radius: 18
-    color: theme.bgContainer
-    border.color: sensorConnected ? theme.borderSubtle : "#6E3E3F"
+    color: AppTheme.bgContainer
+    border.color: sensorConnected ? AppTheme.borderSubtle : "#6E3E3F"
     border.width: 2
     opacity: sensorConnected ? 1.0 : 0.4
     enabled: sensorConnected
@@ -35,7 +35,7 @@ Rectangle {
         Text {
             text: root.title
             font.pixelSize: 14
-            color: root.sensorConnected ? theme.textSecondary : "#8B8B8D"
+            color: root.sensorConnected ? AppTheme.textSecondary : "#8B8B8D"
             horizontalAlignment: Text.AlignHCenter
             Layout.alignment: Qt.AlignHCenter
         }
@@ -48,14 +48,14 @@ Rectangle {
 
             // Row 1
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[7] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[7] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor1HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor1HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 1"
             }
             Item {}
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[0] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[0] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor2HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor2HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 8"
@@ -63,14 +63,14 @@ Rectangle {
 
             // Row 2
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[6] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[6] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor3HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor3HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 2"
             }
             Item {}
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[1] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[1] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor4HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor4HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 7"
@@ -78,14 +78,14 @@ Rectangle {
 
             // Row 3
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[5] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[5] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor5HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor5HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 3"
             }
             Item {}
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[2] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[2] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor6HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor6HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 6"
@@ -93,14 +93,14 @@ Rectangle {
 
             // Row 4
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[4] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[4] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor7HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor7HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 4"
             }
             Item {}
             Rectangle { width: circleSize; height: circleSize; radius: circleSize/2
-                color: sensorActive[3] && root.sensorConnected ? theme.accentBlue : "#666666"; border.color: "black"; border.width: 1
+                color: sensorActive[3] && root.sensorConnected ? AppTheme.accentBlue : "#666666"; border.color: "black"; border.width: 1
                 MouseArea { id: sensor8HoverArea; anchors.fill: parent; hoverEnabled: true; acceptedButtons: Qt.NoButton }
                 Controls.ToolTip.visible: sensor8HoverArea.containsMouse
                 Controls.ToolTip.text: "Sensor ID: 5"

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -10,7 +10,6 @@ Item {
     visible: false
     z: 9998
 
-    AppTheme { id: theme }
 
     // Modal interface — see HistoryModal.qml for rationale.
     readonly property string label: "Settings"
@@ -58,15 +57,15 @@ Item {
     property string appUpdateProgressText: "Update"
 
     // ── Theme tokens (aliased from AppTheme) ──────────────────────────────
-    readonly property color colBgPanel:    theme.bgContainer
-    readonly property color colBgCard:     theme.bgCard
-    readonly property color colBgInput:    theme.bgInput
-    readonly property color colBorder:     theme.borderStrong
-    readonly property color colBorderSoft: theme.borderSoft
-    readonly property color colAccent:     theme.accentBlue
-    readonly property color colTextPri:    theme.textPrimary
-    readonly property color colTextSec:    theme.textSecondary
-    readonly property color colTextMuted:  theme.textTertiary
+    readonly property color colBgPanel:    AppTheme.bgContainer
+    readonly property color colBgCard:     AppTheme.bgCard
+    readonly property color colBgInput:    AppTheme.bgInput
+    readonly property color colBorder:     AppTheme.borderStrong
+    readonly property color colBorderSoft: AppTheme.borderSoft
+    readonly property color colAccent:     AppTheme.accentBlue
+    readonly property color colTextPri:    AppTheme.textPrimary
+    readonly property color colTextSec:    AppTheme.textSecondary
+    readonly property color colTextMuted:  AppTheme.textTertiary
 
     signal settingsChanged()
 
@@ -688,7 +687,7 @@ Item {
                         Text { text: "Max"; color: root.colTextMuted; font.pixelSize: 12; font.weight: Font.DemiBold; Layout.alignment: Qt.AlignHCenter; Layout.preferredWidth: 90 }
                         Item { Layout.fillWidth: true }
 
-                        Text { text: "BFI"; color: theme.readableInk(root.bfiColor); font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
+                        Text { text: "BFI"; color: AppTheme.readableInk(root.bfiColor); font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
                         StyledNumberField {
                             Layout.preferredWidth: 90
                             decimals: 1
@@ -703,7 +702,7 @@ Item {
                         }
                         Item { Layout.fillWidth: true }
 
-                        Text { text: "BVI"; color: theme.readableInk(root.bviColor); font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
+                        Text { text: "BVI"; color: AppTheme.readableInk(root.bviColor); font.pixelSize: 13; font.weight: Font.DemiBold; Layout.preferredWidth: 80 }
                         StyledNumberField {
                             Layout.preferredWidth: 90
                             decimals: 1
@@ -1128,7 +1127,7 @@ Item {
                         property string label: "Update"
                         property bool chipEnabled: true
                         width: chipText.implicitWidth + 18; height: 24; radius: 4
-                        color: chipArea.containsMouse ? Qt.lighter(theme.accentBlue, 1.1) : theme.accentBlue
+                        color: chipArea.containsMouse ? Qt.lighter(AppTheme.accentBlue, 1.1) : AppTheme.accentBlue
                         opacity: chipEnabled ? 1.0 : 0.6
                         Text {
                             id: chipText
@@ -1159,13 +1158,13 @@ Item {
                         Text {
                             visible: !root.clinicalMode && root.appUpdateStatus === "uptodate"
                             text: "Up to date"
-                            color: theme.statusGreen
+                            color: AppTheme.statusGreen
                             font.pixelSize: 12
                         }
                         Text {
                             visible: !root.clinicalMode && root.appUpdateStatus === "failed"
                             text: "Check failed"
-                            color: theme.accentRed
+                            color: AppTheme.accentRed
                             font.pixelSize: 12
                         }
                         UpdateChip {
@@ -1235,7 +1234,7 @@ Item {
                         Text {
                             visible: connected && !updateAvailable
                             text: "Up to date"
-                            color: theme.statusGreen
+                            color: AppTheme.statusGreen
                             font.pixelSize: 12
                         }
                         UpdateChip {
@@ -1366,7 +1365,7 @@ Item {
         }
         function onFirmwareUpdateFinished(deviceKey, ok, msg) {
             fwStatus.text = deviceKey + " — " + msg
-            fwStatus.color = ok ? theme.accentGreen : theme.accentRed
+            fwStatus.color = ok ? AppTheme.accentGreen : AppTheme.accentRed
             fwBar.visible = false
         }
     }

--- a/components/TestResultsWindow.qml
+++ b/components/TestResultsWindow.qml
@@ -14,9 +14,8 @@ Window {
     flags: Qt.Window
     modality: Qt.NonModal
 
-    AppTheme { id: theme }
 
-    color: theme.bgBase
+    color: AppTheme.bgBase
 
     readonly property var rows: MotionInterface.testScanRows
     readonly property string status: MotionInterface.testScanStatus
@@ -86,7 +85,7 @@ Window {
                     case "failed":  return "#F44336"
                     case "aborted": return "#FF9800"
                     case "running": return "#2196F3"
-                    default:        return theme.textPrimary
+                    default:        return AppTheme.textPrimary
                     }
                 }
                 font.bold: true
@@ -109,26 +108,26 @@ Window {
         Rectangle {
             Layout.fillWidth: true
             implicitHeight: 28
-            color: theme.bgCard
-            border.color: theme.borderSoft
+            color: AppTheme.bgCard
+            border.color: AppTheme.borderSoft
             border.width: 1
             RowLayout {
                 anchors.fill: parent
                 anchors.leftMargin: 8
                 anchors.rightMargin: 8
                 spacing: 0
-                Text { Layout.preferredWidth: 50;  text: "Side"; color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 40;  text: "Cam";  color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 90;  text: "Light Mean";    color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 70;  text: "Min Mean";      color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 60;  text: "Mean PF";       color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 90;  text: "Dark Mean";     color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 70;  text: "Max Dark";      color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 60;  text: "Dark PF";       color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 90;  text: "Contrast";      color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 90;  text: "Min Contrast";  color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.preferredWidth: 80;  text: "Contrast PF";   color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
-                Text { Layout.fillWidth: true;     text: "Overall";       color: theme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 50;  text: "Side"; color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 40;  text: "Cam";  color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 90;  text: "Light Mean";    color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 70;  text: "Min Mean";      color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 60;  text: "Mean PF";       color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 90;  text: "Dark Mean";     color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 70;  text: "Max Dark";      color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 60;  text: "Dark PF";       color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 90;  text: "Contrast";      color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 90;  text: "Min Contrast";  color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.preferredWidth: 80;  text: "Contrast PF";   color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
+                Text { Layout.fillWidth: true;     text: "Overall";       color: AppTheme.textSecondary; font.bold: true; font.pixelSize: 12 }
             }
         }
 
@@ -151,13 +150,13 @@ Window {
                     delegate: Rectangle {
                         width: parent.width
                         implicitHeight: 24
-                        color: (index % 2 === 0) ? "transparent" : Qt.darker(theme.bgBase, 1.05)
-                        border.color: theme.borderSoft
+                        color: (index % 2 === 0) ? "transparent" : Qt.darker(AppTheme.bgBase, 1.05)
+                        border.color: AppTheme.borderSoft
                         border.width: 0
 
                         property color _passColor: "#4CAF50"
                         property color _failColor: "#F44336"
-                        property color _naColor:   theme.textSecondary
+                        property color _naColor:   AppTheme.textSecondary
                         function _pfColor(s) {
                             if (s === "PASS") return _passColor
                             if (s === "FAIL") return _failColor
@@ -170,16 +169,16 @@ Window {
                             anchors.rightMargin: 8
                             spacing: 0
 
-                            Text { Layout.preferredWidth: 50;  text: modelData.side; color: theme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 40;  text: modelData.cam;  color: theme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.light_mean, 2); color: theme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 70;  text: testWin._fmtNum(modelData.min_mean, 2);   color: theme.textSecondary; font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 50;  text: modelData.side; color: AppTheme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 40;  text: modelData.cam;  color: AppTheme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.light_mean, 2); color: AppTheme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 70;  text: testWin._fmtNum(modelData.min_mean, 2);   color: AppTheme.textSecondary; font.family: "Consolas"; font.pixelSize: 12 }
                             Text { Layout.preferredWidth: 60;  text: modelData.mean_pf;     color: parent.parent._pfColor(modelData.mean_pf); font.family: "Consolas"; font.bold: true; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.dark_mean, 2); color: theme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 70;  text: testWin._fmtNum(modelData.max_dark, 2);  color: theme.textSecondary; font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.dark_mean, 2); color: AppTheme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 70;  text: testWin._fmtNum(modelData.max_dark, 2);  color: AppTheme.textSecondary; font.family: "Consolas"; font.pixelSize: 12 }
                             Text { Layout.preferredWidth: 60;  text: modelData.dark_pf;     color: parent.parent._pfColor(modelData.dark_pf); font.family: "Consolas"; font.bold: true; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.contrast, 5); color: theme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
-                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.min_contrast, 4); color: theme.textSecondary; font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.contrast, 5); color: AppTheme.textPrimary;  font.family: "Consolas"; font.pixelSize: 12 }
+                            Text { Layout.preferredWidth: 90;  text: testWin._fmtNum(modelData.min_contrast, 4); color: AppTheme.textSecondary; font.family: "Consolas"; font.pixelSize: 12 }
                             Text { Layout.preferredWidth: 80;  text: modelData.contrast_pf; color: parent.parent._pfColor(modelData.contrast_pf); font.family: "Consolas"; font.bold: true; font.pixelSize: 12 }
                             Text { Layout.fillWidth: true;     text: modelData.overall;    color: parent.parent._pfColor(modelData.overall);    font.family: "Consolas"; font.bold: true; font.pixelSize: 12 }
                         }

--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -19,7 +19,6 @@ Rectangle {
     visible: shown && !_clinicalMode
     clip: true
 
-    AppTheme { id: theme }
 
     property string latestVersion: ""
     property string downloadUrl: ""
@@ -28,7 +27,7 @@ Rectangle {
     property bool updating: false
     property string statusText: "Update"
 
-    color: theme.accentBlue
+    color: AppTheme.accentBlue
     radius: 0
 
     Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
@@ -63,7 +62,7 @@ Rectangle {
                 id: downloadBtn
                 anchors.centerIn: parent
                 text: banner.updating ? banner.statusText : "Update"
-                color: theme.accentBlue
+                color: AppTheme.accentBlue
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
             }

--- a/components/WindowMenu.qml
+++ b/components/WindowMenu.qml
@@ -1,13 +1,13 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
+import OpenMotion 1.0
 
 Rectangle {
     id: windowMenu
-    AppTheme { id: theme }
     width: parent.width
     height: 60
-    color: theme.bgContainer // Header background color
+    color: AppTheme.bgContainer // Header background color
     radius: 20
 
     // Emitted when the user clicks the exit (X) icon in the title
@@ -70,19 +70,19 @@ Rectangle {
                 anchors.fill: parent
                 fillMode: Image.PreserveAspectFit
                 smooth: true
-                visible: theme.dark && windowMenu.logoSource !== ""
+                visible: AppTheme.dark && windowMenu.logoSource !== ""
             }
             // Light-mode: paint a dark logo using the white image as an
             // opacity mask over a solid-colour Canvas.  No shaders needed.
             Item {
                 anchors.fill: parent
-                visible: !theme.dark && windowMenu.logoSource !== ""
+                visible: !AppTheme.dark && windowMenu.logoSource !== ""
 
                 Canvas {
                     id: logoDarkCanvas
                     anchors.fill: parent
                     // Re-render whenever the theme changes or the image loads
-                    property color tint: theme.textPrimary
+                    property color tint: AppTheme.textPrimary
                     onTintChanged: requestPaint()
 
                     Image {
@@ -130,9 +130,9 @@ Rectangle {
         Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: 34
-            color: theme.bgElevated
+            color: AppTheme.bgElevated
             radius: 8
-            border.color: theme.borderSubtle
+            border.color: AppTheme.borderSubtle
             border.width: 1
 
             RowLayout {
@@ -141,10 +141,10 @@ Rectangle {
                 anchors.rightMargin: 14
                 spacing: 10
 
-                Text { text: "Session:"; color: theme.textTertiary; font.pixelSize: 13 }
+                Text { text: "Session:"; color: AppTheme.textTertiary; font.pixelSize: 13 }
                 Text {
                     text: windowMenu.sessionId || "—"
-                    color: theme.textLink
+                    color: AppTheme.textLink
                     font.pixelSize: 13
                     font.weight: Font.DemiBold
                 }
@@ -153,7 +153,7 @@ Rectangle {
 
                 Text {
                     text: "Open-Motion"
-                    color: theme.textPrimary
+                    color: AppTheme.textPrimary
                     font.pixelSize: 14
                     font.weight: Font.Bold
                 }
@@ -192,7 +192,7 @@ Rectangle {
                             ? windowMenu.formatSec(windowMenu.elapsedSec) + " / " + windowMenu.formatSec(windowMenu.durationSec)
                             : windowMenu.formatSec(windowMenu.durationSec)
                     }
-                    color: windowMenu.scanning ? theme.statusGreen : theme.textTertiary
+                    color: windowMenu.scanning ? AppTheme.statusGreen : AppTheme.textTertiary
                     font.pixelSize: 13
                     font.family: "Courier New"
                 }

--- a/main.py
+++ b/main.py
@@ -23,8 +23,12 @@ if sys.stderr is None:
 
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QApplication, QMessageBox
-from PyQt6.QtQml import QQmlApplicationEngine, qmlRegisterSingletonInstance
-from PyQt6.QtCore import qInstallMessageHandler, QtMsgType
+from PyQt6.QtQml import (
+    QQmlApplicationEngine,
+    qmlRegisterSingletonInstance,
+    qmlRegisterSingletonType,
+)
+from PyQt6.QtCore import qInstallMessageHandler, QtMsgType, QUrl
 
 from motion_connector import MotionConnector
 from omotion import MotionInterface
@@ -313,6 +317,15 @@ def main():
         app_version=APP_VERSION, log_path=logfile_path,
     )
     qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", connector)
+    # AppTheme as a true QML singleton: one QObject with ~40 color
+    # bindings instead of one instance per file (~24 of them, each
+    # re-evaluating every binding on a darkMode flip). Registered into
+    # the same OpenMotion module QML already imports for MotionInterface;
+    # instantiated lazily on first use, after both registrations.
+    qmlRegisterSingletonType(
+        QUrl.fromLocalFile(str(resource_path("components", "AppTheme.qml"))),
+        "OpenMotion", 1, 0, "AppTheme",
+    )
     engine.rootContext().setContextProperty("appVersion", APP_VERSION)
 
     # Load the QML file

--- a/main.qml
+++ b/main.qml
@@ -14,7 +14,6 @@ ApplicationWindow {
     flags: Qt.FramelessWindowHint | Qt.Window | Qt.CustomizeWindowHint | Qt.WindowTitleHint
     color: "transparent"
 
-    AppTheme { id: theme }
 
     // Issue #75: aggregate 'something is happening' state used by the
     // close-while-busy warning. Anything that the user would not want
@@ -61,7 +60,7 @@ ApplicationWindow {
 
     Rectangle {
         anchors.fill: parent
-        color: theme.bgBase
+        color: AppTheme.bgBase
         radius: 20
         border.color: "transparent"
 
@@ -176,7 +175,7 @@ ApplicationWindow {
             anchors.margins: 3
             onPaint: {
                 var ctx = getContext("2d")
-                ctx.strokeStyle = theme.borderHover
+                ctx.strokeStyle = AppTheme.borderHover
                 ctx.lineWidth = 1
                 var s = width
                 for (var i = 0; i < 3; i++) {

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -12,6 +12,7 @@ from PyQt6.QtCore import (
 )
 from pathlib import Path
 from typing import NamedTuple, Optional
+import itertools
 import logging
 import math
 import base58
@@ -732,6 +733,13 @@ class MotionConnector(QObject):
     # loadPastScan completes. (session_label, ok). HistoryModal uses it
     # to clear its busy overlay and close only on success (issue #152).
     pastScanLoadFinished = pyqtSignal(str, bool)
+    # History → "Export CSV" / "Export to folder": fire on the GUI thread
+    # when the async export workers finish. (ok, path) for the single-scan
+    # export; (exported, skipped, folder) for the batch. HistoryModal shows
+    # the summary toast from these instead of a synchronous return value —
+    # a big batch used to freeze the GUI for its whole materialize loop.
+    scanCsvExportFinished = pyqtSignal(bool, str)
+    scansExportFinished = pyqtSignal(int, int, str)
     # Private worker→main marshalling for loadPastScan results:
     # (seq, session_label, session_id, buffers-or-None, source_tag,
     #  recorded_flags-or-None, display_meta-or-None). recorded_flags is the
@@ -1015,7 +1023,11 @@ class MotionConnector(QObject):
         self._capture_stop = threading.Event()
         self._capture_running = False
         self._cq_quick_running = False
-        self._notification_id_counter = 0  # monotonic id assigned to each notify() call
+        # Monotonic id assigned to each notify() call. itertools.count is a
+        # single atomic step under the GIL — notify() is reachable from
+        # several worker threads (export/bundle/update workers), where a
+        # read-modify-write `+= 1` could hand out duplicate ids.
+        self._notification_ids = itertools.count(1)
         self._safety_cancel_scheduled = False  # True after scheduling cancel-due-to-safety; cleared when capture ends
         self._capture_left_path = ""
         self._capture_right_path = ""
@@ -2475,11 +2487,28 @@ class MotionConnector(QObject):
             self.errorOccurred.emit("Audit log export failed.")
             return ""
 
-    @pyqtSlot(result=str)
-    def prepareDebugLogBundle(self) -> str:
+    @pyqtSlot()
+    def prepareDebugLogBundle(self) -> None:
         """Zip the last 48h of app logs (+ config + system info) into
         data/debug-bundles/, reveal it in the file explorer, and toast
-        the support address. Returns the zip path, or '' on failure."""
+        the support address — on a worker thread. Zipping 48 h of logs
+        is multi-second and used to freeze the GUI for the whole build.
+
+        Fire-and-forget: Settings never used the old return value. The
+        immediate toast gives feedback while the worker runs; the
+        success toast (same tag) replaces it. notify/errorOccurred emit
+        queued signals, so the worker path is safe."""
+        self.notify("Preparing debug logs…", type_="info",
+                    tag="debug-bundle")
+        threading.Thread(
+            target=self._prepare_debug_bundle_sync,
+            name="debug-bundle", daemon=True,
+        ).start()
+
+    def _prepare_debug_bundle_sync(self) -> str:
+        """Build + reveal + audit + toast the debug bundle. Returns the
+        zip path, or '' on failure. Worker body of prepareDebugLogBundle;
+        unit tests call it synchronously."""
         try:
             from debug_bundle import build_debug_bundle, WINDOW_HOURS
             try:
@@ -2508,6 +2537,7 @@ class MotionConnector(QObject):
         except Exception:
             logger.exception("prepareDebugLogBundle: failed to build bundle")
             self.errorOccurred.emit("Could not create the debug log bundle.")
+            self.dismissNotification("debug-bundle")
             return ""
 
         path = meta["path"]
@@ -2991,15 +3021,30 @@ class MotionConnector(QObject):
             logger.exception("loadPastScan failed for label %r", session_label)
             self.pastScanLoadFinished.emit(session_label, False)
 
-    @pyqtSlot(str, str, result=bool)
-    def exportScanCsv(self, session_label: str, output_path: str) -> bool:
-        """Export a scan's session_data to a corrected-format CSV.
-
-        Called from the History modal's "Export CSV" button after the user
-        picks a save path via FileDialog.
-        """
+    @pyqtSlot(str, str)
+    def exportScanCsv(self, session_label: str, output_path: str) -> None:
+        """Export a scan's session_data to a corrected-format CSV, on a
+        worker thread. Called from the History modal's "Export CSV"
+        button after the user picks a save path; the result arrives via
+        scanCsvExportFinished(ok, path) — materializing a long scan is
+        multi-second and used to freeze the GUI for the duration."""
         if not session_label or not output_path:
-            return False
+            self.scanCsvExportFinished.emit(False, output_path or "")
+            return
+        threading.Thread(
+            target=self._export_scan_csv_worker,
+            args=(session_label, output_path),
+            name="scan-csv-export", daemon=True,
+        ).start()
+
+    def _export_scan_csv_worker(self, session_label: str,
+                                output_path: str) -> None:
+        ok = self._export_scan_csv_sync(session_label, output_path)
+        self.scanCsvExportFinished.emit(ok, output_path)
+
+    def _export_scan_csv_sync(self, session_label: str,
+                              output_path: str) -> bool:
+        """Worker body of exportScanCsv; unit tests call it directly."""
         try:
             from omotion.ScanDatabase import ScanDatabase
             from omotion.SessionPlayback import materialize_corrected_csv
@@ -3030,16 +3075,36 @@ class MotionConnector(QObject):
             self.errorOccurred.emit(f"Export failed:\n{exc}")
             return False
 
-    @pyqtSlot('QStringList', str, result='QVariantMap')
-    def exportScansToFolder(self, labels, folder) -> dict:
-        """Export several scans, one CSV each, into ``folder``.
+    @pyqtSlot('QStringList', str)
+    def exportScansToFolder(self, labels, folder) -> None:
+        """Export several scans, one CSV each, into ``folder`` — on a
+        worker thread. Completion arrives via
+        scansExportFinished(exported, skipped, folder); a big batch used
+        to freeze the GUI for its whole materialize loop. (Callers
+        pre-filter interrupted scans, which can't be materialized.)"""
+        labels = [str(x) for x in (labels or [])]
+        if not labels or not folder:
+            self.scansExportFinished.emit(0, 0, str(folder or ""))
+            return
+        self.notify(f"Exporting {len(labels)} scan(s)…", type_="info",
+                    tag="scan-export")
+        threading.Thread(
+            target=self._export_scans_worker, args=(labels, str(folder)),
+            name="scan-batch-export", daemon=True,
+        ).start()
 
-        Writes ``<folder>/<label>_export.csv`` for every label. Opens
-        the scan DB once for the whole batch. Missing or failing scans
-        are counted as skipped and never raise. Returns
-        ``{"exported": int, "skipped": int}``. (Callers pre-filter
-        interrupted scans, which can't be materialized.)
-        """
+    def _export_scans_worker(self, labels, folder) -> None:
+        result = self._export_scans_sync(labels, folder)
+        self.scansExportFinished.emit(
+            result["exported"], result["skipped"], folder)
+
+    def _export_scans_sync(self, labels, folder) -> dict:
+        """Worker body of exportScansToFolder. Writes
+        ``<folder>/<label>_export.csv`` for every label; opens the scan
+        DB once for the whole batch. Missing or failing scans are counted
+        as skipped and never raise. Returns
+        ``{"exported": int, "skipped": int}``. Unit tests call it
+        directly."""
         result = {"exported": 0, "skipped": 0}
         if not labels or not folder:
             return result
@@ -3106,8 +3171,7 @@ class MotionConnector(QObject):
         if type_ not in ("info", "success", "warning", "error"):
             logger.warning(f"notify: unknown type '{type_}', falling back to 'info'")
             type_ = "info"
-        self._notification_id_counter += 1
-        nid = self._notification_id_counter
+        nid = next(self._notification_ids)
         self.notificationRequested.emit({
             "id": nid,
             "tag": str(tag),

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1149,10 +1149,37 @@ class MotionConnector(QObject):
                 logger.warning("Failed to set debug flags on %s sensor", side)
 
     def _schedule_sensor_init(self, side: str):
-        """Delay initial sensor commands to allow USB settle."""
-        QTimer.singleShot(1000, lambda: self._run_sensor_init(side))
+        """Delay initial sensor commands to allow USB settle, then run
+        them on a daemon worker thread. The init sequence is a multi-
+        command USB conversation with a built-in 0.5 s camera-power
+        settle sleep — on the GUI thread it froze the app for >0.5 s on
+        every sensor (re)connect."""
+        QTimer.singleShot(
+            1000, lambda: self._start_sensor_init_worker(side)
+        )
+
+    def _start_sensor_init_worker(self, side: str) -> None:
+        """Spawn the init worker. Worker-safety: the SDK serializes
+        per-device command I/O (CommInterface._io_lock/_send_lock), every
+        signal emitted from the sequence queues to the main thread, and
+        _raise_critical is worker-safe by contract — same pattern as the
+        CQ-check and past-scan-load workers."""
+        threading.Thread(
+            target=self._run_sensor_init, args=(side,),
+            name=f"sensor-init-{side}", daemon=True,
+        ).start()
 
     def _run_sensor_init(self, side: str):
+        """Run the connect-time init sequence for one sensor. Called on
+        a sensor-init worker thread (see _start_sensor_init_worker);
+        unit tests call it synchronously. Never raises — an uncaught
+        exception on a plain worker thread would vanish to stderr."""
+        try:
+            self._run_sensor_init_impl(side)
+        except Exception:
+            logger.exception("sensor init failed for %s sensor", side)
+
+    def _run_sensor_init_impl(self, side: str):
         if side == "left" and not self._leftSensorConnected:
             return
         if side == "right" and not self._rightSensorConnected:

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -10,10 +10,9 @@ Rectangle {
     id: bloodFlow
     width: parent.width
     height: parent.height
-    color: theme.bgBase
+    color: AppTheme.bgBase
     radius: 0
 
-    AppTheme { id: theme }
 
     property bool scanning: false
     property bool camerasReady: true  // gates Start/Check; false only while no sensor is connected

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -210,7 +210,9 @@ def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
     c = _connector(tmp_path, scan_db_path=db)
     # Don't spawn a real file-explorer process during the test.
     c._reveal_in_explorer = lambda p: None
-    path = c.prepareDebugLogBundle()
+    # Call the worker body directly — the prepareDebugLogBundle slot is
+    # fire-and-forget (spawns a daemon thread) since the GUI-freeze fix.
+    path = c._prepare_debug_bundle_sync()
     assert path and os.path.exists(path)
     assert path.endswith(".zip")
     with zipfile.ZipFile(path) as zf:
@@ -231,5 +233,5 @@ def test_prepare_debug_bundle_failure_returns_empty(tmp_path, monkeypatch):
         raise RuntimeError("disk full")
 
     monkeypatch.setattr(debug_bundle, "build_debug_bundle", boom)
-    assert c.prepareDebugLogBundle() == ""
+    assert c._prepare_debug_bundle_sync() == ""
     assert "debug_bundle_created" not in _types(c)

--- a/tests/test_history_export.py
+++ b/tests/test_history_export.py
@@ -1,6 +1,12 @@
-"""exportScansToFolder — batch-export several scans into one folder."""
+"""exportScansToFolder — batch-export several scans into one folder.
+
+The QML-facing slot is fire-and-forget since the GUI-freeze fix (the
+batch runs on a daemon worker and reports via scansExportFinished);
+the logic tests exercise the synchronous worker body directly.
+"""
 
 import os
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -47,7 +53,7 @@ def test_export_scans_to_folder_writes_each_and_skips_missing(
 
     out_dir = tmp_path / "out"
     out_dir.mkdir()
-    res = c.exportScansToFolder(
+    res = c._export_scans_sync(
         ["scanA", "scanB", "missing"], str(out_dir))
 
     assert res["exported"] == 2
@@ -77,7 +83,7 @@ def test_export_scans_to_folder_isolates_per_label_failure(
 
     monkeypatch.setattr(sp, "materialize_corrected_csv", _materialize)
 
-    res = c.exportScansToFolder(["scanA", "scanB"], str(tmp_path))
+    res = c._export_scans_sync(["scanA", "scanB"], str(tmp_path))
 
     assert res == {"exported": 1, "skipped": 1}
     assert len(exported) == 1  # scanB still ran after scanA failed
@@ -86,9 +92,9 @@ def test_export_scans_to_folder_isolates_per_label_failure(
 
 def test_export_scans_to_folder_empty_inputs(tmp_path):
     c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
-    assert c.exportScansToFolder([], str(tmp_path)) == {
+    assert c._export_scans_sync([], str(tmp_path)) == {
         "exported": 0, "skipped": 0}
-    assert c.exportScansToFolder(["x"], "") == {
+    assert c._export_scans_sync(["x"], "") == {
         "exported": 0, "skipped": 0}
 
 
@@ -96,6 +102,41 @@ def test_export_scans_to_folder_no_db(tmp_path):
     c = _connector(tmp_path, scan_db_path=None)
     errors = []
     c.errorOccurred.connect(errors.append)
-    res = c.exportScansToFolder(["scanA"], str(tmp_path))
+    res = c._export_scans_sync(["scanA"], str(tmp_path))
     assert res == {"exported": 0, "skipped": 0}
     assert errors  # errorOccurred was emitted
+
+
+def test_export_slot_is_async_and_reports_via_signal(tmp_path, monkeypatch):
+    """The QML-facing slot returns immediately, runs the batch on a
+    worker thread, and reports via scansExportFinished."""
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, "scanA", 1.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+    import omotion.SessionPlayback as sp
+    monkeypatch.setattr(sp, "materialize_corrected_csv",
+                        lambda *a, **k: None)
+
+    results = []
+    c.scansExportFinished.connect(
+        lambda e, s, f: results.append((e, s, f)))
+    c.exportScansToFolder(["scanA", "missing"], str(tmp_path))
+
+    # The worker's emit is queued to the main thread — pump the event
+    # loop so it can deliver (exactly what the running app's loop does).
+    from PyQt6.QtCore import QCoreApplication
+    app = QCoreApplication.instance() or QCoreApplication([])
+    deadline = time.time() + 5
+    while not results and time.time() < deadline:
+        app.processEvents()
+        time.sleep(0.01)
+    assert results == [(1, 1, str(tmp_path))]
+
+
+def test_export_slot_empty_inputs_signal_immediately(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    results = []
+    c.scansExportFinished.connect(
+        lambda e, s, f: results.append((e, s, f)))
+    c.exportScansToFolder([], str(tmp_path))
+    assert results == [(0, 0, str(tmp_path))]

--- a/tests/test_sensor_init_worker.py
+++ b/tests/test_sensor_init_worker.py
@@ -1,0 +1,60 @@
+"""Sensor connect-time init must not block the GUI thread.
+
+The init sequence (debug flags + camera power + 0.5 s settle + ID-cache
+fill + identity log) froze the GUI for >0.5 s per sensor (re)connect when
+it ran on the main thread. It now runs on a daemon worker; these tests
+pin the scheduling seam. test_send_defer_flag still calls
+_run_sensor_init synchronously — that contract is preserved.
+"""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    return MotionConnector(
+        interface=iface, app_config={"engineeringMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def test_init_worker_runs_off_the_calling_thread(tmp_path):
+    c = _connector(tmp_path)
+    ran_on = []
+    done = threading.Event()
+
+    def fake_init(side):
+        ran_on.append((side, threading.current_thread()))
+        done.set()
+
+    c._run_sensor_init = fake_init  # instance attr shadows the method
+    c._start_sensor_init_worker("left")
+    assert done.wait(5), "init worker never ran"
+    side, thread = ran_on[0]
+    assert side == "left"
+    assert thread is not threading.main_thread()
+    assert thread.daemon
+
+
+def test_run_sensor_init_never_raises(tmp_path):
+    """An exception on a plain worker thread would vanish to stderr and
+    leave the sensor half-initialized silently — the wrapper must catch
+    and log instead."""
+    c = _connector(tmp_path)
+
+    def boom(side):
+        raise RuntimeError("boom")
+
+    c._run_sensor_init_impl = boom
+    c._run_sensor_init("left")  # must not raise


### PR DESCRIPTION
Follow-ups from the 2026-07-01 style audit — the GUI-thread-blocking fixes and the AppTheme singleton. **Stacked on #285** (base branch `feature/style-audit-cleanup`); retarget to `next` after #285 merges.

## Changes

- **Sensor connect-time init off the GUI thread** (`494e2a5`). `_run_sensor_init` (debug flags + camera power + 0.5 s settle sleep + ID-cache fill + identity log) ran on main via `QTimer.singleShot`, freezing the app >0.5 s on every sensor (re)connect. Now a daemon worker per side — the SDK already serializes per-device command I/O (`CommInterface._io_lock`/`_send_lock`), all emitted signals queue to main, and `_raise_critical` is worker-safe by contract (same pattern as the CQ-check and past-scan-load workers). Bonus visible in the log: left/right now init concurrently (debug-flag writes 11 ms apart vs serialized before).
- **Scan export + debug bundle off the GUI thread** (`31fa5aa`). `exportScansToFolder` (whole materialize loop), `exportScanCsv`, and `prepareDebugLogBundle` (zips 48 h of logs) were synchronous QML slots. Now fire-and-forget with progress/summary toasts; completion via new `scansExportFinished(exported, skipped, folder)` / `scanCsvExportFinished(ok, path)` signals, wired in HistoryModal. `notify()`'s id counter became `itertools.count` (atomic — it's now reachable from more worker threads).
- **AppTheme as a real QML singleton** (`b8a73de`). 24 files each instantiated `AppTheme { id: theme }` (~40 bindings × 24 instances re-evaluating on every darkMode flip). Registered once from main.py into the existing `OpenMotion` module; mechanical `theme.` → `AppTheme.` sweep; no token values changed.

## Verification (live bench, GUI-driven)

- Unit suite: **396 passed** (baseline 392 from #285 + new tests; export logic tests retarget the extracted sync bodies, new tests pin the async contracts and the init-worker seam).
- App booted with zero QML errors; **dark↔light flip recolors the entire UI** (page, plots, sidebar, open modal) from the single AppTheme instance.
- **Send Debug Logs**: success toast + Explorer reveal arrived from the worker; 20 KB zip in `data/debug-bundles/`.
- **History → export**: batch of 2 → async "Exported 2 scan(s) to …/data" toast, both CSVs on disk (103 KB + 73 KB); single-scan Save-As → async "Exported to …" toast.
- Full scan ran normally after worker-thread sensor init; clean shutdown, zero ERROR/traceback lines in the session log.

## Still open from the audit (deliberately not here)

Telemetry-thread marshalling (`readSafetyStatus` does sync UART off-main — safety path, owner decision), console connect-time UART sequence (state-machine entangled), `deleteScans` async (needs a refresh-on-signal redesign), f-string→`%` logging normalization and the connector split (conflicts with `refactor/motion-connector-split`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
