### PR TITLE
fix: gate scan/CQ start on post-connect sensor init completion

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -795,6 +795,11 @@ class MotionConnector(QObject):
     signalDisconnected = pyqtSignal(str, str)  # (descriptor, port)
 
     connectionStatusChanged = pyqtSignal()  # 🔹 New signal for connection updates
+    # Notify for ``sensorInitBusy`` (issue #303): a connect-time sensor init
+    # (debug flags, camera power/ID cache, info reads) is scheduled or
+    # running. The drain-side emit fires on the init worker thread; Qt
+    # auto-queues the cross-thread delivery to QML/main-thread consumers.
+    sensorInitBusyChanged = pyqtSignal()
     stateChanged = pyqtSignal()  # Signal to notify QML of state changes
     laserStateChanged = pyqtSignal()  # Signal to notify QML of laser state changes
     safetyFailureStateChanged = pyqtSignal()  # Signal to notify QML of safety
@@ -1063,6 +1068,13 @@ class MotionConnector(QObject):
         self._rightSensorConnected = right_sensor_connected
         self._consoleConnected = console_connected
         self._config_running = False
+        # Per-side count of connect-time sensor inits scheduled or running
+        # (issue #303). Guarded by _sensor_init_lock: +1 on the GUI thread
+        # when _schedule_sensor_init arms the init, -1 on the init worker
+        # thread when it drains (success OR failure). Non-zero blocks
+        # pipeline starts via _ensure_idle / sensorInitBusy.
+        self._sensor_init_pending: dict[str, int] = {"left": 0, "right": 0}
+        self._sensor_init_lock = threading.Lock()
         self._laserOn = False
         self._safetyFailure = False
         self._safety_unknown_streak = 0  # see SAFETY_UNKNOWN_STREAK_THRESHOLD
@@ -1285,12 +1297,43 @@ class MotionConnector(QObject):
             if not sensor.set_debug_flags(flags):
                 logger.warning("Failed to set debug flags on %s sensor", side)
 
+    def _sensor_init_note(self, side: str, delta: int) -> None:
+        """Adjust the per-side init-in-flight counter (issue #303).
+
+        +1 when a connect-time init is scheduled (GUI thread), -1 when the
+        worker drains — success or failure alike, so a failed init can't
+        leak the busy state. Emits sensorInitBusyChanged only on the
+        busy/idle edge; the drain-side emission happens on the init worker
+        thread and Qt auto-queues it to main-thread/QML consumers.
+        """
+        with self._sensor_init_lock:
+            before = any(v > 0 for v in self._sensor_init_pending.values())
+            new = self._sensor_init_pending.get(side, 0) + delta
+            self._sensor_init_pending[side] = max(0, new)
+            after = any(v > 0 for v in self._sensor_init_pending.values())
+        if before != after:
+            self.sensorInitBusyChanged.emit()
+
+    @pyqtProperty(bool, notify=sensorInitBusyChanged)
+    def sensorInitBusy(self) -> bool:
+        """True while any sensor's connect-time init is scheduled/running
+        (issue #303). QML holds Start/Check disabled on this; _ensure_idle
+        refuses pipeline starts with it up. Re-engages on every sensor
+        (re)connect because _schedule_sensor_init re-runs then."""
+        with self._sensor_init_lock:
+            return any(v > 0 for v in self._sensor_init_pending.values())
+
     def _schedule_sensor_init(self, side: str):
         """Delay initial sensor commands to allow USB settle, then run
         them on a daemon worker thread. The init sequence is a multi-
         command USB conversation with a built-in 0.5 s camera-power
         settle sleep — on the GUI thread it froze the app for >0.5 s on
         every sensor (re)connect."""
+        # Raise the init-in-flight gate immediately at schedule time
+        # (issue #303) — a Start clicked during the 1 s settle delay or the
+        # init sequence itself collides with the connect-time USB
+        # conversation and can wedge a camera until DUT power-cycle.
+        self._sensor_init_note(side, +1)
         QTimer.singleShot(
             1000, lambda: self._start_sensor_init_worker(side)
         )
@@ -1315,6 +1358,10 @@ class MotionConnector(QObject):
             self._run_sensor_init_impl(side)
         except Exception:
             logger.exception("sensor init failed for %s sensor", side)
+        finally:
+            # Drop the init-in-flight gate on success AND failure — a
+            # leaked busy state would lock Start/Check forever (issue #303).
+            self._sensor_init_note(side, -1)
 
     def _run_sensor_init_impl(self, side: str):
         if side == "left" and not self._leftSensorConnected:
@@ -4068,6 +4115,15 @@ class MotionConnector(QObject):
 
     def _ensure_idle(self) -> str | None:
         """Gate for pipeline-starting slots (capture / configure / check)."""
+        # Issue #303: the post-connect sensor init (debug flags, camera
+        # power masks, info reads) runs async for a few seconds after the
+        # handles report READY. A capture/CQ/configure started inside that
+        # window collides with the in-flight init — "Failed to program
+        # FPGA" on both sensors, camera wedged until power-cycle. The UI
+        # start gate polls isPipelineIdle and defers past this.
+        if self.sensorInitBusy:
+            return ("Sensors are still initializing — wait a few seconds "
+                    "and try again")
         if self._cq_quick_running:
             return "Contact-quality check already in progress"
         if self._capture_running or self._capture_thread is not None:

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -174,9 +174,15 @@ Rectangle {
             }
             elapsedMs += interval
             // A config in flight legitimately blocks for ~50 s — match
-            // ScanRunner's flash watchdog bound. Anything else holding the
-            // pipeline past 8 s is stuck; give up loudly.
-            var deadline = MotionInterface.isConfigInFlight() ? 250000 : 8000
+            // ScanRunner's flash watchdog bound. The post-connect sensor
+            // init (issue #303) legitimately holds the pipeline for a few
+            // seconds after a (re)connect — wait that out on its own bound
+            // so a start armed just as a sensor replugs defers instead of
+            // erroring. Anything else holding the pipeline past 8 s is
+            // stuck; give up loudly.
+            var deadline = MotionInterface.isConfigInFlight() ? 250000
+                         : MotionInterface.sensorInitBusy ? 30000
+                         : 8000
             if (elapsedMs >= deadline) {
                 stop()
                 if (action === "scan") {
@@ -204,7 +210,13 @@ Rectangle {
 
         scanning: bloodFlow.scanning
         waiting: bloodFlow.scanStartPending
-        camerasReady: bloodFlow.camerasReady
+        // Issue #303: hold Start/Check disabled while the connector's async
+        // post-connect sensor init (debug flags, camera power masks, info
+        // reads) is still in flight — a start in that window collides with
+        // the init sequence ("Failed to program FPGA" on both sensors) and
+        // can wedge a camera until DUT power-cycle. sensorInitBusy re-arms
+        // on every sensor (re)connect, so a mid-session replug re-gates too.
+        camerasReady: bloodFlow.camerasReady && !MotionInterface.sensorInitBusy
         clinicalMode: bloodFlow.clinicalMode
 
         // Action buttons — close any open modal first (which by

--- a/tests/test_sensor_init_start_gate.py
+++ b/tests/test_sensor_init_start_gate.py
@@ -1,0 +1,175 @@
+"""Issue #303: Start clicked during the post-connect sensor init races it.
+
+Repro: the UI enables Start as soon as the handles report READY, but the
+connector's async sensor init (debug flags, camera power masks, sensor
+info reads) keeps running for a few more seconds. A scan/CQ start inside
+that window collides with the in-flight init — "Failed to program FPGA"
+on both sensors within milliseconds — and can wedge a camera "not READY
+for FPGA/config" until a DUT power-cycle.
+
+The connector now raises a per-side init-in-flight counter when
+``_schedule_sensor_init`` arms an init and drops it when the worker
+drains (success or failure). ``sensorInitBusy`` exposes it to QML (Start/
+Check disable on it) and ``_ensure_idle`` refuses pipeline starts while
+it is up, so BloodFlow's start gate defers instead of colliding.
+
+Pure connector-level tests: the interface is a MagicMock, so no hardware
+and no QML. ``_run_sensor_init`` is driven synchronously (its worker
+thread never spawns because no Qt event loop runs the settle QTimer).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+_INIT_BUSY_MSG = "Sensors are still initializing"
+
+
+def _connector(tmp_path):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    return MotionConnector(
+        interface=iface, app_config={"engineeringMode": False},
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+def test_fresh_connector_is_idle(tmp_path):
+    conn = _connector(tmp_path)
+
+    assert conn.sensorInitBusy is False
+    assert conn._ensure_idle() is None
+
+
+def test_schedule_raises_the_gate(tmp_path):
+    """The gate must engage at schedule time — the race window opens the
+    moment the connect handler queues the init, not when the worker starts."""
+    conn = _connector(tmp_path)
+
+    conn._schedule_sensor_init("left")
+
+    assert conn.sensorInitBusy is True
+    err = conn._ensure_idle()
+    assert err is not None and _INIT_BUSY_MSG in err
+
+
+def test_start_capture_refused_while_init_in_flight(tmp_path):
+    conn = _connector(tmp_path)
+    conn._schedule_sensor_init("left")
+    log_lines = []
+    conn.captureLog.connect(log_lines.append)
+
+    ok = conn.startCapture("subj", 5, 0x99, 0x00, True)
+
+    assert ok is False
+    assert conn._capture_running is False
+    assert any(_INIT_BUSY_MSG in line for line in log_lines)
+
+
+def test_cq_check_refused_while_init_in_flight(tmp_path):
+    conn = _connector(tmp_path)
+    conn._schedule_sensor_init("right")
+    finished = []
+    conn.contactQualityCheckFinished.connect(
+        lambda ok, err, warns: finished.append((ok, err)))
+
+    conn.runContactQualityCheck(0x99, 0x00)
+
+    assert finished == [(False, conn._ensure_idle())]
+    assert _INIT_BUSY_MSG in finished[0][1]
+
+
+def test_gate_clears_when_init_completes(tmp_path):
+    conn = _connector(tmp_path)
+    conn._run_sensor_init_impl = lambda side: None  # fast no-op init
+    conn._schedule_sensor_init("left")
+    assert conn.sensorInitBusy is True
+
+    conn._run_sensor_init("left")  # what the worker thread runs
+
+    assert conn.sensorInitBusy is False
+    assert conn._ensure_idle() is None
+
+
+def test_gate_clears_when_init_fails(tmp_path):
+    """A failed init must not leak the busy state — that would lock
+    Start/Check forever."""
+    conn = _connector(tmp_path)
+
+    def _boom(side):
+        raise RuntimeError("init exploded")
+
+    conn._run_sensor_init_impl = _boom
+    conn._schedule_sensor_init("left")
+
+    conn._run_sensor_init("left")  # swallows the exception by contract
+
+    assert conn.sensorInitBusy is False
+    assert conn._ensure_idle() is None
+
+
+def test_gate_rearms_on_reconnect(tmp_path):
+    """Init re-runs on every sensor (re)connect — a mid-session replug
+    must re-engage the gate, not just the app-boot init."""
+    conn = _connector(tmp_path)
+    conn._run_sensor_init_impl = lambda side: None
+    conn._schedule_sensor_init("left")
+    conn._run_sensor_init("left")
+    assert conn.sensorInitBusy is False
+
+    conn._schedule_sensor_init("left")  # replug
+
+    assert conn.sensorInitBusy is True
+    err = conn._ensure_idle()
+    assert err is not None and _INIT_BUSY_MSG in err
+
+
+def test_both_sides_must_drain(tmp_path):
+    conn = _connector(tmp_path)
+    conn._run_sensor_init_impl = lambda side: None
+    conn._schedule_sensor_init("left")
+    conn._schedule_sensor_init("right")
+
+    conn._run_sensor_init("left")
+    assert conn.sensorInitBusy is True  # right still in flight
+
+    conn._run_sensor_init("right")
+    assert conn.sensorInitBusy is False
+
+
+def test_busy_signal_fires_on_edges_only(tmp_path):
+    """QML rebinds on sensorInitBusyChanged — emit on the busy/idle edges,
+    not on every per-side count change."""
+    conn = _connector(tmp_path)
+    conn._run_sensor_init_impl = lambda side: None
+    edges = []
+    conn.sensorInitBusyChanged.connect(
+        lambda: edges.append(conn.sensorInitBusy))
+
+    conn._schedule_sensor_init("left")   # idle -> busy: emit
+    conn._schedule_sensor_init("right")  # still busy: no emit
+    conn._run_sensor_init("left")        # still busy: no emit
+    conn._run_sensor_init("right")       # busy -> idle: emit
+
+    assert edges == [True, False]
+
+
+def test_unbalanced_drain_never_goes_negative(tmp_path):
+    """A drain without a matching schedule (e.g. a test driving
+    _run_sensor_init directly) clamps at zero instead of corrupting the
+    counter for the next real init."""
+    conn = _connector(tmp_path)
+    conn._run_sensor_init_impl = lambda side: None
+
+    conn._run_sensor_init("left")  # no schedule beforehand
+    assert conn.sensorInitBusy is False
+
+    conn._schedule_sensor_init("left")
+    assert conn.sensorInitBusy is True  # next real init still gates


### PR DESCRIPTION
Refs #303

## Root cause (bench, 2026-07-02)

The UI enables Start as soon as the connection state machine reaches READY (handles connected), but the connector's **asynchronous post-connect sensor init** (`_run_sensor_init` per side: debug-flags push, camera power masks + ID-cache fill, sensor info reads) is still running for a few more seconds. Clicking Start (scan or CQ check) in that window makes the ScanWorkflow's camera-configure/FPGA-program step collide with the in-flight init — log shows "Programming left camera FPGA at position 2..." → "Failed to program FPGA" within 5 ms on BOTH sensors — and can leave a camera wedged "not READY for FPGA/config" until a DUT power-cycle. Direct observation: waiting one extra second makes it work every time.

## Mechanism

Three layers, keyed to **actual init completion** (not a timer, unlike #154's original hold):

1. **Connector — init-in-flight tracking.** A lock-guarded per-side counter is raised when `_schedule_sensor_init` arms the init (so the gate engages during the 1 s USB-settle delay too) and dropped in `_run_sensor_init`'s `finally` — success or failure alike, so the busy state can't leak. Exposed to QML as the notifiable `sensorInitBusy` pyqtProperty; the drain-side `sensorInitBusyChanged` emission fires on the init worker thread and Qt auto-queues delivery to the GUI thread (same pattern as the existing `connectionStatusChanged.emit()` at the end of the init sequence).
2. **UI gating.** `ButtonPanel`'s Start **and** Check buttons disable while `sensorInitBusy` (folded into the existing `camerasReady` gate in `BloodFlow.qml`), covering both the clinical (pre-scan CQ → scan) and research start paths. Because `_schedule_sensor_init` re-runs on every sensor (re)connect, the gate **re-arms on a mid-session unplug/replug**, not just at app boot.
3. **Defense in depth.** `_ensure_idle` — the shared gate for `startCapture`, `runContactQualityCheck`, and `startConfigureCameraSensors` — refuses with "Sensors are still initializing — wait a few seconds and try again" while init is in flight (surfaced via `captureLog` / `contactQualityCheckFinished`, like the other busy states). And since BloodFlow's `startGate` polls `isPipelineIdle()`, a start armed right as a sensor replugs is **deferred until init drains** (30 s bound, mirroring how #283/#291 wait out an in-flight FPGA config) instead of colliding or erroring at the 8 s deadline.

## Tests

`tests/test_sensor_init_start_gate.py` (`@pytest.mark.unit`, mocked interface — no hardware): startCapture/CQ refusal while the flag is up, flag drain on init success **and** failure, replug re-arm, both-sides drain, edge-only signal emission, and negative-drain clamping. Full unit suite: **435 passed**.

## Hand-test plan (bench repro is deterministic)

1. **Early Start:** launch the app, click Start IMMEDIATELY when the window appears (while the terminal is still printing connect-time init). Expect: Start/Check disabled (greyed) during the init window — and if a start does get armed (e.g. via the pre-scan CQ Continue), it defers cleanly. **No** "Failed to program FPGA", **no** camera wedge.
2. **Normal scan:** wait for init to finish (button enables), run a normal scan → must work unchanged, including the clinical pre-scan CQ flow and the research Check button.
3. **Replug re-arm:** mid-session, unplug and replug a sensor — Start/Check must grey out again for the init window, then re-enable; a scan afterwards works.

## Out of scope / follow-up

Firmware/SDK-side recovery of an already-wedged camera (issue comment's option c — detect the half-configured state and re-run FPGA config instead of latching until power-cycle) is intentionally **not** attempted here; it needs its own firmware-side ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)