### PR TITLE
fix: key camera dropout and data gaps to frame arrival, not plottability

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -291,43 +291,32 @@ def _safety_unknown_streak_decision(snap, prev_streak, threshold=SAFETY_UNKNOWN_
     return 0, False
 
 
-def _check_dropped_camera_emit(
+def _rearm_dropped_camera(
     side: str,
     cam_id: int,
     dropped: set,
-    already_logged: set,
-) -> tuple[bool, str | None]:
-    """Decide whether to emit a per-camera sample to the UI given the
-    dropout watchdog's view of which cameras are 'Connection Lost'
-    (issue #85).
+) -> str | None:
+    """Un-mark a camera the dropout watchdog flagged 'Connection Lost',
+    now that a fresh frame has arrived (issue #85 follow-up).
 
-    Returns ``(should_emit, recovery_warning)``:
-      - ``should_emit`` is True when the camera is alive (not in
-        ``dropped``); the caller proceeds with the normal emit.
-      - ``should_emit`` is False when the camera is in ``dropped``;
-        the caller suppresses the sample.
-      - ``recovery_warning`` is a non-None string the FIRST time a
-        given dropped camera key sends fresh data — the caller should
-        log it at WARNING. Subsequent calls return None so a flapping
-        camera doesn't spam 40 Hz worth of identical warnings.
+    Dropout marking used to be permanent for the scan and later samples
+    were suppressed, so any transient stall killed the camera's display
+    for the rest of the scan. Frames resuming is proof the camera is back
+    — re-arm the watchdog and resume display. The watchdog will re-fire
+    (with a fresh toast) if the camera goes silent again.
 
-    Mutates ``already_logged`` by inserting the key on the first
-    suppression, which is what gates the one-per-dropout behavior.
+    Returns the recovery message to log when ``(side, cam_id)`` was
+    marked, else None. Mutates ``dropped``.
     """
     key = (side, int(cam_id))
     if key not in dropped:
-        return True, None
-    if key in already_logged:
-        return False, None
-    already_logged.add(key)
-    msg = (
-        f"UNEXPECTED: Camera {side.upper()} {int(cam_id) + 1} sent "
-        f"fresh data after being marked Connection Lost. Suppressing "
-        f"the sample. Investigate the dropout cause — camera flapping, "
-        f"firmware glitch, or a too-tight dropout threshold can all "
-        f"produce this."
+        return None
+    dropped.discard(key)
+    return (
+        f"Camera {side.upper()} {int(cam_id) + 1} resumed sending frames "
+        f"after being marked Connection Lost — re-arming the dropout "
+        f"watchdog and resuming display."
     )
-    return False, msg
 
 
 _SIDE_NAMES = ("left", "right")
@@ -339,7 +328,14 @@ class _LivePlotSink:
 
     The 'live' channel carries a FrameBatch after BfiBvi. Each batch may
     contain multiple frames and both sides; we iterate frame × side × cam_id,
-    gate on the camera-dropout watchdog, and append to the source.
+    feed the camera-liveness bookkeeping, and append to the source.
+
+    Camera liveness is keyed to FRAME ARRIVAL, not to whether a frame
+    yielded a plottable sample. A covered / off-target camera streams
+    light-typed frames whose BFI/BVI are NaN (the SDK dark stage suppresses
+    realtime emission for unlit frames); that camera is connected and
+    healthy. Keying the heartbeat on finite BFI — the old behavior —
+    misdiagnosed covered sensors as camera dropouts.
 
     The 'live_side' channel carries one SideAverageSample per capture per side
     (from the SDK's LiveSideAverageStage, clinical mode) — the realtime per-side
@@ -348,6 +344,11 @@ class _LivePlotSink:
 
     channels = {"live", "live_side"}
 
+    # A camera must present this many consecutive frames of the opposite
+    # low-light state before we log the transition — one operator-facing
+    # line per genuine cover/uncover, not 40 Hz of boundary flapping.
+    _LOW_LIGHT_DEBOUNCE_FRAMES = 80  # ~2 s at 40 fps
+
     def __init__(self, connector: "MotionConnector", plot_t0: float,
                  live_source: "LiveScanSource",
                  nan_gap_tracker: "NanGapTracker | None" = None):
@@ -355,10 +356,16 @@ class _LivePlotSink:
         self._plot_t0 = plot_t0
         self._live_source = live_source
         self._temp_alerted: dict[tuple[str, int], bool] = {}
-        # Records every finite BFI/BVI sample so the scan-complete handler
-        # can report sustained data gaps in the notes footer. Optional so
+        # Records every arriving frame so the scan-complete handler can
+        # report sustained DELIVERY gaps in the notes footer. Optional so
         # the sink works standalone (tests, future callers).
         self._nan_gap_tracker = nan_gap_tracker
+        # Per-camera low-light state (from the SDK's batch.low_light_rt):
+        # True = camera currently sees no meaningful light (covered / off
+        # target). Debounced transitions are logged so an empty plot has an
+        # explanation in the capture log.
+        self._low_light_state: dict[tuple[str, int], bool] = {}
+        self._low_light_streak: dict[tuple[str, int], int] = {}
 
     def on_scan_start(self, meta) -> None:
         self._temp_alerted.clear()
@@ -378,10 +385,13 @@ class _LivePlotSink:
         threshold = connector._camera_temp_alert_threshold_c
         now_mono = time.monotonic()
 
+        low_light_rt = getattr(batch, "low_light_rt", None)
+
         for i in range(n):
             ft = str(batch.frame_type[i]) if batch.frame_type is not None else "light"
-            # Skip frames that carry no useful display signal.
-            if ft in ("warmup", "stale"):
+            # Stale frames are leftover garbage (e.g. an unflushed histogram
+            # buffer) — not evidence of a live camera, never displayed.
+            if ft == "stale":
                 continue
             is_dark = (ft == "dark")
             ts = float(batch.timestamp_s[i])
@@ -390,7 +400,8 @@ class _LivePlotSink:
 
             side_ids = getattr(batch, "side_ids", None)
             cam_ids = getattr(batch, "cam_ids", None)
-            if side_ids is not None and cam_ids is not None:
+            row_addressed = side_ids is not None and cam_ids is not None
+            if row_addressed:
                 side_idx = int(side_ids[i])
                 cam_id = int(cam_ids[i])
                 if side_idx < 0 or side_idx >= len(_SIDE_NAMES) or cam_id < 0 or cam_id >= 8:
@@ -408,50 +419,63 @@ class _LivePlotSink:
                 bvi = float(batch.bvi_live[i, side_idx, cam_id])
                 temp_c = float(batch.temperature_c[i, side_idx, cam_id])
 
-                # Skip NaN samples — Qt plot would otherwise render them as
-                # a spike from baseline to wherever NaN happens to land in
-                # the y-mapping. Common cause: the first dark frame, which
-                # the dark stage emits with mean_dc_rt=NaN (no prior light
-                # to hold over). NaN now propagates cleanly through the
-                # pipeline; skip it here for the plot.
-                if not (math.isfinite(bfi) and math.isfinite(bvi)):
-                    continue
-
                 _key = (side, cam_id)
 
-                # Finite sample — feed the NaN-gap tracker before the
-                # dropout gate: a dropout-suppressed camera still sending
-                # finite data is not a NaN gap.
-                if self._nan_gap_tracker is not None:
-                    self._nan_gap_tracker.record(_key, plot_ts)
+                # ── Liveness: frame ARRIVAL, not plottability ─────────────
+                # An unlit (covered / off-target) camera streams frames whose
+                # BFI/BVI are NaN — it is connected and must keep feeding the
+                # heartbeat and the delivery-gap tracker. Only the
+                # row-addressed path can key on arrival: legacy batches
+                # without side_ids/cam_ids fan every row out to all 16
+                # cameras, where a finite BFI is the only evidence this
+                # camera actually produced the row.
+                row_alive = row_addressed or (
+                    math.isfinite(bfi) and math.isfinite(bvi))
+                if row_alive:
+                    connector._camera_last_seen[_key] = now_mono
+                    recovery_msg = _rearm_dropped_camera(
+                        side, cam_id, connector._camera_dropped)
+                    if recovery_msg is not None:
+                        logger.warning(recovery_msg)
+                        connector._on_camera_dropout_recovered(side, cam_id)
+                    # Delivery gaps: every arriving frame counts. "Data
+                    # gaps" in the notes footer means frames stopped
+                    # arriving — a covered sensor is not a data gap.
+                    if self._nan_gap_tracker is not None:
+                        self._nan_gap_tracker.record(_key, plot_ts)
 
-                # Dropout gate — same logic as the old _on_uncorrected closure.
-                should_emit, recovery_msg = _check_dropped_camera_emit(
-                    side, cam_id,
-                    connector._camera_dropped,
-                    connector._camera_dropped_recovery_logged,
-                )
-                if recovery_msg is not None:
-                    logger.warning(recovery_msg)
-                if not should_emit:
+                # Warmup frames prove liveness but carry no display signal.
+                if ft == "warmup":
                     continue
 
-                # Update dropout-watchdog heartbeat (non-dark frames only, since
-                # dark frames arrive at ~40x lower rate and would skew the timer).
-                if not is_dark:
-                    connector._camera_last_seen[_key] = now_mono
-                    connector._camera_last_temp[_key] = temp_c
+                # Low-light bookkeeping (SDK ≥ low_light_rt): debounced
+                # transition log so an empty plot has an explanation.
+                if low_light_rt is not None and not is_dark:
+                    self._note_low_light(
+                        _key, bool(low_light_rt[i, side_idx, cam_id]))
 
-                # Temperature alert (light frames only — dark frames have no
-                # meaningful camera temperature reading for display).
-                if not is_dark and temp_c >= threshold and _key not in self._temp_alerted:
-                    self._temp_alerted[_key] = True
-                    msg = (
-                        f"ALERT: Camera {cam_id + 1} ({side}) "
-                        f"temperature {temp_c:.1f}°C >= {threshold:.0f}°C threshold."
-                    )
-                    connector.captureLog.emit(msg)
-                    logger.warning(msg)
+                # Temperature cache + alert (light frames only — scheduled
+                # dark frames have no meaningful camera temperature reading).
+                # Deliberately before the NaN gate: a covered camera still
+                # reports a real chip temperature and can still overheat.
+                if not is_dark and math.isfinite(temp_c):
+                    connector._camera_last_temp[_key] = temp_c
+                    if temp_c >= threshold and _key not in self._temp_alerted:
+                        self._temp_alerted[_key] = True
+                        msg = (
+                            f"ALERT: Camera {cam_id + 1} ({side}) "
+                            f"temperature {temp_c:.1f}°C >= {threshold:.0f}°C threshold."
+                        )
+                        connector.captureLog.emit(msg)
+                        logger.warning(msg)
+
+                # Skip NaN samples for the plot — Qt would otherwise render
+                # them as a spike from baseline to wherever NaN lands in the
+                # y-mapping. Common causes: warmup before the first dark
+                # observation, and unlit frames (the dark stage suppresses
+                # realtime emission — see low_light_rt above).
+                if not (math.isfinite(bfi) and math.isfinite(bvi)):
+                    continue
 
                 mean_for_source: Optional[float] = None
                 contrast_for_source: Optional[float] = None
@@ -494,6 +518,34 @@ class _LivePlotSink:
                     temp=temp_for_source,
                 )
 
+    def _note_low_light(self, key: tuple[str, int], is_low: bool) -> None:
+        """Track a camera's low-light state (SDK batch.low_light_rt) and log
+        debounced transitions. A camera flipping state must hold the new
+        state for _LOW_LIGHT_DEBOUNCE_FRAMES consecutive frames before the
+        transition is accepted — one capture-log line per genuine
+        cover/uncover event, not 40 Hz of threshold flapping."""
+        current = self._low_light_state.get(key, False)
+        if is_low == current:
+            self._low_light_streak[key] = 0
+            return
+        streak = self._low_light_streak.get(key, 0) + 1
+        if streak < self._LOW_LIGHT_DEBOUNCE_FRAMES:
+            self._low_light_streak[key] = streak
+            return
+        self._low_light_state[key] = is_low
+        self._low_light_streak[key] = 0
+        side, cam_id = key
+        if is_low:
+            msg = (
+                f"Camera {side.upper()} {cam_id + 1} low light — frames "
+                f"arriving but no meaningful signal (sensor covered or "
+                f"off target?). Plot paused for this camera."
+            )
+        else:
+            msg = f"Camera {side.upper()} {cam_id + 1} signal restored."
+        logger.info(msg)
+        self._connector.captureLog.emit(msg)
+
     def _consume_side_avg(self, sample) -> None:
         """Append one clinical-mode per-side average (SideAverageSample from the
         SDK's LiveSideAverageStage) under cam_id=-1. The stage already emits one
@@ -505,11 +557,11 @@ class _LivePlotSink:
         bfi = float(getattr(sample, "bfi", float("nan")))
         bvi = float(getattr(sample, "bvi", float("nan")))
         t = float(getattr(sample, "t", 0.0))
-        # The side-average path stores NaN as-is (the renderer skips it),
-        # so the tracker must gate on finiteness here — only finite
-        # samples count as "data present".
-        if (self._nan_gap_tracker is not None
-                and math.isfinite(bfi) and math.isfinite(bvi)):
+        # Arrival-based, same as the per-camera path: the stage emitted a
+        # sample for this capture, so the pipeline is delivering — a NaN
+        # average (all cameras unlit, e.g. covered sensors) is not a
+        # delivery gap.
+        if self._nan_gap_tracker is not None:
             self._nan_gap_tracker.record((_SIDE_NAMES[side_idx], -1), t)
         self._live_source.append_uncorrected(
             side=_SIDE_NAMES[side_idx],
@@ -789,6 +841,9 @@ class MotionConnector(QObject):
     contactQualityIssueStateChanged = pyqtSignal(str, str, str, float, bool)
     contactQualityScanInProgress = pyqtSignal(bool)
     cameraDropoutDetected = pyqtSignal(str, int, str)  # side ("left"/"right"), cam_id (0-7), elapsed HH:MM:SS
+    # Frames resumed for a camera previously flagged Connection Lost — the
+    # watchdog was re-armed and display resumed. Mirror of cameraDropoutDetected.
+    cameraDropoutRecovered = pyqtSignal(str, int, str)  # side, cam_id (0-7), elapsed HH:MM:SS
 
     # post-processing signals
     postProgress = pyqtSignal(int)
@@ -867,13 +922,16 @@ class MotionConnector(QObject):
         self._camera_dropout_threshold_sec = float(cfg.get("cameraDropoutThresholdSec", 2.0))
 
         # Camera dropout watchdog state — reset at start of each scan.
+        # _camera_last_seen is refreshed on every FRAME ARRIVAL for the
+        # camera (see _LivePlotSink.consume), so membership in
+        # _camera_dropped means "frames stopped arriving" — a camera
+        # streaming unlit frames (covered sensor) is NOT a dropout.
+        # Dropped cameras re-arm automatically when frames resume
+        # (_rearm_dropped_camera), so the set holds currently-silent
+        # cameras, not a permanent per-scan record.
         self._camera_last_seen: dict[tuple[str, int], float] = {}
         self._camera_last_temp: dict[tuple[str, int], float] = {}
         self._camera_dropped: set[tuple[str, int]] = set()
-        # Tracks dropped-camera keys we've already surfaced a 'sent
-        # data after Connection Lost' warning for. One log per dropout
-        # — at 40 Hz a flapping camera would otherwise spam the logs.
-        self._camera_dropped_recovery_logged: set[tuple[str, int]] = set()
 
         # NaN-gap tracker — replaced with a fresh instance at each scan
         # start. Kept on the instance for debugging/introspection only;
@@ -3251,7 +3309,6 @@ class MotionConnector(QObject):
         self._camera_last_seen = {}
         self._camera_last_temp = {}
         self._camera_dropped = set()
-        self._camera_dropped_recovery_logged = set()
         self._dropout_timer.start()
 
         # NaN-gap tracker — fresh per scan (same lifecycle as the watchdog).
@@ -4262,7 +4319,7 @@ class MotionConnector(QObject):
                 elapsed_str = self._scan_elapsed_str()
                 msg = (
                     f"[{elapsed_str}] Camera {side.upper()} {cam_id + 1} dropout detected "
-                    f"(no data for >{threshold:.0f} s). Last temperature: {temp:.1f}°C"
+                    f"(no frames for >{threshold:.0f} s). Last temperature: {temp:.1f}°C"
                 )
                 logger.warning(msg)
                 self.notify(
@@ -4281,6 +4338,29 @@ class MotionConnector(QObject):
                 src = self._current_scan_source
                 if src is not None and getattr(src, "live", False):
                     src.mark_dropped(side=side, cam_id=cam_id, t=now - self._plot_t0)
+
+    def _on_camera_dropout_recovered(self, side: str, cam_id: int) -> None:
+        """Frames resumed for a camera the watchdog had flagged Connection
+        Lost — surface the recovery. Called from _LivePlotSink.consume on
+        the pipeline runner thread right after _rearm_dropped_camera
+        un-marked the key (signal emits and notify() are thread-safe: both
+        go through queued signal delivery).
+
+        Reuses the dropout toast's tag so the "connection lost" toast is
+        replaced in place rather than stacking a second one.
+        """
+        elapsed_str = self._scan_elapsed_str()
+        self.notify(
+            f"Camera {side.upper()} {cam_id + 1} reconnected at {elapsed_str}",
+            type_="success",
+            duration_ms=8000,
+            tag=f"dropout_{side}_{cam_id}",
+        )
+        self.captureLog.emit(
+            f"[{elapsed_str}] Camera {side.upper()} {cam_id + 1} frames "
+            f"resumed — dropout watchdog re-armed."
+        )
+        self.cameraDropoutRecovered.emit(side, cam_id, elapsed_str)
 
     # --- TRIGGER-ON CLOCK (issue #201) ---
     # Single scan-time clock backing the notes duration line, the header

--- a/nan_gap_tracker.py
+++ b/nan_gap_tracker.py
@@ -1,22 +1,28 @@
-"""Sustained-gap detection over finite BFI/BVI sample timestamps.
+"""Sustained-gap detection over frame-arrival timestamps.
 
 During a scan, _LivePlotSink (motion_connector.py) calls record() for every
-sample whose BFI and BVI are both finite, keyed by (side, cam_id) — cam_id is
--1 for the reduced-mode per-side average. NaN is routine in this data (every
-dark frame, early warmup frames), but light frames flow at ~40 Hz, so during
-healthy capture each key's finite timestamp advances every ~25 ms. A stretch
-where a key produced no finite sample for longer than MIN_GAP_S therefore
-means data was genuinely lost (camera dropout, stall, sustained NaN-fill).
+frame that ARRIVES for a camera, keyed by (side, cam_id) — cam_id is -1 for
+the reduced-mode per-side average. Frames flow at ~40 Hz, so during healthy
+delivery each key's timestamp advances every ~25 ms. A stretch where a key
+received no frame for longer than MIN_GAP_S therefore means delivery
+genuinely stopped (camera dropout, USB stall, pipeline stall).
+
+Arrival, not plottability: a covered / off-target camera streams unlit
+frames whose BFI/BVI are NaN — that is expected operation, not a data gap,
+so it must not appear in the notes footer. (Before 2026-07 the tracker was
+fed only finite-BFI samples, which made covered sensors read as
+catastrophic whole-scan gaps.)
 
 At scan completion the connector unions the per-key gaps into aggregate
-ranges (a range = "at least one camera had no finite data here") and appends
-them to the session notes via gap_note_line().
+ranges (a range = "at least one camera received no frames here") and
+appends them to the session notes via gap_note_line().
 
 Pure Python, no Qt — unit-testable without hardware
 (tests/test_nan_gap_tracker.py). Extracted per the motion_config.py
 precedent rather than growing motion_connector.py further.
 
 Spec: docs/superpowers/specs/2026-06-11-nan-gap-notes-footer-design.md
+(gap semantics updated to arrival-based, 2026-07)
 """
 
 from __future__ import annotations
@@ -24,20 +30,22 @@ from __future__ import annotations
 import math
 from typing import Hashable, Optional
 
-# Minimum silence (seconds) between consecutive finite samples of one key
-# for the stretch to count as a gap. ~40 missed frames at 40 Hz. A single
-# dark-frame NaN produces a ~50 ms interval and never registers.
+# Minimum silence (seconds) between consecutive recorded samples of one key
+# for the stretch to count as a gap. ~40 missed frames at 40 Hz.
 MIN_GAP_S = 1.0
 
 
 class NanGapTracker:
-    """Tracks per-key finite-sample timestamps and the gaps between them.
+    """Tracks per-key recorded timestamps and the gaps between them.
 
-    Timestamps are the pipeline's plot timestamps (sensor firmware clock,
-    seconds). Leading gaps — before a key's first finite sample — are never
-    recorded: that is warmup, expected. Trailing gaps — a key falling silent
-    before the scan's last data — are closed at merged_gaps() time against
-    the global max timestamp seen (or an explicit end_t).
+    The tracker is agnostic about what a recorded sample *means* — the
+    caller decides what counts as "data present" (since 2026-07: frame
+    arrival). Timestamps are the pipeline's plot timestamps (sensor
+    firmware clock, seconds). Leading gaps — before a key's first recorded
+    sample — are never recorded: that is warmup, expected. Trailing gaps —
+    a key falling silent before the scan's last data — are closed at
+    merged_gaps() time against the global max timestamp seen (or an
+    explicit end_t).
     """
 
     def __init__(self, min_gap_s: float = MIN_GAP_S):

--- a/tests/test_dropped_camera_gate.py
+++ b/tests/test_dropped_camera_gate.py
@@ -1,17 +1,22 @@
 """
-Unit tests for _check_dropped_camera_emit (issue #85 + follow-up).
+Unit tests for _rearm_dropped_camera (issue #85 follow-up).
 
 What this exercises
 -------------------
-The pure-function gate that the per-frame and corrected-batch emit
-paths in ``MotionConnector`` consult before pushing a sample to the
-UI:
+The pure-function helper the per-frame emit path in ``MotionConnector``
+consults when a frame arrives for a camera:
 
-  - Alive cameras pass through (return ``(True, None)``).
-  - Dropped cameras are suppressed (return ``(False, ...)``).
-  - The first suppression for a given dropped camera key returns a
-    non-None warning string AND inserts the key into ``already_logged``;
-    subsequent suppressions for the same key return ``(False, None)``.
+  - Alive cameras (not in ``dropped``) are a no-op (return ``None``).
+  - A camera in ``dropped`` is RE-ARMED: removed from the set, and the
+    helper returns a recovery message for the caller to log. Dropout
+    marking is no longer permanent for the scan — frames resuming is
+    proof the camera is back, so display resumes and the watchdog can
+    re-fire if the camera goes silent again.
+
+This replaced the old ``_check_dropped_camera_emit`` gate, which
+suppressed a recovered camera's samples for the rest of the scan —
+turning any transient stall (or a covered sensor, back when liveness was
+keyed to finite BFI instead of frame arrival) into a dead display.
 
 Marker
 ------
@@ -32,86 +37,74 @@ import pytest
 # turning the project into an installed package.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from motion_connector import _check_dropped_camera_emit  # noqa: E402
+from motion_connector import _rearm_dropped_camera  # noqa: E402
 
 pytestmark = pytest.mark.unit
 
 
-def test_alive_camera_passes_through():
-    should, msg = _check_dropped_camera_emit("left", 0, set(), set())
-    assert should is True
+def test_alive_camera_is_noop():
+    dropped = set()
+    msg = _rearm_dropped_camera("left", 0, dropped)
     assert msg is None
+    assert dropped == set()
 
 
-def test_alive_camera_does_not_touch_already_logged():
-    already = set()
-    _check_dropped_camera_emit("left", 0, set(), already)
-    assert already == set()
-
-
-def test_dropped_camera_first_sample_returns_recovery_message():
-    dropped = {("left", 0)}
-    already_logged = set()
-    should, msg = _check_dropped_camera_emit(
-        "left", 0, dropped, already_logged,
-    )
-    assert should is False
-    assert msg is not None
-    # Message identifies the camera (1-indexed, side uppercased) and
-    # includes the 'UNEXPECTED' / 'Connection Lost' framing so an
-    # operator skimming the logs can find it.
-    assert "UNEXPECTED" in msg
-    assert "LEFT 1" in msg
-    assert "Connection Lost" in msg
-
-
-def test_dropped_camera_first_sample_marks_already_logged():
+def test_alive_camera_does_not_touch_other_keys():
     dropped = {("right", 3)}
-    already_logged = set()
-    _check_dropped_camera_emit("right", 3, dropped, already_logged)
-    # The helper mutates already_logged so the caller gets one-per-
-    # dropout semantics for free — no need to track this externally.
-    assert ("right", 3) in already_logged
+    msg = _rearm_dropped_camera("left", 0, dropped)
+    assert msg is None
+    assert dropped == {("right", 3)}
 
 
-def test_dropped_camera_second_sample_silent():
+def test_dropped_camera_is_rearmed_and_returns_message():
     dropped = {("left", 0)}
-    already_logged = {("left", 0)}
-    should, msg = _check_dropped_camera_emit(
-        "left", 0, dropped, already_logged,
-    )
-    assert should is False
-    assert msg is None  # already logged once, don't re-emit
+    msg = _rearm_dropped_camera("left", 0, dropped)
+    assert msg is not None
+    # Camera has been un-marked — display resumes, watchdog re-armed.
+    assert dropped == set()
+    # Message identifies the camera (1-indexed, side uppercased) and the
+    # re-arm framing so an operator skimming the logs can find it.
+    assert "LEFT 1" in msg
+    assert "resumed" in msg
+    assert "re-arming" in msg
 
 
-def test_dropped_camera_repeated_calls_log_only_once():
-    """The 40 Hz uncorrected stream calls the gate per sample. A
-    dropped, flapping camera must produce exactly one warning per
-    dropout — not 40/sec."""
+def test_second_frame_after_rearm_is_silent():
+    """The 40 Hz stream calls the helper per frame. Only the frame that
+    performs the re-arm returns a message — the camera is out of the set
+    afterwards, so subsequent frames are the alive-camera no-op."""
     dropped = {("left", 5)}
-    already_logged = set()
     messages = []
     for _ in range(50):
-        _, msg = _check_dropped_camera_emit(
-            "left", 5, dropped, already_logged,
-        )
+        msg = _rearm_dropped_camera("left", 5, dropped)
         if msg is not None:
             messages.append(msg)
     assert len(messages) == 1
+    assert dropped == set()
 
 
-def test_separate_dropped_cameras_each_log_once():
-    """Each (side, cam_id) key gets its own one-time slot."""
+def test_camera_can_drop_and_recover_repeatedly():
+    """A flapping camera produces one recovery message per dropout
+    episode — the watchdog re-adds the key when frames stop again."""
+    dropped = set()
+    messages = []
+    for _ in range(3):
+        dropped.add(("right", 2))          # watchdog fires
+        msg = _rearm_dropped_camera("right", 2, dropped)
+        if msg is not None:
+            messages.append(msg)
+        assert ("right", 2) not in dropped  # re-armed each time
+    assert len(messages) == 3
+
+
+def test_separate_dropped_cameras_each_rearm_independently():
     dropped = {("left", 0), ("right", 7)}
-    already_logged = set()
-    _, m1 = _check_dropped_camera_emit("left",  0, dropped, already_logged)
-    _, m2 = _check_dropped_camera_emit("right", 7, dropped, already_logged)
-    _, m3 = _check_dropped_camera_emit("left",  0, dropped, already_logged)
-    _, m4 = _check_dropped_camera_emit("right", 7, dropped, already_logged)
-    assert m1 is not None and "LEFT 1"  in m1
+    m1 = _rearm_dropped_camera("left", 0, dropped)
+    assert m1 is not None and "LEFT 1" in m1
+    assert dropped == {("right", 7)}
+    m2 = _rearm_dropped_camera("right", 7, dropped)
     assert m2 is not None and "RIGHT 8" in m2
-    assert m3 is None
-    assert m4 is None
+    assert dropped == set()
 
 
 def test_cam_id_accepts_numeric_strings():
@@ -119,20 +112,15 @@ def test_cam_id_accepts_numeric_strings():
     value off the SDK; the helper must coerce so set membership uses
     a canonical int in the tuple key."""
     dropped = {("left", 4)}
-    already_logged = set()
-    should, msg = _check_dropped_camera_emit(
-        "left", "4", dropped, already_logged,
-    )
-    assert should is False
+    msg = _rearm_dropped_camera("left", "4", dropped)
     assert msg is not None
+    assert dropped == set()
 
 
 def test_cam_id_one_indexed_in_message():
     """Internal cam_id is 0..7, but the operator-facing label is 1..8
     to match the physical camera numbering on the modules."""
-    dropped = {("left", 0)}
-    _, msg = _check_dropped_camera_emit("left", 0, dropped, set())
+    msg = _rearm_dropped_camera("left", 0, {("left", 0)})
     assert "LEFT 1" in msg
-    dropped = {("right", 7)}
-    _, msg = _check_dropped_camera_emit("right", 7, dropped, set())
+    msg = _rearm_dropped_camera("right", 7, {("right", 7)})
     assert "RIGHT 8" in msg

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -34,14 +34,18 @@ class _RecorderLiveSource:
 
 
 def _connector():
-    return SimpleNamespace(
+    conn = SimpleNamespace(
         _camera_temp_alert_threshold_c=100.0,
         _camera_dropped=set(),
-        _camera_dropped_recovery_logged=set(),
         _camera_last_seen={},
         _camera_last_temp={},
         captureLog=_Signal(),
+        recovered=[],
     )
+    # Called by the sink when a dropped camera's frames resume.
+    conn._on_camera_dropout_recovered = (
+        lambda side, cam_id: conn.recovered.append((side, cam_id)))
+    return conn
 
 
 def _make_sink(conn, live_source=None):
@@ -301,7 +305,10 @@ def test_live_plot_sink_no_temp_when_non_finite():
     assert src.appended[0]["temp"] is None
 
 
-def test_live_plot_sink_records_finite_samples_into_nan_gap_tracker():
+def test_live_plot_sink_records_every_arrival_into_gap_tracker():
+    """The gap tracker is fed on frame ARRIVAL — an unlit frame whose
+    BFI is NaN (covered sensor) is still delivery, not a data gap. Gaps
+    now mean "frames stopped arriving"."""
     from nan_gap_tracker import NanGapTracker
 
     conn = _connector()
@@ -321,10 +328,9 @@ def test_live_plot_sink_records_finite_samples_into_nan_gap_tracker():
         side_ids=np.array([0, 0, 0], dtype=np.int8),
         cam_ids=np.array([1, 1, 1], dtype=np.int8),
     )
-    # Middle sample is NaN-filled → skipped by the sink AND absent from
-    # the tracker, leaving a 0.1→3.0 gap for ("left", 1). The gap starts
-    # at the last finite sample before the silence (t=0.1, frame 0);
-    # t=0.125 (frame 1) is NaN and never recorded.
+    # Middle sample is NaN → skipped for the PLOT, but still recorded in
+    # the tracker (the frame arrived). The only gap is the genuine
+    # delivery silence between t=0.125 and t=3.0.
     batch.bfi_live[:] = 7.0
     batch.bvi_live[:] = 4.0
     batch.bfi_live[1, 0, 1] = np.nan
@@ -332,26 +338,54 @@ def test_live_plot_sink_records_finite_samples_into_nan_gap_tracker():
     sink.consume("live", batch)
 
     assert tracker.merged_gaps() == [
-        (pytest.approx(0.1), pytest.approx(3.0))
+        (pytest.approx(0.125), pytest.approx(3.0))
     ]
-    # Sink behavior unchanged: NaN sample not appended to the live source.
+    # Plot behavior unchanged: NaN sample not appended to the live source.
     assert [r["t"] for r in src.appended] == [
         pytest.approx(0.1), pytest.approx(3.0)
     ]
 
 
-def test_live_plot_sink_records_dropout_suppressed_samples_in_tracker():
-    """A camera in the dropped set is suppressed from the live source, but
-    its finite samples still reach the tracker — record() sits before the
-    dropout gate (arriving finite data is not a NaN gap)."""
+def test_live_plot_sink_covered_camera_stays_alive_and_unplotted():
+    """A covered / off-target camera streams light-typed frames whose
+    BFI/BVI are NaN. It must keep feeding the heartbeat and the gap
+    tracker (it is connected), while appending nothing to the plot."""
     from nan_gap_tracker import NanGapTracker
 
     conn = _connector()
-    conn._camera_dropped = {("left", 1)}
     tracker = NanGapTracker()
     src = _RecorderLiveSource()
     sink = _LivePlotSink(connector=conn, plot_t0=0.0, live_source=src,
                          nan_gap_tracker=tracker)
+    batch = SimpleNamespace(
+        bfi_live=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        bvi_live=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        mean_dc_rt=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        contrast_sn_rt=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        temperature_c=np.full((2, 2, 8), 55.0, dtype=np.float32),
+        frame_type=np.array(["light", "light"], dtype="<U8"),
+        timestamp_s=np.array([0.1, 0.125], dtype=np.float64),
+        abs_frame_ids=np.array([10, 11], dtype=np.int64),
+        side_ids=np.array([0, 0], dtype=np.int8),
+        cam_ids=np.array([2, 2], dtype=np.int8),
+    )
+
+    sink.consume("live", batch)
+
+    assert ("left", 2) in conn._camera_last_seen   # alive
+    assert tracker.t0 == pytest.approx(0.1)        # delivery recorded
+    assert src.appended == []                      # nothing plottable
+    # Chip temperature is real even when the camera sees no light.
+    assert conn._camera_last_temp[("left", 2)] == pytest.approx(55.0, abs=1e-4)
+
+
+def test_live_plot_sink_rearms_dropped_camera_on_frame_arrival():
+    """A camera in the dropped set that sends a fresh frame is re-armed:
+    removed from the set, recovery surfaced, and the sample plotted —
+    dropout marking is no longer permanent for the scan."""
+    conn = _connector()
+    conn._camera_dropped = {("left", 1)}
+    sink, src = _make_sink(conn)
     batch = SimpleNamespace(
         bfi_live=np.full((1, 2, 8), 7.0, dtype=np.float32),
         bvi_live=np.full((1, 2, 8), 4.0, dtype=np.float32),
@@ -367,11 +401,53 @@ def test_live_plot_sink_records_dropout_suppressed_samples_in_tracker():
 
     sink.consume("live", batch)
 
-    assert src.appended == []          # suppressed from the live source
-    assert tracker.t0 == pytest.approx(0.1)  # but recorded in the tracker
+    assert conn._camera_dropped == set()           # re-armed
+    assert conn.recovered == [("left", 1)]         # recovery surfaced
+    assert len(src.appended) == 1                  # display resumed
 
 
-def test_live_plot_sink_side_average_records_only_finite_into_tracker():
+def test_live_plot_sink_low_light_transition_logged_after_debounce():
+    """batch.low_light_rt drives a debounced per-camera state: after
+    _LOW_LIGHT_DEBOUNCE_FRAMES consecutive unlit frames, one capture-log
+    line explains the empty plot. No spam before the debounce."""
+    conn = _connector()
+    sink, _ = _make_sink(conn)
+    n = sink._LOW_LIGHT_DEBOUNCE_FRAMES
+
+    def _covered_batch(n_frames, t0):
+        b = SimpleNamespace(
+            bfi_live=np.full((n_frames, 2, 8), np.nan, dtype=np.float32),
+            bvi_live=np.full((n_frames, 2, 8), np.nan, dtype=np.float32),
+            mean_dc_rt=np.full((n_frames, 2, 8), np.nan, dtype=np.float32),
+            contrast_sn_rt=np.full((n_frames, 2, 8), np.nan, dtype=np.float32),
+            temperature_c=np.full((n_frames, 2, 8), 40.0, dtype=np.float32),
+            frame_type=np.array(["light"] * n_frames, dtype="<U8"),
+            timestamp_s=t0 + np.arange(n_frames, dtype=np.float64) * 0.025,
+            abs_frame_ids=np.arange(10, 10 + n_frames, dtype=np.int64),
+            side_ids=np.zeros(n_frames, dtype=np.int8),
+            cam_ids=np.full(n_frames, 3, dtype=np.int8),
+            low_light_rt=np.ones((n_frames, 2, 8), dtype=bool),
+        )
+        return b
+
+    # One frame short of the debounce: no message yet.
+    sink.consume("live", _covered_batch(n - 1, 0.0))
+    low_msgs = [c[0] for c in conn.captureLog.calls if "low light" in c[0]]
+    assert low_msgs == []
+
+    # One more unlit frame crosses the debounce: exactly one message.
+    sink.consume("live", _covered_batch(1, (n - 1) * 0.025))
+    low_msgs = [c[0] for c in conn.captureLog.calls if "low light" in c[0]]
+    assert len(low_msgs) == 1
+    assert "LEFT 4" in low_msgs[0]
+
+    # Staying covered produces no further messages.
+    sink.consume("live", _covered_batch(n, n * 0.025))
+    low_msgs = [c[0] for c in conn.captureLog.calls if "low light" in c[0]]
+    assert len(low_msgs) == 1
+
+
+def test_live_plot_sink_side_average_records_arrivals_into_tracker():
     from nan_gap_tracker import NanGapTracker
 
     conn = _connector()
@@ -389,9 +465,11 @@ def test_live_plot_sink_side_average_records_only_finite_into_tracker():
 
     # Side-average appends still store NaN (existing behavior)...
     assert len(src.appended) == 3
-    # ...but the tracker only saw the finite samples → 0.5→2.0 gap.
+    # ...and the tracker records every arriving sample — the NaN average
+    # at t=0.6 (e.g. all cameras covered) is delivery, so the only gap is
+    # the genuine 0.6→2.0 silence.
     assert tracker.merged_gaps() == [
-        (pytest.approx(0.5), pytest.approx(2.0))
+        (pytest.approx(0.6), pytest.approx(2.0))
     ]
 
 


### PR DESCRIPTION
## Summary

Camera "dropout" detection, dropout recovery, and the scan-notes "Data gaps" footer are now keyed to **frame arrival**, not to whether a frame produced a plottable BFI/BVI sample.

## Problem

On 2026-07-01 bench scans (sensors mostly covered — expected operation), every scan showed cameras "dropping out" within 30–40 s and never recovering, plus catastrophic gap footers (`Data gaps: 35.2–1034.4s`) — while frame delivery was provably lossless (continuous frame IDs in scans.db, zero firmware overruns). Root cause chain:

1. A covered camera streams light-typed frames; the SDK dark stage suppresses realtime emission for unlit frames → BFI/BVI = NaN.
2. `_LivePlotSink` skipped NaN samples *before* refreshing the dropout-watchdog heartbeat → the watchdog starved → "dropout detected (no data for >2 s)" for a camera that was streaming perfectly.
3. Dropout marking was permanent per scan: when light returned, samples were suppressed forever ("UNEXPECTED: … Suppressing the sample").
4. The gap tracker recorded only finite samples, so covered periods read as whole-scan data gaps.

## Changes

- **Heartbeat on arrival:** `_camera_last_seen` refreshes for every non-stale frame, before the NaN plot gate. "Dropout" now means frames stopped arriving. (Legacy batches without `side_ids` keep the finite-BFI gate.)
- **Dropouts re-arm:** `_check_dropped_camera_emit` (permanent suppression) → `_rearm_dropped_camera`. Frames resuming un-mark the camera, display resumes, a "reconnected" toast replaces the connection-lost toast (same tag), new `cameraDropoutRecovered` signal mirrors `cameraDropoutDetected`.
- **Gap footer = delivery gaps:** the tracker records arrivals; a covered sensor is no longer a "data gap".
- **Low-light surfacing:** the SDK's new `batch.low_light_rt` (companion PR: openmotion-sdk `feature/low-light-rt-flag`) drives a debounced capture-log line — *"Camera RIGHT 3 low light — frames arriving but no meaningful signal (sensor covered or off target?)"* — so an empty plot explains itself. Degrades gracefully on older SDKs.
- Camera temp cache/alert moved ahead of the NaN gate — a covered camera still reports real chip temperature and can still overheat.

NaN remains the numeric "no measurement" sentinel throughout — no sentinel values flow into averaging/filtering math.

## Testing

- `pytest tests -m unit` — **379 passed, 0 failed** (rewrote gate tests for re-arm semantics; new covered-sensor, re-arm, and low-light-debounce tests)
- **Live 10-minute hardware scan** (right sensor 0x66, FW 1.8.1-rc.2, sensors on bench): zero dropout warnings across 10 min (previous builds flagged dropouts by 40 s), all 4 cameras tracked the whole scan, one debounced low-light line for the chronically light-starved position, **no gaps footer**, 24,002 samples with 0 missing frames and 0 gaps — matching the firmware fsync count exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
