### PR TITLE
fix: rename release artifacts to Open-Motion[-Research][-Setup]-<ver>

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -122,8 +122,8 @@ jobs:
           echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
           echo "ARTIFACT_NAME=Open-Motion-${TAG}" >> "$GITHUB_OUTPUT"
           echo "ARTIFACT_ZIP=Open-Motion-${TAG}.zip" >> "$GITHUB_OUTPUT"
-          echo "ARTIFACT_NAME_RESEARCH=Open-Motion-${TAG}_Research" >> "$GITHUB_OUTPUT"
-          echo "ARTIFACT_ZIP_RESEARCH=Open-Motion-${TAG}_Research.zip" >> "$GITHUB_OUTPUT"
+          echo "ARTIFACT_NAME_RESEARCH=Open-Motion-Research-${TAG}" >> "$GITHUB_OUTPUT"
+          echo "ARTIFACT_ZIP_RESEARCH=Open-Motion-Research-${TAG}.zip" >> "$GITHUB_OUTPUT"
 
           # pre-release flag — X.Y.Z-dev.N (dev) and X.Y.Z-rc.N (release
           # candidate) tags both mark prerelease in the GitHub release UI.
@@ -195,7 +195,8 @@ jobs:
           files: |
             ${{ steps.meta.outputs.ARTIFACT_ZIP }}
             ${{ steps.meta.outputs.ARTIFACT_ZIP_RESEARCH }}
-            build/installer/Openwater-Setup-*.exe
+            build/installer/Open-Motion-Setup-*.exe
+            build/installer/Open-Motion-Research-Setup-*.exe
             resources/OpenMotionDriver-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ python -m PyInstaller -y openwater.spec # package .exe → dist/Open-Motion/
 # 4 artifacts: Clinical/Research × Portable/Installer
 #   Open-Motion-<ver>.zip                (Clinical portable)
 #   Open-Motion-Research-<ver>.zip       (Research portable)
-#   build/installer/Openwater-Setup-<ver>.exe          (Clinical installer)
-#   build/installer/Openwater-Setup-<ver>_Research.exe (Research installer)
+#   build/installer/Open-Motion-Setup-<ver>.exe          (Clinical installer)
+#   build/installer/Open-Motion-Research-Setup-<ver>.exe (Research installer)
 # build_and_zip.ps1 runs PyInstaller once, then scripts/package_artifacts.ps1
 # loops the variants. Installers are skipped with a warning if WiX isn't found;
 # scripts/package_artifacts.ps1 -SkipInstaller forces portable-only.

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -2,7 +2,8 @@
 param(
     [ValidateSet("clinical", "research")][string]$Variant = "clinical",
     [string]$DistDir = "dist\Open-Motion",
-    [string]$Version = ""   # override the numeric X.Y.Z (else derived from git)
+    [string]$Version = "",      # override the numeric X.Y.Z (else derived from git)
+    [string]$FullVersion = ""   # full semver for the bundle filename, e.g. 1.4.0-dev.2 (else $Version)
 )
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
@@ -15,13 +16,13 @@ $guids = @{
         ProductName       = "Open-Motion"
         UpgradeCode       = "3d5dec27-6f62-484b-85f0-1b7b07076022"
         BundleUpgradeCode = "2e60deaa-8959-4f57-912b-71f60fc6ad5a"
-        Suffix            = ""
+        FileBase          = "Open-Motion"
     }
     research = @{
         ProductName       = "Open-Motion Research"
         UpgradeCode       = "81f5e9b0-36d8-4aeb-8457-461fe4fe6c2f"
         BundleUpgradeCode = "e363d244-2161-4a28-a855-835643b14a10"
-        Suffix            = "_Research"
+        FileBase          = "Open-Motion-Research"
     }
 }
 $g = $guids[$Variant]
@@ -39,7 +40,9 @@ if ($Version) {
         $version = "0.0.0"
     }
 }
-Write-Host "Variant=$Variant  Version=$version  Product='$($g.ProductName)'" -ForegroundColor Green
+# -- full semver for the bundle filename (MSI/Burn internals stay numeric) --
+if (-not $FullVersion) { $FullVersion = $version }
+Write-Host "Variant=$Variant  Version=$version  Bundle=$FullVersion  Product='$($g.ProductName)'" -ForegroundColor Green
 
 # -- extract the driver MSI from the bundled zip --
 $drvZip = "resources\OpenMotionDriver-x64.zip"
@@ -52,8 +55,8 @@ if (-not (Test-Path $driverMsi)) { throw "driver MSI not found in $drvZip" }
 # -- output names --
 $outDir = "build\installer"
 New-Item -ItemType Directory -Force $outDir | Out-Null
-$appMsi    = Join-Path $outDir "Open-Motion$($g.Suffix).msi"
-$bundleExe = Join-Path $outDir "Openwater-Setup-$version$($g.Suffix).exe"
+$appMsi    = Join-Path $outDir "$($g.FileBase).msi"
+$bundleExe = Join-Path $outDir "$($g.FileBase)-Setup-$FullVersion.exe"
 
 # -- build the app MSI --
 # Resolve the PyInstaller output to an ABSOLUTE path. WiX resolves the

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -94,16 +94,18 @@ _REQUIRE_SIGNED_UPDATES = False
 def _select_update_asset(assets: list, is_research: bool):
     """Return download URL of the Setup bundle matching the running variant.
 
-    Research builds match ``Openwater-Setup-*_Research.exe``; clinical
-    builds match the non-Research ``Openwater-Setup-*.exe``. Returns None
-    if no match.
+    Research builds match ``Open-Motion-Research-Setup-*.exe``; clinical
+    builds match ``Open-Motion-Setup-*.exe``. Variant detection is a
+    case-insensitive "research" substring check so the pre-1.4.0 asset
+    names (``Openwater-Setup-*[_Research].exe``) still match. Returns
+    None if no match.
     """
     for asset in assets:
         name = (asset.get("name") or "")
         low = name.lower()
         if not low.endswith(".exe"):
             continue
-        asset_is_research = low.endswith("_research.exe")
+        asset_is_research = "research" in low
         if asset_is_research == is_research:
             return asset.get("browser_download_url")
     return None

--- a/scripts/UPDATE_E2E_TEST.md
+++ b/scripts/UPDATE_E2E_TEST.md
@@ -28,9 +28,9 @@ powershell -File scripts\build_update_test_bundles.ps1
 
 Produces (in `build\installer\`):
 
-- `Openwater-Setup-1.3.0_Research.exe` — **OLD**, the build under test (its update
+- `Open-Motion-Research-Setup-1.3.0.exe` — **OLD**, the build under test (its update
   check points at `http://127.0.0.1:8077/releases/latest`).
-- `Openwater-Setup-1.3.1_Research.exe` — **NEW**, the upgrade target.
+- `Open-Motion-Research-Setup-1.3.1.exe` — **NEW**, the upgrade target.
 
 The script prints the SDK path it built against — confirm it's a clean `next`.
 
@@ -38,7 +38,7 @@ The script prints the SDK path it built against — confirm it's a clean `next`.
 
 ```powershell
 conda run -n pylib python scripts\fake_release_server.py `
-    --bundle build\installer\Openwater-Setup-1.3.1_Research.exe --tag 1.3.1 --port 8077
+    --bundle build\installer\Open-Motion-Research-Setup-1.3.1.exe --tag 1.3.1 --port 8077
 ```
 
 It serves `releases/latest` (advertising 1.3.1) and the bundle file. Watch its
@@ -46,7 +46,7 @@ log — you'll see the app's requests, confirming nothing goes to the internet.
 
 ## 3. Install the OLD bundle + run the test
 
-1. Double-click `Openwater-Setup-1.3.0_Research.exe` → SmartScreen "More info → Run
+1. Double-click `Open-Motion-Research-Setup-1.3.0.exe` → SmartScreen "More info → Run
    anyway" + UAC. Installs to `C:\Program Files\Openwater\Open-Motion\`.
 2. Launch **Open-Motion Research** from the Start menu.
 3. Within ~3 s the banner appears: *"A new version is available: 1.3.1."*

--- a/scripts/build_update_test_bundles.ps1
+++ b/scripts/build_update_test_bundles.ps1
@@ -61,5 +61,5 @@ Write-Host "=== NEW 1.3.1  (upgrade target) ===" -ForegroundColor Green
 Build-ResearchBundle "1.3.1" ""
 
 Write-Host "=== Artifacts (build\installer) ===" -ForegroundColor Green
-Get-ChildItem "build\installer\Openwater-Setup-1.3.*_Research.exe" |
+Get-ChildItem "build\installer\Open-Motion-Research-Setup-1.3.*.exe" |
     Select-Object Name, @{N='MB';E={[math]::Round($_.Length/1MB,1)}} | Format-Table -AutoSize

--- a/scripts/fake_release_server.py
+++ b/scripts/fake_release_server.py
@@ -9,7 +9,7 @@ detect -> download -> verify -> install -> relaunch flow runs over loopback.
 
 Usage:
     python scripts/fake_release_server.py \
-        --bundle build/installer/Openwater-Setup-1.3.1_RUO.exe \
+        --bundle build/installer/Open-Motion-Research-Setup-1.3.1.exe \
         --tag 1.3.1 --port 8077
 
 Then the old build's bundled config/app_config.json must contain:

--- a/scripts/package_artifacts.ps1
+++ b/scripts/package_artifacts.ps1
@@ -44,10 +44,10 @@ if ($buildInstallers -and -not (Test-WixAvailable)) {
     $buildInstallers = $false
 }
 
-# -- per-variant suffix + clinicalMode value --
+# -- per-variant file base + clinicalMode value --
 $variantMap = @{
-    clinical = @{ Suffix = "";          Clinical = $true  }
-    research = @{ Suffix = "_Research"; Clinical = $false }
+    clinical = @{ FileBase = "Open-Motion";          Clinical = $true  }
+    research = @{ FileBase = "Open-Motion-Research"; Clinical = $false }
 }
 
 $produced = @()
@@ -62,18 +62,19 @@ foreach ($variant in $Variants) {
         # build_installer.ps1 below independently forces portableMode:false
         # onto the same file before harvesting it for the MSI.
         [void](Set-PortableMode -ConfigPath $cfgPath -Portable $true)
-        $zip = Join-Path $OutDir "Open-Motion-$verFull$($m.Suffix).zip"
+        $zip = Join-Path $OutDir "$($m.FileBase)-$verFull.zip"
         Write-Host "=== Portable ($variant): $zip ===" -ForegroundColor Cyan
         New-PortableZip -DistDir $DistDir -OutZip $zip
         $produced += $zip
 
-        # installer (numeric version)
+        # installer (numeric version inside the MSI/Burn metadata, full
+        # version in the bundle filename)
         if ($buildInstallers) {
             Write-Host "=== Installer ($variant) ===" -ForegroundColor Cyan
             & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $root "installer\build_installer.ps1") `
-                -Variant $variant -DistDir $DistDir -Version $verNumeric
+                -Variant $variant -DistDir $DistDir -Version $verNumeric -FullVersion $verFull
             if ($LASTEXITCODE -ne 0) { throw "build_installer failed for $variant" }
-            $produced += (Join-Path $root "build\installer\Openwater-Setup-$verNumeric$($m.Suffix).exe")
+            $produced += (Join-Path $root "build\installer\$($m.FileBase)-Setup-$verFull.exe")
         }
     } finally {
         Restore-ConfigText -ConfigPath $cfgPath -Text $orig

--- a/tests/test_apply_update.py
+++ b/tests/test_apply_update.py
@@ -33,8 +33,8 @@ def test_unsigned_rejected_when_required():
 
 @pytest.mark.unit
 def test_is_bundle_url_accepts_only_exe():
-    assert _is_bundle_url("https://x/OpenWater-Setup-1.2.3.exe")
-    assert _is_bundle_url("https://x/OpenWater-Setup-1.2.3_RUO.EXE")
+    assert _is_bundle_url("https://x/Open-Motion-Setup-1.2.3.exe")
+    assert _is_bundle_url("https://x/Open-Motion-Research-Setup-1.2.3.EXE")
     assert not _is_bundle_url("https://github.com/o/r/releases/tag/1.2.3")
     assert not _is_bundle_url("")
     assert not _is_bundle_url(None)
@@ -51,11 +51,11 @@ def test_looks_like_pe_rejects_non_executables():
 @pytest.mark.unit
 def test_helper_script_waits_installs_silently_and_relaunches():
     s = _build_update_helper_script(
-        1234, r"C:\Users\u\updates\Openwater-Setup-1.2.3.exe",
+        1234, r"C:\Users\u\updates\Open-Motion-Setup-1.2.3.exe",
         r"C:\Program Files\Open-Motion\Open-Motion.exe",
     )
     assert "1234" in s                              # waits for our PID
     assert "Get-Process" in s
     assert "/passive" in s                          # non-interactive install
-    assert "Openwater-Setup-1.2.3.exe" in s         # runs the installer
+    assert "Open-Motion-Setup-1.2.3.exe" in s       # runs the installer
     assert "Open-Motion.exe" in s                   # relaunches the app

--- a/tests/test_update_asset_select.py
+++ b/tests/test_update_asset_select.py
@@ -2,21 +2,35 @@ import pytest
 from motion_connector import _select_update_asset
 
 
-CLINICAL = {"name": "Openwater-Setup-1.2.3.exe", "browser_download_url": "u/clinical"}
-RESEARCH = {"name": "Openwater-Setup-1.2.3_Research.exe", "browser_download_url": "u/research"}
-ZIP = {"name": "OpenMotionDriver-x64.zip", "browser_download_url": "u/zip"}
+CLINICAL = {"name": "Open-Motion-Setup-1.2.3.exe", "browser_download_url": "u/clinical"}
+RESEARCH = {"name": "Open-Motion-Research-Setup-1.2.3.exe", "browser_download_url": "u/research"}
+RESEARCH_ZIP = {"name": "Open-Motion-Research-1.2.3.zip", "browser_download_url": "u/research-zip"}
+DRIVER_ZIP = {"name": "OpenMotionDriver-x64.zip", "browser_download_url": "u/zip"}
+
+# pre-1.4.0 naming — releases in the wild that a build may still be pointed at
+LEGACY_CLINICAL = {"name": "Openwater-Setup-1.2.3.exe", "browser_download_url": "u/old-clinical"}
+LEGACY_RESEARCH = {"name": "Openwater-Setup-1.2.3_Research.exe", "browser_download_url": "u/old-research"}
 
 
 @pytest.mark.unit
 def test_selects_research_bundle_for_research_variant():
-    assert _select_update_asset([CLINICAL, RESEARCH, ZIP], is_research=True) == "u/research"
+    assets = [DRIVER_ZIP, RESEARCH_ZIP, CLINICAL, RESEARCH]
+    assert _select_update_asset(assets, is_research=True) == "u/research"
 
 
 @pytest.mark.unit
 def test_selects_clinical_bundle_for_clinical_variant():
-    assert _select_update_asset([CLINICAL, RESEARCH, ZIP], is_research=False) == "u/clinical"
+    assets = [DRIVER_ZIP, RESEARCH_ZIP, RESEARCH, CLINICAL]
+    assert _select_update_asset(assets, is_research=False) == "u/clinical"
 
 
 @pytest.mark.unit
 def test_returns_none_when_no_matching_exe():
-    assert _select_update_asset([ZIP], is_research=True) is None
+    assert _select_update_asset([DRIVER_ZIP, RESEARCH_ZIP], is_research=True) is None
+
+
+@pytest.mark.unit
+def test_selects_legacy_named_bundles():
+    assets = [DRIVER_ZIP, LEGACY_CLINICAL, LEGACY_RESEARCH]
+    assert _select_update_asset(assets, is_research=True) == "u/old-research"
+    assert _select_update_asset(assets, is_research=False) == "u/old-clinical"


### PR DESCRIPTION
Closes #299

## What

Renames the four release artifacts to one consistent convention — product, variant, artifact kind, version:

| Artifact | Old name | New name |
|---|---|---|
| Clinical portable | `Open-Motion-<ver>.zip` | `Open-Motion-<ver>.zip` (unchanged) |
| Research portable | `Open-Motion-<ver>_Research.zip` | `Open-Motion-Research-<ver>.zip` |
| Clinical installer | `Openwater-Setup-<X.Y.Z>.exe` | `Open-Motion-Setup-<ver>.exe` |
| Research installer | `Openwater-Setup-<X.Y.Z>_Research.exe` | `Open-Motion-Research-Setup-<ver>.exe` |

The installer filename now carries the **full** semver (`1.4.0-dev.2`, not just `1.4.0`), so consecutive pre-releases no longer produce identically-named bundles. The numeric `X.Y.Z` stays confined to the MSI/Burn metadata where WiX requires it (`build_installer.ps1` gains a `-FullVersion` param). `CLAUDE.md`/`AGENTS.md` already documented the Research zip under the new name — the scripts just never produced it.

## Changes

- `scripts/package_artifacts.ps1` + `installer/build_installer.ps1` — per-variant `FileBase` replaces the `_Research` suffix; full-version bundle filenames.
- `.github/workflows/release-build.yml` — Research artifact name + release-upload globs for both Setup exes.
- `motion_connector.py` — `_select_update_asset` picked the variant via `endswith("_research.exe")`, which the new names break; now a case-insensitive `"research"` substring match that accepts both new and pre-1.4.0 asset names.
- Tests — fixtures renamed; new cases for legacy-named assets and for skipping the Research *zip* (whose name now also contains "research").
- Docs/tooling — `CLAUDE.md`, `scripts/UPDATE_E2E_TEST.md`, `scripts/build_update_test_bundles.ps1`, `scripts/fake_release_server.py`.

## Updater transition note

Deployed builds ≤ 1.4.0-dev.2 run the **old** matcher. Against the first release published with the new names: old *Research* installs find no `_Research.exe` asset → no update banner (needs one manual update); old *Clinical* installs treat any exe not ending `_Research.exe` as clinical, so they could grab the Research bundle if it's listed first in the release assets. Recommend hand-updating the few deployed dev boxes across this one release.

## Verification

- `pytest tests/test_update_asset_select.py tests/test_apply_update.py -m unit` — 11 passed.
- All three edited PowerShell scripts parse clean (`[Language.Parser]::ParseFile`).
- Repo-wide grep: no remaining `Openwater-Setup`/`_Research`/`_RUO` references outside the intentional legacy-compat docstring/test fixtures and gitignored `docs/superpowers/` history.

Not exercised here: a full WiX build + tagged CI run (needs the release pipeline). Suggest cutting the next `-dev` tag from this to confirm the five assets land with the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)