### PR TITLE
feat: split debug log out of audit view and add audit filters (#227, #226)

### DIFF
--- a/audit_log.py
+++ b/audit_log.py
@@ -48,6 +48,34 @@ EV_DEBUG_BUNDLE_CREATED = "debug_bundle_created"
 _CSV_FIELDS = ["ts_iso", "ts_epoch", "event_type", "details"]
 
 
+def _escape_like(needle: str) -> str:
+    """Escape LIKE wildcards so ``needle`` matches literally (used with
+    ``ESCAPE '\\'``)."""
+    return (
+        needle.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
+
+
+def parse_date_bound(text: Any, end: bool = False) -> Optional[float]:
+    """Parse a ``YYYY-MM-DD`` date string into a local-time epoch bound
+    for filtering on ``ts_epoch``.
+
+    Returns midnight at the start of the day, or — when ``end`` is True —
+    midnight at the start of the *next* day (an exclusive upper bound
+    covering the whole named day). ``None`` for empty/invalid input, so
+    a malformed filter simply doesn't constrain the query.
+    """
+    if not text:
+        return None
+    try:
+        day = datetime.datetime.strptime(str(text).strip(), "%Y-%m-%d")
+    except ValueError:
+        return None
+    if end:
+        day += datetime.timedelta(days=1)
+    return day.timestamp()
+
+
 def gather_host_info() -> Dict[str, Any]:
     """Collect host/system facts for the ``system_info`` event. Best-effort
     — any probe that fails is simply omitted."""
@@ -163,21 +191,75 @@ class AuditLog:
                 "AuditLog: failed to write %s event", event_type, exc_info=True
             )
 
-    def query(self, limit: int = 500) -> List[Dict[str, Any]]:
-        """Return up to ``limit`` rows, newest first, as plain dicts."""
+    def query(
+        self,
+        limit: int = 500,
+        event_type: Optional[str] = None,
+        since_epoch: Optional[float] = None,
+        until_epoch: Optional[float] = None,
+        contains: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` rows, newest first, as plain dicts.
+
+        Optional filters (ANDed together; #226):
+          - ``event_type``: exact match on the event type.
+          - ``since_epoch``: inclusive lower bound on ``ts_epoch``.
+          - ``until_epoch``: exclusive upper bound on ``ts_epoch`` (pair
+            with ``parse_date_bound(..., end=True)`` for whole days).
+          - ``contains``: case-insensitive substring across event_type
+            and details; LIKE wildcards in the needle match literally.
+
+        ``limit`` applies to the filtered rows.
+        """
+        sql = "SELECT id, ts_epoch, ts_iso, event_type, details FROM logs"
+        where: List[str] = []
+        params: List[Any] = []
+        if event_type:
+            where.append("event_type = ?")
+            params.append(str(event_type))
+        if since_epoch is not None:
+            where.append("ts_epoch >= ?")
+            params.append(float(since_epoch))
+        if until_epoch is not None:
+            where.append("ts_epoch < ?")
+            params.append(float(until_epoch))
+        if contains:
+            pat = f"%{_escape_like(str(contains))}%"
+            where.append(
+                "(event_type LIKE ? ESCAPE '\\'"
+                " OR IFNULL(details, '') LIKE ? ESCAPE '\\')"
+            )
+            params += [pat, pat]
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY id DESC LIMIT ?"
+        params.append(int(limit))
+        try:
+            with self._lock:
+                if self._conn is None:
+                    return []
+                cur = self._conn.execute(sql, params)
+                cols = [c[0] for c in cur.description]
+                return [dict(zip(cols, row)) for row in cur.fetchall()]
+        except Exception:
+            logger.warning("AuditLog: query failed", exc_info=True)
+            return []
+
+    def distinct_event_types(self) -> List[str]:
+        """Sorted list of the distinct event types present in the log
+        (for filter dropdowns). Empty when disabled / on error."""
         try:
             with self._lock:
                 if self._conn is None:
                     return []
                 cur = self._conn.execute(
-                    "SELECT id, ts_epoch, ts_iso, event_type, details"
-                    " FROM logs ORDER BY id DESC LIMIT ?",
-                    (int(limit),),
+                    "SELECT DISTINCT event_type FROM logs"
+                    " ORDER BY event_type ASC"
                 )
-                cols = [c[0] for c in cur.description]
-                return [dict(zip(cols, row)) for row in cur.fetchall()]
+                return [row[0] for row in cur.fetchall()]
         except Exception:
-            logger.warning("AuditLog: query failed", exc_info=True)
+            logger.warning("AuditLog: distinct_event_types failed",
+                           exc_info=True)
             return []
 
     def count(self) -> int:

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -4,9 +4,12 @@ import QtQuick.Layouts 6.0
 import QtQuick.Dialogs as Dialogs
 import OpenMotion 1.0
 
-// Audit-log viewer. Lists machine-readable audit entries (newest first)
-// and exports them as CSV. Opened from the password gate in SettingsModal.
-// Governed by ModalManager (see HistoryModal.qml for the modal contract).
+// Audit-log viewer. Lists machine-readable audit entries (newest first),
+// filterable by event type / date range / free text (#226), and exports
+// them as CSV (always the COMPLETE log — filters are view-only, so the
+// export stays the full audit record). Opened from the password gate in
+// SettingsModal. Governed by ModalManager (see HistoryModal.qml for the
+// modal contract).
 Item {
     id: root
     anchors.fill: parent
@@ -17,17 +20,80 @@ Item {
     readonly property string label: "Audit Log"
     property var entries: []
 
+    // ── filter state (#226) ────────────────────────────────────────
+    property var eventTypes: []
+    property string filterEventType: ""
+    readonly property bool filtersActive: filterEventType !== ""
+                                          || fromField.text !== ""
+                                          || toField.text !== ""
+                                          || searchField.text !== ""
+
     function open() {
         // Record the view first, then load (so the view event is included).
         MotionInterface.recordAuditLogViewed()
+        reloadEventTypes()
         refresh()
         root.visible = true
     }
     function close() { root.visible = false }
 
     function refresh() {
-        try { entries = MotionInterface.auditLogEntries(500) || [] }
-        catch (e) { entries = [] }
+        try {
+            entries = MotionInterface.filteredAuditLogEntries({
+                eventType: filterEventType,
+                dateFrom: fromField.text,
+                dateTo: toField.text,
+                text: searchField.text,
+                limit: 500
+            }) || []
+        } catch (e) { entries = [] }
+    }
+
+    function reloadEventTypes() {
+        try { eventTypes = MotionInterface.auditEventTypes() || [] }
+        catch (e) { eventTypes = [] }
+        // Rebinding the combo model resets its index — restore the active
+        // selection (or fall back to "All events" if the type vanished).
+        var idx = eventTypes.indexOf(filterEventType)
+        typeCombo.currentIndex = idx >= 0 ? idx + 1 : 0
+        if (idx < 0) filterEventType = ""
+    }
+
+    function clearFilters() {
+        typeCombo.currentIndex = 0
+        filterEventType = ""
+        fromField.text = ""
+        toField.text = ""
+        searchField.text = ""
+        refresh()
+    }
+
+    // Debounce free-typing in the filter fields so each keystroke doesn't
+    // hit the database.
+    Timer {
+        id: filterDebounce
+        interval: 250
+        onTriggered: root.refresh()
+    }
+
+    // Shared look for the filter text inputs. validDate drives the red
+    // border on malformed dates (a malformed date simply doesn't filter).
+    component FilterField: TextField {
+        id: ff
+        property bool validDate: true
+        Layout.preferredHeight: 30
+        font.pixelSize: 12
+        color: AppTheme.textPrimary
+        placeholderTextColor: AppTheme.textTertiary
+        selectByMouse: true
+        background: Rectangle {
+            color: AppTheme.bgInput
+            radius: 4
+            border.color: !ff.validDate ? "#C0392B"
+                          : ff.activeFocus ? AppTheme.accentBlue
+                                           : AppTheme.borderSubtle
+            border.width: 1
+        }
     }
 
     QtObject {
@@ -123,6 +189,123 @@ Item {
                 }
             }
 
+            // ── filter bar (#226) ──────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                ComboBox {
+                    id: typeCombo
+                    objectName: "auditFilterType"
+                    Layout.preferredWidth: 190
+                    Layout.preferredHeight: 30
+                    font.pixelSize: 12
+                    model: ["All events"].concat(root.eventTypes)
+                    onActivated: {
+                        root.filterEventType =
+                            currentIndex === 0 ? "" : currentText
+                        root.refresh()
+                    }
+                    contentItem: Text {
+                        leftPadding: 10; rightPadding: 24
+                        text: typeCombo.displayText
+                        font: typeCombo.font
+                        color: AppTheme.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideRight
+                    }
+                    background: Rectangle {
+                        color: AppTheme.bgInput; radius: 4
+                        border.color: typeCombo.activeFocus
+                                      ? AppTheme.accentBlue : AppTheme.borderSubtle
+                        border.width: 1
+                    }
+                    indicator: Text {
+                        x: typeCombo.width - width - 8
+                        y: (typeCombo.height - height) / 2
+                        text: "▾"; font.pixelSize: 12
+                        color: AppTheme.textSecondary
+                    }
+                    popup: Popup {
+                        y: typeCombo.height
+                        width: typeCombo.width
+                        implicitHeight: Math.min(contentItem.implicitHeight + 2, 320)
+                        padding: 1
+                        contentItem: ListView {
+                            clip: true
+                            implicitHeight: contentHeight
+                            model: typeCombo.delegateModel
+                            ScrollBar.vertical: ScrollBar {}
+                        }
+                        background: Rectangle {
+                            color: AppTheme.bgCard; radius: 4
+                            border.color: AppTheme.borderSubtle; border.width: 1
+                        }
+                    }
+                    delegate: ItemDelegate {
+                        width: typeCombo.width
+                        height: 28
+                        highlighted: typeCombo.highlightedIndex === index
+                        contentItem: Text {
+                            text: modelData
+                            font.pixelSize: 12
+                            color: AppTheme.textPrimary
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: 8
+                        }
+                        background: Rectangle {
+                            color: highlighted ? AppTheme.accentBlue : "transparent"
+                        }
+                    }
+                }
+
+                FilterField {
+                    id: fromField
+                    objectName: "auditFilterFrom"
+                    Layout.preferredWidth: 118
+                    placeholderText: "From YYYY-MM-DD"
+                    validDate: text === "" || /^\d{4}-\d{2}-\d{2}$/.test(text)
+                    onTextChanged: filterDebounce.restart()
+                }
+                Text { text: "–"; color: AppTheme.textSecondary; font.pixelSize: 12 }
+                FilterField {
+                    id: toField
+                    objectName: "auditFilterTo"
+                    Layout.preferredWidth: 118
+                    placeholderText: "To YYYY-MM-DD"
+                    validDate: text === "" || /^\d{4}-\d{2}-\d{2}$/.test(text)
+                    onTextChanged: filterDebounce.restart()
+                }
+                FilterField {
+                    id: searchField
+                    objectName: "auditFilterSearch"
+                    Layout.fillWidth: true
+                    placeholderText: "Search events and details…"
+                    onTextChanged: filterDebounce.restart()
+                }
+                Button {
+                    text: "Clear"
+                    enabled: root.filtersActive
+                    Layout.preferredWidth: 64; Layout.preferredHeight: 30
+                    hoverEnabled: true
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 12
+                        color: parent.enabled ? AppTheme.textSecondary
+                                              : AppTheme.textTertiary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: parent.enabled && parent.hovered
+                               ? AppTheme.accentBlue : AppTheme.bgInput
+                        border.color: parent.enabled && parent.hovered
+                                      ? AppTheme.textPrimary : AppTheme.borderSubtle
+                        radius: 4
+                    }
+                    onClicked: root.clearFilters()
+                }
+            }
+
             // ── table header ───────────────────────────────────────
             Rectangle {
                 Layout.fillWidth: true
@@ -189,7 +372,9 @@ Item {
                     Text {
                         anchors.centerIn: parent
                         visible: root.entries.length === 0
-                        text: "No audit entries yet."
+                        text: root.filtersActive
+                              ? "No entries match the current filters."
+                              : "No audit entries yet."
                         color: AppTheme.textSecondary; font.pixelSize: 14
                     }
                 }

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -195,8 +195,12 @@ Item {
 
     // ── Reusable building blocks ────────────────────────────────────────────
     component SectionCard: Rectangle {
+        id: sectionCard
         property string title: ""
         default property alias contentItem: cardContent.data
+        // Optional item(s) right-aligned on the title row — e.g. the
+        // About card's Send Debug Logs button (#227).
+        property alias headerItem: headerSlot.data
         Layout.fillWidth: true
         Layout.leftMargin: 20
         Layout.rightMargin: 20
@@ -212,12 +216,19 @@ Item {
             anchors.margins: 18
             spacing: 14
 
-            Text {
-                text:           parent.parent.title
-                color:          root.colTextPri
-                font.pixelSize: 15
-                font.weight:    Font.DemiBold
-                font.letterSpacing: 0.3
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Text {
+                    text:           sectionCard.title
+                    color:          root.colTextPri
+                    font.pixelSize: 15
+                    font.weight:    Font.DemiBold
+                    font.letterSpacing: 0.3
+                }
+                Item { Layout.fillWidth: true }
+                RowLayout { id: headerSlot; spacing: 8 }
             }
 
             Rectangle { Layout.fillWidth: true; height: 1; color: root.colBorderSoft }
@@ -802,39 +813,6 @@ Item {
                     }
                 }
 
-                // ── Support ──────────────────────────────────────────────────
-                // Debug-log bundle for support. Deliberately separate from
-                // the Audit Log section: the audit log is the clinical
-                // record, the debug bundle is engineering diagnostics
-                // (#227). Visible in all modes — it is the designated
-                // support path for clinical sites and the bundle contains
-                // no scan or patient data.
-                SectionCard {
-                    title: "Support"
-
-                    FieldRow {
-                        label: "Debug logs"
-                        ActionButton {
-                            text: "Send Debug Logs"
-                            Layout.preferredWidth: 150
-                            // Direct action — zips the last 48h of app logs,
-                            // reveals the file, and toasts the support address.
-                            onClicked: MotionInterface.prepareDebugLogBundle()
-                        }
-                        Item { Layout.fillWidth: true }
-                    }
-                    Text {
-                        text: "Packages the last 48 hours of app logs plus system "
-                              + "info into a zip for troubleshooting — email it to "
-                              + "support@openwater.cc. Contains no scan data or "
-                              + "patient information."
-                        color: root.colTextMuted
-                        font.pixelSize: 11
-                        wrapMode: Text.WordWrap
-                        Layout.fillWidth: true
-                    }
-                }
-
                 // ── Engineering ──────────────────────────────────────────────
                 SectionCard {
                     title: "Engineering"
@@ -1145,6 +1123,21 @@ Item {
                 // ── About ─────────────────────────────────────────────────────
                 SectionCard {
                     title: "About"
+
+                    // Debug-log bundle for support, top-right of the About
+                    // (firmware info) card per #227 — deliberately away from
+                    // the Audit Log section: the audit log is the clinical
+                    // record, the debug bundle is engineering diagnostics.
+                    // Visible in ALL modes — it is the designated support
+                    // path for clinical sites and the bundle contains no
+                    // scan or patient data.
+                    headerItem: ActionButton {
+                        text: "Send Debug Logs"
+                        Layout.preferredWidth: 150
+                        // Direct action — zips the last 48h of app logs,
+                        // reveals the file, and toasts the support address.
+                        onClicked: MotionInterface.prepareDebugLogBundle()
+                    }
 
                     // Small pill button reused for the Application row and
                     // each device firmware row.

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -777,6 +777,8 @@ Item {
                 }
 
                 // ── Audit Log ────────────────────────────────────────────────
+                // Clinical record only — debug/diagnostic tooling lives in
+                // the Support section below (#227).
                 SectionCard {
                     title: "Audit Log"
 
@@ -787,6 +789,31 @@ Item {
                             Layout.preferredWidth: 130
                             onClicked: logsPasswordModal.open()
                         }
+                        Item { Layout.fillWidth: true }
+                    }
+                    Text {
+                        text: "Password-protected, machine-readable record of system "
+                              + "events for auditors. Open the viewer to browse entries "
+                              + "or export them as CSV."
+                        color: root.colTextMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                }
+
+                // ── Support ──────────────────────────────────────────────────
+                // Debug-log bundle for support. Deliberately separate from
+                // the Audit Log section: the audit log is the clinical
+                // record, the debug bundle is engineering diagnostics
+                // (#227). Visible in all modes — it is the designated
+                // support path for clinical sites and the bundle contains
+                // no scan or patient data.
+                SectionCard {
+                    title: "Support"
+
+                    FieldRow {
+                        label: "Debug logs"
                         ActionButton {
                             text: "Send Debug Logs"
                             Layout.preferredWidth: 150
@@ -797,10 +824,10 @@ Item {
                         Item { Layout.fillWidth: true }
                     }
                     Text {
-                        text: "Password-protected, machine-readable record of system "
-                              + "events for auditors. Open the viewer to browse entries "
-                              + "or export them as CSV. Send Debug Logs zips the last "
-                              + "48 hours of app logs to email to support@openwater.cc."
+                        text: "Packages the last 48 hours of app logs plus system "
+                              + "info into a zip for troubleshooting — email it to "
+                              + "support@openwater.cc. Contains no scan data or "
+                              + "patient information."
                         color: root.colTextMuted
                         font.pixelSize: 11
                         wrapMode: Text.WordWrap

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -122,9 +122,9 @@ LIMIT 50;
 
 Debug logs are **not part of the audit log** — the audit log is the
 clinical record, while the debug bundle is engineering diagnostics for
-support. The **Send Debug Logs** button lives in its own **Settings →
-Support** section. It packages the app's diagnostic logs for support,
-writing a zip to
+support. The **Send Debug Logs** button sits in the top-right corner of
+the **Settings → About** section (with the firmware information). It
+packages the app's diagnostic logs for support, writing a zip to
 `<dataDirectory>/data/debug-bundles/debug-bundle-<timestamp>.zip`
 containing the app log files from the last 48 hours, `app_config.json`,
 and a `system_info.txt` (app/SDK version + host details). The file

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -30,6 +30,21 @@ The viewer lists entries **newest first**, with three columns:
 Use **Refresh** to reload, and **Export CSV** to save the full log to a file
 (see [Exporting](#exporting-to-csv)).
 
+### Filtering the view
+
+A filter bar above the table narrows what is shown (the underlying log is
+never modified):
+
+| Filter | Behavior |
+|---|---|
+| **Event type** | Dropdown of the event types actually present in the log; pick one, or "All events". |
+| **Date range** | `From` / `To` fields, `YYYY-MM-DD` (local time). Both days are inclusive; either side may be left empty. A malformed date shows a red border and is ignored. |
+| **Search** | Case-insensitive substring match across the event type and the `details` JSON (e.g. a scan label). |
+
+Filters combine (AND) and apply to the on-screen view only — **Export CSV
+always writes the complete log**, so the exported file remains the full
+audit record regardless of active filters. **Clear** resets all filters.
+
 ---
 
 ## What gets recorded

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -105,15 +105,19 @@ LIMIT 50;
 
 ## Sending debug logs to Openwater
 
-The **Send Debug Logs** button (top of the audit-log viewer) packages the
-app's diagnostic logs for support. It writes a zip to
+Debug logs are **not part of the audit log** — the audit log is the
+clinical record, while the debug bundle is engineering diagnostics for
+support. The **Send Debug Logs** button lives in its own **Settings →
+Support** section. It packages the app's diagnostic logs for support,
+writing a zip to
 `<dataDirectory>/data/debug-bundles/debug-bundle-<timestamp>.zip`
 containing the app log files from the last 48 hours, `app_config.json`,
 and a `system_info.txt` (app/SDK version + host details). The file
 explorer opens with the zip selected, and a message shows the path —
 **email that zip to support@openwater.cc**. No data is sent
 automatically, and the bundle contains no scan data or patient
-information.
+information. The only trace in the audit log is the
+`debug_bundle_created` event recording that a bundle was made.
 
 ## Exporting to CSV
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2641,6 +2641,39 @@ class MotionConnector(QObject):
             logger.warning("auditLogEntries failed", exc_info=True)
             return []
 
+    @pyqtSlot("QVariantMap", result="QVariantList")
+    def filteredAuditLogEntries(self, filters):
+        """Audit-log rows (newest first) matching the Logs modal's filter
+        bar (#226). ``filters`` keys, all optional: ``eventType`` (exact
+        event type), ``dateFrom`` / ``dateTo`` (``YYYY-MM-DD``, local,
+        inclusive whole days), ``text`` (case-insensitive substring
+        across event type + details), ``limit`` (int, default 500).
+        Empty/invalid values are ignored. Pure read — does not itself
+        log, so refreshing never double-logs."""
+        try:
+            from audit_log import parse_date_bound
+            f = dict(filters or {})
+            return self._audit.query(
+                limit=int(f.get("limit") or 500),
+                event_type=str(f.get("eventType") or "") or None,
+                since_epoch=parse_date_bound(f.get("dateFrom")),
+                until_epoch=parse_date_bound(f.get("dateTo"), end=True),
+                contains=str(f.get("text") or "") or None,
+            )
+        except Exception:
+            logger.warning("filteredAuditLogEntries failed", exc_info=True)
+            return []
+
+    @pyqtSlot(result="QVariantList")
+    def auditEventTypes(self):
+        """Distinct event types present in the audit log (sorted), for
+        the Logs modal's filter dropdown (#226)."""
+        try:
+            return self._audit.distinct_event_types()
+        except Exception:
+            logger.warning("auditEventTypes failed", exc_info=True)
+            return []
+
     @pyqtSlot()
     def recordAuditLogViewed(self):
         """Record that the audit log was opened. Called once from

--- a/tests/test_audit_connector.py
+++ b/tests/test_audit_connector.py
@@ -224,6 +224,80 @@ def test_prepare_debug_bundle_creates_zip_and_logs(tmp_path):
     assert "debug_bundle_created" in _types(c)
 
 
+# ── Filtered entries + event types (#226) ───────────────────────────────
+
+def test_filtered_entries_by_event_type(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._audit.log("scan_started", {"n": 1})
+    c._audit.log("scan_ended", {"n": 2})
+    out = c.filteredAuditLogEntries({"eventType": "scan_ended"})
+    assert out
+    assert all(e["event_type"] == "scan_ended" for e in out)
+
+
+def test_filtered_entries_text_search(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._audit.log("scan_started", {"label": "owXYZ"})
+    out = c.filteredAuditLogEntries({"text": "owxyz"})
+    assert len(out) == 1
+    assert json.loads(out[0]["details"])["label"] == "owXYZ"
+
+
+def test_filtered_entries_date_range(tmp_path):
+    import datetime
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    today = datetime.date.today()
+    # From today (inclusive): startup events logged "now" must match.
+    out = c.filteredAuditLogEntries({"dateFrom": today.isoformat(),
+                                     "dateTo": today.isoformat()})
+    assert "system_startup" in [e["event_type"] for e in out]
+    # To yesterday: everything logged today is excluded.
+    yesterday = (today - datetime.timedelta(days=1)).isoformat()
+    assert c.filteredAuditLogEntries({"dateTo": yesterday}) == []
+
+
+def test_filtered_entries_empty_filters_match_unfiltered(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    c._audit.log("scan_started", {"n": 1})
+    unfiltered = c.auditLogEntries()
+    for f in ({}, {"eventType": "", "dateFrom": "", "dateTo": "",
+                   "text": ""}):
+        out = c.filteredAuditLogEntries(f)
+        assert [e["id"] for e in out] == [e["id"] for e in unfiltered]
+
+
+def test_filtered_entries_invalid_dates_are_ignored(tmp_path):
+    # Garbage date strings must not raise and must not filter anything.
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    out = c.filteredAuditLogEntries({"dateFrom": "not-a-date",
+                                     "dateTo": "2026-99-99"})
+    assert "system_startup" in [e["event_type"] for e in out]
+
+
+def test_filtered_entries_fail_soft_on_bad_limit(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    assert c.filteredAuditLogEntries({"limit": "garbage"}) == []
+
+
+def test_filtered_entries_no_db_noop(tmp_path):
+    c = _connector(tmp_path, scan_db_path=None)
+    assert c.filteredAuditLogEntries({"eventType": "scan_started"}) == []
+
+
+def test_audit_event_types_slot(tmp_path):
+    c = _connector(tmp_path, scan_db_path=str(tmp_path / "scans.db"))
+    types = c.auditEventTypes()
+    # Construction always logs these two.
+    assert "system_startup" in types
+    assert "system_info" in types
+    assert types == sorted(types)
+
+
+def test_audit_event_types_no_db_noop(tmp_path):
+    c = _connector(tmp_path, scan_db_path=None)
+    assert c.auditEventTypes() == []
+
+
 def test_prepare_debug_bundle_failure_returns_empty(tmp_path, monkeypatch):
     # If the bundle build raises, the slot must return "" and NOT log a
     # debug_bundle_created event (fail-soft, mirrors the other slots).

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,12 +1,18 @@
 """Unit tests for the append-only audit log (audit_log.py)."""
 import csv
+import datetime
 import json
 import sqlite3
 import threading
 
 import pytest
 
-from audit_log import AuditLog, gather_host_info, EV_SYSTEM_STARTUP
+from audit_log import (
+    AuditLog,
+    gather_host_info,
+    parse_date_bound,
+    EV_SYSTEM_STARTUP,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -133,3 +139,130 @@ def test_empty_dict_details_is_serialized_not_null(tmp_path):
     val = conn.execute("SELECT details FROM logs").fetchone()[0]
     conn.close()
     assert val == "{}"
+
+
+# ── Query filters (#226) ────────────────────────────────────────────────
+
+def test_query_filters_by_event_type(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"n": 1})
+    a.log("scan_ended", {"n": 2})
+    a.log("scan_started", {"n": 3})
+    out = a.query(event_type="scan_started")
+    a.close()
+    assert [e["event_type"] for e in out] == ["scan_started"] * 2
+    # still newest first
+    assert [json.loads(e["details"])["n"] for e in out] == [3, 1]
+
+
+def test_query_filters_by_epoch_range(tmp_path, monkeypatch):
+    import audit_log as mod
+    # Modern epochs — Windows can't .astimezone() near-1970 timestamps.
+    t0 = 1_750_000_000.0
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for ts, n in ((t0 + 100, 1), (t0 + 200, 2), (t0 + 300, 3)):
+        monkeypatch.setattr(mod.time, "time", lambda ts=ts: ts)
+        a.log("scan_started", {"n": n})
+    # since is inclusive
+    out = a.query(since_epoch=t0 + 200)
+    assert [json.loads(e["details"])["n"] for e in out] == [3, 2]
+    # until is exclusive (a whole-day upper bound is next-day midnight)
+    out = a.query(until_epoch=t0 + 200)
+    assert [json.loads(e["details"])["n"] for e in out] == [1]
+    # combined range
+    out = a.query(since_epoch=t0 + 150, until_epoch=t0 + 250)
+    assert [json.loads(e["details"])["n"] for e in out] == [2]
+    a.close()
+
+
+def test_query_text_search_matches_details_case_insensitive(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"label": "owABC"})
+    a.log("scan_started", {"label": "other"})
+    out = a.query(contains="owabc")
+    a.close()
+    assert len(out) == 1
+    assert json.loads(out[0]["details"])["label"] == "owABC"
+
+
+def test_query_text_search_matches_event_type(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("calibration_started", None)
+    a.log("scan_started", None)
+    out = a.query(contains="calib")
+    a.close()
+    assert len(out) == 1
+    assert out[0]["event_type"] == "calibration_started"
+
+
+def test_query_text_search_escapes_like_wildcards(tmp_path):
+    # A "%" in the needle must match literally, not as a LIKE wildcard.
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", {"progress": "50% done"})
+    a.log("scan_started", {"progress": "plain"})
+    out = a.query(contains="%")
+    assert len(out) == 1
+    assert "50%" in out[0]["details"]
+    # Same for "_" (would otherwise match any single character).
+    out = a.query(contains="50_")
+    a.close()
+    assert out == []
+
+
+def test_query_combined_filters_honor_limit(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    for i in range(5):
+        a.log("scan_started", {"n": i})
+        a.log("scan_ended", {"n": i})
+    out = a.query(limit=3, event_type="scan_started")
+    a.close()
+    # limit applies to the FILTERED rows, newest first
+    assert [json.loads(e["details"])["n"] for e in out] == [4, 3, 2]
+
+
+def test_query_filters_when_disabled_return_empty(tmp_path):
+    a = AuditLog(None)
+    assert a.query(event_type="scan_started", contains="x") == []
+    a.close()
+
+
+def test_distinct_event_types_sorted_unique(tmp_path):
+    a = AuditLog(str(tmp_path / "scans.db"))
+    a.log("scan_started", None)
+    a.log("scan_ended", None)
+    a.log("scan_started", None)
+    a.log("calibration_started", None)
+    assert a.distinct_event_types() == [
+        "calibration_started", "scan_ended", "scan_started",
+    ]
+    a.close()
+
+
+def test_distinct_event_types_disabled_returns_empty():
+    a = AuditLog(None)
+    assert a.distinct_event_types() == []
+    a.close()
+
+
+# ── parse_date_bound (#226) ─────────────────────────────────────────────
+
+def test_parse_date_bound_start_is_local_midnight():
+    want = datetime.datetime(2026, 6, 15).timestamp()
+    assert parse_date_bound("2026-06-15") == want
+
+
+def test_parse_date_bound_end_is_next_day_midnight():
+    want = datetime.datetime(2026, 6, 16).timestamp()
+    assert parse_date_bound("2026-06-15", end=True) == want
+
+
+def test_parse_date_bound_tolerates_whitespace():
+    want = datetime.datetime(2026, 6, 15).timestamp()
+    assert parse_date_bound("  2026-06-15  ") == want
+
+
+@pytest.mark.parametrize("bad", [None, "", "garbage", "2026-13-40",
+                                 "15/06/2026", "2026-06"])
+def test_parse_date_bound_invalid_returns_none(bad):
+    assert parse_date_bound(bad) is None
+    assert parse_date_bound(bad, end=True) is None

--- a/tests/test_logs_modal_filters.py
+++ b/tests/test_logs_modal_filters.py
@@ -1,0 +1,235 @@
+"""Unit tests for the audit-log filter bar in components/LogsModal.qml
+(#226).
+
+Loads the real LogsModal.qml in a bare QQmlEngine with a stubbed
+MotionInterface singleton, then drives the filter controls the way the
+UI does and asserts the filter map handed to
+``filteredAuditLogEntries`` — the Python side of that slot is covered by
+tests/test_audit_connector.py; these tests pin the QML → slot contract.
+
+Unit-marked: no app launch, no hardware, offscreen Qt platform.
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+# A QGuiApplication must exist before any QML Quick item is created, and
+# it must be constructed before conftest's session-scoped autouse
+# fixture instantiates a bare QCoreApplication (a QGuiApplication cannot
+# be created once a plain QCoreApplication exists). Module import runs
+# at collection time — ahead of every fixture — so create it here. The
+# offscreen platform is passed via argv, NOT via QT_QPA_PLATFORM, so the
+# process environment is untouched (see test_plot_viewer_masks.py).
+from PyQt6.QtCore import (  # noqa: E402
+    QCoreApplication,
+    QMetaObject,
+    QObject,
+    QUrl,
+    pyqtProperty,
+    pyqtSignal,
+    pyqtSlot,
+)
+from PyQt6.QtGui import QGuiApplication  # noqa: E402
+
+if QCoreApplication.instance() is None:
+    _qt_app = QGuiApplication([sys.argv[0], "-platform", "offscreen"])
+else:
+    _qt_app = QCoreApplication.instance()
+
+import pytest  # noqa: E402
+from PyQt6.QtQml import (  # noqa: E402
+    QQmlComponent,
+    QQmlEngine,
+    qmlRegisterSingletonInstance,
+    qmlRegisterSingletonType,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOGS_MODAL_QML = REPO_ROOT / "components" / "LogsModal.qml"
+APP_THEME_QML = REPO_ROOT / "components" / "AppTheme.qml"
+
+_ROWS = [
+    {"id": 2, "ts_epoch": 2.0, "ts_iso": "2026-06-15T09:00:02-07:00",
+     "event_type": "scan_started", "details": '{"label":"owABC"}'},
+    {"id": 1, "ts_epoch": 1.0, "ts_iso": "2026-06-15T09:00:01-07:00",
+     "event_type": "system_startup", "details": "{}"},
+]
+
+
+class _StubMotionInterface(QObject):
+    """Minimal MotionInterface stand-in covering every property/slot
+    LogsModal.qml (and AppTheme.qml) actually reference."""
+
+    directoryChanged = pyqtSignal()
+    _neverEmitted = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.filter_calls = []          # every map handed to the slot
+        self.viewed_count = 0
+        self.event_types = ["scan_started", "system_startup"]
+
+    @pyqtProperty("QVariantMap", notify=_neverEmitted)
+    def appConfig(self):
+        return {"darkMode": True}
+
+    @pyqtProperty(str, notify=directoryChanged)
+    def directory(self):
+        return ""
+
+    @pyqtSlot()
+    def recordAuditLogViewed(self):
+        self.viewed_count += 1
+
+    @pyqtSlot(result="QVariantList")
+    def auditEventTypes(self):
+        return list(self.event_types)
+
+    @pyqtSlot("QVariantMap", result="QVariantList")
+    def filteredAuditLogEntries(self, filters):
+        self.filter_calls.append(dict(filters))
+        return list(_ROWS)
+
+
+@contextlib.contextmanager
+def _basic_controls_style():
+    """Temporarily force the always-available Basic Controls style (the
+    platform-native style plugin fails to load in a bare offscreen test
+    process; restore right after so HIL subprocesses can't inherit it)."""
+    prev = os.environ.get("QT_QUICK_CONTROLS_STYLE")
+    os.environ["QT_QUICK_CONTROLS_STYLE"] = "Basic"
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("QT_QUICK_CONTROLS_STYLE", None)
+        else:
+            os.environ["QT_QUICK_CONTROLS_STYLE"] = prev
+
+
+@pytest.fixture(scope="module")
+def modal_factory():
+    """Compile components/LogsModal.qml once; hand out fresh instances."""
+    stub = _StubMotionInterface()
+    qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", stub)
+    qmlRegisterSingletonType(
+        QUrl.fromLocalFile(str(APP_THEME_QML)), "OpenMotion", 1, 0,
+        "AppTheme",
+    )
+    engine = QQmlEngine()
+    with _basic_controls_style():
+        component = QQmlComponent(
+            engine, QUrl.fromLocalFile(str(LOGS_MODAL_QML))
+        )
+    if component.isError():
+        raise RuntimeError(
+            "LogsModal.qml failed to compile:\n"
+            + "\n".join(e.toString() for e in component.errors())
+        )
+
+    created = []
+
+    def make():
+        obj = component.create()
+        if obj is None:
+            raise RuntimeError(
+                "LogsModal.qml failed to instantiate:\n"
+                + "\n".join(e.toString() for e in component.errors())
+            )
+        created.append(obj)
+        stub.filter_calls.clear()
+        return obj
+
+    make.stub = stub
+
+    yield make
+
+    for obj in created:
+        obj.deleteLater()
+    del engine
+    del stub
+
+
+def _call(obj, name):
+    """Invoke a parameterless JS function declared on the modal root.
+    PyQt6's invokeMethod returns None for void QML functions, so
+    success is asserted by the callers' downstream checks."""
+    QMetaObject.invokeMethod(obj, name)
+
+
+def _child(obj, object_name):
+    c = obj.findChild(QObject, object_name)
+    assert c is not None, f"child {object_name!r} not found"
+    return c
+
+
+def test_open_records_view_and_loads_filtered_entries(modal_factory):
+    modal = modal_factory()
+    stub = modal_factory.stub
+    before = stub.viewed_count
+    _call(modal, "open")
+    assert stub.viewed_count == before + 1
+    # open() loads via the filtered slot with no filters active.
+    assert stub.filter_calls
+    f = stub.filter_calls[-1]
+    assert f["eventType"] == ""
+    assert f["dateFrom"] == "" and f["dateTo"] == ""
+    assert f["text"] == ""
+    assert f["limit"] == 500
+    assert len(modal.property("entries")) == len(_ROWS)
+    assert modal.property("filtersActive") is False
+    # Event types for the dropdown come from the connector.
+    assert list(modal.property("eventTypes")) == stub.event_types
+
+
+def test_event_type_filter_is_passed_to_slot(modal_factory):
+    modal = modal_factory()
+    stub = modal_factory.stub
+    modal.setProperty("filterEventType", "scan_started")
+    _call(modal, "refresh")
+    assert stub.filter_calls[-1]["eventType"] == "scan_started"
+    assert modal.property("filtersActive") is True
+
+
+def test_date_and_text_fields_are_passed_to_slot(modal_factory):
+    modal = modal_factory()
+    stub = modal_factory.stub
+    _child(modal, "auditFilterFrom").setProperty("text", "2026-06-01")
+    _child(modal, "auditFilterTo").setProperty("text", "2026-06-15")
+    _child(modal, "auditFilterSearch").setProperty("text", "owABC")
+    _call(modal, "refresh")
+    f = stub.filter_calls[-1]
+    assert f["dateFrom"] == "2026-06-01"
+    assert f["dateTo"] == "2026-06-15"
+    assert f["text"] == "owABC"
+    assert modal.property("filtersActive") is True
+
+
+def test_date_field_validity_flag(modal_factory):
+    modal = modal_factory()
+    from_field = _child(modal, "auditFilterFrom")
+    from_field.setProperty("text", "garbage")
+    assert from_field.property("validDate") is False
+    from_field.setProperty("text", "2026-06-15")
+    assert from_field.property("validDate") is True
+    from_field.setProperty("text", "")
+    assert from_field.property("validDate") is True
+
+
+def test_clear_filters_resets_everything_and_refreshes(modal_factory):
+    modal = modal_factory()
+    stub = modal_factory.stub
+    modal.setProperty("filterEventType", "scan_started")
+    _child(modal, "auditFilterFrom").setProperty("text", "2026-06-01")
+    _child(modal, "auditFilterSearch").setProperty("text", "x")
+    _call(modal, "clearFilters")
+    f = stub.filter_calls[-1]
+    assert f["eventType"] == ""
+    assert f["dateFrom"] == "" and f["dateTo"] == ""
+    assert f["text"] == ""
+    assert modal.property("filtersActive") is False
+    assert modal.property("filterEventType") == ""


### PR DESCRIPTION
## Summary

Two audit-log-cluster tickets, one logical commit each (plus a follow-up placement commit per Ethan's review):

**#227 — Move debug log away from audit log** (`cd8fb65`, placement finalized in `0023eda`)
- The Settings **Audit Log** section mixed the clinical audit record with the engineering debug-bundle button ("Send Debug Logs") and described both in one helper text.
- The audit section is now purely the clinical record; **Send Debug Logs lives in the top-right corner of the About (firmware info) section** — final placement per Ethan's decision on this PR (initially proposed as a separate "Support" section, since dropped).
- **Un-gated** (visible in all modes): the bundle is the designated support path for clinical sites — support asks the operator to click it and email the zip, and the bundle contains no scan/patient data.
- `SectionCard` gained an optional right-aligned `headerItem` slot on its title row to host the button.
- Debug-bundle path (`prepareDebugLogBundle` / `debug_bundle.py`) unchanged; creating a bundle is still audited (`debug_bundle_created`).
- `docs/audit-log.md` fixed: it claimed the button sat "top of the audit-log viewer" (never true); it now names the About-section placement and states the audit-vs-debug separation explicitly.

**#226 — Add filter conditions to Audit Log** (`11f3bda`)
- Filter bar in `LogsModal`: **event-type dropdown** (distinct types present in the log), **From/To date range** (`YYYY-MM-DD`, local, inclusive whole days; malformed dates get a red border and are ignored), and a debounced **case-insensitive text search** across event type + details JSON.
- Filters AND together and are **view-only — Export CSV still writes the complete log**, so the export stays the full audit record.
- Filtering is SQL-side: `AuditLog.query()` grows optional `event_type` / `since_epoch` / `until_epoch` (exclusive) / `contains` params (LIKE with wildcard escaping, so searching `50%` matches literally), plus `distinct_event_types()` and a testable `parse_date_bound()` date parser. New fail-soft connector slots `filteredAuditLogEntries(filters)` and `auditEventTypes()` bridge QML.
- Empty-result state distinguishes "No entries match the current filters." from "No audit entries yet.", and **Clear** resets everything.

## Design notes
- `since` bound is inclusive midnight, `until` bound is exclusive next-day midnight — so both user-entered days are fully covered, DST-safe via local-time parsing.
- Combo/date/search state persists while the app runs; reopening the viewer refreshes the type list and restores the active selection (or falls back to "All events" if that type disappeared).
- QML-side contract is unit-tested by compiling the real `LogsModal.qml` offscreen against a stubbed `MotionInterface` singleton (`tests/test_logs_modal_filters.py`, pattern from `test_plot_viewer_masks.py`) — no app launch, no hardware.

## Verification
- Full unit suite green from the worktree root after the relocation: `python -m pytest tests -m unit -q` → **480 passed, 121 deselected** (baseline before this branch: 448 passed).
- `SettingsModal.qml` + `LogsModal.qml` verified to compile in an offscreen `QQmlEngine` after the SectionCard header-row change.
- New coverage: 13 filter/date-parser tests in `tests/test_audit_log.py`, 9 slot tests in `tests/test_audit_connector.py`, 5 QML contract tests in `tests/test_logs_modal_filters.py`.
- `config/app_config.json` untouched.
- Not hand-tested on the bench (shared hardware in use) — QA manual-test steps posted on #227 and below (step 2–3 of the #227 section supersede: the button is now top-right of About, no Support section).

Refs #227
Refs #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
