### PR TITLE
chore: remove console exe from build; feat: engineering Logs window (#57)

### DIFF
--- a/components/ButtonPanel.qml
+++ b/components/ButtonPanel.qml
@@ -186,6 +186,24 @@ Rectangle {
         // ── spacer pushes bottom controls down ──
         Item { Layout.fillHeight: true }
 
+        // Logs \u2014 live app-log viewer window (LogViewerWindow), the
+        // replacement for the removed console=True second exe (#57).
+        PanelButton {
+            visible: panel.engineeringMode
+            iconText: "\ue9a8"  // code icon
+            label: "Logs"
+            onClicked: panel.logsClicked()
+        }
+
+        // Divider between Logs and History \u2014 engineering mode only, so
+        // the bar looks unchanged when the Logs button is hidden.
+        Rectangle {
+            visible: panel.engineeringMode
+            Layout.preferredWidth: 52; Layout.preferredHeight: 1
+            Layout.topMargin: 4; Layout.bottomMargin: 4
+            Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle
+        }
+
         // History
         PanelButton {
             enabled: !panel.scanning
@@ -202,24 +220,6 @@ Rectangle {
             iconText: "\ueabe"  // setting-2 icon
             label: "Settings"
             onClicked: panel.settingsClicked()
-        }
-
-        // Divider between Settings and Logs \u2014 engineering mode only, so
-        // the bar never ends on a dangling divider.
-        Rectangle {
-            visible: panel.engineeringMode
-            Layout.preferredWidth: 52; Layout.preferredHeight: 1
-            Layout.topMargin: 4; Layout.bottomMargin: 4
-            Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle
-        }
-
-        // Logs \u2014 live app-log viewer window (LogViewerWindow), the
-        // replacement for the removed console=True second exe (#57).
-        PanelButton {
-            visible: panel.engineeringMode
-            iconText: "\ue9a8"  // code icon
-            label: "Logs"
-            onClicked: panel.logsClicked()
         }
     }
 

--- a/components/ButtonPanel.qml
+++ b/components/ButtonPanel.qml
@@ -18,6 +18,12 @@ Rectangle {
     property bool camerasReady: false  // gates Start/Check enablement
     property bool clinicalMode: false       // FDA mode hides scan-settings button
 
+    // Engineering-gated extras (Logs button). Live binding: appConfig is
+    // a notify property, so the button appears the moment the runtime
+    // EngineeringUnlockModal persists engineeringMode via setConfig.
+    readonly property bool engineeringMode:
+        MotionInterface.appConfig.engineeringMode === true
+
     // Connection state — drives start button icon and enablement.
     // A laser-safety trip is surfaced via a persistent NotificationCenter
     // toast (see motion_connector.safetyFailure setter), not by faking
@@ -30,6 +36,7 @@ Rectangle {
     signal checkClicked()
     signal historyClicked()
     signal settingsClicked()
+    signal logsClicked()
 
     FontLoader {
         id: iconFont
@@ -195,6 +202,24 @@ Rectangle {
             iconText: "\ueabe"  // setting-2 icon
             label: "Settings"
             onClicked: panel.settingsClicked()
+        }
+
+        // Divider between Settings and Logs \u2014 engineering mode only, so
+        // the bar never ends on a dangling divider.
+        Rectangle {
+            visible: panel.engineeringMode
+            Layout.preferredWidth: 52; Layout.preferredHeight: 1
+            Layout.topMargin: 4; Layout.bottomMargin: 4
+            Layout.alignment: Qt.AlignHCenter; color: AppTheme.borderSubtle
+        }
+
+        // Logs \u2014 live app-log viewer window (LogViewerWindow), the
+        // replacement for the removed console=True second exe (#57).
+        PanelButton {
+            visible: panel.engineeringMode
+            iconText: "\ue9a8"  // code icon
+            label: "Logs"
+            onClicked: panel.logsClicked()
         }
     }
 

--- a/components/LogViewerWindow.qml
+++ b/components/LogViewerWindow.qml
@@ -1,0 +1,220 @@
+import QtQuick 6.0
+import QtQuick.Controls 6.0
+import QtQuick.Layouts 6.0
+import QtQuick.Window 6.0
+import OpenMotion 1.0
+
+/*
+ * LogViewerWindow — live view of this launch's app log. Engineering-only
+ * (the icon-bar Logs button that opens it is engineeringMode-gated); it
+ * replaces the console=True second exe removed from the build (#57).
+ *
+ * A separate non-modal Window — not a ModalManager overlay — so it can
+ * sit beside the main UI (or on another monitor) during a scan.
+ *
+ *  - Tails the per-launch log via MotionInterface.readAppLog() on a
+ *    500 ms QTimer. Reads are incremental, bounded, and shared-read
+ *    (see utils/log_tail.py), so the poll never blocks the GUI thread
+ *    or interferes with the writer.
+ *  - Search = case-insensitive substring FILTER: the list shows only
+ *    lines containing the text; clearing it restores every line.
+ *  - Auto-follow: sticks to the newest line while at the bottom;
+ *    scrolling up pauses following, scrolling back down (or the
+ *    "Resume follow" button) resumes it.
+ *
+ * The window retains the last `maxLines` raw lines (ring-trimmed) so a
+ * long verbose session cannot grow memory unbounded; the ListView is
+ * virtualized, so even a full buffer stays cheap. Content persists
+ * across close/reopen — the tail just resumes where it left off.
+ */
+Window {
+    id: logWin
+    title: "Application Log" + (logPath !== "" ? " — " + logPath : "")
+    width: 980
+    height: 560
+    minimumWidth: 560
+    minimumHeight: 280
+    flags: Qt.Window
+    modality: Qt.NonModal
+    color: AppTheme.bgBase
+
+    property string logPath: ""
+    property int maxLines: 5000
+
+    // Retained raw lines (capped at maxLines); lineModel holds the
+    // filtered view of them. _pending buffers a partial trailing line
+    // between polls so lines are only ever appended whole. totalLines
+    // mirrors _allLines.length as a notifying int — pushes into a
+    // `var` array don't signal, so bindings can't read .length live.
+    property var _allLines: []
+    property int totalLines: 0
+    property string _pending: ""
+    property bool _follow: true
+    property bool _autoScroll: false
+
+    // The Logs button disappears when engineering mode is switched off;
+    // an already-open viewer must go with it.
+    readonly property bool engineeringUnlocked:
+        MotionInterface.appConfig.engineeringMode === true
+    onEngineeringUnlockedChanged: if (!engineeringUnlocked) logWin.close()
+
+    function open() {
+        logWin.show()
+        logWin.raise()
+        logWin.requestActivate()
+    }
+
+    function _matches(line) {
+        var q = searchField.text
+        return q === "" || line.toLowerCase().indexOf(q.toLowerCase()) !== -1
+    }
+
+    function _scrollToEnd() {
+        // Guarded so the programmatic jump can't read back as a user
+        // scroll and flip _follow in onContentYChanged.
+        _autoScroll = true
+        logList.positionViewAtEnd()
+        _autoScroll = false
+    }
+
+    function _rebuildModel() {
+        lineModel.clear()
+        for (var i = 0; i < _allLines.length; i++)
+            if (_matches(_allLines[i]))
+                lineModel.append({ line: _allLines[i] })
+        if (_follow) _scrollToEnd()
+    }
+
+    function _appendChunk(chunk) {
+        if (chunk === "") return
+        var text = _pending + chunk
+        var parts = text.split("\n")
+        _pending = parts.pop()  // "" when the chunk ended on a newline
+        if (parts.length === 0) return
+        for (var i = 0; i < parts.length; i++) {
+            _allLines.push(parts[i])
+            if (_matches(parts[i]))
+                lineModel.append({ line: parts[i] })
+        }
+        // Ring-trim in batches (hysteresis avoids trimming every poll).
+        // The model may still reference dropped lines, so rebuild it.
+        if (_allLines.length > maxLines + 500) {
+            _allLines.splice(0, _allLines.length - maxLines)
+            _rebuildModel()
+        } else if (_follow) {
+            _scrollToEnd()
+        }
+        totalLines = _allLines.length
+    }
+
+    // Poll only while the window is visible. triggeredOnStart pulls the
+    // initial tail the moment the window opens.
+    Timer {
+        interval: 500
+        repeat: true
+        running: logWin.visible
+        triggeredOnStart: true
+        onTriggered: {
+            if (logWin.logPath === "")
+                logWin.logPath = MotionInterface.appLogPath()
+            logWin._appendChunk(MotionInterface.readAppLog())
+        }
+    }
+
+    // Debounce filter rebuilds so fast typing doesn't rebuild the model
+    // on every keystroke.
+    Timer {
+        id: filterDebounce
+        interval: 200
+        onTriggered: logWin._rebuildModel()
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 12
+        spacing: 8
+
+        // Header — filter field, match count, follow state
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            TextField {
+                id: searchField
+                objectName: "logSearchField"
+                Layout.fillWidth: true
+                placeholderText: "Filter (case-insensitive substring)…"
+                color: AppTheme.textPrimary
+                onTextChanged: filterDebounce.restart()
+            }
+
+            Text {
+                text: searchField.text === ""
+                      ? lineModel.count + " lines"
+                      : lineModel.count + " / " + logWin.totalLines + " lines"
+                font.pixelSize: 12
+                color: AppTheme.textTertiary
+            }
+
+            Button {
+                text: "Resume follow"
+                visible: !logWin._follow
+                onClicked: {
+                    logWin._follow = true
+                    logWin._scrollToEnd()
+                }
+            }
+        }
+
+        // Log body
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: AppTheme.bgPlot
+            radius: 6
+            border.color: AppTheme.borderStrong
+            border.width: 1
+
+            ListView {
+                id: logList
+                anchors.fill: parent
+                anchors.margins: 8
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                model: ListModel { id: lineModel; objectName: "logLineModel" }
+
+                // User scrolls drive follow: away from the bottom pauses,
+                // back at the bottom resumes. Programmatic follow jumps
+                // are excluded via the _autoScroll guard.
+                onContentYChanged: {
+                    if (!logWin._autoScroll)
+                        logWin._follow = logList.atYEnd
+                }
+
+                delegate: Text {
+                    width: ListView.view ? ListView.view.width : 0
+                    text: model.line
+                    textFormat: Text.PlainText
+                    font.family: "Consolas"
+                    font.pixelSize: 12
+                    color: AppTheme.textSecondary
+                    wrapMode: Text.WrapAnywhere
+                }
+
+                ScrollBar.vertical: ScrollBar { }
+            }
+
+            Text {
+                anchors.centerIn: parent
+                visible: lineModel.count === 0
+                text: logWin.logPath === ""
+                      ? "No log file found."
+                      : (searchField.text !== ""
+                         ? "No lines match the filter."
+                         : "Waiting for log output…")
+                font.pixelSize: 13
+                color: AppTheme.textTertiary
+            }
+        }
+    }
+}

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -56,7 +56,7 @@ import error_codes
 import bug_report
 from nan_gap_tracker import NanGapTracker, gap_note_line
 from utils.resource_path import resource_path
-from utils import app_paths, config_store
+from utils import app_paths, config_store, log_tail
 from data_sources import (
     LiveScanSource, PastScanSource, ScanDataSource, buffers_are_empty,
 )
@@ -949,6 +949,10 @@ class MotionConnector(QObject):
         self._log_path = log_path
         self._support_email = cfg.get("support_email", "support@openwater.health")
         self._bug_report_smtp = cfg.get("bug_report_smtp")
+
+        # Incremental app-log reader behind readAppLog() (engineering
+        # Logs window). Created lazily on the first poll.
+        self._app_log_tail: log_tail.LogTail | None = None
 
         # Connection watchdog (E-104/E-106): one-shot check armed at startup
         # that flags expected devices that never enumerated. 0 disables it.
@@ -2760,6 +2764,37 @@ class MotionConnector(QObject):
                 "could not reveal %s in file explorer", path, exc_info=True
             )
 
+    # ── Engineering log viewer (LogViewerWindow.qml) ─────────────────────
+    @pyqtSlot(result=str)
+    def appLogPath(self) -> str:
+        """Absolute path of this launch's app log file, or ''.
+
+        Prefers the exact path main.py handed in (log_path); falls back
+        to the newest logs/open-motion-*.log under the data root for
+        callers that construct the connector without one (tests).
+        """
+        if self._log_path and os.path.isfile(self._log_path):
+            return self._log_path
+        return log_tail.latest_log_path(
+            os.path.join(self._directory, app_paths.LOGS_DIRNAME))
+
+    @pyqtSlot(result=str)
+    def readAppLog(self) -> str:
+        """New app-log text since the last call (see utils/log_tail.py).
+
+        Bounded, shared-read, opens the file per call — safe for the
+        Logs window's GUI-thread QTimer poll. The first call returns
+        the tail of the file; '' means nothing new (or no log file
+        yet). Re-resolves the path each call so the viewer recovers if
+        the log only appears after the connector was constructed.
+        """
+        path = self.appLogPath()
+        if not path:
+            return ""
+        if self._app_log_tail is None or self._app_log_tail.path != path:
+            self._app_log_tail = log_tail.LogTail(path)
+        return self._app_log_tail.read_new()
+
     @pyqtProperty(str, notify=directoryChanged)
     def directory(self):
         return self._directory
@@ -2780,8 +2815,8 @@ class MotionConnector(QObject):
     def _data_root(self) -> str:
         """Where scan files, calibrations, debug-bundles, and
         the scan DB live: self._directory/data. A sibling of the app-wide
-        logs/ folder (main.py's concern only — the connector never touches
-        it)."""
+        logs/ folder (written by main.py only; the connector reads it for
+        the engineering log viewer — see appLogPath)."""
         return os.path.join(self._directory, app_paths.DATA_DIRNAME)
 
     # ── App config — generic read/write API ──────────────────────────────────

--- a/openwater.spec
+++ b/openwater.spec
@@ -119,17 +119,8 @@ exe_gui = EXE(
     upx=False   # safer for DLLs on Windows
 )
 
-exe_cli = EXE(
-    pyz, a.scripts, [],
-    exclude_binaries=True,
-    name=f"{APP_NAME}_console",
-    console=True,
-    icon=ICON_FILE,
-    upx=False
-)
-
 coll = COLLECT(
-    exe_gui, exe_cli,
+    exe_gui,
     a.binaries, a.zipfiles, a.datas,
     strip=False, upx=False, upx_exclude=[],
     name=APP_NAME

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -267,6 +267,9 @@ Rectangle {
         onNotesClicked:    modalManager.toggle(notesModal)
         onHistoryClicked:  modalManager.toggle(historyModal)
         onSettingsClicked: modalManager.toggle(settingsModal)
+        // App-log viewer is a separate Window, not a ModalManager modal —
+        // clicking Logs just shows/raises it (close via its title bar).
+        onLogsClicked:     logViewerWindow.open()
     }
 
     // Allow external callers (firmware banner) to open the Settings overlay.
@@ -405,6 +408,12 @@ Rectangle {
 
     LogsModal {
         id: logsModal
+    }
+
+    // Engineering live app-log viewer (icon-bar Logs button) — a separate
+    // non-modal Window, distinct from the audit-log LogsModal above.
+    LogViewerWindow {
+        id: logViewerWindow
     }
 
     ContactQualityModal {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -923,7 +923,7 @@ def _report_get_app_version() -> str:
     ``$OPENWATER_VERSION`` if no app process is detected.
     """
     try:
-        for proc_name in ("Open-Motion.exe", "Open-Motion_console.exe"):
+        for proc_name in ("Open-Motion.exe",):
             try:
                 result = subprocess.run(
                     ["wmic", "process", "where", f"name='{proc_name}'",

--- a/tests/test_log_tail.py
+++ b/tests/test_log_tail.py
@@ -1,0 +1,194 @@
+"""Unit tests for the engineering Logs window's file seam.
+
+components/LogViewerWindow.qml polls ``MotionConnector.readAppLog()`` on a
+GUI-thread QTimer; these tests cover the Python side it wraps
+(``utils/log_tail.py`` + the two connector slots): incremental offsets,
+the bounded first read, truncation recovery, shared-read behavior against
+a writer that keeps the file open (main.py's logging FileHandler), and
+the latest-log fallback glob. No app-config keys are involved, so no
+FORCE_APP_CONFIG here (the engineeringMode gate is QML-side only).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.log_tail import LogTail, latest_log_path
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+
+
+# ── LogTail.read_new ─────────────────────────────────────────────────────
+
+def test_first_read_returns_existing_content(tmp_path):
+    log = tmp_path / "open-motion-x.log"
+    _write(log, "line 1\nline 2\n")
+
+    assert LogTail(log).read_new() == "line 1\nline 2\n"
+
+
+def test_subsequent_reads_return_only_appended(tmp_path):
+    log = tmp_path / "open-motion-x.log"
+    _write(log, "line 1\n")
+    tail = LogTail(log)
+    assert tail.read_new() == "line 1\n"
+
+    with open(log, "a", encoding="utf-8") as f:
+        f.write("line 2\n")
+
+    assert tail.read_new() == "line 2\n"
+    assert tail.read_new() == ""  # nothing new
+
+
+def test_missing_file_returns_empty_then_recovers(tmp_path):
+    log = tmp_path / "open-motion-x.log"
+    tail = LogTail(log)
+    assert tail.read_new() == ""
+
+    _write(log, "late arrival\n")
+    assert tail.read_new() == "late arrival\n"
+
+
+def test_truncation_restarts_from_top(tmp_path):
+    log = tmp_path / "open-motion-x.log"
+    _write(log, "old old old old\n")
+    tail = LogTail(log)
+    tail.read_new()
+
+    _write(log, "fresh\n")  # rewritten shorter than the old offset
+
+    assert tail.read_new() == "fresh\n"
+
+
+def test_first_read_is_capped_and_starts_on_a_line_boundary(tmp_path):
+    log = tmp_path / "open-motion-x.log"
+    full = "".join(f"row {i:04d}\n" for i in range(100))
+    _write(log, full)
+
+    text = LogTail(log, max_initial_bytes=100).read_new()
+
+    assert 0 < len(text) <= 100
+    assert full.endswith(text)                    # a true suffix...
+    assert full[-len(text) - 1] == "\n"           # ...starting after a \n
+    assert text.startswith("row ")                # no partial first line
+
+
+def test_poll_cap_drains_backlog_across_calls(tmp_path):
+    log = tmp_path / "open-motion-x.log"
+    _write(log, "seed\n")
+    tail = LogTail(log, max_poll_bytes=16)
+    tail.read_new()
+
+    appended = "".join(f"bulk line {i}\n" for i in range(10))
+    with open(log, "a", encoding="utf-8") as f:
+        f.write(appended)
+
+    got = ""
+    for _ in range(100):
+        chunk = tail.read_new()
+        if not chunk:
+            break
+        assert len(chunk.encode("utf-8")) <= 17  # poll cap (+1 carried "\r")
+        got += chunk
+    assert got == appended
+
+
+def test_shared_read_while_writer_holds_the_file_open(tmp_path):
+    # main.py's FileHandler keeps the log open for writing for the whole
+    # run; reading must neither fail nor lock the writer out (Windows).
+    log = tmp_path / "open-motion-x.log"
+    tail = LogTail(log)
+    with open(log, "w", encoding="utf-8") as writer:
+        writer.write("while open 1\n")
+        writer.flush()
+        assert tail.read_new() == "while open 1\n"
+
+        writer.write("while open 2\n")
+        writer.flush()
+        assert tail.read_new() == "while open 2\n"
+
+
+# ── latest_log_path ──────────────────────────────────────────────────────
+
+def test_latest_log_path_picks_newest_by_timestamp_name(tmp_path):
+    _write(tmp_path / "open-motion-20260101_090000.log", "old")
+    _write(tmp_path / "open-motion-20260102_120000.log", "new")
+    _write(tmp_path / "open-motion-20260102_080000.log", "mid")
+    _write(tmp_path / "unrelated.log", "ignore me")
+
+    assert latest_log_path(tmp_path).endswith(
+        "open-motion-20260102_120000.log")
+
+
+def test_latest_log_path_empty_or_missing_dir(tmp_path):
+    assert latest_log_path(tmp_path) == ""
+    assert latest_log_path(tmp_path / "nope") == ""
+
+
+# ── Connector slots (appLogPath / readAppLog) ────────────────────────────
+
+def _connector(tmp_path, log_path=""):
+    """MotionConnector with a mocked interface, mirroring the pattern in
+    test_console_debug_flags.py. scan_db_path=None keeps the audit log a
+    no-op; _save_app_config is stubbed so nothing touches the repo config.
+    """
+    from motion_connector import MotionConnector
+
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = None
+    c = MotionConnector(
+        interface=iface, app_config={}, data_dir=str(tmp_path),
+        config_dir="config", log_path=log_path,
+    )
+    c._save_app_config = MagicMock()
+    return c
+
+
+def test_app_log_path_prefers_the_path_main_handed_in(tmp_path):
+    log = tmp_path / "logs" / "open-motion-20260702_120000.log"
+    log.parent.mkdir()
+    _write(log, "hello\n")
+
+    c = _connector(tmp_path, log_path=str(log))
+
+    assert c.appLogPath() == str(log)
+
+
+def test_app_log_path_falls_back_to_newest_in_logs_dir(tmp_path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write(logs / "open-motion-20260701_000000.log", "old\n")
+    newest = logs / "open-motion-20260702_000000.log"
+    _write(newest, "new\n")
+
+    c = _connector(tmp_path)  # no log_path from main.py
+
+    assert c.appLogPath() == str(newest)
+
+
+def test_app_log_path_empty_when_no_log_exists(tmp_path):
+    c = _connector(tmp_path)
+    assert c.appLogPath() == ""
+    assert c.readAppLog() == ""
+
+
+def test_read_app_log_is_incremental(tmp_path):
+    log = tmp_path / "logs" / "open-motion-20260702_120000.log"
+    log.parent.mkdir()
+    _write(log, "boot\n")
+    c = _connector(tmp_path, log_path=str(log))
+
+    assert c.readAppLog() == "boot\n"
+
+    with open(log, "a", encoding="utf-8") as f:
+        f.write("scan started\n")
+
+    assert c.readAppLog() == "scan started\n"
+    assert c.readAppLog() == ""

--- a/utils/log_tail.py
+++ b/utils/log_tail.py
@@ -1,0 +1,99 @@
+"""Incremental, shared-read tailing of the per-launch app log.
+
+Backs the engineering "Logs" window (components/LogViewerWindow.qml —
+the replacement for the removed console=True second exe, #57): the GUI
+polls ``MotionConnector.readAppLog()`` on a QTimer and appends whatever
+this module returns. Reads are bounded and the file is opened per call
+(ordinary CRT sharing — never an exclusive lock, never a held handle),
+so polling from the GUI thread stays cheap and the logging FileHandler
+that owns the file for writing is never disturbed.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# First read returns at most this much from the end of the file (starting
+# at a line boundary) so opening the viewer late in a verbose session
+# doesn't dump tens of MB into the UI.
+MAX_INITIAL_BYTES = 512 * 1024
+# Cap per read_new() call; a backlog simply drains over the next polls.
+MAX_POLL_BYTES = 256 * 1024
+
+# Matches the per-launch file main.py creates: open-motion-<ts>.log.
+LOG_GLOB = "open-motion-*.log"
+
+
+def latest_log_path(logs_dir) -> str:
+    """Newest ``open-motion-*.log`` under ``logs_dir``, or ``''``.
+
+    Newest by filename: the embedded ``YYYYMMDD_HHMMSS`` timestamp
+    (see main.py) sorts lexicographically in chronological order.
+    """
+    try:
+        names = sorted(p.name for p in Path(logs_dir).glob(LOG_GLOB))
+    except OSError:
+        return ""
+    if not names:
+        return ""
+    return str(Path(logs_dir) / names[-1])
+
+
+class LogTail:
+    """Stateful incremental reader for a single log file."""
+
+    def __init__(self, path,
+                 max_initial_bytes: int = MAX_INITIAL_BYTES,
+                 max_poll_bytes: int = MAX_POLL_BYTES):
+        self.path = str(path)
+        self._max_initial_bytes = max_initial_bytes
+        self._max_poll_bytes = max_poll_bytes
+        self._offset: int | None = None  # None until the first read
+        # A chunk ending in "\r" is (almost certainly) half of a "\r\n"
+        # whose "\n" lands in the next poll; hold it back so newline
+        # normalization can't leak a stray "\r" at a chunk boundary.
+        self._carry = ""
+
+    def read_new(self) -> str:
+        """Text appended since the last call (``''`` when nothing new).
+
+        Newlines are normalized to ``\\n`` (the FileHandler writes the
+        log in text mode, so on-disk lines end ``\\r\\n`` on Windows).
+        The first call tails the last ``max_initial_bytes`` starting at
+        a line boundary; later calls resume from the stored offset and
+        return at most ``max_poll_bytes`` (a backlog drains across
+        subsequent calls). A shrunken file (truncate/replace) restarts
+        from the top. A missing/unreadable file returns ``''`` — the
+        caller just polls again later.
+        """
+        first = self._offset is None
+        try:
+            with open(self.path, "rb") as f:
+                size = f.seek(0, os.SEEK_END)
+                if first:
+                    start = max(0, size - self._max_initial_bytes)
+                elif self._offset > size:
+                    start = 0  # file was truncated/replaced — start over
+                else:
+                    start = self._offset
+                if size <= start:
+                    self._offset = start
+                    return ""
+                f.seek(start)
+                data = f.read(self._max_poll_bytes)
+                self._offset = start + len(data)
+        except OSError:
+            return ""
+        text = self._carry + data.decode("utf-8", errors="replace")
+        self._carry = ""
+        if text.endswith("\r"):
+            self._carry = "\r"
+            text = text[:-1]
+        text = text.replace("\r\n", "\n")
+        if first and start > 0:
+            # Mid-file entry point: drop the partial first line so the
+            # viewer starts on a boundary. The skipped bytes are already
+            # consumed (offset advanced) — they are never re-read.
+            nl = text.find("\n")
+            text = text[nl + 1:] if nl >= 0 else ""
+        return text


### PR DESCRIPTION
## Summary

Two commits for #57 (scope extended by Ethan after the removal was confirmed):

1. **`chore:` remove `Open-Motion_console.exe` from the build** — every packaged artifact ships exactly one executable.
2. **`feat:` engineering Logs window** — the replacement for the lost console window: a "Logs" button in the left icon bar (engineering mode only) opens a second window that live-tails this launch's app log with search.

## Commit 1 — console exe removal

- `openwater.spec` — deleted the `exe_cli` EXE block (`{APP_NAME}_console`, `console=True`) and removed it from `COLLECT`.
- `tests/conftest.py` — dropped the stale `Open-Motion_console.exe` entry from the HIL-report process scan.
- No other references existed: repo-wide case-insensitive grep for `_console` / `console.exe` matches only console *hardware* code (kept). `installer/app.wxs` harvests the entire `dist\Open-Motion\` folder and its shortcuts target `Open-Motion.exe` only, so the MSI loses the file automatically with no WiX edits. CI workflows and packaging scripts reference `Open-Motion.exe` only.

**Rationale vs the May-2026 three-variant idea** (Reduced / RUO / developer, only developer keeping the console exe): it predates the current packaging scheme — `build_and_zip.ps1` → `scripts/package_artifacts.ps1` already builds 4 artifacts (Clinical/Research × Portable/Installer) and none is a "developer" artifact, so no variant would carry the console exe. Diagnostics live in the per-launch app log — and, with this PR, in the in-app Logs window.

## Commit 2 — engineering Logs window

**UI**
- `components/ButtonPanel.qml` — "Logs" button + divider at the bottom of the icon bar, `visible` bound to `MotionInterface.appConfig.engineeringMode === true` (same live-notify pattern as `FirmwareUpdateBanner`, so the runtime `EngineeringUnlockModal` unlock reveals it without a restart; the divider is gated too, so the bar never ends on a dangling divider).
- `components/LogViewerWindow.qml` (new) — a separate **non-modal `Window`** (not a ModalManager overlay), instantiated in `pages/BloodFlow.qml`; clicking Logs shows/raises it. Closes itself if engineering mode is switched off. **Distinct from the audit-log `LogsModal` — `LogsModal.qml`/`SettingsModal.qml` untouched.**
- Tail behavior: 500 ms `QTimer` poll (only while visible), auto-follow sticks to the newest line, **pauses naturally when the user scrolls up and resumes when scrolled back to the bottom** (plus a "Resume follow" button). Retains the last 5,000 lines (ring-trimmed) in a virtualized `ListView`; content persists across close/reopen and the tail resumes.
- **Search = case-insensitive substring *filter*** (the list shows only matching lines; clearing restores everything). Chosen over find-highlighting: with a line-based model it's a strictly simpler, more robust implementation (no `TextDocument` highlight machinery), and filtering is the operation actually wanted when hunting a log. Header shows `matched / total` counts.

**Python seam**
- `utils/log_tail.py` (new) — `LogTail.read_new()`: incremental offset-tracked reads, **file opened per poll in shared read mode (never an exclusive lock, never a held handle)**; first read capped to the last 512 KB starting at a line boundary; ≤256 KB per subsequent poll (a backlog drains across polls) so the GUI-thread timer never does a large blocking read; CRLF→LF normalization with a cross-chunk `\r` carry; truncation/rotation restarts from the top. Plus `latest_log_path()` (newest `logs/open-motion-*.log`, name-sorted = chronological).
- `motion_connector.py` — thin `appLogPath()` / `readAppLog()` slots; prefers the exact `log_path` main.py already hands the connector, falls back to the newest log under the data root.

## Verification

- `python -m PyInstaller -y openwater.spec` — clean build; `dist/Open-Motion/` top level contains exactly one exe (`Open-Motion.exe` + `_internal/`; only other exes anywhere are the SDK's bundled dfu-util tools).
- `python -m pytest tests -m unit -q` — **461 passed, 121 deselected** (includes 13 new `tests/test_log_tail.py` tests: incremental reads, bounded first read at a line boundary, poll-cap backlog drain, truncation restart, missing-file recovery, shared read against a writer holding the file open — the FileHandler case — and the connector slots' path preference/fallback). No app-config keys are involved, so no FORCE_APP_CONFIG needed (the engineeringMode gate is QML-side).
- Headless QML check (offscreen platform, software scenegraph, Material style, stub `MotionInterface` + real `AppTheme`; **no GUI launch, no hardware**): `ButtonPanel.qml`, `BloodFlow.qml`, `LogViewerWindow.qml` all compile clean; `LogViewerWindow` instantiated against a real temp log through the real `log_tail` seam verified end-to-end — initial tail (2 lines), poll-appended lines (4), case-insensitive filter `"warning"` → 1 match, cleared filter → 4, follow still active.
- Visual/manual pass is on Ethan (QA note below) — geometry and window behavior need eyes per project convention.

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)