### PR TITLE
fix: gate scan start on contact-quality completion in reduced mode (#268)

### DIFF
--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -510,17 +510,28 @@ Item {
                 }
                 Button {
                     visible: root.preScanMode
+                    // Never startable mid-check (issue #268): engineering
+                    // mode makes this footer visible during "checking" (for
+                    // Force Dismiss), which used to let Start Scan arm the
+                    // scan before the check reported — the scan then began
+                    // regardless of the contact-quality outcome.
+                    enabled: root.state_ !== "checking"
                     text: "Start Scan"
-                    hoverEnabled: true
+                    hoverEnabled: enabled
                     Layout.preferredHeight: 45
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 12
-                        color: parent.hovered ? "#FFFFFF" : AppTheme.textSecondary
+                        color: !parent.enabled ? AppTheme.textDisabled
+                              : (parent.hovered ? "#FFFFFF" : AppTheme.textSecondary)
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentGreen : AppTheme.bgInput
-                        radius: 4; border.color: parent.hovered ? AppTheme.accentGreen : AppTheme.borderSoft; border.width: 1
+                        color: !parent.enabled ? AppTheme.bgCard
+                              : (parent.hovered ? AppTheme.accentGreen : AppTheme.bgInput)
+                        radius: 4
+                        border.color: !parent.enabled ? AppTheme.borderSubtle
+                                    : (parent.hovered ? AppTheme.accentGreen : AppTheme.borderSoft)
+                        border.width: 1
                     }
                     onClicked: { root.continueRequested(); root.close(); root.dismissed() }
                 }

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -420,6 +420,13 @@ Rectangle {
         }
         onContinueRequested: {
             if (bloodFlow.clinicalStartPending) {
+                // Defense in depth for issue #268: never arm the scan while
+                // the pre-scan check is still in flight. The modal already
+                // disables Start Scan during "checking"; this catches any
+                // other path that fires continueRequested early. By the time
+                // results are on screen the runner is idle, so the normal
+                // click-through is unaffected.
+                if (bloodFlow.checkRunning) return
                 contactQualityModal.close()
                 // Gated, not direct: the CQ check's worker is often still
                 // unwinding when the user clicks Start Scan, and an


### PR DESCRIPTION
## Root cause

In the clinical (reduced-mode) pre-scan flow, the Contact Quality modal's footer row has an engineering-mode exception — `visible: state_ !== "checking" || engineeringMode` — that exists to expose **Force Dismiss** during a check. On builds with `engineeringMode` on (as in the reporter's 1.4.0-dev.0 setup — Force Dismiss is visible in the issue screenshots), that exception drags the pre-scan **Start Scan** button into view while the check is still running.

Clicking Start Scan mid-check:

1. fired `continueRequested` → `beginScanWhenReady()` armed the pipeline-idle start gate → the main Start button flipped **Green → Yellow** (`waiting`) immediately, and
2. launched the full scan the instant the CQ scan's pipeline drained — before any results were shown and **regardless of the pass/fail outcome**. The attached log shows exactly this: check ends 08:42:30 with all 16 cameras `poor_contact`, full scan auto-starts 08:42:33.
3. As a side effect the click also ran `dismissed()`, clearing `clinicalStartPending`, so `onContactQualityCheckStarted` reopened the modal as a plain quick-check ("checking" spinner with Dismiss/Retest) orphaned above the already-armed scan start — matching the first screenshot.

## What changed

- **`components/ContactQualityModal.qml`** — the pre-scan **Start Scan** button is now `enabled: state_ !== "checking"`, with the same disabled styling idiom as the live-scan Continue button. It renders greyed-out during the check and becomes clickable only once results (ok / warnings / error) are on screen.
- **`pages/BloodFlow.qml`** — `onContinueRequested` now ignores a request that arrives while `checkRunning` (check runner active or check gate pending) — defense in depth for any other early-fire path. The normal click-through is unaffected: by the time results are displayed, the check runner is idle.

With the mid-check click blocked, the main Start button stays green through the entire CQ check; the brief yellow `waiting` state only appears after a legitimate Start Scan click while the CQ worker unwinds (~2 s), then red once the scan actually runs.

Fixes #268

## Hand-test plan

Requires hardware (console + at least one sensor). Uses a Clinical/reduced-mode config **with `engineeringMode: true`** in `config/app_config.json` (the repro precondition — you should see "Force Dismiss" in the CQ modal).

1. Launch the app in Reduced Mode; wait for READY (green Start).
2. Click **Start**. The Contact Quality modal opens with the spinner ("Checking contact quality…").
3. **While the spinner is showing**, look at the footer: Dismiss / Retest / Force Dismiss should be clickable, but **Start Scan must be greyed out**. Click it anyway a few times — nothing should happen: no scan start in the log, and the main Start button must stay **green** for the whole check.
4. Let the check finish (sensors off-head → expect orange warning dots). Start Scan becomes enabled. Click it → main Start button may show yellow briefly, then the scan starts (Stop button, timer running). Stop the scan.
5. Repeat with sensors on-head (or Force-Dismiss path): confirm the normal flow — check completes → "Good signal quality" / warnings → Start Scan click starts the scan as before.
6. Regression check (non-clinical build or `clinicalMode: false`): Check button quick-check still works, and the live-scan CQ warning modal (Stop scan / Continue with hold-off) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)