### PR TITLE
feat: pair mode — averaged row-pair plots for abbreviated grid (#289)

### DIFF
--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -13,6 +13,11 @@ Item {
     property var source: null            // ScanDataSource (Python QObject) or null
     property string side: "left"
     property int    camId: 0
+    // Pair mode (issue #289): when >= 0 this cell renders the AVERAGED
+    // row pair (camId, camIdB) via the source's pair_* slots — one
+    // trace per metric, labeled "L 4/5". -1 (the default) keeps the
+    // original single-camera behavior byte-for-byte.
+    property int    camIdB: -1
     property real   windowSeconds: 15
 
     // Time-axis state — when followLive=true, the cell tracks the
@@ -101,6 +106,16 @@ Item {
         return v
     }
 
+    // Value readout for the top-left labels / temperature — pair cells
+    // read the staleness-gated pair average (a stalled member drops out
+    // instead of pinning its last value); single-cam cells keep value_at.
+    function _valueAt(metricName, t) {
+        if (cell.camIdB >= 0)
+            return cell.source.pair_value_at(
+                cell.side, cell.camId, cell.camIdB, metricName, t)
+        return cell.source.value_at(cell.side, cell.camId, metricName, t)
+    }
+
     // Y-axis tick decimals chosen per axis from its span so all three
     // ticks format consistently — whole numbers for wide ranges (mean's
     // 0–500), one decimal for BFI/BVI's 0–10, two for contrast's 0–1
@@ -144,9 +159,14 @@ Item {
     function _drawTrace(ctx, metricName, color, yMinVal, yMaxVal,
                        tLo, tHi, dt, maxPts, w, h) {
         if (!metricName || metricName.length === 0) return 0
-        var pts = cell.source.points_for_window(
-            cell.side, cell.camId, metricName, tLo, tHi, maxPts
-        )
+        // Pair cells fetch the row pair's averaged series (falls back to
+        // the surviving camera when one member is dead/masked — see
+        // data_sources.merge_pair_points).
+        var pts = cell.camIdB >= 0
+            ? cell.source.pair_points_for_window(
+                  cell.side, cell.camId, cell.camIdB, metricName, tLo, tHi, maxPts)
+            : cell.source.points_for_window(
+                  cell.side, cell.camId, metricName, tLo, tHi, maxPts)
         if (pts.length < 2) return 0
         var dy = yMaxVal - yMinVal
         if (dy <= 0) return 0
@@ -236,16 +256,22 @@ Item {
                             tLo, tHi, dt, maxPts, width, height)
 
             // Dropout marker — vertical red bar at the recorded
-            // dropout time for this (side, cam).
-            var dropT = cell.source.dropped_at_for(cell.side, cell.camId)
-            if (isFinite(dropT) && dropT >= tLo && dropT <= tHi) {
-                var dropX = ((dropT - tLo) / dt) * width
-                ctx.strokeStyle = AppTheme.accentRed
-                ctx.lineWidth = 2
-                ctx.beginPath()
-                ctx.moveTo(Math.floor(dropX) + 0.5, 0)
-                ctx.lineTo(Math.floor(dropX) + 0.5, height)
-                ctx.stroke()
+            // dropout time for this (side, cam). Pair cells draw one
+            // per member so a single-camera dropout stays visible even
+            // while the averaged trace continues from the survivor.
+            var dropCams = cell.camIdB >= 0
+                ? [cell.camId, cell.camIdB] : [cell.camId]
+            for (var dc = 0; dc < dropCams.length; dc++) {
+                var dropT = cell.source.dropped_at_for(cell.side, dropCams[dc])
+                if (isFinite(dropT) && dropT >= tLo && dropT <= tHi) {
+                    var dropX = ((dropT - tLo) / dt) * width
+                    ctx.strokeStyle = AppTheme.accentRed
+                    ctx.lineWidth = 2
+                    ctx.beginPath()
+                    ctx.moveTo(Math.floor(dropX) + 0.5, 0)
+                    ctx.lineTo(Math.floor(dropX) + 0.5, height)
+                    ctx.stroke()
+                }
             }
 
             // Crosshair — vertical line at cursorT (broadcast by the
@@ -283,8 +309,10 @@ Item {
             // cam_id = -1 is the side-averaged stream fed by the SDK's
             // SideAveragingStage in clinical mode — hide the label there;
             // the large side panel next to the plot already names the side.
+            // Pair cells name both members ("LEFT 4/5", issue #289).
             visible: cell.camId !== -1
             text: cell.side.toUpperCase() + " " + (cell.camId + 1)
+                  + (cell.camIdB >= 0 ? "/" + (cell.camIdB + 1) : "")
             color: AppTheme.textSecondary
             font.pixelSize: 11
             font.family: "Roboto Mono"
@@ -302,7 +330,7 @@ Item {
                 void cell.paintTick  // dependency
                 if (!cell.source) return cell.metric.toUpperCase() + "  --"
                 var v = cell._displayValue(cell.metric,
-                    cell.source.value_at(cell.side, cell.camId, cell.metric, cell.liveEdgeSnapshot))
+                    cell._valueAt(cell.metric, cell.liveEdgeSnapshot))
                 return cell.metric.toUpperCase() + "  "
                        + (isFinite(v) ? v.toFixed(2) : "--")
             }
@@ -317,7 +345,7 @@ Item {
                 void cell.paintTick
                 if (!cell.source) return cell.secondaryMetric.toUpperCase() + "  --"
                 var v = cell._displayValue(cell.secondaryMetric,
-                    cell.source.value_at(cell.side, cell.camId, cell.secondaryMetric, cell.liveEdgeSnapshot))
+                    cell._valueAt(cell.secondaryMetric, cell.liveEdgeSnapshot))
                 return cell.secondaryMetric.toUpperCase() + "  "
                        + (isFinite(v) ? v.toFixed(2) : "--")
             }
@@ -335,8 +363,8 @@ Item {
         property real tempC: {
             void cell.paintTick  // dependency
             if (!cell.source || !cell.showTemperature) return NaN
-            return cell.source.value_at(cell.side, cell.camId, "temp",
-                                        cell.liveEdgeSnapshot)
+            // Pair cells show the pair-mean chip temperature.
+            return cell._valueAt("temp", cell.liveEdgeSnapshot)
         }
         visible: cell.showTemperature && cell.width >= 80 && isFinite(tempC)
         anchors.top: parent.top

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -78,6 +78,14 @@ Rectangle {
     // it from settingsModal.showBfiBvi). "bfi_bvi" overlays BFI+BVI on
     // each cell; "mean_contrast" overlays Mean+Contrast.
     property string displayMode: "bfi_bvi"
+    // Pair mode (issue #289) — collapse each grid row's two cameras
+    // (1-based pairs 4/5, 3/6, 2/7, 1/8 per side) into ONE cell that
+    // renders their averaged trace, halving the grid to ≤4 panels per
+    // side. Config is the source of truth (same pattern as
+    // showAxisLabels): the ⋯ popup toggle writes plotPairMode through
+    // MotionInterface.setConfig, which notifies appConfigChanged.
+    // Per-camera view only — clinical mode already shows side averages.
+    property bool pairMode: MotionInterface.appConfig.plotPairMode === true
     // autoScale — driven externally from Settings; when true, the 3 s
     // _recomputeAutoscale timer below repins primary/secondary YMin/YMax
     // to per-metric percentile bounds across the buffer.
@@ -243,6 +251,43 @@ Rectangle {
         return entries
     }
 
+    // Pair mode (issue #289) — collapse each U row's two cameras into
+    // ONE cell rendering their averaged trace. Same row order and
+    // shared-row compaction as _devCellModel (row r pairs 1-based cams
+    // 4-r | 5+r — top row 4/5 … bottom row 1/8, issue #164), so
+    // toggling pair mode keeps rows vertically in place. camIdB names
+    // the pair's second camera; when one member is masked out the cell
+    // falls back to the remaining camera alone (camIdB -1 → PlotCell's
+    // plain single-camera path). Left module owns column 0, right
+    // column 2 — column 1 is the side-break spacer when both sides are
+    // active (a side with nothing selected gives up its column).
+    readonly property var _pairCellModel: {
+        var masks = [viewer._effLeftMask & 0xFF, viewer._effRightMask & 0xFF]
+        var sides = ["left", "right"]
+        var colBase = [0, masks[0] !== 0 ? 2 : 0]
+        var entries = []
+        var displayRow = 0
+        for (var r = 0; r < 4; r++) {
+            var armA = 3 - r   // zero-based camId, 1-based cam 4-r
+            var armB = 4 + r   // zero-based camId, 1-based cam 5+r
+            var rowBits = (1 << armA) | (1 << armB)
+            if (!((masks[0] | masks[1]) & rowBits)) continue
+            for (var s = 0; s < 2; s++) {
+                var hasA = (masks[s] & (1 << armA)) !== 0
+                var hasB = (masks[s] & (1 << armB)) !== 0
+                if (!hasA && !hasB) continue
+                entries.push({
+                    side: sides[s],
+                    camId: hasA ? armA : armB,
+                    camIdB: (hasA && hasB) ? armB : -1,
+                    row: displayRow, col: colBase[s]
+                })
+            }
+            displayRow++
+        }
+        return entries
+    }
+
     // Clinical mode — one cell per ACTIVE side, each rendering the
     // side-averaged stream (cam_id=-1, fed by SDK's SideAveragingStage
     // via _LivePlotSink.consume). Stacked vertically in a single column.
@@ -261,7 +306,7 @@ Rectangle {
 
     readonly property var _activeCellModel: viewer.effectiveClinical
         ? _clinicalCellModel
-        : _devCellModel
+        : (viewer.pairMode ? _pairCellModel : _devCellModel)
 
     // ── Autoscale recompute (shared by Timer + displayMode change) ────
     // Writes to _auto* — the derived primaryYMin/Max bindings above
@@ -761,19 +806,23 @@ Rectangle {
                 Layout.fillHeight: true
                 // Clinical mode: single column, 2 stacked cells. Engineering mode:
                 // 4 columns; +1 spacer column (col 2) when both sides are
-                // active, for a visual break between the modules.
-                columns: viewer.effectiveClinical ? 1 : (viewer._sideGapActive ? 5 : 4)
+                // active, for a visual break between the modules. Pair mode
+                // halves that: 1 column per side, spacer at col 1.
+                columns: viewer.effectiveClinical ? 1
+                    : viewer.pairMode ? (viewer._sideGapActive ? 3 : 2)
+                    : (viewer._sideGapActive ? 5 : 4)
                 rowSpacing: 6
                 columnSpacing: 6
 
                 // Side-break spacer — fixed-width empty column 2 between the
-                // left (cols 0-1) and right (cols 3-4) modules. fillWidth is
-                // false so it stays a fixed gap; the plot cells (fillWidth)
-                // absorb the rest of the row width around it.
+                // left (cols 0-1) and right (cols 3-4) modules; in pair mode
+                // the modules are single columns (0 and 2), spacer at col 1.
+                // fillWidth is false so it stays a fixed gap; the plot cells
+                // (fillWidth) absorb the rest of the row width around it.
                 Item {
                     visible: viewer._sideGapActive
                     Layout.row: 0
-                    Layout.column: 2
+                    Layout.column: viewer.pairMode ? 1 : 2
                     Layout.fillWidth: false
                     Layout.fillHeight: false
                     Layout.preferredWidth: viewer._sideGapPx
@@ -789,6 +838,10 @@ Rectangle {
                         source: viewer.scanSource
                         side: modelData.side
                         camId: modelData.camId
+                        // Pair mode (issue #289): second camera of the row
+                        // pair; -1 (also for dev/clinical entries, which
+                        // don't carry the key) keeps the single-cam path.
+                        camIdB: modelData.camIdB !== undefined ? modelData.camIdB : -1
                         windowSeconds: viewer.windowSeconds
                         followLive: viewer.followLive
                         windowStartT: viewer.windowStartT
@@ -808,10 +861,14 @@ Rectangle {
                         panZoomTarget: viewer
                         cursorT: viewer.cursorT
                         // Live-source only: past scans have no "current"
-                        // connection state to report (issue #174).
+                        // connection state to report (issue #174). A pair
+                        // cell only reads lost when EVERY member is lost —
+                        // with one survivor the averaged trace continues.
                         connectionLost: viewer.scanSource !== null
                             && viewer.scanSource.live === true
                             && viewer._lostCameras[modelData.side + ":" + modelData.camId] === true
+                            && (modelData.camIdB === undefined || modelData.camIdB < 0
+                                || viewer._lostCameras[modelData.side + ":" + modelData.camIdB] === true)
                     }
                 }
             }
@@ -898,16 +955,23 @@ Rectangle {
             var rows = []
             for (var i = 0; i < viewer._activeCellModel.length; i++) {
                 var c = viewer._activeCellModel[i]
-                var pv = viewer.clampForDisplay(primMetric,
-                    viewer.scanSource.value_at(c.side, c.camId, primMetric, t))
-                var sv = viewer.clampForDisplay(secMetric,
-                    viewer.scanSource.value_at(c.side, c.camId, secMetric, t))
+                // Pair cells (issue #289) read the staleness-gated pair
+                // average; single-cam / clinical entries keep value_at.
+                var b = (c.camIdB !== undefined && c.camIdB >= 0) ? c.camIdB : -1
+                var pv = viewer.clampForDisplay(primMetric, b >= 0
+                    ? viewer.scanSource.pair_value_at(c.side, c.camId, b, primMetric, t)
+                    : viewer.scanSource.value_at(c.side, c.camId, primMetric, t))
+                var sv = viewer.clampForDisplay(secMetric, b >= 0
+                    ? viewer.scanSource.pair_value_at(c.side, c.camId, b, secMetric, t)
+                    : viewer.scanSource.value_at(c.side, c.camId, secMetric, t))
                 // Clinical mode uses camId=-1 for the side-averaged stream;
                 // (c.camId + 1) would render "L0"/"R0" instead of the
-                // cell's own "LEFT AVG" / "RIGHT AVG" label.
+                // cell's own "LEFT AVG" / "RIGHT AVG" label. Pair cells
+                // name both members ("L4/5") like the panel label.
                 var label = c.camId === -1
                     ? c.side.charAt(0).toUpperCase() + " AVG"
                     : c.side.charAt(0).toUpperCase() + (c.camId + 1)
+                          + (b >= 0 ? "/" + (b + 1) : "")
                 rows.push({
                     label: label,
                     pVal: pv, pColor: primColor,
@@ -1308,6 +1372,27 @@ Rectangle {
                         Text {
                             anchors.verticalCenter: axisLabelsSwitch.verticalCenter
                             text: "Axis labels"
+                            color: AppTheme.textPrimary
+                            font.pixelSize: 12
+                            font.family: "Roboto Mono"
+                        }
+                    }
+                    Row {
+                        // Pair mode (issue #289): collapse each grid row's
+                        // camera pair (4/5, 3/6, 2/7, 1/8) into one averaged
+                        // panel — 4 per side. Hidden in clinical mode, which
+                        // already averages whole sides. Persisted via config
+                        // like Axis labels above.
+                        visible: !viewer.effectiveClinical
+                        spacing: 8
+                        PopupPillSwitch {
+                            id: pairModeSwitch
+                            checked: viewer.pairMode
+                            onToggled: MotionInterface.setConfig("plotPairMode", checked)
+                        }
+                        Text {
+                            anchors.verticalCenter: pairModeSwitch.verticalCenter
+                            text: "Pair mode"
                             color: AppTheme.textPrimary
                             font.pixelSize: 12
                             font.family: "Roboto Mono"

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -30,6 +30,7 @@
     "autoScale": false,
     "autoScalePerPlot": false,
     "showAxisLabels": true,
+    "plotPairMode": false,
     "darkMode": true,
     "max_calibration_time_sec": 600,
     "calibration_scan_duration_sec": 15,

--- a/data_sources.py
+++ b/data_sources.py
@@ -268,24 +268,126 @@ class _CameraBuffer:
         Lock-protected: the GUI hover tooltip reads while the pipeline
         thread appends/ring-trims. A torn read of `n` previously caused
         IndexErrors when a searchsorted idx passed a stale-n clamp."""
+        _, v = self.sample_near(t)
+        return v if math.isfinite(v) else float("nan")
+
+    def sample_near(self, t: float) -> tuple[float, float]:
+        """(timestamp, value) of the sample nearest to time `t`, or
+        (NaN, NaN) when the buffer is empty. The value is returned as
+        stored — including NaN — so callers can tell "no sample near t"
+        (NaN timestamp) apart from "the nearest sample is non-finite".
+        Backs pair_value_at's staleness gate (issue #289).
+
+        Lock-protected like value_near: the pipeline thread appends /
+        ring-trims concurrently with GUI-thread reads."""
         with self._lock:
             n = self.n
             if n == 0:
-                return float("nan")
+                return float("nan"), float("nan")
             t_slice = self.t[:n]
             idx = int(np.searchsorted(t_slice, t, side="left"))
             if idx >= n:
                 idx = n - 1
             elif idx > 0 and abs(t_slice[idx - 1] - t) < abs(t_slice[idx] - t):
                 idx -= 1
-            v = float(self.v[idx])
-            return v if np.isfinite(v) else float("nan")
+            return float(t_slice[idx]), float(self.v[idx])
 
     def mark_dropped(self, t: float) -> None:
         """Record the first dropout timestamp for this stream. Idempotent —
         later calls don't overwrite the earlier dropout."""
         if self.dropped_at is None:
             self.dropped_at = float(t)
+
+
+# ── Pair mode (issue #289) ────────────────────────────────────────────────
+# The plot viewer's pair mode collapses each grid row's two cameras
+# (1-based pairs 1+8, 2+7, 3+6, 4+5 per side) into one panel rendering
+# their averaged trace. The averaging lives here, at read time — no
+# extra per-pair buffers, and both live DB-tail stitching and past-scan
+# replay inherit it because pair_points_for_window rides the polymorphic
+# points_for_window.
+
+_PAIR_NOMINAL_HZ = 40.0  # SDK histogram cadence (matches window_decimated)
+# A camera contributes to the pair average at a grid point only if one
+# of its own finite samples lies within this many output-sample
+# spacings — a dropped/covered camera stops contributing where its data
+# ends instead of being flat-line extrapolated across the gap by
+# np.interp, so the pair panel falls back to the surviving camera.
+_PAIR_GAP_SPACINGS = 1.5
+# ...and the gate is never tighter than this (seconds): raw 40 Hz
+# samples are 25 ms apart, so a 100 ms floor tolerates a few missed
+# frames without the trace flickering between "pair" and "single".
+_PAIR_GAP_MIN_S = 0.1
+# pair_value_at: a camera's nearest sample must be at most this stale
+# to count toward the pair readout — a stalled camera drops out of the
+# label/tooltip average instead of pinning its last value forever.
+# Matches nan_gap_tracker.MIN_GAP_S ("delivery genuinely stopped").
+_PAIR_VALUE_STALENESS_S = 1.0
+
+
+def merge_pair_points(pts_a, pts_b, t_lo: float, t_hi: float,
+                      max_points: int) -> list:
+    """Merge two per-camera decimated [t, v] series into one averaged
+    series for a pair-mode panel (issue #289).
+
+    Both inputs are points_for_window outputs for the SAME window and
+    point budget. Either side empty → the other is returned VERBATIM,
+    so a pair whose second camera never delivered renders exactly like
+    the survivor's own single-camera cell.
+
+    Otherwise both series are linearly resampled onto a common grid of
+    absolute-time multiples of the window's output spacing (the same
+    stride math as _CameraBuffer.window_decimated, so grid positions
+    are invariant under pan/data growth and the merged trace doesn't
+    morph between paints). Each camera contributes at a grid point only
+    when one of its own finite samples is nearby (_PAIR_GAP_SPACINGS);
+    the output value is the mean of the contributing cameras. Grid
+    points where neither camera contributes are omitted (the renderer
+    draws nothing there, same as a single camera's own gap)."""
+    if not pts_a:
+        return pts_b
+    if not pts_b:
+        return pts_a
+
+    t_lo = float(t_lo)
+    t_hi = float(t_hi)
+    expected = max(1.0, (t_hi - t_lo) * _PAIR_NOMINAL_HZ)
+    stride = max(1, int(-(-expected // max(1, int(max_points)))))
+    spacing = stride / _PAIR_NOMINAL_HZ
+    k_lo = math.ceil(t_lo / spacing)
+    k_hi = math.floor(t_hi / spacing)
+    if k_hi < k_lo:
+        return []
+    grid = np.arange(k_lo, k_hi + 1, dtype=np.float64) * spacing
+    gap_max = max(_PAIR_GAP_SPACINGS * spacing, _PAIR_GAP_MIN_S)
+
+    acc = np.zeros(grid.size, dtype=np.float64)
+    cnt = np.zeros(grid.size, dtype=np.int64)
+    for pts in (pts_a, pts_b):
+        arr = np.asarray(pts, dtype=np.float64)
+        finite = np.isfinite(arr[:, 1])
+        if not finite.any():
+            continue
+        t_f = arr[finite, 0]
+        v_f = arr[finite, 1]
+        v_i = np.interp(grid, t_f, v_f)
+        # Distance from each grid point to this camera's nearest finite
+        # sample — the contribution gate.
+        idx = np.searchsorted(t_f, grid)
+        left = np.clip(idx - 1, 0, t_f.size - 1)
+        right = np.clip(idx, 0, t_f.size - 1)
+        dist = np.minimum(np.abs(grid - t_f[left]),
+                          np.abs(t_f[right] - grid))
+        ok = dist <= gap_max
+        acc[ok] += v_i[ok]
+        cnt[ok] += 1
+
+    have = cnt > 0
+    if not have.any():
+        return []
+    t_out = grid[have]
+    v_out = acc[have] / cnt[have]
+    return [[float(t), float(v)] for t, v in zip(t_out, v_out)]
 
 
 _FLUSH_INTERVAL_MS = 100  # spec §"Throttled UI notify"
@@ -484,6 +586,66 @@ class ScanDataSource(QObject):
         if buf is None:
             return float("nan")
         return buf.value_near(t)
+
+    @pyqtSlot(str, int, int, str, float, float, int, result="QVariantList")
+    def pair_points_for_window(
+        self,
+        side: str,
+        cam_a: int,
+        cam_b: int,
+        metric: str,
+        t_lo: float,
+        t_hi: float,
+        max_points: int,
+    ) -> list:
+        """QML-facing pair-mode variant of points_for_window (issue
+        #289): the row pair (cam_a, cam_b) averaged into one series.
+        Rides the polymorphic points_for_window per camera, so
+        LiveScanSource's DB-tail stitching and PastScanSource replay
+        behave identically to the single-camera cells. Fallbacks live in
+        merge_pair_points: one dead/masked camera → the survivor's own
+        series verbatim, never a NaN/blank panel."""
+        pts_a = self.points_for_window(
+            side, cam_a, metric, t_lo, t_hi, max_points)
+        pts_b = self.points_for_window(
+            side, cam_b, metric, t_lo, t_hi, max_points)
+        return merge_pair_points(
+            pts_a, pts_b, float(t_lo), float(t_hi), int(max_points))
+
+    def _sample_near(
+        self, side: str, cam_id: int, metric: str, t: float
+    ) -> tuple[float, float]:
+        """(timestamp, value) of the sample nearest to `t` for one
+        stream, or (NaN, NaN) when the buffer doesn't exist / is empty.
+        Hook for pair_value_at's staleness gate; LiveScanSource
+        overrides it with the DB-tail branch."""
+        buf = self.buffers.get((side, int(cam_id), metric))
+        if buf is None:
+            return float("nan"), float("nan")
+        return buf.sample_near(t)
+
+    @pyqtSlot(str, int, int, str, float, result=float)
+    def pair_value_at(
+        self, side: str, cam_a: int, cam_b: int, metric: str, t: float
+    ) -> float:
+        """Pair-mode value readout (issue #289): the mean over the
+        pair's cameras at time `t`, counting only cameras whose nearest
+        sample is FRESH (within _PAIR_VALUE_STALENESS_S of `t`). A
+        camera that stopped delivering drops out of the average instead
+        of pinning its stale last value into the cell label / hover
+        tooltip; NaN when neither camera qualifies (renders "--")."""
+        t = float(t)
+        total = 0.0
+        count = 0
+        for cam_id in (cam_a, cam_b):
+            t_n, v = self._sample_near(side, int(cam_id), metric, t)
+            if not (math.isfinite(t_n) and math.isfinite(v)):
+                continue
+            if abs(t_n - t) > _PAIR_VALUE_STALENESS_S:
+                continue
+            total += v
+            count += 1
+        return (total / count) if count else float("nan")
 
     @pyqtSlot(str, int, result=float)
     def dropped_at_for(self, side: str, cam_id: int) -> float:
@@ -901,6 +1063,22 @@ class LiveScanSource(ScanDataSource):
         if buf is None:
             return float("nan")
         return buf.value_near(t)
+
+    def _sample_near(
+        self, side: str, cam_id: int, metric: str, t: float
+    ) -> tuple[float, float]:
+        """DB-tail-aware _sample_near (pair mode, issue #289) — mirrors
+        value_at: serve from memory unless `t` falls below the
+        ring-trimmed in-memory range, then read the transient DB
+        window."""
+        if (not self._needs_db_tail(side, int(cam_id), metric, t)
+                or not self._db_ready()):
+            return super()._sample_near(side, cam_id, metric, t)
+        self._ensure_db_window(t, t)
+        buf = self._db_window_buffers.get((side, int(cam_id), metric))
+        if buf is None:
+            return float("nan"), float("nan")
+        return buf.sample_near(t)
 
     def append_uncorrected(
         self,

--- a/main.py
+++ b/main.py
@@ -150,6 +150,10 @@ def _load_app_config() -> dict:
         "autoScalePerPlot": False,
         # Y-axis tick labels on plot cells; runtime toggle in the ⋯ popup.
         "showAxisLabels": True,
+        # Pair mode (issue #289): collapse each plot row's camera pair
+        # (1/8, 2/7, 3/6, 4/5 per side) into one averaged panel; runtime
+        # toggle in the ⋯ popup. Default off — full per-camera grid.
+        "plotPairMode": False,
         # Build-time flag: true keeps ALL writable state (config overrides,
         # logs, scan data/db) next to the exe, like the old un-installed
         # layout; false scatters it to %PROGRAMDATA%\Openwater (the

--- a/tests/test_plot_pair_mode.py
+++ b/tests/test_plot_pair_mode.py
@@ -1,0 +1,256 @@
+"""Unit tests for plot pair mode (issue #289) — row-pair averaging in
+data_sources.py.
+
+Pair mode collapses each U-shape grid row's two cameras (1+8, 2+7, 3+6,
+4+5 per side, 1-based) into one panel rendering the mean of the two
+cameras' BFI/BVI. The averaging lives Python-side:
+
+  - merge_pair_points()       — common-grid resampled mean of two
+                                decimated [t, v] series with per-camera
+                                gap gating (a dead camera stops
+                                contributing where its data ends).
+  - pair_points_for_window()  — QML-facing slot; rides the polymorphic
+                                points_for_window so DB-tail / replay
+                                behavior is inherited.
+  - pair_value_at()           — staleness-gated mean for the cell value
+                                labels + hover tooltip.
+  - _CameraBuffer.sample_near — (t, v) of the nearest sample, backing
+                                the staleness gate.
+
+The QML grid-model half of the feature (cell pairing/labels/fallback
+layout) is tested in tests/test_plot_viewer_masks.py.
+"""
+
+import math
+
+import pytest
+
+from data_sources import (
+    LiveScanSource,
+    _CameraBuffer,
+    merge_pair_points,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _pts(value, t0=0.0, t1=10.0, hz=40.0):
+    """Constant-valued [t, v] series over [t0, t1) at `hz` — the shape
+    points_for_window returns for an undecimated window."""
+    n = int(round((t1 - t0) * hz))
+    return [[t0 + i / hz, value] for i in range(n)]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# merge_pair_points
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_merge_averages_two_full_series():
+    merged = merge_pair_points(_pts(1.0), _pts(3.0), 0.0, 10.0, 1000)
+    assert len(merged) > 0
+    assert all(v == pytest.approx(2.0) for _, v in merged)
+    assert all(0.0 <= t <= 10.0 for t, _ in merged)
+
+
+def test_merge_empty_side_passes_other_through_verbatim():
+    a = _pts(1.0)
+    assert merge_pair_points(a, [], 0.0, 10.0, 1000) is a
+    assert merge_pair_points([], a, 0.0, 10.0, 1000) is a
+    assert merge_pair_points([], [], 0.0, 10.0, 1000) == []
+
+
+def test_merge_respects_point_budget():
+    merged = merge_pair_points(
+        _pts(1.0, t1=60.0), _pts(3.0, t1=60.0), 0.0, 60.0, 100)
+    # Same stride math as window_decimated: the count can exceed the
+    # budget by at most the fencepost sample.
+    assert 0 < len(merged) <= 101
+    assert all(v == pytest.approx(2.0) for _, v in merged)
+
+
+def test_merge_dropped_camera_falls_back_to_survivor():
+    """Camera B stops delivering mid-window: grid points past its last
+    sample (+ gap) must carry camera A's value alone — the pair trace
+    never goes blank because one member died."""
+    a = _pts(1.0, t1=10.0)
+    b = _pts(3.0, t1=5.0)  # B dies at t=5
+    merged = merge_pair_points(a, b, 0.0, 10.0, 1000)
+    early = [v for t, v in merged if t < 4.5]
+    late = [v for t, v in merged if t > 5.5]
+    assert early and late
+    assert all(v == pytest.approx(2.0) for v in early)
+    assert all(v == pytest.approx(1.0) for v in late)
+
+
+def test_merge_interior_gap_not_bridged():
+    """Camera B has an interior dropout [3, 7]: inside the gap only A
+    contributes; interp must not flat-line B across it."""
+    a = _pts(1.0, t1=10.0)
+    b = [p for p in _pts(3.0, t1=10.0) if not (3.0 <= p[0] <= 7.0)]
+    merged = merge_pair_points(a, b, 0.0, 10.0, 1000)
+    inside = [v for t, v in merged if 3.5 < t < 6.5]
+    outside = [v for t, v in merged if t < 2.5 or t > 7.5]
+    assert inside and outside
+    assert all(v == pytest.approx(1.0) for v in inside)
+    assert all(v == pytest.approx(2.0) for v in outside)
+
+
+def test_merge_all_nan_partner_yields_survivor_values():
+    a = _pts(1.0)
+    b = [[t, float("nan")] for t, _ in _pts(0.0)]
+    merged = merge_pair_points(a, b, 0.0, 10.0, 1000)
+    assert len(merged) > 0
+    assert all(v == pytest.approx(1.0) for _, v in merged)
+
+
+def test_merge_grid_is_absolute_time_aligned():
+    """Output timestamps sit at absolute multiples of the output spacing,
+    so a panning window re-lands points on the same grid (no morphing).
+    Windows chosen so both resolve the same stride."""
+    a = _pts(1.0, t1=20.0)
+    b = _pts(3.0, t1=20.0)
+    m1 = merge_pair_points(a, b, 0.0, 20.0, 100)      # stride 8 → 0.2 s
+    m2 = merge_pair_points(a, b, 0.55, 20.0, 100)     # stride 8 → 0.2 s
+    t1s = {round(t, 6) for t, _ in m1}
+    t2s = {round(t, 6) for t, _ in m2}
+    assert t2s <= t1s  # the shifted window's grid is a subset
+    v1 = {round(t, 6): v for t, v in m1}
+    for t, v in m2:
+        assert v == pytest.approx(v1[round(t, 6)])
+
+
+def test_merge_no_overlap_with_window_returns_empty():
+    a = _pts(1.0, t0=100.0, t1=101.0)
+    b = _pts(3.0, t0=100.0, t1=101.0)
+    assert merge_pair_points(a, b, 0.0, 0.001, 100) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _CameraBuffer.sample_near
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_sample_near_empty_buffer_is_nan_nan():
+    buf = _CameraBuffer(initial_capacity=4)
+    t, v = buf.sample_near(1.0)
+    assert math.isnan(t) and math.isnan(v)
+
+
+def test_sample_near_returns_nearest_sample_pair():
+    buf = _CameraBuffer(initial_capacity=4)
+    buf.append(t=0.5, v=1.0, frame_id=0)
+    buf.append(t=1.0, v=2.0, frame_id=1)
+    assert buf.sample_near(0.6) == (0.5, 1.0)
+    assert buf.sample_near(0.9) == (1.0, 2.0)
+    assert buf.sample_near(-5.0) == (0.5, 1.0)   # clamped to oldest
+    assert buf.sample_near(50.0) == (1.0, 2.0)   # clamped to newest
+
+
+def test_sample_near_passes_nan_value_through():
+    """Unlike value_near, sample_near returns the stored value verbatim
+    (with its timestamp) so callers can distinguish 'no sample near t'
+    from 'the nearest sample is non-finite'."""
+    buf = _CameraBuffer(initial_capacity=4)
+    buf.append(t=2.0, v=float("nan"), frame_id=0)
+    t, v = buf.sample_near(2.0)
+    assert t == 2.0 and math.isnan(v)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource.pair_points_for_window (via LiveScanSource, in-memory)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _feed(src, side, cam_id, value, t0=0.0, t1=10.0, hz=40.0):
+    n = int(round((t1 - t0) * hz))
+    for i in range(n):
+        src.append_uncorrected(side=side, cam_id=cam_id, frame_id=i,
+                               t=t0 + i / hz, bfi=value, bvi=value + 10.0)
+
+
+def test_pair_points_averages_row_pair():
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.0)
+    _feed(src, "left", 7, 3.0)
+    pts = src.pair_points_for_window("left", 0, 7, "bfi", 0.0, 10.0, 1000)
+    assert len(pts) > 0
+    assert all(v == pytest.approx(2.0) for _, v in pts)
+
+
+def test_pair_points_missing_partner_matches_single_camera():
+    """A pair whose second camera never delivered (masked out at the
+    firmware level, dead from t=0, …) renders EXACTLY the survivor's
+    own single-camera series."""
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.5)
+    single = src.points_for_window("left", 0, "bfi", 0.0, 10.0, 1000)
+    paired = src.pair_points_for_window("left", 0, 7, "bfi", 0.0, 10.0, 1000)
+    assert paired == single
+    assert len(paired) > 0
+
+
+def test_pair_points_both_missing_is_empty():
+    src = LiveScanSource(plot_t0=0.0)
+    assert src.pair_points_for_window(
+        "left", 0, 7, "bfi", 0.0, 10.0, 1000) == []
+
+
+def test_pair_points_partner_dropout_survivor_continues():
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "right", 1, 2.0, t1=10.0)
+    _feed(src, "right", 6, 4.0, t1=5.0)  # dies halfway
+    pts = src.pair_points_for_window("right", 1, 6, "bfi", 0.0, 10.0, 1000)
+    early = [v for t, v in pts if t < 4.5]
+    late = [v for t, v in pts if t > 5.5]
+    assert early and late
+    assert all(v == pytest.approx(3.0) for v in early)
+    assert all(v == pytest.approx(2.0) for v in late)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ScanDataSource.pair_value_at
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_pair_value_at_means_fresh_cameras():
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.0)
+    _feed(src, "left", 7, 3.0)
+    assert src.pair_value_at("left", 0, 7, "bfi", 9.9) == pytest.approx(2.0)
+    # bvi streams got value + 10.
+    assert src.pair_value_at("left", 0, 7, "bvi", 9.9) == pytest.approx(12.0)
+
+
+def test_pair_value_at_excludes_stale_camera():
+    """Camera 8 stalled 5 s ago: its last value must NOT pin the pair
+    readout — only the delivering camera counts."""
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.0, t1=10.0)
+    _feed(src, "left", 7, 3.0, t1=5.0)
+    assert src.pair_value_at("left", 0, 7, "bfi", 9.9) == pytest.approx(1.0)
+
+
+def test_pair_value_at_missing_partner_uses_survivor():
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.0)
+    assert src.pair_value_at("left", 0, 7, "bfi", 9.9) == pytest.approx(1.0)
+
+
+def test_pair_value_at_nothing_fresh_is_nan():
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.0, t1=10.0)
+    _feed(src, "left", 7, 3.0, t1=10.0)
+    # Query 5 s past the last sample — both stale → NaN (renders "--").
+    assert math.isnan(src.pair_value_at("left", 0, 7, "bfi", 15.0))
+
+
+def test_pair_value_at_no_buffers_is_nan():
+    src = LiveScanSource(plot_t0=0.0)
+    assert math.isnan(src.pair_value_at("left", 0, 7, "bfi", 1.0))
+
+
+def test_pair_value_at_nan_nearest_sample_excluded():
+    """The nearest sample being non-finite excludes that camera (same
+    semantics as value_at), leaving the finite partner."""
+    src = LiveScanSource(plot_t0=0.0)
+    _feed(src, "left", 0, 1.0)
+    buf = src.get_or_create_buffer("left", 7, "bfi")
+    buf.append(t=9.9, v=float("nan"), frame_id=0)
+    assert src.pair_value_at("left", 0, 7, "bfi", 9.9) == pytest.approx(1.0)

--- a/tests/test_plot_viewer_masks.py
+++ b/tests/test_plot_viewer_masks.py
@@ -129,6 +129,15 @@ class _StubPastScanSource(QObject):
     def value_at(self, side, cam_id, metric, t):
         return float("nan")
 
+    @pyqtSlot(str, int, int, str, float, float, int, result="QVariantList")
+    def pair_points_for_window(self, side, cam_a, cam_b, metric,
+                               t_lo, t_hi, max_points):
+        return []
+
+    @pyqtSlot(str, int, int, str, float, result=float)
+    def pair_value_at(self, side, cam_a, cam_b, metric, t):
+        return float("nan")
+
     @pyqtSlot(str, int, result=float)
     def dropped_at_for(self, side, cam_id):
         return float("nan")
@@ -614,6 +623,175 @@ def test_past_scan_ignores_connection_gate(viewer_factory):
     finally:
         viewer_factory.stub.setScanSource(None)
         viewer_factory.stub.setSensorsConnected(left=True, right=True)
+
+
+# ── Issue #289 — pair mode grid model ───────────────────────────────────
+# Pair mode collapses each U row's two cameras (1-based 4-r | 5+r → pairs
+# 4/5, 3/6, 2/7, 1/8 top-to-bottom, same order as the dev grid) into ONE
+# cell per side rendering their averaged trace — ≤4 panels per side. A
+# pair member missing from the mask falls the cell back to the single
+# remaining camera (camIdB == -1 → plain single-cam PlotCell path); a
+# row with neither camera selected is dropped. Left module owns column
+# 0, right column 2 (column 1 is the side-break spacer). The averaging
+# itself is Python-side — tests/test_plot_pair_mode.py.
+
+
+def _pair_cells(viewer):
+    val = viewer.property("_pairCellModel")
+    if hasattr(val, "toVariant"):
+        val = val.toVariant()
+    assert isinstance(val, list)
+    return val
+
+
+def _active_cells(viewer):
+    val = viewer.property("_activeCellModel")
+    if hasattr(val, "toVariant"):
+        val = val.toVariant()
+    assert isinstance(val, list)
+    return val
+
+
+def _pair_pos(cells, side, cam_id, cam_id_b):
+    matches = [(c["row"], c["col"]) for c in cells
+               if c["side"] == side and c["camId"] == cam_id
+               and c["camIdB"] == cam_id_b]
+    assert len(matches) == 1, \
+        f"expected exactly one cell for {side} pair {cam_id}/{cam_id_b}"
+    return matches[0]
+
+
+def test_pair_mode_all_masks_collapse_to_four_rows_per_side(viewer_factory):
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", ALL_MASK)
+    viewer.setProperty("rightMask", ALL_MASK)
+    viewer.setProperty("pairMode", True)
+    cells = _pair_cells(viewer)
+    assert len(cells) == 8  # 4 rows × 2 sides
+    # Row r pairs zero-based camIds (3-r, 4+r) — same U order as the
+    # dev grid (row 0 = 4/5 … row 3 = 1/8). Left col 0, right col 2.
+    for r in range(4):
+        assert _pair_pos(cells, "left", 3 - r, 4 + r) == (r, 0)
+        assert _pair_pos(cells, "right", 3 - r, 4 + r) == (r, 2)
+
+
+def test_pair_mode_rows_compact_like_dev_grid(viewer_factory):
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", MIDDLE_MASK)
+    viewer.setProperty("rightMask", MIDDLE_MASK)
+    viewer.setProperty("pairMode", True)
+    cells = _pair_cells(viewer)
+    assert len(cells) == 4
+    # Middle = U rows 1 (cams 3|6) and 2 (cams 2|7), compacted to 0,1.
+    assert _pair_pos(cells, "left", 2, 5) == (0, 0)
+    assert _pair_pos(cells, "right", 2, 5) == (0, 2)
+    assert _pair_pos(cells, "left", 1, 6) == (1, 0)
+    assert _pair_pos(cells, "right", 1, 6) == (1, 2)
+
+
+def test_pair_mode_masked_partner_falls_back_to_single_camera(viewer_factory):
+    """One camera of a pair masked out → the cell carries only the
+    remaining camera (camIdB -1), i.e. the plain single-camera render
+    path, labeled with just that camera."""
+    viewer = viewer_factory()
+    # Left: cam 4 only (camId 3, U row 0) — partner cam 5 masked out.
+    viewer.setProperty("leftMask", 0x08)
+    viewer.setProperty("rightMask", 0x00)
+    viewer.setProperty("pairMode", True)
+    cells = _pair_cells(viewer)
+    assert len(cells) == 1
+    assert cells[0]["side"] == "left"
+    assert cells[0]["camId"] == 3
+    assert cells[0]["camIdB"] == -1
+    assert (cells[0]["row"], cells[0]["col"]) == (0, 0)
+
+
+def test_pair_mode_single_side_takes_first_column(viewer_factory):
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", 0x00)
+    viewer.setProperty("rightMask", ALL_MASK)
+    viewer.setProperty("pairMode", True)
+    cells = _pair_cells(viewer)
+    assert len(cells) == 4
+    assert all(c["side"] == "right" and c["col"] == 0 for c in cells)
+
+
+def test_active_model_follows_pair_mode_toggle(viewer_factory):
+    """Toggling pair mode mid-session swaps the active grid model between
+    the 16-cell dev grid and the 8-cell pair grid (and back)."""
+    viewer = viewer_factory()
+    viewer.setProperty("leftMask", ALL_MASK)
+    viewer.setProperty("rightMask", ALL_MASK)
+    viewer.setProperty("pairMode", False)
+    assert len(_active_cells(viewer)) == 16
+    viewer.setProperty("pairMode", True)
+    cells = _active_cells(viewer)
+    assert len(cells) == 8
+    assert all(c["camIdB"] >= 0 for c in cells)
+    viewer.setProperty("pairMode", False)
+    assert len(_active_cells(viewer)) == 16
+
+
+def test_pair_mode_defaults_off(viewer_factory):
+    viewer = viewer_factory()
+    assert viewer.property("pairMode") is False
+
+
+def test_clinical_mode_wins_over_pair_mode(viewer_factory):
+    """Clinical mode already averages (whole side, cam_id -1) — pair mode
+    must not replace its 2-cell layout."""
+    viewer = viewer_factory()
+    try:
+        viewer.setProperty("clinicalMode", True)
+        viewer.setProperty("leftMask", ALL_MASK)
+        viewer.setProperty("rightMask", ALL_MASK)
+        viewer.setProperty("pairMode", True)
+        cells = _active_cells(viewer)
+        assert [c["camId"] for c in cells] == [-1, -1]
+    finally:
+        viewer.setProperty("clinicalMode", False)
+        viewer.setProperty("pairMode", False)
+
+
+def test_pair_mode_respects_connection_gate(viewer_factory):
+    """The issue-#298 per-side connection gate applies unchanged: a lone
+    right sensor must not draw phantom left pair panels."""
+    viewer = viewer_factory()
+    try:
+        viewer_factory.stub.setSensorsConnected(left=False, right=True)
+        viewer.setProperty("leftMask", 0x99)
+        viewer.setProperty("rightMask", 0x99)
+        viewer.setProperty("pairMode", True)
+        cells = _pair_cells(viewer)
+        assert all(c["side"] == "right" for c in cells)
+        # 0x99 = cams 1,4,5,8 → U rows 0 (4/5) and 3 (1/8), compacted.
+        assert _pair_pos(cells, "right", 3, 4) == (0, 0)
+        assert _pair_pos(cells, "right", 0, 7) == (1, 0)
+    finally:
+        viewer_factory.stub.setSensorsConnected(left=True, right=True)
+        viewer.setProperty("pairMode", False)
+
+
+def test_pair_mode_replay_uses_recorded_masks(viewer_factory):
+    """Pair mode on a replayed past scan lays out from the scan's own
+    recorded masks (issue #175 semantics carry over)."""
+    viewer = viewer_factory()
+    try:
+        viewer.setProperty("leftMask", ALL_MASK)
+        viewer.setProperty("rightMask", ALL_MASK)
+        viewer.setProperty("pairMode", True)
+        past = _StubPastScanSource(FAR_MASK, FAR_MASK)
+        viewer_factory.stub.setScanSource(past)
+        cells = _pair_cells(viewer)
+        # Far = cams 1,2,7,8 → U rows 2 (2/7) and 3 (1/8), both sides.
+        assert len(cells) == 4
+        assert _pair_pos(cells, "left", 1, 6) == (0, 0)
+        assert _pair_pos(cells, "right", 1, 6) == (0, 2)
+        assert _pair_pos(cells, "left", 0, 7) == (1, 0)
+        assert _pair_pos(cells, "right", 0, 7) == (1, 2)
+    finally:
+        viewer_factory.stub.setScanSource(None)
+        viewer.setProperty("pairMode", False)
 
 
 def test_clinical_model_drops_disconnected_side(viewer_factory):


### PR DESCRIPTION
## Summary

Implements plot **Pair mode** (issue #289): each grid row's two cameras — 1-based pairs **4/5, 3/6, 2/7, 1/8 per side** — collapse into ONE panel rendering their **averaged** BFI/BVI trace, halving the per-camera grid to at most 4 panels per side for easier readability. Toggled from the plot's bottom-right `⋯` popup ("Pair mode"), persisted as the new `plotPairMode` config key (same pattern as `showAxisLabels`). **Default OFF** — the full per-camera grid is unchanged out of the box.

## Design notes

**Averaging is Python-side, read-time — no new buffers, no ingest changes** (`data_sources.py`):

- `merge_pair_points()` resamples both cameras' decimated series onto a common absolute-time grid (same stride math as `window_decimated`, so grid positions are invariant under pan/data growth and the merged trace doesn't morph between paints) and means the cameras that have finite samples nearby.
- **Dropout / masked fallback:** a camera contributes at a grid point only when one of its own finite samples is within ~1.5 output-sample spacings (floor 100 ms). A dropped, covered, or stalled camera stops contributing exactly where its data ends — the pair panel keeps drawing the surviving camera's trace, never NaN/blank from averaging with a dead channel. A pair member that never delivered (or is masked out) → the survivor's own series is returned **verbatim**.
- `ScanDataSource.pair_points_for_window()` rides the polymorphic `points_for_window` per camera, so **LiveScanSource's DB-tail stitching and PastScanSource replay inherit pair mode with zero extra code**.
- `ScanDataSource.pair_value_at()` feeds the cell value labels + hover tooltip: mean of the members whose nearest sample is within **1.0 s** of the query time — a stalled camera drops out of the readout instead of pinning its stale last value. Backed by new `_CameraBuffer.sample_near` and a `_sample_near` hook with a LiveScanSource DB-tail override.

**QML:**

- `PlotViewer._pairCellModel` — same U row order / shared-row compaction as the dev grid (top row 4/5 … bottom row 1/8, issue #164 convention), one column per side (left col 0, side-break spacer col 1, right col 2). If one camera of a pair is masked out in Scan Settings the cell falls back to the single remaining camera via the untouched single-camera path (labeled e.g. "LEFT 2"); both masked → row slot dropped.
- `PlotCell` gains `camIdB` (−1 = original single-camera behavior byte-for-byte). Pair cells: label "LEFT 4/5", dropout markers drawn for **both** members, CONNECTION LOST badge only when **every** member is lost (one survivor → the averaged trace continues).
- The issue-#298 per-side connection gate is inherited unchanged (pair model reads the same `_effLeftMask`/`_effRightMask`), verified by a dedicated regression test.
- Clinical mode is untouched — it already averages whole sides; the Pair mode switch is hidden there.

**Scope:** live scans AND replay/DVR are both first-class — replay fell out naturally from the polymorphic data path plus recorded-mask layout (issue #175 semantics carry over; tested). Autoscale needs no change (pair means lie within the per-camera percentile bounds).

## Verification

- `python -m pytest tests -m unit -q` — **478 passed, 121 deselected** (full unit suite green, run twice).
- New `tests/test_plot_pair_mode.py` (20 tests): averaging, verbatim single-survivor passthrough, mid-scan dropout fallback, interior-gap no-bridging, all-NaN partner, absolute-grid stability, point-budget respect, `pair_value_at` staleness gating, `sample_near`.
- New pair-mode section in `tests/test_plot_viewer_masks.py` (9 tests): 4-rows-per-side collapse, row compaction, masked-partner single-cam fallback, single-side column takeover, mid-session toggle, default-off, clinical-mode precedence, #298 connection gate, replay recorded masks.
- **Not bench-verified** — hardware is in use; manual QA steps posted as a comment on #289 and below.

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
