### PR TITLE
fix: gate plot grid on per-side sensor connection (#298)

### DIFF
--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -163,14 +163,25 @@ Rectangle {
     // the operator's current Scan Settings selection (issue #175). A live
     // source — or no source, before the first scan — reports -1 (unknown),
     // so the grid keeps following the live leftMask/rightMask selection.
+    //
+    // For the live fallback, additionally gate each side on its sensor
+    // actually being connected (issue #298): the live leftMask/rightMask
+    // carry the config default (e.g. 0x99 = 4 cams) regardless of which
+    // ports are populated, so a single sensor on the right port would
+    // otherwise draw 4 phantom left plots. A disconnected side contributes
+    // no cells; the binding re-flows on connect/disconnect because
+    // leftSensorConnected/rightSensorConnected notify connectionStatusChanged.
+    // Past scans are unaffected — their recorded masks win before this gate.
     readonly property int _effLeftMask:
         (viewer.scanSource && viewer.scanSource.leftMask !== undefined
          && viewer.scanSource.leftMask >= 0)
-            ? viewer.scanSource.leftMask : viewer.leftMask
+            ? viewer.scanSource.leftMask
+            : (MotionInterface.leftSensorConnected ? viewer.leftMask : 0x00)
     readonly property int _effRightMask:
         (viewer.scanSource && viewer.scanSource.rightMask !== undefined
          && viewer.scanSource.rightMask >= 0)
-            ? viewer.scanSource.rightMask : viewer.rightMask
+            ? viewer.scanSource.rightMask
+            : (MotionInterface.rightSensorConnected ? viewer.rightMask : 0x00)
 
     // Replay adopts the loaded scan's recorded mode: when the source reports a
     // known mode (clinicalMode >= 0) use it, else fall back to the live-config
@@ -232,13 +243,21 @@ Rectangle {
         return entries
     }
 
-    // Clinical mode — 2 cells, one per side, each rendering the
+    // Clinical mode — one cell per ACTIVE side, each rendering the
     // side-averaged stream (cam_id=-1, fed by SDK's SideAveragingStage
     // via _LivePlotSink.consume). Stacked vertically in a single column.
-    readonly property var _clinicalCellModel: [
-        { side: "left",  camId: -1, row: 0, col: 0 },
-        { side: "right", camId: -1, row: 1, col: 0 }
-    ]
+    // A side with no active cameras (disconnected sensor / recorded mask 0)
+    // is dropped and the survivor compacts to row 0 so a single-sided
+    // clinical scan doesn't reserve a blank row (issue #298).
+    readonly property var _clinicalCellModel: {
+        var entries = []
+        var displayRow = 0
+        if ((viewer._effLeftMask & 0xFF) !== 0)
+            entries.push({ side: "left", camId: -1, row: displayRow++, col: 0 })
+        if ((viewer._effRightMask & 0xFF) !== 0)
+            entries.push({ side: "right", camId: -1, row: displayRow++, col: 0 })
+        return entries
+    }
 
     readonly property var _activeCellModel: viewer.effectiveClinical
         ? _clinicalCellModel
@@ -715,15 +734,23 @@ Rectangle {
                 Layout.preferredWidth: 250
                 spacing: 6
 
+                // Each side's readout panel is shown only when that side
+                // has active cameras, mirroring _clinicalCellModel — a
+                // disconnected sensor (or a single-sided recorded scan)
+                // leaves no dead "--" panel behind (issue #298).
                 SideMetricPanel {
                     panelSide: "left"
+                    visible: (viewer._effLeftMask & 0xFF) !== 0
                     Layout.fillWidth: true
-                    Layout.fillHeight: true
+                    Layout.fillHeight: visible
+                    Layout.preferredHeight: visible ? -1 : 0
                 }
                 SideMetricPanel {
                     panelSide: "right"
+                    visible: (viewer._effRightMask & 0xFF) !== 0
                     Layout.fillWidth: true
-                    Layout.fillHeight: true
+                    Layout.fillHeight: visible
+                    Layout.preferredHeight: visible ? -1 : 0
                 }
             }
 

--- a/tests/test_plot_viewer_masks.py
+++ b/tests/test_plot_viewer_masks.py
@@ -139,11 +139,17 @@ class _StubMotionInterface(QObject):
     PlotViewer.qml (and its child components) actually reference."""
 
     currentScanSourceChanged = pyqtSignal()
+    connectionStatusChanged = pyqtSignal()
     _neverEmitted = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._scan_source = None
+        # Both sensors present by default so the legacy grid tests (which
+        # predate the issue-#298 connection gate) still render both sides
+        # on the live-fallback path. The #298 tests flip these.
+        self._left_connected = True
+        self._right_connected = True
 
     @pyqtProperty("QVariantMap", notify=_neverEmitted)
     def appConfig(self):
@@ -169,6 +175,19 @@ class _StubMotionInterface(QObject):
     @pyqtProperty(bool, notify=_neverEmitted)
     def liveSourceAvailable(self):
         return False
+
+    @pyqtProperty(bool, notify=connectionStatusChanged)
+    def leftSensorConnected(self):
+        return self._left_connected
+
+    @pyqtProperty(bool, notify=connectionStatusChanged)
+    def rightSensorConnected(self):
+        return self._right_connected
+
+    def setSensorsConnected(self, left, right):
+        self._left_connected = bool(left)
+        self._right_connected = bool(right)
+        self.connectionStatusChanged.emit()
 
     @pyqtSlot()
     def showLiveSource(self):
@@ -490,3 +509,132 @@ def test_row_compaction_is_shared_across_modules(viewer_factory):
     # U row 3 (cams 1|8) → display row 2: left side only.
     assert _pos(cells, "left", 0) == (2, 0)
     assert _pos(cells, "left", 7) == (2, 1)
+
+
+# ── Issue #298 — single sensor draws only its own side ─────────────────
+# The live leftMask/rightMask carry the config default (e.g. 0x99 = 4
+# cams) regardless of which sensor ports are populated. On the live
+# fallback (no past-scan source, so masks read -1) PlotViewer must gate
+# each side on its sensor actually being connected, or a lone right-port
+# sensor draws 4 phantom left plots. The gate re-flows on connect/
+# disconnect because leftSensorConnected/rightSensorConnected notify.
+
+
+def _clinical_cells(viewer):
+    """Read the clinical (side-averaged) grid model."""
+    val = viewer.property("_clinicalCellModel")
+    if hasattr(val, "toVariant"):
+        val = val.toVariant()
+    assert isinstance(val, list)
+    return val
+
+
+def test_right_only_sensor_hides_left_plots(viewer_factory):
+    """The reported bug: only the right sensor is connected, but the live
+    leftMask default (0x99, 4 cams) would draw 4 left plots. The connection
+    gate must drop them, leaving only the right side."""
+    viewer = viewer_factory()
+    try:
+        viewer_factory.stub.setSensorsConnected(left=False, right=True)
+        # BloodFlow.qml never clears leftMask when the left sensor is
+        # absent — it keeps the config default. Reproduce that here.
+        viewer.setProperty("leftMask", 0x99)
+        viewer.setProperty("rightMask", 0x99)
+        cells = _cells(viewer)
+        assert _cam_ids(cells, "left") == []
+        assert _cam_ids(cells, "right") == [0, 3, 4, 7]
+        # Single side active ⇒ no side-break spacer, right module at col 0-1.
+        assert viewer.property("_sideGapActive") is False
+    finally:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+
+
+def test_left_only_sensor_hides_right_plots(viewer_factory):
+    viewer = viewer_factory()
+    try:
+        viewer_factory.stub.setSensorsConnected(left=True, right=False)
+        viewer.setProperty("leftMask", 0x99)
+        viewer.setProperty("rightMask", 0x99)
+        cells = _cells(viewer)
+        assert _cam_ids(cells, "right") == []
+        assert _cam_ids(cells, "left") == [0, 3, 4, 7]
+        assert viewer.property("_sideGapActive") is False
+    finally:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+
+
+def test_both_sensors_connected_render_both_sides(viewer_factory):
+    viewer = viewer_factory()
+    try:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+        viewer.setProperty("leftMask", 0x99)
+        viewer.setProperty("rightMask", 0x99)
+        cells = _cells(viewer)
+        assert _cam_ids(cells, "left") == [0, 3, 4, 7]
+        assert _cam_ids(cells, "right") == [0, 3, 4, 7]
+        assert viewer.property("_sideGapActive") is True
+    finally:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+
+
+def test_grid_reflows_on_left_sensor_connect_midsession(viewer_factory):
+    """Re-flow on connect/disconnect: start right-only (left hidden), then
+    the left sensor enumerates → left plots appear without re-touching the
+    masks. Proves the binding tracks connectionStatusChanged."""
+    viewer = viewer_factory()
+    try:
+        viewer.setProperty("leftMask", 0x99)
+        viewer.setProperty("rightMask", 0x99)
+        viewer_factory.stub.setSensorsConnected(left=False, right=True)
+        assert _cam_ids(_cells(viewer), "left") == []
+
+        # Left sensor plugs in mid-session.
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+        assert _cam_ids(_cells(viewer), "left") == [0, 3, 4, 7]
+
+        # And unplugs again — plots must disappear.
+        viewer_factory.stub.setSensorsConnected(left=False, right=True)
+        assert _cam_ids(_cells(viewer), "left") == []
+    finally:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+
+
+def test_past_scan_ignores_connection_gate(viewer_factory):
+    """A replayed past scan lays out from its recorded masks even with the
+    matching sensor disconnected — you can review a two-sided scan with no
+    hardware attached (issue #175 must survive the #298 gate)."""
+    viewer = viewer_factory()
+    try:
+        viewer_factory.stub.setSensorsConnected(left=False, right=False)
+        past = _StubPastScanSource(FAR_MASK, FAR_MASK)
+        viewer_factory.stub.setScanSource(past)
+        cells = _cells(viewer)
+        assert _cam_ids(cells, "left") == [0, 1, 6, 7]
+        assert _cam_ids(cells, "right") == [0, 1, 6, 7]
+    finally:
+        viewer_factory.stub.setScanSource(None)
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+
+
+def test_clinical_model_drops_disconnected_side(viewer_factory):
+    """Clinical mode: a right-only sensor shows only the RIGHT side-average
+    cell, compacted to row 0 — no blank LEFT panel/row."""
+    viewer = viewer_factory()
+    try:
+        viewer.setProperty("clinicalMode", True)
+        viewer.setProperty("leftMask", 0xC3)
+        viewer.setProperty("rightMask", 0xC3)
+        viewer_factory.stub.setSensorsConnected(left=False, right=True)
+        cells = _clinical_cells(viewer)
+        assert len(cells) == 1
+        assert cells[0]["side"] == "right"
+        assert cells[0]["row"] == 0
+
+        # Both connected → both cells, stacked.
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+        cells = _clinical_cells(viewer)
+        assert [c["side"] for c in cells] == ["left", "right"]
+        assert [c["row"] for c in cells] == [0, 1]
+    finally:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+        viewer.setProperty("clinicalMode", False)


### PR DESCRIPTION
## Summary

With **only one sensor module connected on the RIGHT port**, the plot area also drew **4 phantom LEFT plots**, producing a disorganized grid. This gates each side's plot cells on that side's sensor actually being connected.

## Root cause

`components/PlotViewer.qml` builds its grid from `_effLeftMask` / `_effRightMask` (lines ~175-184). For a **live** source these fall back to the operator's live `leftMask`/`rightMask` selection — which carry the app-config default (`0x99` = 4 cams, bits 0/3/4/7) **regardless of which sensor ports are populated**. `BloodFlow.applyDefaultCameras()` only assigns `leftMask` when `leftSensorConnected` is true; it never *clears* it to `0x00` for an absent side, so a lone right-port sensor left `leftMask` at its `0x99` default → 4 left plots. (`0x99` == the reported "4 left plots".)

The scan-source/data side already excluded the disconnected side (`motion_connector.py` gates capture masks on `_leftSensorConnected`/`_rightSensorConnected`), but the QML grid layout still allocated cells from the raw config mask.

## The fix (pure QML binding)

- Gate the **live-fallback** branch of `_effLeftMask` / `_effRightMask` on `MotionInterface.leftSensorConnected` / `rightSensorConnected`. Both notify `connectionStatusChanged`, so the grid **re-flows on connect/disconnect mid-session**.
- **Past scans are untouched**: their recorded masks (`scanSource.leftMask/rightMask >= 0`) win *before* the gate, so a two-sided scan still replays with no hardware attached (issue #175 preserved — covered by a new test).
- Clinical mode: `_clinicalCellModel` and the two `SideMetricPanel`s now derive from the effective masks, so a right-only sensor shows only the RIGHT side-average cell/panel, compacted to row 0 (no blank LEFT panel/row).

## Tests

Adds 6 `@pytest.mark.unit` regression tests to `tests/test_plot_viewer_masks.py` (right-only, left-only, both, mid-session reflow, past-scan override, clinical single-side). The stub `MotionInterface` gains `leftSensorConnected`/`rightSensorConnected` (defaulting to `True`, preserving all pre-existing grid tests).

`python -m pytest tests/test_plot_viewer_masks.py -m unit` → **21 passed** (15 pre-existing + 6 new).

## Hand-test plan

Per the constraints I did **not** launch the GUI (bench in use). Please verify on hardware:

1. **Single sensor on RIGHT port** → only the right-side plots render, in a clean grid, no left plots, no dangling side-gap spacer.
2. **Single sensor on LEFT port** → only left-side plots, clean grid.
3. **Both sensors** → both sides render as before, with the side-break spacer between modules.
4. **Unplug one sensor mid-session** → its plots disappear and the grid re-flows; **replug** → they come back — without re-opening Scan Settings.
5. **Clinical (reduced) mode** with a single sensor → only the connected side's big BFI/BVI panel + side-average plot shows, at the top (no empty second panel).
6. **Replay a past two-sided scan with a sensor unplugged** → both recorded sides still render (regression guard for #175).

Refs #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)