### PR TITLE
feat: boot into a default scan preset when no device is connected (#314)

### DIFF
--- a/components/ScanSettingsModal.qml
+++ b/components/ScanSettingsModal.qml
@@ -127,6 +127,26 @@ Item {
         secondsField.text = String(s).padStart(2, '0')
     }
 
+    // Seed the modal's duration state from the page's current values
+    // (BloodFlow calls this on open, alongside setInitialSelection). Field
+    // texts and the switch are set imperatively because user edits break
+    // their declarative bindings — same reason commitDurationFields writes
+    // the text back. In free-run the page holds the 43200 sentinel, so the
+    // H:M:S fields are left alone (they're hidden and don't apply).
+    function setInitialDuration(fr, durSec) {
+        root.freeRun = (fr === true)
+        modeSwitch.checked = root.freeRun
+        if (!root.freeRun && durSec > 0) {
+            var d = Math.min(durSec, 99 * 3600 + 59 * 60 + 59)
+            root.hours   = Math.floor(d / 3600)
+            root.minutes = Math.floor((d % 3600) / 60)
+            root.seconds = d % 60
+            hoursField.text   = String(root.hours)
+            minutesField.text = String(root.minutes).padStart(2, '0')
+            secondsField.text = String(root.seconds).padStart(2, '0')
+        }
+    }
+
     function setInitialSelection(leftArr, rightArr) {
         leftSensorActive = leftArr
         rightSensorActive = rightArr

--- a/config/default_scan.json
+++ b/config/default_scan.json
@@ -1,0 +1,7 @@
+{
+    "name": "Default Scan",
+    "leftMask": 255,
+    "rightMask": 255,
+    "freeRun": false,
+    "durationSec": 3600
+}

--- a/motion_config.py
+++ b/motion_config.py
@@ -143,6 +143,92 @@ def select_tec_voltage(console, params: TecVoltageParams):
     return params.default_v, f"board id {board_id!r}"
 
 
+# --- Default scan preset (issue #314) ----------------------------------------
+# The single scan configuration the app boots into when no device has been
+# detected — camera masks + duration only; nothing is replayed and Start stays
+# gated on device readiness. The shipped values live in
+# config/default_scan.json (bundled by openwater.spec) — edit THAT file to
+# change the preset. This dict is only the fallback for a missing/corrupt
+# file or invalid values, and must be kept in sync with the shipped file
+# (pinned by tests/test_default_scan_preset.py).
+DEFAULT_SCAN_PRESET = {
+    "name": "Default Scan",
+    "leftMask": 0xFF,   # all 8 cameras ("All" pattern) — placeholder
+    "rightMask": 0xFF,
+    "freeRun": False,
+    "durationSec": 3600,  # timed 1 h — matches the research-mode boot default
+}
+
+
+def load_default_scan_preset(config_dir: str = "config") -> dict:
+    """Load `default_scan.json` — the boot-time default scan preset (#314).
+
+    Returns a dict with exactly the DEFAULT_SCAN_PRESET keys. File values
+    override the fallbacks; a key that is absent or invalid (mask outside
+    0-255, non-bool freeRun, non-positive durationSec, non-string name)
+    falls back individually, and a missing/corrupt file falls back wholesale.
+    Never raises.
+    """
+    preset = dict(DEFAULT_SCAN_PRESET)
+    config_path = (
+        resource_path("config", "default_scan.json")
+        if config_dir == "config"
+        else Path(config_dir) / "default_scan.json"
+    )
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+    except FileNotFoundError:
+        logger.warning(
+            "Default scan preset file not found: %s; using built-in preset",
+            config_path,
+        )
+        return preset
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(
+            "Could not read default scan preset %s: %s; using built-in preset",
+            config_path, e,
+        )
+        return preset
+
+    if not isinstance(loaded, dict):
+        logger.error(
+            "Default scan preset %s is not a JSON object; using built-in "
+            "preset", config_path,
+        )
+        return preset
+
+    def _valid(key, value):
+        if key in ("leftMask", "rightMask"):
+            return (
+                isinstance(value, int) and not isinstance(value, bool)
+                and 0 <= value <= 0xFF
+            )
+        if key == "freeRun":
+            return isinstance(value, bool)
+        if key == "durationSec":
+            return (
+                isinstance(value, int) and not isinstance(value, bool)
+                and value > 0
+            )
+        return isinstance(value, str) and bool(value)  # name
+
+    for key in preset:
+        if key not in loaded:
+            continue
+        if _valid(key, loaded[key]):
+            preset[key] = loaded[key]
+        else:
+            logger.warning(
+                "Default scan preset %s: invalid %r (%r); using fallback %r",
+                config_path, key, loaded[key], preset[key],
+            )
+
+    logger.info("Loaded default scan preset from %s: %s", config_path, preset)
+    return preset
+
+
 # --- TEC over-temp trip (TEC_TRIP) -------------------------------------------
 # Hardcoded guard rails (°C) for the configured TEC_TRIP. A value outside this
 # range is rejected so a config typo can't disable the firmware over-temp trip

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -50,6 +50,7 @@ from motion_config import (
     TEC_TRIP_MIN_C,
     TecTripOutcome,
     ensure_tec_trip,
+    load_default_scan_preset,
     load_tec_voltage_params,
     select_tec_voltage,
 )
@@ -1120,6 +1121,11 @@ class MotionConnector(QObject):
         self._past_scan_load_seq = 0
 
         self._tec_voltage_params = load_tec_voltage_params(config_dir)
+        # Boot-time default scan preset (issue #314): the single scan
+        # configuration BloodFlow.qml loads when no device has been
+        # detected. Read once — config/default_scan.json never changes at
+        # runtime (defaultScanPreset property below is constant).
+        self._default_scan_preset = load_default_scan_preset(config_dir)
         self._console_mutex = QRecursiveMutex()
 
         ft_mean     = cfg.get("ft_min_mean_per_camera")
@@ -2800,6 +2806,16 @@ class MotionConnector(QObject):
     @pyqtProperty('QVariantMap', notify=appConfigChanged)
     def appConfig(self):
         return self._app_config
+
+    @pyqtProperty('QVariantMap', constant=True)
+    def defaultScanPreset(self):
+        """Boot-time default scan preset (issue #314).
+
+        Loaded once at startup from config/default_scan.json — edit that
+        file to change the preset. BloodFlow.qml applies it at page load
+        while no device has been detected; see its Component.onCompleted.
+        """
+        return self._default_scan_preset
 
     def _save_app_config(self):
         """Persist runtime config changes as a diff vs the shipped baseline.

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -261,6 +261,12 @@ Rectangle {
                     maskToArray(leftMask),
                     maskToArray(rightMask)
                 )
+                // Seed the modal's duration state from the page too —
+                // close() always commits the modal's freeRun/duration back
+                // to the page, so without this an open+close would clobber
+                // a boot-preset duration (issue #314) with the modal's
+                // hardcoded 1:00:00 default.
+                scanSettingsModal.setInitialDuration(freeRun, durationSec)
             }
             modalManager.toggle(scanSettingsModal)
         }
@@ -648,6 +654,27 @@ Rectangle {
     }
 
     Component.onCompleted: {
+        // Boot into the single default scan preset when no device has been
+        // detected (issue #314, config/default_scan.json). At QML load the
+        // connector is always DISCONNECTED (state 0) — the connection
+        // monitor starts after the engine loads — so this defines the
+        // page's no-device ready state. Nothing is replayed and Start
+        // stays gated on device readiness. Deliberately does NOT set the
+        // _*MaskInitialApplied flags: when a device does connect, the
+        // config-default masks are adopted exactly as before (issue #127).
+        // The clinicalMode branch below still runs afterwards and wins, so
+        // clinical builds keep their forced FDA configuration — the preset
+        // shapes the research-mode boot state only.
+        if (!clinicalMode && MotionInterface.state === 0) {
+            var preset = MotionInterface.defaultScanPreset
+            if (preset && preset.leftMask !== undefined) {
+                leftMask  = preset.leftMask
+                rightMask = preset.rightMask
+                freeRun   = preset.freeRun === true
+                durationSec = freeRun ? 43200
+                            : (preset.durationSec > 0 ? preset.durationSec : 3600)
+            }
+        }
         if (clinicalMode) {
             freeRun = true
             durationSec = 43200

--- a/tests/test_default_scan_preset.py
+++ b/tests/test_default_scan_preset.py
@@ -1,0 +1,229 @@
+"""Unit tests for the boot-time default scan preset — issue #314.
+
+When the app boots and no device has been detected, the scan page loads
+a single named default scan configuration (camera masks + duration) so
+it comes up in a defined ready state. Nothing is replayed and Start
+stays gated on device readiness — the preset only shapes the page's
+initial scan settings.
+
+The preset lives in ONE place — ``config/default_scan.json`` — so the
+placeholder contents can be swapped for the real ones later with a
+one-file edit. ``motion_config.load_default_scan_preset`` loads and
+validates it (per-key fallback on bad values, whole-file fallback on a
+missing/corrupt file) and the connector exposes it to QML as
+``MotionInterface.defaultScanPreset``.
+
+Unit-marked: no app launch, no hardware.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from motion_config import DEFAULT_SCAN_PRESET, load_default_scan_preset
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ── Loader: file resolution + fallbacks ──────────────────────────────────────
+
+
+def test_missing_file_falls_back_to_builtin(tmp_path):
+    preset = load_default_scan_preset(str(tmp_path))
+    assert preset == DEFAULT_SCAN_PRESET
+    assert preset is not DEFAULT_SCAN_PRESET  # caller gets a copy
+
+
+def test_valid_file_values_are_adopted(tmp_path):
+    (tmp_path / "default_scan.json").write_text(
+        json.dumps({
+            "name": "Bench Preset",
+            "leftMask": 0x66,
+            "rightMask": 0xC3,
+            "freeRun": True,
+            "durationSec": 300,
+        }),
+        encoding="utf-8",
+    )
+    preset = load_default_scan_preset(str(tmp_path))
+    assert preset["name"] == "Bench Preset"
+    assert preset["leftMask"] == 0x66
+    assert preset["rightMask"] == 0xC3
+    assert preset["freeRun"] is True
+    assert preset["durationSec"] == 300
+
+
+def test_corrupt_json_falls_back_to_builtin(tmp_path):
+    (tmp_path / "default_scan.json").write_text(
+        "{not valid json", encoding="utf-8"
+    )
+    assert load_default_scan_preset(str(tmp_path)) == DEFAULT_SCAN_PRESET
+
+
+def test_non_object_json_falls_back_to_builtin(tmp_path):
+    (tmp_path / "default_scan.json").write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_default_scan_preset(str(tmp_path)) == DEFAULT_SCAN_PRESET
+
+
+def test_partial_file_merges_builtin_for_missing_keys(tmp_path):
+    (tmp_path / "default_scan.json").write_text(
+        json.dumps({"leftMask": 0x0F}), encoding="utf-8"
+    )
+    preset = load_default_scan_preset(str(tmp_path))
+    assert preset["leftMask"] == 0x0F
+    assert preset["rightMask"] == DEFAULT_SCAN_PRESET["rightMask"]
+    assert preset["freeRun"] == DEFAULT_SCAN_PRESET["freeRun"]
+    assert preset["durationSec"] == DEFAULT_SCAN_PRESET["durationSec"]
+    assert preset["name"] == DEFAULT_SCAN_PRESET["name"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"leftMask": 999},          # out of 0-255 range
+        {"leftMask": -1},
+        {"leftMask": "0xFF"},       # strings are not coerced
+        {"leftMask": True},         # bool is not a mask
+        {"rightMask": 4096},
+        {"freeRun": "yes"},         # non-bool
+        {"durationSec": 0},         # zero-length scan is invalid
+        {"durationSec": -5},
+        {"durationSec": True},
+        {"name": 42},               # non-string
+    ],
+    ids=lambda bad: json.dumps(bad),
+)
+def test_invalid_values_fall_back_per_key(tmp_path, bad):
+    (tmp_path / "default_scan.json").write_text(
+        json.dumps(bad), encoding="utf-8"
+    )
+    preset = load_default_scan_preset(str(tmp_path))
+    key = next(iter(bad))
+    assert preset[key] == DEFAULT_SCAN_PRESET[key]
+
+
+def test_invalid_key_does_not_poison_valid_siblings(tmp_path):
+    (tmp_path / "default_scan.json").write_text(
+        json.dumps({"leftMask": 999, "rightMask": 0x5A}), encoding="utf-8"
+    )
+    preset = load_default_scan_preset(str(tmp_path))
+    assert preset["leftMask"] == DEFAULT_SCAN_PRESET["leftMask"]
+    assert preset["rightMask"] == 0x5A
+
+
+def test_default_config_dir_resolves_via_resource_path():
+    """config_dir='config' (the connector default) must resolve through
+    resource_path so the preset is found inside a PyInstaller bundle."""
+    preset = load_default_scan_preset("config")
+    assert preset == load_default_scan_preset(str(REPO_ROOT / "config"))
+
+
+# ── Shipped file sanity ──────────────────────────────────────────────────────
+
+
+def test_shipped_preset_file_is_valid():
+    """The repo's config/default_scan.json must parse and hold sane values
+    — it ships in the PyInstaller bundle (openwater.spec bundles config/)."""
+    shipped = REPO_ROOT / "config" / "default_scan.json"
+    assert shipped.exists(), "config/default_scan.json missing from repo"
+    with open(shipped, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert isinstance(data["name"], str) and data["name"]
+    assert isinstance(data["leftMask"], int) and 0 <= data["leftMask"] <= 0xFF
+    assert isinstance(data["rightMask"], int) and 0 <= data["rightMask"] <= 0xFF
+    assert isinstance(data["freeRun"], bool)
+    assert isinstance(data["durationSec"], int) and data["durationSec"] > 0
+
+
+def test_shipped_preset_matches_builtin_fallback():
+    """Shipped file and in-code fallback must agree, so a missing/corrupt
+    file in the field degrades to the same preset the build shipped with."""
+    shipped = REPO_ROOT / "config" / "default_scan.json"
+    with open(shipped, "r", encoding="utf-8") as f:
+        assert json.load(f) == DEFAULT_SCAN_PRESET
+
+
+def test_shipped_preset_has_no_bom():
+    raw = (REPO_ROOT / "config" / "default_scan.json").read_bytes()
+    assert not raw.startswith(b"\xef\xbb\xbf"), (
+        "config/default_scan.json has a UTF-8 BOM — plain json.load in a "
+        "strict decoder path would reject it"
+    )
+
+
+# ── Connector exposure ───────────────────────────────────────────────────────
+
+
+def test_connector_exposes_default_scan_preset():
+    """QML reads MotionInterface.defaultScanPreset; the property must
+    return the dict loaded at __init__ into _default_scan_preset."""
+    conn = MotionConnector.__new__(MotionConnector)
+    conn._default_scan_preset = {"leftMask": 0x42}
+    assert conn.defaultScanPreset == {"leftMask": 0x42}
+
+
+def test_connector_init_loads_preset_from_config_dir():
+    """__init__ must populate _default_scan_preset via
+    load_default_scan_preset(config_dir) — pinned at source level because
+    constructing a full MotionConnector wires hardware/telemetry."""
+    src = (REPO_ROOT / "motion_connector.py").read_text(encoding="utf-8")
+    assert "load_default_scan_preset" in src
+    assert (
+        "self._default_scan_preset = load_default_scan_preset(config_dir)"
+        in src
+    )
+
+
+# ── QML wiring pins (text-based, like test_contact_quality_modal) ────────────
+
+
+def _bloodflow_oncompleted_block() -> str:
+    qml = REPO_ROOT / "pages" / "BloodFlow.qml"
+    text = qml.read_text(encoding="utf-8")
+    start = text.index("Component.onCompleted:")
+    end = text.index("Component.onDestruction:", start)
+    return text[start:end]
+
+
+def test_bloodflow_applies_preset_at_boot():
+    block = _bloodflow_oncompleted_block()
+    assert "MotionInterface.defaultScanPreset" in block
+
+
+def test_preset_applies_before_clinical_forcing():
+    """Clinical mode's forced FDA configuration must win: the preset
+    application has to come BEFORE the ``if (clinicalMode)`` block so the
+    clinical branch overwrites it, leaving clinical boot state unchanged."""
+    block = _bloodflow_oncompleted_block()
+    preset_at = block.index("MotionInterface.defaultScanPreset")
+    clinical_at = block.index("if (clinicalMode)")
+    assert preset_at < clinical_at
+
+
+def test_preset_does_not_mark_masks_initial_applied():
+    """The preset must NOT set _leftMaskInitialApplied /
+    _rightMaskInitialApplied — device connect must still adopt the config
+    default masks exactly as before (issue #127 logic)."""
+    block = _bloodflow_oncompleted_block()
+    assert "_leftMaskInitialApplied" not in block
+    assert "_rightMaskInitialApplied" not in block
+
+
+def test_scan_settings_open_seeds_duration_from_page():
+    """Opening Scan Settings must seed the modal's duration state from the
+    page's current freeRun/durationSec — otherwise open+close silently
+    resets a preset duration to the modal's hardcoded 1:00:00 default."""
+    qml = (REPO_ROOT / "pages" / "BloodFlow.qml").read_text(encoding="utf-8")
+    handler_start = qml.index("onScanSettingsClicked:")
+    handler_end = qml.index("onNotesClicked:", handler_start)
+    handler = qml[handler_start:handler_end]
+    assert "setInitialDuration" in handler
+
+    modal = (REPO_ROOT / "components" / "ScanSettingsModal.qml").read_text(
+        encoding="utf-8"
+    )
+    assert "function setInitialDuration" in modal


### PR DESCRIPTION
## Summary

When the app boots and no device has been detected, the scan page now loads a **single named default scan configuration** (camera masks + duration) so it comes up in a defined ready state. Per Ethan's clarification on the ticket: it just *loads* a configuration — nothing is replayed, no demo data, and Start stays gated on device readiness exactly as before.

## The preset — where to edit it later

**`config/default_scan.json`** is the one and only place to change the preset (it ships in the PyInstaller bundle; `openwater.spec` already bundles `config/`):

```json
{
    "name": "Default Scan",
    "leftMask": 255,
    "rightMask": 255,
    "freeRun": false,
    "durationSec": 3600
}
```

Placeholder contents to be replaced together later: all 8 cameras on both sides ("All" pattern), timed 1-hour scan. 3600 s deliberately matches the current research-mode boot default so shipped behavior with a device attached is unchanged. `motion_config.DEFAULT_SCAN_PRESET` is the in-code fallback for a missing/corrupt file — a test pins it equal to the shipped file, so editing the JSON will remind you to keep the fallback in sync.

## How it behaves

- **Boot, no device (research mode):** `BloodFlow.qml` applies the preset at page load while the connector is still DISCONNECTED — masks, freeRun, duration. Previously the page sat on hardcoded `leftMask=0x99, rightMask=0x00`.
- **Device connects (whenever):** unchanged. The preset deliberately does NOT set the `_*MaskInitialApplied` flags, so the existing config-default mask adoption (issue #127 logic) runs exactly as before. With the shipped placeholder values, duration is also identical to today; if the preset duration is later changed, it serves as the initial selection until a user edits Scan Settings — the least-invasive option flagged on the ticket.
- **Clinical mode:** unchanged. The clinical forced configuration (free-run, 12 h, clinical masks) still runs after the preset block and wins.
- **Scan Settings modal:** now seeds its duration fields from the page's current freeRun/durationSec on open (it already did this for masks). Without this, opening + closing the modal would silently clobber a preset duration back to the modal's hardcoded 1:00:00 default.

## Plumbing

- `motion_config.load_default_scan_preset(config_dir)` — mirrors the `load_tec_params` pattern; per-key validation (masks 0–255, bool freeRun, positive int durationSec) with per-key fallback, wholesale fallback on missing/corrupt file; never raises.
- `MotionConnector.defaultScanPreset` — constant `QVariantMap` property, loaded once in `__init__`.

## Verification

- Full unit suite green, no hardware, no GUI launch: `python -m pytest tests -m unit -q` → **474 passed, 121 deselected** (includes 26 new tests in `tests/test_default_scan_preset.py`: loader validation matrix, shipped-file sanity + BOM check, fallback/shipped-file parity, connector exposure, and text-level QML wiring pins — preset applied before the clinical branch, no `_*MaskInitialApplied` writes, modal duration seeding).
- `config/app_config.json` untouched; flake8 clean on the changed Python files.
- Not yet hand-tested on the bench (hardware in use) — QA note with manual steps posted on the issue and below.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)