### PR TITLE
fix: export the History scan by unique session id, not label

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -164,7 +164,9 @@ Item {
                 MotionInterface.notify("Interrupted scans can't be exported.", "warning")
                 return
             }
-            exportDialog.selectedScanId = rows[0].label
+            // Export by the unique DB session id — labels can collide, and a
+            // by-label lookup silently exports the newest match (issue #254).
+            exportDialog.exportSessionId = rows[0].sessionId
             exportDialog.selectedFile = "file:///" + MotionInterface.directory
                                         + "/" + rows[0].label + "_export.csv"
             exportDialog.open()
@@ -173,16 +175,16 @@ Item {
 
         // 2+ checked -> pick a destination folder. Interrupted scans can't be
         // exported, so drop them here and fold them into the skip count.
-        var labels = [], skipped = 0
+        var ids = [], skipped = 0
         for (var i = 0; i < rows.length; i++) {
             if (rows[i].interrupted) { skipped += 1; continue }
-            labels.push(rows[i].label)
+            ids.push(rows[i].sessionId)
         }
-        if (labels.length === 0) {
+        if (ids.length === 0) {
             MotionInterface.notify("Interrupted scans can't be exported.", "warning")
             return
         }
-        exportFolderDialog.pendingLabels = labels
+        exportFolderDialog.pendingSessionIds = ids
         exportFolderDialog.pendingSkipped = skipped
         exportFolderDialog.open()
     }
@@ -614,12 +616,13 @@ Item {
         title: "Export Scan CSV"
         fileMode: Dialogs.FileDialog.SaveFile
         nameFilters: ["CSV files (*.csv)", "All files (*)"]
-        property string selectedScanId: ""
+        property int exportSessionId: -1
         onAccepted: {
             var path = selectedFile.toString().replace("file:///", "")
             // Async: runs on a worker thread; the success toast fires
-            // from onScanCsvExportFinished below.
-            MotionInterface.exportScanCsv(selectedScanId, path)
+            // from onScanCsvExportFinished below. By unique session id
+            // (labels can collide — #254).
+            MotionInterface.exportScanCsv(exportSessionId, path)
         }
     }
 
@@ -627,14 +630,15 @@ Item {
         id: exportFolderDialog
         title: "Export Scans to Folder"
         currentFolder: "file:///" + (MotionInterface.directory || "")
-        property var pendingLabels: []
+        property var pendingSessionIds: []
         property int pendingSkipped: 0
         onAccepted: {
             var folder = selectedFolder.toString().replace("file:///", "")
             // Async: the batch runs on a worker thread; the summary
             // toast fires from onScansExportFinished below, which folds
             // in pendingSkipped (interrupted scans filtered pre-dialog).
-            MotionInterface.exportScansToFolder(pendingLabels, folder)
+            // By unique session id (labels can collide — #254).
+            MotionInterface.exportScansToFolder(pendingSessionIds, folder)
         }
     }
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -3104,28 +3104,30 @@ class MotionConnector(QObject):
             logger.exception("loadPastScan failed for label %r", session_label)
             self.pastScanLoadFinished.emit(session_label, False)
 
-    @pyqtSlot(str, str)
-    def exportScanCsv(self, session_label: str, output_path: str) -> None:
+    @pyqtSlot(int, str)
+    def exportScanCsv(self, session_id: int, output_path: str) -> None:
         """Export a scan's session_data to a corrected-format CSV, on a
         worker thread. Called from the History modal's "Export CSV"
         button after the user picks a save path; the result arrives via
         scanCsvExportFinished(ok, path) — materializing a long scan is
-        multi-second and used to freeze the GUI for the duration."""
-        if not session_label or not output_path:
+        multi-second and used to freeze the GUI for the duration.
+        Resolves the scan by its unique DB id — a by-label lookup can
+        silently pick a different session when labels collide (#254)."""
+        if session_id < 0 or not output_path:
             self.scanCsvExportFinished.emit(False, output_path or "")
             return
         threading.Thread(
             target=self._export_scan_csv_worker,
-            args=(session_label, output_path),
+            args=(int(session_id), output_path),
             name="scan-csv-export", daemon=True,
         ).start()
 
-    def _export_scan_csv_worker(self, session_label: str,
+    def _export_scan_csv_worker(self, session_id: int,
                                 output_path: str) -> None:
-        ok = self._export_scan_csv_sync(session_label, output_path)
+        ok = self._export_scan_csv_sync(session_id, output_path)
         self.scanCsvExportFinished.emit(ok, output_path)
 
-    def _export_scan_csv_sync(self, session_label: str,
+    def _export_scan_csv_sync(self, session_id: int,
                               output_path: str) -> bool:
         """Worker body of exportScanCsv; unit tests call it directly."""
         try:
@@ -3136,60 +3138,61 @@ class MotionConnector(QObject):
             if not db_path:
                 self.errorOccurred.emit("No scan database available.")
                 return False
-            db = ScanDatabase(db_path)
-            session = db.get_session_by_label(session_label)
+            with ScanDatabase(db_path) as db:
+                session = db.get_session(int(session_id))
             if not session:
                 self.errorOccurred.emit(
-                    f"No database session found for '{session_label}'."
+                    f"No database session found for id {session_id}."
                 )
                 return False
-            session_id = int(session["id"])
             materialize_corrected_csv(
-                str(db_path), session_id, output_path,
+                str(db_path), int(session_id), output_path,
                 include_quality=True,
             )
             logger.info(
                 "exportScanCsv: exported %r (sid=%d) → %s",
-                session_label, session_id, output_path,
+                session.get("session_label"), session_id, output_path,
             )
             return True
         except Exception as exc:
-            logger.exception("exportScanCsv failed for %r", session_label)
+            logger.exception("exportScanCsv failed for sid %s", session_id)
             self.errorOccurred.emit(f"Export failed:\n{exc}")
             return False
 
-    @pyqtSlot('QStringList', str)
-    def exportScansToFolder(self, labels, folder) -> None:
+    @pyqtSlot('QVariantList', str)
+    def exportScansToFolder(self, session_ids, folder) -> None:
         """Export several scans, one CSV each, into ``folder`` — on a
         worker thread. Completion arrives via
         scansExportFinished(exported, skipped, folder); a big batch used
-        to freeze the GUI for its whole materialize loop. (Callers
-        pre-filter interrupted scans, which can't be materialized.)"""
-        labels = [str(x) for x in (labels or [])]
-        if not labels or not folder:
+        to freeze the GUI for its whole materialize loop. Takes each
+        label from the id-resolved DB session (ids are unique; labels
+        can collide — #254). (Callers pre-filter interrupted scans,
+        which can't be materialized.)"""
+        session_ids = [int(x) for x in (session_ids or [])]
+        if not session_ids or not folder:
             self.scansExportFinished.emit(0, 0, str(folder or ""))
             return
-        self.notify(f"Exporting {len(labels)} scan(s)…", type_="info",
+        self.notify(f"Exporting {len(session_ids)} scan(s)…", type_="info",
                     tag="scan-export")
         threading.Thread(
-            target=self._export_scans_worker, args=(labels, str(folder)),
+            target=self._export_scans_worker, args=(session_ids, str(folder)),
             name="scan-batch-export", daemon=True,
         ).start()
 
-    def _export_scans_worker(self, labels, folder) -> None:
-        result = self._export_scans_sync(labels, folder)
+    def _export_scans_worker(self, session_ids, folder) -> None:
+        result = self._export_scans_sync(session_ids, folder)
         self.scansExportFinished.emit(
             result["exported"], result["skipped"], folder)
 
-    def _export_scans_sync(self, labels, folder) -> dict:
+    def _export_scans_sync(self, session_ids, folder) -> dict:
         """Worker body of exportScansToFolder. Writes
-        ``<folder>/<label>_export.csv`` for every label; opens the scan
-        DB once for the whole batch. Missing or failing scans are counted
-        as skipped and never raise. Returns
+        ``<folder>/<label>_export.csv`` for every session id; opens the
+        scan DB once for the whole batch. Missing or failing scans are
+        counted as skipped and never raise. Returns
         ``{"exported": int, "skipped": int}``. Unit tests call it
         directly."""
         result = {"exported": 0, "skipped": 0}
-        if not labels or not folder:
+        if not session_ids or not folder:
             return result
         try:
             from omotion.ScanDatabase import ScanDatabase
@@ -3200,27 +3203,28 @@ class MotionConnector(QObject):
                 self.errorOccurred.emit("No scan database available.")
                 return result
             with ScanDatabase(db_path) as db:
-                for label in labels:
+                for sid in session_ids:
                     try:
-                        session = db.get_session_by_label(label)
+                        sid = int(sid)
+                        session = db.get_session(sid)
                         if not session:
                             result["skipped"] += 1
                             continue
-                        session_id = int(session["id"])
+                        label = session.get("session_label") or f"scan_{sid}"
                         out_path = os.path.join(
                             folder, f"{label}_export.csv")
                         materialize_corrected_csv(
-                            str(db_path), session_id, out_path,
+                            str(db_path), sid, out_path,
                             include_quality=True,
                         )
                         result["exported"] += 1
                         logger.info(
                             "exportScansToFolder: exported %r (sid=%d) -> %s",
-                            label, session_id, out_path,
+                            label, sid, out_path,
                         )
                     except Exception:
                         logger.exception(
-                            "exportScansToFolder: failed for %r", label)
+                            "exportScansToFolder: failed for %r", sid)
                         result["skipped"] += 1
             return result
         except Exception as exc:

--- a/tests/test_history_export.py
+++ b/tests/test_history_export.py
@@ -1,8 +1,13 @@
-"""exportScansToFolder — batch-export several scans into one folder.
+"""History export slots — exportScanCsv / exportScansToFolder.
 
-The QML-facing slot is fire-and-forget since the GUI-freeze fix (the
-batch runs on a daemon worker and reports via scansExportFinished);
-the logic tests exercise the synchronous worker body directly.
+Both slots resolve scans by their unique DB session id (issue #254: a
+by-label lookup returns the newest session with that label, so a
+duplicate label silently exported a different scan than selected).
+
+The QML-facing slots are fire-and-forget since the GUI-freeze fix (the
+work runs on a daemon worker and reports via scanCsvExportFinished /
+scansExportFinished); the logic tests exercise the synchronous worker
+bodies (_export_scan_csv_sync / _export_scans_sync) directly.
 """
 
 import os
@@ -31,16 +36,17 @@ def _connector(tmp_path, scan_db_path=None):
 
 def _session(db_path, label, start):
     db = ScanDatabase(db_path=db_path)
-    db.create_session(session_label=label, session_start=start,
-                      session_notes=None, session_meta={})
+    sid = db.create_session(session_label=label, session_start=start,
+                            session_notes=None, session_meta={})
     db.close()
+    return sid
 
 
 def test_export_scans_to_folder_writes_each_and_skips_missing(
         tmp_path, monkeypatch):
     db_path = str(tmp_path / "scans.db")
-    _session(db_path, "scanA", 1.0)
-    _session(db_path, "scanB", 2.0)
+    sid_a = _session(db_path, "scanA", 1.0)
+    sid_b = _session(db_path, "scanB", 2.0)
     c = _connector(tmp_path, scan_db_path=db_path)
 
     # Mock the heavy materialize step; capture its output paths instead.
@@ -54,22 +60,22 @@ def test_export_scans_to_folder_writes_each_and_skips_missing(
     out_dir = tmp_path / "out"
     out_dir.mkdir()
     res = c._export_scans_sync(
-        ["scanA", "scanB", "missing"], str(out_dir))
+        [sid_a, sid_b, 9999], str(out_dir))
 
     assert res["exported"] == 2
-    assert res["skipped"] == 1            # 'missing' has no DB session
+    assert res["skipped"] == 1            # 9999 has no DB session
     assert len(calls) == 2
     names = sorted(os.path.basename(p) for p in calls)
     assert names == ["scanA_export.csv", "scanB_export.csv"]
 
 
-def test_export_scans_to_folder_isolates_per_label_failure(
+def test_export_scans_to_folder_isolates_per_scan_failure(
         tmp_path, monkeypatch):
     """A scan whose materialize raises is counted skipped, and the batch
     keeps going for the remaining scans."""
     db_path = str(tmp_path / "scans.db")
-    _session(db_path, "scanA", 1.0)
-    _session(db_path, "scanB", 2.0)
+    sid_a = _session(db_path, "scanA", 1.0)
+    sid_b = _session(db_path, "scanB", 2.0)
     c = _connector(tmp_path, scan_db_path=db_path)
 
     exported = []
@@ -83,7 +89,7 @@ def test_export_scans_to_folder_isolates_per_label_failure(
 
     monkeypatch.setattr(sp, "materialize_corrected_csv", _materialize)
 
-    res = c._export_scans_sync(["scanA", "scanB"], str(tmp_path))
+    res = c._export_scans_sync([sid_a, sid_b], str(tmp_path))
 
     assert res == {"exported": 1, "skipped": 1}
     assert len(exported) == 1  # scanB still ran after scanA failed
@@ -94,7 +100,7 @@ def test_export_scans_to_folder_empty_inputs(tmp_path):
     c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
     assert c._export_scans_sync([], str(tmp_path)) == {
         "exported": 0, "skipped": 0}
-    assert c._export_scans_sync(["x"], "") == {
+    assert c._export_scans_sync([1], "") == {
         "exported": 0, "skipped": 0}
 
 
@@ -102,16 +108,17 @@ def test_export_scans_to_folder_no_db(tmp_path):
     c = _connector(tmp_path, scan_db_path=None)
     errors = []
     c.errorOccurred.connect(errors.append)
-    res = c._export_scans_sync(["scanA"], str(tmp_path))
+    res = c._export_scans_sync([1], str(tmp_path))
     assert res == {"exported": 0, "skipped": 0}
     assert errors  # errorOccurred was emitted
 
 
-def test_export_slot_is_async_and_reports_via_signal(tmp_path, monkeypatch):
-    """The QML-facing slot returns immediately, runs the batch on a
-    worker thread, and reports via scansExportFinished."""
+def test_export_batch_slot_is_async_and_reports_via_signal(
+        tmp_path, monkeypatch):
+    """The QML-facing batch slot returns immediately, runs on a worker
+    thread, and reports via scansExportFinished — resolving by id."""
     db_path = str(tmp_path / "scans.db")
-    _session(db_path, "scanA", 1.0)
+    sid_a = _session(db_path, "scanA", 1.0)
     c = _connector(tmp_path, scan_db_path=db_path)
     import omotion.SessionPlayback as sp
     monkeypatch.setattr(sp, "materialize_corrected_csv",
@@ -120,7 +127,7 @@ def test_export_slot_is_async_and_reports_via_signal(tmp_path, monkeypatch):
     results = []
     c.scansExportFinished.connect(
         lambda e, s, f: results.append((e, s, f)))
-    c.exportScansToFolder(["scanA", "missing"], str(tmp_path))
+    c.exportScansToFolder([sid_a, 9999], str(tmp_path))  # 9999 missing
 
     # The worker's emit is queued to the main thread — pump the event
     # loop so it can deliver (exactly what the running app's loop does).
@@ -133,10 +140,85 @@ def test_export_slot_is_async_and_reports_via_signal(tmp_path, monkeypatch):
     assert results == [(1, 1, str(tmp_path))]
 
 
-def test_export_slot_empty_inputs_signal_immediately(tmp_path):
+def test_export_batch_slot_empty_inputs_signal_immediately(tmp_path):
     c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
     results = []
     c.scansExportFinished.connect(
         lambda e, s, f: results.append((e, s, f)))
     c.exportScansToFolder([], str(tmp_path))
     assert results == [(0, 0, str(tmp_path))]
+
+
+# ── exportScanCsv (single-scan Save As path) ─────────────────────────
+# The QML slot is async (emits scanCsvExportFinished); the logic tests
+# drive the synchronous worker body _export_scan_csv_sync directly.
+
+
+def test_export_scan_csv_materializes_the_given_session_id(
+        tmp_path, monkeypatch):
+    db_path = str(tmp_path / "scans.db")
+    sid = _session(db_path, "scanA", 1.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    calls = []
+    import omotion.SessionPlayback as sp
+    monkeypatch.setattr(
+        sp, "materialize_corrected_csv",
+        lambda *a, **k: calls.append(a),  # a == (db_path, sid, out_path)
+    )
+
+    out = str(tmp_path / "scanA_export.csv")
+    assert c._export_scan_csv_sync(sid, out) is True
+    assert len(calls) == 1
+    assert calls[0][1] == sid
+    assert calls[0][2] == out
+
+
+def test_export_scan_csv_duplicate_labels_export_the_selected_scan(
+        tmp_path, monkeypatch):
+    """Regression for issue #254: two sessions sharing a label must not
+    make the export fall through to the newest one — the id passed from
+    the History selection wins."""
+    db_path = str(tmp_path / "scans.db")
+    older = _session(db_path, "dup_label", 1.0)
+    newer = _session(db_path, "dup_label", 2.0)
+    assert older != newer
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    exported_ids = []
+    import omotion.SessionPlayback as sp
+    monkeypatch.setattr(
+        sp, "materialize_corrected_csv",
+        lambda *a, **k: exported_ids.append(a[1]),  # a[1] == session_id
+    )
+
+    assert c._export_scan_csv_sync(older, str(tmp_path / "old.csv")) is True
+    assert exported_ids == [older]  # not `newer`, which shares the label
+
+
+def test_export_scan_csv_missing_session_emits_error(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, "scanA", 1.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    import omotion.SessionPlayback as sp
+    monkeypatch.setattr(
+        sp, "materialize_corrected_csv",
+        lambda *a, **k: pytest.fail("must not materialize a missing id"),
+    )
+
+    errors = []
+    c.errorOccurred.connect(errors.append)
+    assert c._export_scan_csv_sync(9999, str(tmp_path / "x.csv")) is False
+    assert errors  # errorOccurred was emitted
+
+
+def test_export_scan_csv_slot_invalid_inputs_signal_false(tmp_path):
+    """The async slot guards bad inputs and reports failure via signal
+    without spawning a worker."""
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    results = []
+    c.scanCsvExportFinished.connect(lambda ok, p: results.append((ok, p)))
+    c.exportScanCsv(-1, str(tmp_path / "x.csv"))
+    c.exportScanCsv(1, "")
+    assert results == [(False, str(tmp_path / "x.csv")), (False, "")]


### PR DESCRIPTION
## Root cause (issue #254)

The Export CSV dialog showed/exported a different scan than the one selected in History. Two layers:

1. **Field build (1.3.0-dev.5, per the screenshot):** `components/HistoryModal.qml` bound Export to the *highlighted* `focusedRow` — which `refresh()` auto-defaulted to the newest scan on open — while the user "selects" scans with the **checkboxes**. In the screenshot the checked row is `owYDR3Y2` (18:20:09) but the focused row / detail pane / pre-populated filename are all `owQ0PWDS` (22:52:02). This split was already fixed on `next` by 7bfb21f ("unify History selection so Load/Export follow the clicked scan", 2026-06-25) but was never linked to #254 and has not shipped in any tagged build (1.3.0 predates it).

2. **Still live on `next` (this PR):** `motion_connector.py` `exportScanCsv` / `exportScansToFolder` resolved the scan **by label** via `ScanDatabase.get_session_by_label`, which does `ORDER BY session_start DESC LIMIT 1` — i.e. "the newest session with that label". Any duplicate `session_label` (same user-label token + same-second timestamp, interrupted/restarted sessions, imported DBs) silently exports a different session than the selected row, reproducing the exact symptom class of #254 even after the QML fix.

## What changed

- `components/HistoryModal.qml` (`requestExport`, export dialogs): pass the selected row's unique `sessionId` (DB primary key) instead of its label. The label is still used only to build the *suggested filename*, taken from the same selected row.
- `motion_connector.py:3026` `exportScanCsv(int, str)`: resolves via `ScanDatabase.get_session(session_id)`; also now closes the DB handle (matching a89a96f's fix in the folder variant).
- `motion_connector.py:3066` `exportScansToFolder(QVariantList ids, str)`: resolves each id via `get_session`, takes the `<label>_export.csv` filename from the id-resolved session.
- `tests/test_history_export.py`: updated to ids; added `exportScanCsv` coverage including a **duplicate-label regression test** (two sessions sharing a label — the selected/older id must be materialized, not the newest match).

Note: `loadPastScan` and `get_scan_details` still resolve by label (`motion_connector.py:2261/2749/2882`) — same theoretical ambiguity, left out of this surgical diff.

## Verification

`python -m pytest tests -m unit` — 405 passed. No GUI/hardware run (per HIL policy).

## Hand-test plan

1. Create 2–3 scans with distinct user labels (restart the app between scans so the `owXXXXXX` token differs).
2. Open **History**, click a scan's **row** → Export CSV → verify the dialog filename is `<timestamp>_<thatScansLabel>_export.csv` and matches the detail pane's Full label. Repeat for each scan.
3. Select via the **checkbox** only (no row click) → Export CSV → filename must match the checked scan.
4. Sort by each column and scroll, then re-select and re-export — filename must still match the clicked scan.
5. Multi-check 2 scans → Export CSV (2) → pick a folder → verify one `<label>_export.csv` per selected scan, with the right contents (spot-check timestamps in the CSVs).
6. Regression: export the same scan twice in a row, and export scan A then scan B — the second dialog must show B's filename, not a stale A.

Fixes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)