### PR TITLE
fix: live plot freezes for seconds on zoom/pan during an active scan

### DIFF
--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -421,6 +421,13 @@ Rectangle {
             viewer._dirty = true
             viewer._profSamplesAccum += n
         }
+        // Live source only (ignoreUnknownSignals covers PastScanSource):
+        // an async DB-tail window finished loading off-thread — repaint so
+        // the history appears even when no live samples are ticking the
+        // throttle (e.g. panned back after the scan ended).
+        function onHistoryWindowLoaded() {
+            viewer._dirty = true
+        }
     }
 
     // ── Profile HUD state ──────────────────────────────────────────────

--- a/data_sources.py
+++ b/data_sources.py
@@ -599,9 +599,18 @@ class LiveScanSource(ScanDataSource):
     BEFORE the in-memory window, points_for_window / value_at lazily
     load the requested range from the DB into a transient window so the
     full scan history stays navigable without unbounded memory growth.
+    The load runs on a worker thread (issue #256) — until it lands,
+    reads serve the in-memory portion plus whatever the previous cached
+    window covers, then historyWindowLoaded triggers a repaint.
 
     Pass scan_db_path to enable the DB tail; None (the default, e.g. in
     unit tests) keeps the legacy in-memory-only behavior."""
+
+    # Emitted (from the loader thread — PyQt queues it to the GUI thread)
+    # when an async DB-window load lands. PlotViewer marks itself dirty on
+    # this so the newly-available history paints even when no live samples
+    # are arriving to tick the paint throttle.
+    historyWindowLoaded = pyqtSignal()
 
     def __init__(self, plot_t0: float, parent: Optional[QObject] = None,
                  scan_db_path: Optional[str] = None,
@@ -622,6 +631,15 @@ class LiveScanSource(ScanDataSource):
         self._db_window_buffers: dict = {}     # transient (side,cam,metric)->buffer
         self._db_window_lo = float("inf")     # loaded range, exclusive sentinel
         self._db_window_hi = float("-inf")
+        # Async DB-window loader (issue #256): the query + bucketize run on
+        # a worker thread; the GUI thread only checks coverage and schedules.
+        # _db_load_lock guards the window bounds/buffers install and the
+        # thread handle. One load in flight at a time — a stale request is
+        # simply re-issued by a later paint if still uncovered.
+        self._db_load_lock = threading.Lock()
+        self._db_load_thread: Optional[threading.Thread] = None
+        # Test hook: False runs loads inline so assertions are deterministic.
+        self._db_load_async = True
 
     def release(self) -> None:
         """Base release plus DB-tail teardown: close the read handle and
@@ -714,10 +732,18 @@ class LiveScanSource(ScanDataSource):
         return int(row[0]) if row is not None else None
 
     def _ensure_db_window(self, t_lo: float, t_hi: float) -> None:
-        """Materialize session_data rows for [t_lo, t_hi] (padded) into
-        the transient DB-window buffers, if not already covered. Padding
-        by one window each side means small pans reuse the cached load
-        instead of re-querying every paint.
+        """Make sure the transient DB-window buffers cover [t_lo, t_hi]
+        (padded), scheduling an ASYNC load when they don't. Never blocks
+        the GUI thread on the SQLite query + bucketize — loading the
+        window synchronously here froze the whole app for seconds per
+        zoom/pan step on long All-camera scans (issue #256: 16 cams ×
+        40 Hz ≈ 640 rows/s of history, so one padded 60 s window is
+        ~10⁵ rows re-bucketized per interaction). Until the load lands,
+        callers serve the in-memory portion plus whatever the previous
+        cached window still covers; historyWindowLoaded then triggers a
+        repaint with the fresh history. Padding by one window each side
+        means small pans reuse the cached load instead of re-querying
+        every paint.
 
         want_hi is capped at the newest available sample (liveEdge) so the
         cached window never claims to cover future/nonexistent rows — that
@@ -733,12 +759,19 @@ class LiveScanSource(ScanDataSource):
         "Back to live" mid-scan — requests t_lo = liveEdge - windowSeconds
         < 0 on EVERY paint; unclamped, that request can never be satisfied
         by the cache, so every points_for_window call (cells × metrics,
-        ~30 Hz) re-queried and re-bucketized the whole DB window on the GUI
-        thread, freezing the app until liveEdge outgrew the window or the
-        scan ended (issue #151)."""
+        ~30 Hz) re-queried and re-bucketized the whole DB window
+        (issue #151)."""
         t_lo = max(0.0, float(t_lo))
         t_hi = max(t_lo, float(t_hi))
-        if t_lo >= self._db_window_lo and t_hi <= self._db_window_hi:
+        with self._db_load_lock:
+            if t_lo >= self._db_window_lo and t_hi <= self._db_window_hi:
+                return
+            loader_busy = (self._db_load_thread is not None
+                           and self._db_load_thread.is_alive())
+        if loader_busy:
+            # One load in flight at a time. If this request is still
+            # uncovered when the in-flight load lands, the next paint
+            # re-issues it — the range converges without a queue.
             return
         span = max(1.0, t_hi - t_lo)
         want_lo = max(0.0, t_lo - span)
@@ -746,15 +779,46 @@ class LiveScanSource(ScanDataSource):
         want_hi = t_hi + span
         if edge > 0.0:
             want_hi = min(want_hi, edge)
+        if not self._db_load_async:
+            self._db_window_load(want_lo, want_hi)
+            return
+        thread = threading.Thread(
+            target=self._db_window_load, args=(want_lo, want_hi),
+            name="plot-db-window-load", daemon=True,
+        )
+        with self._db_load_lock:
+            self._db_load_thread = thread
+        thread.start()
+
+    def _db_window_load(self, want_lo: float, want_hi: float) -> None:
+        """Loader body — worker thread in the app, inline when
+        _db_load_async is False (tests). Queries + bucketizes the padded
+        range, installs the fresh window under the lock, and pings the
+        viewer. Sharing the sqlite handle with the GUI thread is safe:
+        it's opened check_same_thread=False, the GUI only touches it for
+        the one-shot session-id resolve in _db_ready (before any load can
+        be scheduled), and the single-inflight rule serializes loads."""
         try:
-            self._db_window_buffers, _ = _bucketize_session_rows(
+            buffers, _ = _bucketize_session_rows(
                 self._db, self._db_session_id, t_lo=want_lo, t_hi=want_hi
             )
+        except Exception:
+            if self._released:
+                # release() closed the DB under an in-flight load — the
+                # result would have been discarded anyway.
+                logger.debug("LiveScanSource: DB window load aborted by "
+                             "release", exc_info=True)
+            else:
+                logger.exception("LiveScanSource: DB window load failed")
+            # Leave the previous window in place; a later paint retries.
+            return
+        if self._released:
+            return
+        with self._db_load_lock:
+            self._db_window_buffers = buffers
             self._db_window_lo = want_lo
             self._db_window_hi = want_hi
-        except Exception:
-            logger.exception("LiveScanSource: DB window load failed")
-            # Leave the previous window in place; a later paint retries.
+        self.historyWindowLoaded.emit()
 
     def _needs_db_tail(self, side: str, cam_id: int, metric: str, t_lo: float) -> bool:
         """True iff the requested t_lo is below the oldest IN-MEMORY
@@ -811,6 +875,10 @@ class LiveScanSource(ScanDataSource):
 
         db_pts: list = []
         if db_span > 0.0:
+            # Non-blocking: schedules an async load when the cached window
+            # doesn't cover the range. Until it lands we render whatever
+            # overlap the previous cached window still has (possibly
+            # nothing) — historyWindowLoaded repaints with the fresh rows.
             self._ensure_db_window(float(t_lo), db_hi)
             dbuf = self._db_window_buffers.get((side, int(cam_id), metric))
             if dbuf is not None:

--- a/main.py
+++ b/main.py
@@ -125,10 +125,15 @@ def _load_app_config() -> dict:
         "writeCorrectedCsv": False,
         # Seconds of live data held in memory per plot buffer before the
         # oldest half is ring-trimmed; older data then lazy-loads from the
-        # scan DB on pan-into-past. 60 s keeps memory tiny (~1 MB vs ~37 MB
-        # at 30 min) and leans on the verified DB tail for deep history.
-        # Raise it if synchronous DB queries on deep pan-back ever stutter.
-        "liveCacheMaxSeconds": 60,
+        # scan DB (async, off the GUI thread) on pan-into-past. The old
+        # 60 s default put the in-memory boundary a mere 30–60 s behind
+        # live, so nearly EVERY zoom/pan interaction fell through to the
+        # DB tail — with 16 cams × 40 Hz that re-bucketized ~10⁵ rows per
+        # interaction and froze the app for seconds (issue #256). 900 s
+        # keeps even the largest preset window (5 min) fully in memory
+        # after trims (post-trim floor = 450 s) at a bounded cost of
+        # ~0.7 MB per buffer (~58 MB for an All/All scan).
+        "liveCacheMaxSeconds": 900,
         "autoScale": False,
         "autoScalePerPlot": False,
         # Y-axis tick labels on plot cells; runtime toggle in the ⋯ popup.

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -343,7 +343,9 @@ def session_data_db(tmp_path):
     """Returns a (db, session_id) pair pre-populated with synthetic rows
     spanning two sides × two cameras × 5 timestamps each."""
     db_path = tmp_path / "scan.db"
-    conn = sqlite3.connect(str(db_path))
+    # check_same_thread=False matches the real ScanDatabase read handle —
+    # the async DB-window loader queries it from a worker thread.
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.executescript(_SESSION_DATA_DDL)
     session_id = 7
 
@@ -1375,6 +1377,7 @@ def test_live_scan_source_pans_into_db_tail(session_data_db):
         buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
+    src._db_load_async = False  # inline loads: assert on first call
 
     pts = src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
     assert len(pts) > 0
@@ -1427,6 +1430,7 @@ def test_live_scan_source_straddle_stitches_db_and_memory(session_data_db):
         buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
+    src._db_load_async = False  # inline loads: assert on first call
 
     pts = src.points_for_window("left", 0, "bfi", 0.0, 10.1, max_points=200)
     vals = [p[1] for p in pts]
@@ -1447,6 +1451,7 @@ def test_live_scan_source_db_window_not_padded_into_future(session_data_db):
         buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
+    src._db_load_async = False  # inline loads: assert on first call
 
     src.points_for_window("left", 0, "bfi", 0.0, 10.1, max_points=200)
     # The DB window's claimed upper bound never exceeds the newest sample.
@@ -1484,6 +1489,7 @@ def test_live_scan_source_negative_t_lo_paint_loop_hits_cache(session_data_db):
         buf.ring_trimmed = True
     src._db = counting
     src._db_session_id = sid
+    src._db_load_async = False  # inline loads: count real query calls
 
     # Simulate the followLive paint loop: windowSeconds=600 ≫ liveEdge,
     # so t_lo is negative and creeps up as the live edge advances.
@@ -1520,6 +1526,7 @@ def test_live_scan_source_value_at_negative_t_cache_valid(session_data_db):
         buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
+    src._db_load_async = False  # inline loads: assert on first call
 
     v = src.value_at("left", 0, "bfi", -5.0)
     # Cache bounds remain a valid (lo <= hi), non-negative range.
@@ -1542,10 +1549,71 @@ def test_live_scan_source_value_at_uses_db_tail(session_data_db):
         buf.ring_trimmed = True
     src._db = db
     src._db_session_id = sid
+    src._db_load_async = False  # inline loads: assert on first call
 
     v = src.value_at("left", 0, "bfi", 0.0)
     assert isfinite_or_nan(v)
     assert v < 50  # DB value, not in-memory 99.0
+
+
+def test_live_scan_source_db_window_load_is_async_by_default(session_data_db):
+    """Issue #256: the DB-window load must NOT run on the calling (GUI)
+    thread. The first pan-into-past paint returns immediately with only
+    the in-memory portion; once the worker lands, a later paint serves
+    the DB rows. (The synchronous query + bucketize used to freeze the
+    app for seconds per zoom step on long All-camera scans.)"""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
+    src._db = db
+    src._db_session_id = sid
+    assert src._db_load_async  # production default
+
+    # First call: pure-past window, load only just scheduled -> no DB
+    # rows yet (in-memory has nothing below t=10 either).
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
+    assert pts == []
+
+    # The load ran on a worker thread; wait for it to land.
+    thread = src._db_load_thread
+    assert thread is not None
+    thread.join(timeout=10.0)
+    assert not thread.is_alive()
+
+    # Next paint serves the freshly-loaded history (~1.0..1.4, not 99.0).
+    pts = src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
+    assert len(pts) > 0
+    assert all(p[1] < 50 for p in pts)
+
+
+def test_live_scan_source_db_window_load_emits_history_window_loaded(
+        session_data_db):
+    """A landed DB-window load pings historyWindowLoaded so the viewer
+    repaints even when no live samples are ticking the throttle (e.g. the
+    user pans back after the scan ended). Inline mode keeps the emission
+    on the test thread -> synchronous direct-connection delivery."""
+    db, sid = session_data_db
+    src = LiveScanSource(plot_t0=0.0)
+    for i in range(5):
+        src.append_uncorrected(side="left", cam_id=0, frame_id=2000 + i,
+                               t=10.0 + i * 0.025, bfi=99.0, bvi=99.0)
+    for buf in src.buffers.values():
+        buf.ring_trimmed = True
+    src._db = db
+    src._db_session_id = sid
+    src._db_load_async = False
+    hits = []
+    src.historyWindowLoaded.connect(lambda: hits.append(1))
+
+    src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
+    assert hits == [1]
+    # Covered window -> cache hit -> no reload, no second ping.
+    src.points_for_window("left", 0, "bfi", 0.0, 0.1, max_points=100)
+    assert hits == [1]
 
 
 def test_live_scan_source_db_ready_resolve_path_no_nameerror(tmp_path):


### PR DESCRIPTION
## Root cause

Zoom/pan on the live plot hands `PlotCell.onPaint` a time window; when that window reaches below the in-memory ring-trim boundary, `LiveScanSource.points_for_window` falls through to the scan-DB tail and `_ensure_db_window` runs the SQLite query **plus the Python-loop bucketize synchronously on the GUI thread** (`data_sources.py` — old lines 716–757 feeding `_bucketize_session_rows`, lines 894–937). On an All-camera scan (16 cams × 40 Hz ≈ 640 `session_data` rows per scan-second) one padded 60 s window is ~10⁵ rows re-bucketized per zoom/pan step — and each wheel notch that grows the window past the cached padded range triggers another full reload. That's the multi-second UI freeze.

Two factors compound it:

1. **`liveCacheMaxSeconds` defaulted to 60** (`main.py:131`), so the in-memory boundary sits only 30–60 s behind live — nearly *every* interaction beyond the 15 s default view fell through to the DB. The attached log from the issue confirms it: `LiveScanSource: DB tail engaged` fires ~12 min into the reporter's scan, on the first plot interaction, in a scan whose designed in-memory horizon was supposed to be 30 min.
2. The reporter's scan was All/All (`left=0xFF right=0xFF`), doubling the row rate vs the usual Middle masks.

(Same failure family as #151, which fixed one *specific* cache-thrash path but left the load itself synchronous.)

## Fix

- **`data_sources.py`** — `_ensure_db_window` no longer blocks: the GUI thread only checks coverage and schedules the query+bucketize on a daemon worker thread (single in-flight load; a still-uncovered request is simply re-issued by a later paint, so ranges converge without a queue). Until the load lands, paints serve the in-memory portion plus whatever the previous cached window overlaps; a new `historyWindowLoaded` signal then marks the viewer dirty so the fresh history paints even when no live samples are ticking the paint throttle. The sqlite read handle is opened `check_same_thread=False` by the SDK and its use is serialized, so sharing it is safe.
- **`components/PlotViewer.qml`** — handle `onHistoryWindowLoaded` → `_dirty = true` (in the existing `Connections` block; `ignoreUnknownSignals` keeps `PastScanSource` happy).
- **`main.py`** — `liveCacheMaxSeconds` 60 → 900 so the largest preset window (5 min) always renders from memory, even right after a trim (post-trim floor = 450 s). Cost is bounded: ~0.7 MB/buffer, ~58 MB for an All/All scan (freed at source retirement since #285). The async DB tail remains the deep-history path.

## Expected effect

- Zooming/panning during an active scan never blocks the GUI thread on DB work — worst case the pre-boundary portion of the trace appears a fraction of a second after the gesture instead of the whole app freezing.
- Steady-state live plotting is untouched (fast path is identical; the loader only runs when a window actually reaches past the in-memory boundary).

## Tests

`python -m pytest tests -m unit`: **403 passed**. Existing DB-tail tests pin the new `_db_load_async=False` inline mode (deterministic first-call assertions, including the #151 regression counter); new tests cover the async default (first call returns memory-only, worker backfills after join) and the `historyWindowLoaded` ping. Test fixture sqlite connection now uses `check_same_thread=False` to match the real `ScanDatabase`.

## Hand-test plan

1. Start a scan with **All cameras on both sensors**, laser on.
2. Let it run several minutes (>2 min is enough to have history; >15 min exercises post-trim).
3. Wheel-zoom in and out aggressively on a plot cell, drag-pan, ride the scrubber to early scan times, switch window presets (15 s ↔ 5 min), then "Back to live".
4. Expect: no multi-second freeze at any point; when jumping deep into history the trace may take a beat to backfill, but the app stays responsive and live cells keep scrolling.
5. Optional: engineering mode → ⋯ → Profiler; `tick`/`canvas` ms should stay low during zoom.

Fixes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)