### PR TITLE
fix: anchor the camera-dropout plot marker on the sample time axis (#284)

### DIFF
--- a/data_sources.py
+++ b/data_sources.py
@@ -17,6 +17,7 @@ Nothing in QML consumes these yet — Phase 1 is purely additive.
 from __future__ import annotations
 
 import logging
+import math
 import threading
 from typing import Optional
 
@@ -496,6 +497,31 @@ class ScanDataSource(QObject):
             if buf is not None and buf.dropped_at is not None:
                 return float(buf.dropped_at)
         return float("nan")
+
+    def last_sample_t(self, side: str, cam_id: int) -> float:
+        """Newest sample timestamp across this (side, cam)'s metric
+        buffers, or NaN when the camera has no samples yet.
+
+        This is where the camera's trace visibly ends — the dropout
+        watchdog anchors the plot's dropout marker here so the marker
+        lives on the SAME time axis as the samples (SDK-normalized,
+        t=0 at the scan's first frame). See issue #284: a marker
+        computed on any other clock lands off the sample axis and
+        renders clipped or at the wrong x."""
+        latest = float("nan")
+        for metric in ("bfi", "bvi", "mean", "contrast"):
+            buf = self.buffers.get((side, int(cam_id), metric))
+            if buf is None:
+                continue
+            # Under the buffer lock: the pipeline thread appends (and
+            # ring-trims, shifting data + rewriting n) concurrently.
+            with buf._lock:
+                if buf.n == 0:
+                    continue
+                t = float(buf.t[buf.n - 1])
+            if math.isnan(latest) or t > latest:
+                latest = t
+        return latest
 
     @pyqtSlot(str, result="QVariantMap")
     @pyqtSlot(str, float, float, float, result="QVariantMap")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -934,7 +934,7 @@ class MotionConnector(QObject):
         self._dropout_timer = QTimer(self)
         self._dropout_timer.setInterval(1000)
         self._dropout_timer.timeout.connect(self._on_dropout_check)
-        self._plot_t0: float = 0.0  # set at scan start; consumed by _on_dropout_check
+        self._plot_t0: float = 0.0  # set at scan start; scan-start monotonic anchor
 
         # Trigger-ON clock (issue #201) — the single scan-time source of
         # truth for the notes duration line, the header elapsed counter and
@@ -3250,7 +3250,9 @@ class MotionConnector(QObject):
         # after a mid-scan unplug/replug, the two sides' clocks diverge and the
         # QML plot's shared `latestTimestamp` prunes the lagging side to empty.
         plot_t0 = time.monotonic()
-        self._plot_t0 = plot_t0  # used by _on_dropout_check to compute dropout-marker t
+        self._plot_t0 = plot_t0  # scan-start anchor (NOT the sample t axis —
+        # samples carry SDK-normalized timestamps, t=0 at the first frame,
+        # which arrives seconds after this line; see issue #284)
         # Real-time plot viewer: construct a fresh LiveScanSource for this scan
         # and install it on the connector. Phase 1 has no QML consumer yet —
         # the sinks (added in subsequent tasks) accumulate samples here in
@@ -4144,13 +4146,23 @@ class MotionConnector(QObject):
                 )
                 self._camera_dropped.add(key)
                 self.cameraDropoutDetected.emit(side, cam_id, elapsed_str)
-                # Also feed the new LiveScanSource so Phase 2+'s PlotViewer can
-                # render a dropout bar. Time is relative to plot_t0 to match the
-                # per-sample t axis (sample timestamps from the SDK use the same
-                # plot_t0-anchored monotonic origin).
+                # Also feed the LiveScanSource so the PlotViewer renders a
+                # dropout bar. The marker must live on the SAME time axis
+                # as the plotted samples — SDK-normalized timestamps, t=0
+                # at the scan's FIRST FRAME. (`now - self._plot_t0` counted
+                # from startCapture instead, which runs seconds of sensor
+                # setup before the first frame, so the marker landed past
+                # the live edge — clipped invisible while following live —
+                # and at a wrong x afterwards; issue #284.) Anchor at the
+                # camera's own newest sample: exactly where its trace
+                # stops. NaN (no plottable samples ever, e.g. a covered
+                # camera) means there is no trace to mark — skip the bar,
+                # the toast/signal above still surface the dropout.
                 src = self._current_scan_source
                 if src is not None and getattr(src, "live", False):
-                    src.mark_dropped(side=side, cam_id=cam_id, t=now - self._plot_t0)
+                    drop_t = src.last_sample_t(side, cam_id)
+                    if math.isfinite(drop_t):
+                        src.mark_dropped(side=side, cam_id=cam_id, t=drop_t)
 
     def _on_camera_dropout_recovered(self, side: str, cam_id: int) -> None:
         """Frames resumed for a camera the watchdog had flagged Connection

--- a/tests/test_dropout_marker_time_axis.py
+++ b/tests/test_dropout_marker_time_axis.py
@@ -1,0 +1,175 @@
+"""Unit tests for the camera-dropout plot marker's time axis (issue #284).
+
+What this exercises
+-------------------
+``MotionConnector._on_dropout_check`` — the 1 Hz watchdog — feeds the
+LiveScanSource a dropout timestamp that PlotCell.qml renders as a
+vertical red bar. The samples in that source carry SDK-normalized
+timestamps (t = 0 at the FIRST FRAME of the scan; see the SDK's
+``_BaseSource._t0_normalize``), so the marker must live on that same
+axis.
+
+The bug: the watchdog recorded ``time.monotonic() - self._plot_t0``,
+where ``_plot_t0`` is captured at the top of ``startCapture`` — seconds
+of sensor init / trigger setup BEFORE the first frame arrives. The
+marker therefore landed ahead of the source's live edge: PlotCell's
+``dropT <= tHi`` window check clipped it invisible while following
+live, and once the live edge finally caught up the bar drew at an x
+offset by the whole setup latency (or never, if every camera had
+stopped and the live edge froze).
+
+The fix anchors the marker at the dropped camera's own newest sample —
+exactly where its trace visibly stops.
+
+Marker
+------
+``pytest.mark.unit`` — pure Python, no QApplication, no hardware. The
+watchdog method is invoked unbound on a stub ``self`` (same pattern as
+the other connector-seam unit tests).
+
+Run with:  pytest tests/test_dropout_marker_time_axis.py -v
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import motion_connector  # noqa: E402
+from data_sources import LiveScanSource  # noqa: E402
+from motion_connector import MotionConnector  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class _Signal:
+    def __init__(self):
+        self.calls = []
+
+    def emit(self, *args):
+        self.calls.append(args)
+
+
+def _watchdog_self(src, *, plot_t0, last_seen, threshold=2.0):
+    """Stub `self` carrying exactly the state _on_dropout_check reads."""
+    return SimpleNamespace(
+        _capture_running=True,
+        _trigger_state="ON",
+        _camera_dropout_threshold_sec=threshold,
+        _camera_last_seen=dict(last_seen),
+        _camera_dropped=set(),
+        _camera_last_temp={},
+        _plot_t0=plot_t0,
+        _current_scan_source=src,
+        _scan_elapsed_str=lambda: "00:00:13",
+        notify=lambda *a, **k: None,
+        cameraDropoutDetected=_Signal(),
+    )
+
+
+def test_dropout_marker_lands_on_sample_time_axis(monkeypatch):
+    """Timeline (monotonic seconds):
+
+      1000.0  startCapture         → plot_t0
+      1008.0  first frame arrives  → SDK-normalized sample t = 0.0
+      1018.0  LEFT 1's last frame  → sample t = 10.0, then silence
+      1021.0  watchdog fires (3 s > 2 s threshold); LEFT 2 still
+              streaming, its newest sample t = 13.0 (= liveEdge)
+
+    The marker must land at sample-t 10.0 — the end of LEFT 1's trace —
+    not at 1021.0 - 1000.0 = 21.0, which is past the live edge (13.0)
+    and therefore never renders while the viewer follows live.
+    """
+    src = LiveScanSource(plot_t0=1000.0)
+    for i in range(401):  # LEFT 1: t = 0.0 .. 10.0
+        src.append_uncorrected(side="left", cam_id=0, frame_id=i,
+                               t=i * 0.025, bfi=1.0, bvi=2.0)
+    for i in range(521):  # LEFT 2: t = 0.0 .. 13.0 (keeps liveEdge moving)
+        src.append_uncorrected(side="left", cam_id=1, frame_id=i,
+                               t=i * 0.025, bfi=1.0, bvi=2.0)
+
+    fake = _watchdog_self(
+        src,
+        plot_t0=1000.0,
+        last_seen={("left", 0): 1018.0, ("left", 1): 1021.0},
+    )
+    monkeypatch.setattr(motion_connector.time, "monotonic", lambda: 1021.0)
+
+    MotionConnector._on_dropout_check(fake)
+
+    # Watchdog fired for the silent camera only.
+    assert fake._camera_dropped == {("left", 0)}
+    assert fake.cameraDropoutDetected.calls == [("left", 0, "00:00:13")]
+
+    drop_t = src.dropped_at_for("left", 0)
+    # The marker must be on the plotted time axis — at or before the
+    # newest plotted sample — or PlotCell clips it invisible.
+    assert drop_t <= src.liveEdge
+    # And specifically at the dropped camera's own trace end.
+    assert drop_t == pytest.approx(10.0)
+
+
+def test_dropout_marker_without_samples_does_not_mark_nan(monkeypatch):
+    """A camera that delivered frames (heartbeat alive) but never any
+    plottable sample (e.g. covered — NaN BFI gate) has no trace to
+    anchor a bar on. The watchdog must still fire the toast/signal, and
+    must not poison the source with a NaN/garbage marker."""
+    import math
+
+    src = LiveScanSource(plot_t0=1000.0)
+
+    fake = _watchdog_self(
+        src,
+        plot_t0=1000.0,
+        last_seen={("right", 3): 1018.0},
+    )
+    monkeypatch.setattr(motion_connector.time, "monotonic", lambda: 1021.0)
+
+    MotionConnector._on_dropout_check(fake)
+
+    assert fake._camera_dropped == {("right", 3)}  # detection still fires
+    assert math.isnan(src.dropped_at_for("right", 3))  # no bogus bar
+
+
+def test_dropout_marker_uses_camera_own_trace_end_not_live_edge(monkeypatch):
+    """Regression guard for the anchor choice: the bar belongs where THIS
+    camera's data stops, not at the global live edge (which other
+    cameras keep advancing)."""
+    src = LiveScanSource(plot_t0=500.0)
+    src.append_uncorrected(side="right", cam_id=6, frame_id=1,
+                           t=4.0, bfi=1.0, bvi=2.0)
+    src.append_uncorrected(side="right", cam_id=7, frame_id=2,
+                           t=9.0, bfi=1.0, bvi=2.0)  # live edge = 9.0
+
+    fake = _watchdog_self(
+        src,
+        plot_t0=500.0,
+        last_seen={("right", 6): 510.0, ("right", 7): 515.0},
+    )
+    monkeypatch.setattr(motion_connector.time, "monotonic", lambda: 515.0)
+
+    MotionConnector._on_dropout_check(fake)
+
+    assert src.dropped_at_for("right", 6) == pytest.approx(4.0)
+
+
+def test_last_sample_t_newest_across_metric_buffers():
+    """last_sample_t returns the newest timestamp across the (side, cam)
+    metric buffers — metrics can trail (e.g. mean absent on some
+    samples), and the trace end is the newest of any of them."""
+    src = LiveScanSource(plot_t0=0.0)
+    src.append_uncorrected(side="left", cam_id=2, frame_id=1, t=1.0,
+                           bfi=1.0, bvi=2.0, mean=100.0, contrast=0.3)
+    src.append_uncorrected(side="left", cam_id=2, frame_id=2, t=2.0,
+                           bfi=1.0, bvi=2.0)  # no mean/contrast this sample
+    assert src.last_sample_t("left", 2) == pytest.approx(2.0)
+
+
+def test_last_sample_t_nan_when_no_samples():
+    import math
+
+    src = LiveScanSource(plot_t0=0.0)
+    assert math.isnan(src.last_sample_t("left", 0))


### PR DESCRIPTION
Closes #284

## Diagnosis

The dropout red bar was recorded on the wrong clock. `_on_dropout_check` fed the LiveScanSource `t = time.monotonic() - self._plot_t0`, where `_plot_t0` is captured at the **top of `startCapture`** — but the plotted samples carry **SDK-normalized timestamps** (t = 0 at the scan's *first frame*; the SDK's `_BaseSource._t0_normalize` anchors each side's zero at its first sample). Sensor init + trigger setup run between those two moments, so the marker landed ahead of the sample axis by the whole setup latency:

- At detection time, `dropT > liveEdge`, so PlotCell's `dropT >= tLo && dropT <= tHi` window check clipped the bar **invisible** while following live.
- Once other cameras advanced the live edge past `dropT`, the bar appeared — at an x offset **right by the setup latency**.
- If every camera stopped (live edge frozen), the bar **never** appeared.

The stale comment on the marker call ("sample timestamps from the SDK use the same plot_t0-anchored monotonic origin") was simply wrong — the sink has appended raw SDK `batch.timestamp_s` since the viewer landed in #142 (`test_live_plot_sink_uses_per_frame_sdk_timestamps` pins that).

## Fix

Anchor the marker at the dropped camera's **own newest plotted sample** — exactly where its trace visibly stops. New `ScanDataSource.last_sample_t(side, cam_id)` (newest t across the 4 metric buffers, read under the buffer lock); `_on_dropout_check` uses it instead of the monotonic delta. Surgical: 2 files + tests, no signal/QML changes.

## Suspects from the issue — ruled in/out

1. **Time-origin mismatch — CONFIRMED root cause** (see above; reproduced in `test_dropout_marker_lands_on_sample_time_axis`, which failed with `assert 21.0 <= 13.0` pre-fix).
2. **Buffer doesn't exist yet** — real code path but *not a rendering bug*: post-#288 the heartbeat is arrival-keyed, so a camera with frames-but-no-plottable-samples (covered, NaN BFI gate) can drop with no buffers. There is no trace to hang a bar on, and the cell has nothing drawn anyway; toast/log/signal still fire. Left as a deliberate skip (now explicit + commented + tested).
3. **`src is not None and src.live` gate** — correct as-is: the gate only excludes past-scan sources and the no-scan case; during a running scan `_current_scan_source` is always the live source (set in `startCapture` before the watchdog starts).
4. **Window clipping** — by design (crosshair uses the identical clip). It only *hid* the bug because the marker was off-axis; with the marker on the sample axis the bar is inside the window whenever the trace end is.

## Did #288 change the picture?

No — #288 rekeyed *detection* (heartbeat on frame arrival, re-arm on resume, gap tracker) but did not touch the marker's `t` computation or the render path. Two notes: (a) re-arm means a camera can drop **again** after recovering; `mark_dropped` keeps first-dropout-wins semantics (pre-existing, unchanged); (b) arrival-keyed liveness widened suspect 2's window slightly (covered cameras now heartbeat), which is why the no-samples case is now explicitly guarded + tested.

## Tests

New `tests/test_dropout_marker_time_axis.py` (`@pytest.mark.unit`, no hardware) — drives `MotionConnector._on_dropout_check` unbound on a stub with a real `LiveScanSource`, monotonic patched: marker lands on the sample axis at the camera's trace end; no-samples camera still detected but no NaN marker; anchor is the camera's own trace end, not the global live edge; `last_sample_t` unit coverage.

`python -m pytest -m unit`: **398 passed, 121 deselected**.

## QA manual-test note

🔧 Ready for manual QA — PR #<this PR>

**What this is:** Fixes the vertical red "camera dropped out" bar on the live plot. It previously never showed up (or showed up in the wrong place) because it was timestamped against scan-setup time instead of the plot's own time axis. It now draws exactly where the dropped camera's trace stops.

**How to test manually:**
1. Start a scan with both sensors (developer mode on, per-camera grid visible).
2. Mid-scan, force one camera silent — unplug one sensor module's USB (drops all 8 of its cameras) or induce a known thermal dropout.
3. Watch the affected camera's plot cell about 2 s after frames stop; also try pausing follow-live and panning around the dropout moment.
**Expected result:** A 2 px vertical red bar appears at the exact point the camera's trace ends (right edge of the drawn trace), visible immediately at detection while following live, and stays at that time when panning/zooming. The "connection lost" toast still appears; if frames resume, the trace continues after the gap and the bar stays at the original dropout point.
**Hardware needed:** Console + 2 sensor modules (1 is enough if you drop a single camera instead of a whole module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)