### PR TITLE
fix: wait out in-flight FPGA config instead of erroring on scan/check start

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -3925,6 +3925,19 @@ class MotionConnector(QObject):
         — BloodFlow's scan-start gate polls this instead of firing blind."""
         return self._ensure_idle() is None
 
+    @pyqtSlot(result=bool)
+    def isConfigInFlight(self) -> bool:
+        """QML probe: True while a camera-sensor configuration (FPGA
+        flash) is in flight or still draining after a cancel. Unlike the
+        other _ensure_idle busy states (a few seconds at most), a config
+        holds the pipeline for ~50 s — BloodFlow's start gate (issue #283)
+        stretches its wait deadline to flash timescale while this is True
+        instead of erroring out at the short deadline."""
+        if self._config_running:
+            return True
+        workflow = getattr(self, "_scan_workflow", None)
+        return bool(workflow is not None and getattr(workflow, "config_running", False))
+
     # ──────────────────────────────────────────────────────────────────
     @pyqtSlot(int, int)
     def runContactQualityCheck(self, left_camera_mask: int, right_camera_mask: int):

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -21,7 +21,10 @@ Rectangle {
     // Aggregate live state of the contact-quality runners so main.qml
     // can detect 'check in progress' for the close-while-busy warning
     // (issue #75). Either runner being non-idle counts as busy.
-    readonly property bool checkRunning: qualityCheckRunner.running
+    // Includes a gate-pending check (armed but waiting for the pipeline
+    // to go idle) so main.qml's close-while-busy warning still covers it.
+    readonly property bool checkRunning: qualityCheckRunner.running ||
+                                         (startGate.running && startGate.action === "check")
 
     // Hand main.qml the same ModalManager BloodFlow's icon-bar uses,
     // so the close-while-busy handler can dismiss any open modal
@@ -127,36 +130,65 @@ Rectangle {
         scanRunner.start()
     }
 
-    // Scan-start gate: the pre-scan CQ check's SDK worker keeps unwinding
+    // Start gate: the pre-scan CQ check's SDK worker keeps unwinding
     // for ~2 s after its results are displayed, and a start issued in that
     // window is refused synchronously by the connector's _ensure_idle gate
     // (the failure used to be swallowed — modal closed, nothing happened).
-    // Poll isPipelineIdle() and begin the scan the moment the connector is
-    // actually free; give up loudly after 8 s.
-    property bool scanStartPending: scanStartGate.running
+    // Poll isPipelineIdle() and begin the moment the connector is actually
+    // free; give up loudly after 8 s — unless a camera configuration (FPGA
+    // flash, ~50 s) is what holds the pipeline (issue #283), in which case
+    // wait it out on the flash watchdog's timescale instead of erroring.
+    property bool scanStartPending: startGate.running && startGate.action === "scan"
     function beginScanWhenReady() {
-        if (bloodFlow.scanning || scanStartGate.running) return
-        scanStartGate.elapsedMs = 0
-        scanStartGate.start()
+        if (bloodFlow.scanning || startGate.running) return
+        startGate.arm("scan")
+    }
+    // Same gate for starting a contact-quality check (Check button and the
+    // clinical pre-scan check): firing qualityCheckRunner while a
+    // configuration was still draining used to surface a raw "Camera
+    // configuration already in progress" error in the modal (issue #283).
+    function beginCheckWhenReady() {
+        if (bloodFlow.scanning || startGate.running || qualityCheckRunner.running)
+            return
+        startGate.arm("check")
     }
     Timer {
-        id: scanStartGate
+        id: startGate
         interval: 200
         repeat: true
-        triggeredOnStart: true   // idle path starts the scan with no delay
+        triggeredOnStart: true   // idle path starts with no delay
+        property string action: "scan"   // "scan" | "check"
         property int elapsedMs: 0
+        function arm(what) {
+            action = what
+            elapsedMs = 0
+            start()
+        }
         onTriggered: {
             if (MotionInterface.isPipelineIdle()) {
                 stop()
-                beginScanNow()
+                if (action === "scan")
+                    beginScanNow()
+                else
+                    qualityCheckRunner.start()
                 return
             }
             elapsedMs += interval
-            if (elapsedMs >= 8000) {
+            // A config in flight legitimately blocks for ~50 s — match
+            // ScanRunner's flash watchdog bound. Anything else holding the
+            // pipeline past 8 s is stuck; give up loudly.
+            var deadline = MotionInterface.isConfigInFlight() ? 250000 : 8000
+            if (elapsedMs >= deadline) {
                 stop()
-                MotionInterface.notify(
-                    "Could not start scan — the previous check is still " +
-                    "finishing. Please press Start again.", "error")
+                if (action === "scan") {
+                    MotionInterface.notify(
+                        "Could not start scan — the previous step is still " +
+                        "finishing. Please press Start again.", "error")
+                } else {
+                    contactQualityModal.showError(
+                        "Could not start check — the previous step is still " +
+                        "finishing. Please try again.")
+                }
             }
         }
     }
@@ -197,7 +229,7 @@ Rectangle {
                     clinicalStartPending = true
                     contactQualityModal.preScanMode = true
                     contactQualityModal.reset(true)
-                    qualityCheckRunner.start()
+                    beginCheckWhenReady()
                 } else {
                     beginScanWhenReady()
                 }
@@ -206,7 +238,7 @@ Rectangle {
         onCheckClicked: {
             modalManager.closeCurrent()
             contactQualityModal.reset(false)
-            qualityCheckRunner.start()
+            beginCheckWhenReady()
         }
 
         // Toggle buttons — open the named modal, or close it if it's
@@ -400,7 +432,7 @@ Rectangle {
         onRetestRequested: {
             contactQualityModal.preScanMode = bloodFlow.clinicalStartPending
             contactQualityModal.reset(bloodFlow.clinicalStartPending)
-            qualityCheckRunner.start()
+            beginCheckWhenReady()
         }
         onDismissed: {
             if (!bloodFlow.scanning)

--- a/tests/test_scan_lifecycle_gates.py
+++ b/tests/test_scan_lifecycle_gates.py
@@ -72,4 +72,61 @@ def test_is_pipeline_idle_mirrors_ensure_idle(connector):
     assert connector.isPipelineIdle() is False
     connector._capture_running = False
 
+    connector._config_running = True
+    assert connector.isPipelineIdle() is False
+    connector._config_running = False
+
     assert connector.isPipelineIdle() is True
+
+
+def test_is_config_in_flight_tracks_both_config_flags(connector):
+    """Issue #283: a camera configuration (FPGA flash) can hold the
+    pipeline for ~50 s. QML's start gate stretches its wait deadline
+    while — and only while — a configuration is actually draining, so
+    the probe must reflect both the connector-local flag and the SDK
+    workflow's config_running."""
+    assert connector.isConfigInFlight() is False
+
+    connector._config_running = True
+    assert connector.isConfigInFlight() is True
+    connector._config_running = False
+
+    connector._scan_workflow.config_running = True
+    assert connector.isConfigInFlight() is True
+    connector._scan_workflow.config_running = False
+
+    # Other busy states are NOT a config in flight — the gate keeps its
+    # short deadline for those.
+    connector._capture_running = True
+    assert connector.isConfigInFlight() is False
+    connector._capture_running = False
+
+    connector._cq_quick_running = True
+    assert connector.isConfigInFlight() is False
+    connector._cq_quick_running = False
+
+
+def test_start_capture_refused_while_config_running(connector):
+    """Issue #283's failure mode at the Python seam: a scan started while
+    the FPGA flash is still in flight must be refused (the QML gate is
+    what waits it out — the connector itself never queues)."""
+    connector._config_running = True
+
+    ok = connector.startCapture("subject", 5, 0x66, 0x66, False)
+
+    assert ok is False
+    connector._interface.start_scan.assert_not_called()
+
+
+def test_start_configure_refused_while_config_running(connector):
+    """A second configure while one is draining is refused with the
+    canonical message QML used to surface raw to the user (issue #283)."""
+    connector._config_running = True
+    seen = []
+    connector.configFinished.connect(lambda ok, err: seen.append((ok, err)))
+
+    ok = connector.startConfigureCameraSensors(0x66, 0x66)
+
+    assert ok is False
+    connector._interface.start_configure_camera_sensors.assert_not_called()
+    assert seen == [(False, "Camera configuration already in progress")]


### PR DESCRIPTION
﻿Closes #283

## Diagnosis (re-verified on current `next`, 8bfd226)

The issue body's suspected mechanism is partially stale:

- `FlashSensorsTask.onFinished` **does** wait for the SDK's completion — it connects to `configFinished` and only advances the pipeline when the flash actually finishes (fixed back in #124).
- The startup FPGA auto-flash no longer exists — removed for #154, so "too soon after startup" can no longer collide with a startup flash per se.

What **does** still reproduce the reported UX on current `next` is any scan/check start issued while a camera configuration (FPGA flash, ~50 s) is in flight or draining — e.g. Check clicked then Start, a clinical pre-scan check canceled mid-flash then Start pressed again, or a check's flash still unwinding after a device hiccup:

1. **Non-clinical Start** — `BloodFlow.qml`'s scan-start gate polls `isPipelineIdle()` but hard-fails after **8 s** (it was designed for the ~2 s CQ-worker unwind), so a start during a ~50 s flash always errors with "Could not start scan…" instead of waiting.
2. **Check button / clinical Start / Retest** — these called `qualityCheckRunner.start()` with **no gate at all**. `FlashSensorsTask` then gets refused by `_ensure_idle()` and the raw **"Camera configuration already in progress"** error surfaces in the contact-quality modal. This is the literal error from the issue.

## Change

- **`motion_connector.py`** — new `isConfigInFlight()` QML probe (`_config_running` OR the SDK workflow's `config_running`), placed next to `isPipelineIdle()`. Lets QML distinguish a legitimately long config drain from the other (short) busy states. 13 lines.
- **`pages/BloodFlow.qml`** — the scan-start gate is generalized to arm either action (`"scan"` | `"check"`):
  - While `isConfigInFlight()` is true, the wait deadline stretches to 250 s (same bound as ScanRunner's flash watchdog) instead of the 8 s bail — the start proceeds the moment the pipeline goes idle, which is what the issue asks for ("the scan should wait"). Other busy states keep the original 8 s loud failure so a wedged pipeline can't pin the Start button for minutes.
  - Check button, clinical pre-scan Start, and Retest now route through the same gate (`beginCheckWhenReady()`), so the raw refusal error can no longer surface. On gate timeout the check path reports into the CQ modal, the scan path via toast, as before.
  - `checkRunning` includes a gate-pending check so main.qml's close-while-busy warning still covers the armed-but-waiting window.
- **`tests/test_scan_lifecycle_gates.py`** — unit coverage (`@pytest.mark.unit`) for the new probe (tracks both config flags, false for non-config busy states) and for the `_config_running` refusal seams of `startCapture` / `startConfigureCameraSensors`.

The ButtonPanel already renders `scanStartPending` as a waiting state, so during the wait the Start control shows busy and ignores further clicks — i.e. the start control is also effectively blocked until it's safe, the issue's alternative suggestion.

## Alternative considered

Queueing the start inside the connector (Python-side: `startCapture` defers until `_on_config_finished`). Rejected as more invasive: it adds cross-thread queued-start state to a 4000-line connector, duplicates the wait logic the QML gate already owns, and is harder to reason about on disconnect-mid-config. The QML gate + a one-slot probe is the smallest change and is provable at the Python seam by unit test.

## Verification

- `python -m pytest -m unit` → **396 passed, 121 deselected** (includes the 4 new/extended gate tests; the probe test fails without the connector change).
- Hardware validation pending (see QA note below) — I cannot run the app against hardware.

---

🔧 Ready for manual QA — PR #291

**What this is:** Starting a scan (or contact-quality check) while the sensors' FPGA configuration is still in flight used to throw "Camera configuration already in progress" or "Could not start scan…". Now the app waits for the in-flight configuration to finish (Start button shows the waiting state) and begins automatically the moment it's safe.

**How to test manually:**
1. Launch the app with console + sensor connected; wait for READY.
2. Click **Check** so the FPGA flash (~50 s) starts, then within a few seconds cancel/dismiss and immediately click **Start** (or, in non-clinical mode, click Check then Start right after).
3. Watch the Start button and the contact-quality modal while the flash drains.
**Expected result:** No "Camera configuration already in progress" or "Could not start scan" error. The Start control shows a waiting/busy state and the scan (or check) begins on its own once the configuration completes. A scan started with the pipeline fully idle still starts immediately as before.
**Hardware needed:** console + at least 1 sensor module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

