### PR TITLE
fix: load the History scan by unique session id, not label

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -576,7 +576,12 @@ Item {
                     }
                     onClicked: {
                         root.loadingPlot = true
-                        MotionInterface.loadPastScan(root.focusedRow.label)
+                        // Load by the unique DB session id — labels can
+                        // collide, and a by-label lookup silently loads
+                        // the newest match (issue #254). The label still
+                        // names the scan's CSVs and log lines.
+                        MotionInterface.loadPastScan(root.focusedRow.sessionId,
+                                                     root.focusedRow.label)
                     }
                 }
             }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2227,11 +2227,18 @@ class MotionConnector(QObject):
         return sorted(ids, key=ts_key, reverse=True)
 
     @pyqtSlot(str, result=QVariant)
-    def get_scan_details(self, scan_id: str):
+    def get_scan_details(self, scan_id: str, session_id: int = -1):
         """
         scan_id is either:
           New / mid format: 'YYYYMMDD_HHMMSS_userLabel'
           Legacy format:    'userLabel_YYYYMMDD_HHMMSS'
+
+        session_id, when >= 0, is the unique DB session id: the DB-side
+        fields (notes, row-count) are resolved by it instead of by
+        label — a by-label lookup returns the newest session with that
+        label, so duplicate labels silently read a different session's
+        notes (issue #254). File resolution always keys off scan_id;
+        the CSVs are named by label on disk.
 
         For each format we try to resolve the canonical CSV across
         all naming generations (#44):
@@ -2286,9 +2293,9 @@ class MotionConnector(QObject):
             if m:
                 right_mask = m.group(1)
 
-        # Notes live in the scan DB (sessions.session_notes, keyed by
-        # session_label == scan_id). Scans from before the DB migration
-        # only have a *_notes.txt on disk — fall back to that.
+        # Notes live in the scan DB (sessions.session_notes). Scans from
+        # before the DB migration only have a *_notes.txt on disk — fall
+        # back to that.
         notes = ""
         has_db_rows = False
         db_path = getattr(self._interface, "scan_db_path", None)
@@ -2297,7 +2304,10 @@ class MotionConnector(QObject):
                 from omotion.ScanDatabase import ScanDatabase
                 db = ScanDatabase(db_path)
                 try:
-                    session = db.get_session_by_label(scan_id)
+                    if session_id >= 0:
+                        session = db.get_session(int(session_id))
+                    else:
+                        session = db.get_session_by_label(scan_id)
                     if session and session.get("session_notes"):
                         notes = session["session_notes"]
                     if session:
@@ -2874,12 +2884,18 @@ class MotionConnector(QObject):
         self._set_current_scan_source(self._live_scan_source)
         logger.info("[Plot] viewer switched back to live source")
 
-    @pyqtSlot(str)
-    def loadPastScan(self, session_label: str) -> None:
-        """Open the saved scan with the given session_label (the
-        YYYYMMDD_HHMMSS_userLabel string used elsewhere in the UI) and
+    @pyqtSlot(int, str)
+    def loadPastScan(self, session_id: int, session_label: str) -> None:
+        """Open the saved scan with the given unique DB session id and
         display it in the PlotViewer. The held live source is left
         intact so a subsequent showLiveSource() can return to it.
+
+        session_label (the YYYYMMDD_HHMMSS_userLabel string used
+        elsewhere in the UI) still names the scan's CSVs on disk and the
+        log/signal payloads, but the DB session is resolved by id — a
+        by-label lookup returns the newest session with that label, so
+        duplicate labels silently loaded a different scan than the one
+        selected in History (issue #254, same fix as the exports).
 
         Asynchronous load (issue #152): the bulk SQLite walk / CSV parse
         is multi-second for long scans (a ~70-min scan measured ~8.3M
@@ -2889,9 +2905,12 @@ class MotionConnector(QObject):
         where the PastScanSource QObject is constructed and bound to the
         viewer. pastScanLoadFinished(label, ok) fires on completion
         either way so the History modal can clear its busy state."""
-        if not session_label:
-            logger.warning("loadPastScan: empty session_label")
-            self.pastScanLoadFinished.emit("", False)
+        if session_id < 0 or not session_label:
+            logger.warning(
+                "loadPastScan: invalid session_id %r / label %r",
+                session_id, session_label,
+            )
+            self.pastScanLoadFinished.emit(session_label or "", False)
             return
         db_path = getattr(self._interface, "scan_db_path", None)
         if not db_path:
@@ -2900,7 +2919,8 @@ class MotionConnector(QObject):
             )
             self.pastScanLoadFinished.emit(session_label, False)
             return
-        self._audit.log("scan_viewed", {"label": session_label})
+        self._audit.log("scan_viewed", {"label": session_label,
+                                        "session_id": int(session_id)})
         # Per-cam corrected CSV ({scan_id}.csv, 82-col wide format)
         # is the only source of per-cam BFI/BVI/mean/contrast for
         # past replay — the DB's session_data only holds side-
@@ -2909,13 +2929,15 @@ class MotionConnector(QObject):
         # available. Resolving the path is a cheap directory glob —
         # fine on the GUI thread (the modal already does it per
         # selection); the heavy parse happens on the worker.
-        details = self.get_scan_details(session_label) or {}
+        details = self.get_scan_details(
+            session_label, session_id=int(session_id)) or {}
         corrected_csv = details.get("correctedPath") or None
         self._past_scan_load_seq += 1
         seq = self._past_scan_load_seq
         threading.Thread(
             target=self._load_past_scan_worker,
-            args=(seq, session_label, str(db_path), corrected_csv),
+            args=(seq, int(session_id), session_label, str(db_path),
+                  corrected_csv),
             name=f"past-scan-load-{seq}",
             daemon=True,
         ).start()
@@ -2923,6 +2945,7 @@ class MotionConnector(QObject):
     def _load_past_scan_worker(
         self,
         seq: int,
+        session_id: int,
         session_label: str,
         db_path: str,
         corrected_csv: Optional[str],
@@ -2936,17 +2959,17 @@ class MotionConnector(QObject):
             from data_sources import load_past_scan_buffers
             db = ScanDatabase(db_path)
             try:
-                session = db.get_session_by_label(session_label)
+                session = db.get_session(session_id)
                 if not session:
                     logger.warning(
-                        "loadPastScan: no session found for label %r",
-                        session_label,
+                        "loadPastScan: no session found for id %d "
+                        "(label %r)",
+                        session_id, session_label,
                     )
                     self._pastScanBuffersReady.emit(
                         seq, session_label, -1, None, "", None, None
                     )
                     return
-                session_id = int(session["id"])
                 # The camera config the scan was RUN with lives in
                 # session_meta.sdk_flags (written by ScanDBSink). Thread it to
                 # the GUI thread so PastScanSource lays its grid out from the

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -193,11 +193,13 @@ def test_delete_scans_logs_scan_deleted(tmp_path):
 def test_load_past_scan_logs_scan_viewed(tmp_path):
     db_path = str(tmp_path / "scans.db")
     c = _connector(tmp_path, scan_db_path=db_path)
-    c.loadPastScan("20260101_000000_owABC")
+    c.loadPastScan(1, "20260101_000000_owABC")
     ev = [e for e in c.auditLogEntries()
           if e["event_type"] == "scan_viewed"]
     assert ev
-    assert json.loads(ev[0]["details"])["label"] == "20260101_000000_owABC"
+    details = json.loads(ev[0]["details"])
+    assert details["label"] == "20260101_000000_owABC"
+    assert details["session_id"] == 1
 
 
 def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -296,7 +296,8 @@ def test_load_past_scan_worker_emits_display_meta_from_session(tmp_path):
     captured = []
     c._pastScanBuffersReady.connect(lambda *a: captured.append(a))
     c._load_past_scan_worker(
-        c._past_scan_load_seq, "20260623_111935_PatientA", db_path, None)
+        c._past_scan_load_seq, sid, "20260623_111935_PatientA", db_path,
+        None)
 
     assert captured, "worker did not emit _pastScanBuffersReady"
     display_meta = captured[-1][-1]

--- a/tests/test_load_past_scan_by_id.py
+++ b/tests/test_load_past_scan_by_id.py
@@ -1,0 +1,171 @@
+"""loadPastScan / get_scan_details — resolve DB sessions by unique id.
+
+Regression for issue #254 (same family as the export fix in PR #296):
+``get_session_by_label`` returns the newest session with that label, so
+duplicate labels (a persistent user-label token across scans, imported
+DBs) made the by-label call sites silently load a different scan than
+the one selected in History.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, scan_db_path=None):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    # explicit: MagicMock default would be truthy
+    iface.scan_db_path = scan_db_path
+    return MotionConnector(
+        interface=iface, app_config={"engineeringMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def _session(db_path, label, start, notes=None, meta=None):
+    db = ScanDatabase(db_path=db_path)
+    sid = db.create_session(session_label=label, session_start=start,
+                            session_notes=notes, session_meta=meta or {})
+    db.close()
+    return sid
+
+
+DUP_LABEL = "20260610_163915_owDUP"
+
+
+# ── get_scan_details ─────────────────────────────────────────────────
+
+
+def test_get_scan_details_by_id_wins_over_duplicate_labels(tmp_path):
+    """Two sessions sharing a label: session_id must select the exact
+    session, not the newest one with that label."""
+    db_path = str(tmp_path / "scans.db")
+    older = _session(db_path, DUP_LABEL, 1.0, notes="older notes")
+    newer = _session(db_path, DUP_LABEL, 2.0, notes="newer notes")
+    assert older != newer
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    details = c.get_scan_details(DUP_LABEL, session_id=older)
+    assert details["notes"] == "older notes"
+
+
+def test_get_scan_details_without_id_keeps_by_label_fallback(tmp_path):
+    """No session_id → the legacy by-label lookup still works (used by
+    callers that only have a label, e.g. CSV-era scans)."""
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, DUP_LABEL, 1.0, notes="only notes")
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    details = c.get_scan_details(DUP_LABEL)
+    assert details["notes"] == "only notes"
+
+
+# ── loadPastScan worker ──────────────────────────────────────────────
+
+
+def _worker_emissions(c):
+    """Collect _pastScanBuffersReady emissions (direct connection — the
+    worker is called synchronously on the test thread)."""
+    emitted = []
+    c._pastScanBuffersReady.connect(
+        lambda *args: emitted.append(args))
+    return emitted
+
+
+def test_worker_loads_the_selected_session_not_newest_dup(tmp_path):
+    """Regression for issue #254: with a duplicate label, the worker
+    must resolve the id it was given — proven by the recorded sdk_flags
+    (per-session meta) it emits, which differ between the two dups."""
+    db_path = str(tmp_path / "scans.db")
+    older = _session(
+        db_path, DUP_LABEL, 1.0,
+        meta={"sdk_flags": {"left_camera_mask": 0x11,
+                            "right_camera_mask": 0x22}})
+    _session(
+        db_path, DUP_LABEL, 2.0,
+        meta={"sdk_flags": {"left_camera_mask": 0xEE,
+                            "right_camera_mask": 0xFF}})
+    c = _connector(tmp_path, scan_db_path=db_path)
+    emitted = _worker_emissions(c)
+
+    c._load_past_scan_worker(1, older, DUP_LABEL, db_path, None)
+
+    assert len(emitted) == 1
+    seq, label, sid, buffers, _tag, flags, _meta = emitted[0]
+    assert sid == older
+    assert label == DUP_LABEL
+    assert buffers is not None
+    assert flags["left_camera_mask"] == 0x11  # older's meta, not newer's
+
+
+def test_worker_missing_id_emits_failure(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    _session(db_path, DUP_LABEL, 1.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+    emitted = _worker_emissions(c)
+
+    c._load_past_scan_worker(1, 9999, DUP_LABEL, db_path, None)
+
+    assert len(emitted) == 1
+    _seq, _label, sid, buffers, *_ = emitted[0]
+    assert sid == -1
+    assert buffers is None
+
+
+# ── loadPastScan slot (GUI-thread half) ──────────────────────────────
+
+
+def test_load_past_scan_rejects_invalid_id(tmp_path, monkeypatch):
+    """A negative id must fail fast: finished(False), no worker thread."""
+    db_path = str(tmp_path / "scans.db")
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    import threading
+
+    def _no_thread(*a, **k):
+        pytest.fail("no worker thread may start for an invalid id")
+    monkeypatch.setattr(threading, "Thread", _no_thread)
+
+    finished = []
+    c.pastScanLoadFinished.connect(lambda label, ok: finished.append(
+        (label, ok)))
+    c.loadPastScan(-1, DUP_LABEL)
+    assert finished == [(DUP_LABEL, False)]
+
+
+def test_load_past_scan_audits_label_and_id(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "scans.db")
+    sid = _session(db_path, DUP_LABEL, 1.0)
+    c = _connector(tmp_path, scan_db_path=db_path)
+
+    # Don't actually spawn the load; the audit fires before it.
+    started = []
+    import threading
+
+    class _FakeThread:
+        def __init__(self, *a, **k):
+            started.append(k.get("args"))
+
+        def start(self):
+            pass
+    monkeypatch.setattr(threading, "Thread", _FakeThread)
+
+    c.loadPastScan(sid, DUP_LABEL)
+
+    ev = [e for e in c.auditLogEntries()
+          if e["event_type"] == "scan_viewed"]
+    assert ev
+    details = json.loads(ev[0]["details"])
+    assert details["label"] == DUP_LABEL
+    assert details["session_id"] == sid
+    # The worker was handed the id (second arg after seq).
+    assert started and started[0][1] == sid


### PR DESCRIPTION
## Summary

`loadPastScan` and `get_scan_details` were the last call sites still resolving scan sessions by user label via `ScanDatabase.get_session_by_label`, which does `ORDER BY session_start DESC LIMIT 1` — so with duplicate labels (a persistent user-label token across scans, imported DBs) **"Load in viewer" silently displayed the newest matching session instead of the selected one**, and `get_scan_details` read the wrong session's notes.

This follows the exact pattern #296 established for the export slots:

- `components/HistoryModal.qml` passes the History row's unique `sessionId` (already in every row) down to Python alongside the label.
- `loadPastScan(sessionId, label)` resolves the DB session with `get_session(id)` — in the GUI-thread half (corrected-CSV/notes resolution via `get_scan_details`) and in the async worker (buffers, recorded sdk_flags, badge meta).
- `get_scan_details` gains an optional `session_id` parameter; when `>= 0` the DB-side fields (notes, row-count) resolve by id. The by-label fallback stays for callers that only have a label (legacy CSV-era scans). File resolution is untouched — CSVs are named by label on disk.
- The `scan_viewed` audit event now records the session id next to the label.

## Test plan

- New `tests/test_load_past_scan_by_id.py` (`pytest -m unit`), mirroring #296's duplicate-label coverage:
  - `get_scan_details` with a `session_id` returns the **selected** duplicate's notes, not the newest's; by-label fallback still works without an id.
  - the load worker resolves the id it was given — proven via the emitted per-session `sdk_flags`, which differ between the two duplicates.
  - missing id emits the failure payload; negative id fails fast with `pastScanLoadFinished(label, false)` and never spawns a worker.
  - the audit event carries both label and session id.
- Updated the two existing tests that used the old signatures (`test_audit_connector`, `test_history_sessions`).
- Full unit suite: **411 passed, 121 deselected**; `config/app_config.json` untouched.

Closes #302.

Related: #254 (same duplicate-label failure mode as the export dialog; #296 fixed the export half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
