### PR TITLE
fix: blink console LED blue while a critical error is showing (#257)

### DIFF
--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -45,6 +45,11 @@ Item {
 
     function _showNext() {
         if (root._queue.length === 0) {
+            if (root.visible) {
+                // Last queued error dismissed — let the connector stop the
+                // console error-LED blink and restore idle green (#257).
+                MotionInterface.criticalErrorsDismissed()
+            }
             root.visible = false
             return
         }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -72,6 +72,17 @@ _CQ_DEFAULT_DARK_THRESHOLD_DN = 3.0
 _CQ_DEFAULT_LIGHT_THRESHOLD_DN = 15.0
 _CQ_DEFAULT_ROLLING_WINDOW = 10
 
+# Console front-panel RGB LED states — wire values of the firmware's
+# OW_CTRL_SET_IND command (console-fw led_driver.c, via
+# omotion.MotionConsole.set_rgb_led): 0=off, 1=red, 2=blue, 3=green.
+# The firmware itself shows solid green when idle and solid blue while the
+# trigger/laser is active; its hard-fault Error_Handler blinks blue at
+# 500 ms. The app-side error blink below mirrors that error indication.
+_RGB_LED_OFF = 0
+_RGB_LED_BLUE = 2
+_RGB_LED_GREEN = 3
+_ERROR_LED_BLINK_MS = 500  # on/off half-period, matches firmware Error_Handler
+
 # ── Engineering-mode unlock ──────────────────────────────────────────────
 # Hardcoded engineering-mode password. Double-clicking the Openwater logo
 # opens a prompt; entering this value sets engineeringMode=true (persisted).
@@ -772,6 +783,10 @@ class MotionConnector(QObject):
     # dismissible modal with a stable error code (see error_codes.py).
     # Payload: (code, title, message, suggestedAction, detail).
     criticalErrorRaised = pyqtSignal(str, str, str, str, str)
+    # Private worker→main marshalling: _raise_critical may fire from USB I/O
+    # or scanner worker threads, but the console error-LED blink QTimer lives
+    # on the GUI thread that owns it (issue #257). Wired in connect_signals.
+    _errorLedBlinkRequested = pyqtSignal()
     notificationRequested = pyqtSignal('QVariant')  # toast notification payload dict
     notificationDismissByIdRequested = pyqtSignal(int)   # dismiss the toast with this id
     notificationDismissByTagRequested = pyqtSignal(str)  # dismiss the toast with this tag
@@ -934,6 +949,16 @@ class MotionConnector(QObject):
         self._dropout_timer = QTimer(self)
         self._dropout_timer.setInterval(1000)
         self._dropout_timer.timeout.connect(self._on_dropout_check)
+
+        # Console error-LED blink (issue #257): while the critical-error
+        # modal is up, blink the console front-panel LED blue instead of
+        # leaving it solid green. Started via _errorLedBlinkRequested
+        # (queued from worker threads); stopped and restored to idle green
+        # by criticalErrorsDismissed() when the modal queue empties.
+        self._error_led_timer = QTimer(self)
+        self._error_led_timer.setInterval(_ERROR_LED_BLINK_MS)
+        self._error_led_timer.timeout.connect(self._on_error_led_tick)
+        self._error_led_on = False  # True while the blue half-period is lit
         self._plot_t0: float = 0.0  # set at scan start; scan-start monotonic anchor
 
         # Trigger-ON clock (issue #201) — the single scan-time source of
@@ -4617,6 +4642,9 @@ class MotionConnector(QObject):
         Looks ``code`` up in :mod:`error_codes`, logs it, and emits
         ``criticalErrorRaised``. Safe to call from worker threads — the QML
         side connects with a queued connection. Never raises.
+
+        Also starts the console error-LED blink (issue #257) so the hardware
+        mirrors the on-screen error state until the modal is dismissed.
         """
         try:
             err = error_codes.lookup(code)
@@ -4624,8 +4652,59 @@ class MotionConnector(QObject):
                          f" ({detail})" if detail else "")
             self.criticalErrorRaised.emit(
                 code, err.title, err.message, err.suggested_action, detail)
+            self._errorLedBlinkRequested.emit()
         except Exception:
             logger.exception("Failed to raise critical error %s", code)
+
+    # --- Console error-LED blink (issue #257) -----------------------------
+    # While the critical-error modal is showing, the console front-panel LED
+    # blinks blue (mirroring the firmware Error_Handler's 500 ms blink)
+    # instead of staying solid green. There is no firmware "blink" command —
+    # OW_CTRL_SET_IND only sets solid states — so the app toggles blue/off on
+    # a GUI-thread QTimer and restores idle green on dismissal.
+
+    def _start_error_led_blink(self) -> None:
+        """Main-thread slot: begin blinking the console LED blue.
+
+        Idempotent — additional critical errors queued while the modal is
+        already up keep the one running timer.
+        """
+        if self._error_led_timer.isActive():
+            return
+        self._error_led_on = False
+        self._error_led_timer.start()
+        self._on_error_led_tick()  # first (blue) edge now, not after 500 ms
+
+    def _on_error_led_tick(self) -> None:
+        """Toggle the console LED between blue and off; stop on failure."""
+        self._error_led_on = not self._error_led_on
+        state = _RGB_LED_BLUE if self._error_led_on else _RGB_LED_OFF
+        if not self._set_console_led(state):
+            # Console unreachable (e.g. disconnected while the modal is up)
+            # — stop retrying rather than spamming failing UART writes.
+            self._error_led_timer.stop()
+            self._error_led_on = False
+
+    def _set_console_led(self, state: int) -> bool:
+        """Best-effort console RGB LED write. True on success; never raises."""
+        try:
+            return self._interface.console.set_rgb_led(state) == state
+        except Exception:
+            logger.debug("console LED write failed (state %d)", state,
+                         exc_info=True)
+            return False
+
+    @pyqtSlot()
+    def criticalErrorsDismissed(self):
+        """Called from CriticalErrorModal when the last queued error is
+        dismissed: stop the error blink and restore the idle green LED
+        (issue #257). No-op if the blink never started (e.g. the console
+        was never reachable)."""
+        if not self._error_led_timer.isActive() and not self._error_led_on:
+            return
+        self._error_led_timer.stop()
+        self._error_led_on = False
+        self._set_console_led(_RGB_LED_GREEN)
 
     def _device_info_str(self) -> str:
         """Best-effort one-line device identity for bug reports."""
@@ -4709,6 +4788,10 @@ class MotionConnector(QObject):
         self.scanWorkerFailedDuringCapture.connect(
             self._on_scan_worker_failed
         )
+        # Worker → Qt main thread: start the console error-LED blink for a
+        # critical error (issue #257). The QTimer must be driven from the
+        # GUI thread that owns it.
+        self._errorLedBlinkRequested.connect(self._start_error_led_blink)
         # Worker → Qt main thread for the calibration completion callback.
         self._calibrationCompleteSignal.connect(self._on_calibration_complete)
         self._testScanCompleteSignal.connect(self._on_test_scan_complete)

--- a/tests/test_console_led_error_blink.py
+++ b/tests/test_console_led_error_blink.py
@@ -1,0 +1,121 @@
+"""Issue #257: critical errors must blink the console LED blue.
+
+Repro: read-only output folder → Start scan → E-301 modal shows, but the
+console front-panel LED stayed solid green. The connector now starts a
+blue/off blink (mirroring the firmware Error_Handler's 500 ms blink) when
+``_raise_critical`` fires, and ``criticalErrorsDismissed`` — called by
+CriticalErrorModal when its queue empties — stops the blink and restores
+the idle green state.
+
+Pure connector-level tests: the console handle is a MagicMock, so no
+hardware and no QML. The blink QTimer is started/stopped synchronously;
+ticks are driven by calling ``_on_error_led_tick`` directly (no event loop
+runs in unit tests).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import (
+    MotionConnector,
+    _RGB_LED_BLUE,
+    _RGB_LED_GREEN,
+    _RGB_LED_OFF,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    # set_rgb_led echoes the requested state back, like the SDK on success.
+    iface.console.set_rgb_led.side_effect = lambda s: s
+    return MotionConnector(
+        interface=iface, app_config={"engineeringMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _led_calls(conn):
+    return [c.args[0] for c in
+            conn._interface.console.set_rgb_led.call_args_list]
+
+
+def test_raise_critical_starts_blue_blink(tmp_path):
+    conn = _connector(tmp_path)
+
+    conn._raise_critical("E-301", detail="scan DB read-only")
+
+    # First edge fires immediately: LED driven blue, timer running for the
+    # subsequent off/blue toggles.
+    assert _led_calls(conn) == [_RGB_LED_BLUE]
+    assert conn._error_led_timer.isActive()
+
+
+def test_ticks_toggle_blue_and_off(tmp_path):
+    conn = _connector(tmp_path)
+    conn._raise_critical("E-301")
+
+    conn._on_error_led_tick()  # what the QTimer does every 500 ms
+    conn._on_error_led_tick()
+
+    assert _led_calls(conn) == [_RGB_LED_BLUE, _RGB_LED_OFF, _RGB_LED_BLUE]
+
+
+def test_second_error_keeps_single_blink(tmp_path):
+    """Errors queued while the modal is already up must not restart or
+    double-drive the blink."""
+    conn = _connector(tmp_path)
+
+    conn._raise_critical("E-301")
+    conn._raise_critical("E-302")
+
+    assert _led_calls(conn) == [_RGB_LED_BLUE]  # one first-edge only
+    assert conn._error_led_timer.isActive()
+
+
+def test_dismiss_stops_blink_and_restores_green(tmp_path):
+    conn = _connector(tmp_path)
+    conn._raise_critical("E-301")
+
+    conn.criticalErrorsDismissed()
+
+    assert not conn._error_led_timer.isActive()
+    assert _led_calls(conn)[-1] == _RGB_LED_GREEN
+
+
+def test_dismiss_without_prior_error_leaves_led_alone(tmp_path):
+    """criticalErrorsDismissed with no blink running must not touch the
+    LED — the firmware owns it in normal operation."""
+    conn = _connector(tmp_path)
+
+    conn.criticalErrorsDismissed()
+
+    conn._interface.console.set_rgb_led.assert_not_called()
+
+
+def test_console_write_failure_stops_blink_and_never_raises(tmp_path):
+    """Console unreachable (e.g. not connected): the SDK raises ValueError.
+    _raise_critical must still emit the modal signal and the blink must
+    stop retrying instead of spamming failing UART writes."""
+    conn = _connector(tmp_path)
+    conn._interface.console.set_rgb_led.side_effect = ValueError(
+        "Console controller not connected")
+    received = []
+    conn.criticalErrorRaised.connect(lambda *a: received.append(a))
+
+    conn._raise_critical("E-301")
+
+    assert len(received) == 1  # modal still raised
+    assert not conn._error_led_timer.isActive()
+
+    # A later dismiss is a clean no-op (no restore attempted on top of the
+    # failed blink).
+    conn._interface.console.set_rgb_led.reset_mock()
+    conn.criticalErrorsDismissed()
+    conn._interface.console.set_rgb_led.assert_not_called()


### PR DESCRIPTION
## Root cause

No app error path ever drove the console front-panel LED. The critical-error flow (`MotionConnector._raise_critical` -> `CriticalErrorModal`) only showed the on-screen modal; the SDK's `MotionConsole.set_rgb_led` (`OW_CTRL_SET_IND`: 0=off, 1=red, 2=blue, 3=green) was reachable only from the manual `setRGBState` debug slot. The firmware keeps the LED solid green when idle (and solid blue while the trigger is active) and exposes **no blink command** - its own `Error_Handler` blinks blue at 500 ms, but that runs only on a hard fault, never on host request. So when E-301 fired, nothing told the console anything was wrong and the LED stayed solid green.

## What changed

- **`motion_connector.py`**
  - `_raise_critical` now also emits a private `_errorLedBlinkRequested` signal (auto-queued from USB/scanner worker threads, same pattern as `scanWorkerFailedDuringCapture`) that starts a GUI-thread 500 ms `QTimer` toggling the console LED blue/off - mirroring the firmware Error_Handler blink. Covers **every** critical-modal code (E-301 and siblings), not just this repro.
  - New `criticalErrorsDismissed()` slot stops the blink and restores idle green. LED writes are best-effort and never raise; a failing write (console unplugged mid-error) stops the timer instead of spamming failing UART commands, and a dismiss with no blink running leaves the LED untouched (the firmware owns it in normal operation).
- **`components/CriticalErrorModal.qml`** - when the error queue drains and the modal hides, it calls `MotionInterface.criticalErrorsDismissed()`. Errors queued while the modal is up keep the single running blink until the *last* one is dismissed.
- **`tests/test_console_led_error_blink.py`** - 6 `@pytest.mark.unit` tests with a mocked console handle: blink starts blue on `_raise_critical`, toggles blue/off, stays single across stacked errors, dismiss restores green, dismiss-without-error is a no-op, console-write failure stops the blink and still raises the modal.

`python -m pytest tests -m unit`: **407 passed**.

## Hand-test plan

1. Connect console + sensors; wait for READY (LED solid green).
2. Make the OpenMotion output folder read-only (folder Properties -> Read-only).
3. Click **Start** -> app shows **E-301**; console LED should now **blink blue** (~1 Hz).
4. Dismiss the error modal -> LED returns to **solid green**.
5. (Optional) Trigger two errors back-to-back: blink persists until the last queued error is dismissed.
6. (Optional) Unplug the console while the modal is up: no error spam in the log; app keeps running.

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)