### PR TITLE
fix: report actual scan time (not pipeline wall-clock) in History duration (#335)

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -239,26 +239,30 @@ def _config_name(mask) -> str:
     return _CONFIG_NAMES.get(m, f"0x{m:02X}")
 
 
-def _sdk_flags_from_session(session) -> Optional[dict]:
-    """Pull the ``sdk_flags`` block out of a ScanDatabase session dict's
-    ``session_meta`` (the camera config / clinical-mode the scan was RUN with,
-    written by the SDK's ScanDBSink). Returns None when absent or unparseable.
-
-    ScanDatabase already json-decodes session_meta into a dict, but tolerate a
-    raw JSON string too — the same defensive parse the History list uses
-    (_session_to_row). Used to lay a replayed scan's plot grid out from its
-    recorded config rather than only the cameras that logged data (#175)."""
+def _sdk_meta_dict(session) -> dict:
+    """Decode a ScanDatabase session dict's ``session_meta`` into a dict.
+    ScanDatabase already json-decodes it, but tolerate a raw JSON string too —
+    the same defensive parse the History list uses. Returns an empty dict when
+    absent or unparseable so callers can merge into it safely."""
     if not isinstance(session, dict):
-        return None
+        return {}
     meta = session.get("session_meta")
     if isinstance(meta, str):
         try:
             meta = json.loads(meta)
         except Exception:
-            return None
-    if not isinstance(meta, dict):
-        return None
-    flags = meta.get("sdk_flags")
+            return {}
+    return meta if isinstance(meta, dict) else {}
+
+
+def _sdk_flags_from_session(session) -> Optional[dict]:
+    """Pull the ``sdk_flags`` block out of a ScanDatabase session dict's
+    ``session_meta`` (the camera config / clinical-mode the scan was RUN with,
+    written by the SDK's ScanDBSink). Returns None when absent or unparseable.
+
+    Used to lay a replayed scan's plot grid out from its recorded config rather
+    than only the cameras that logged data (#175)."""
+    flags = _sdk_meta_dict(session).get("sdk_flags")
     return flags if isinstance(flags, dict) else None
 
 
@@ -2503,10 +2507,23 @@ class MotionConnector(QObject):
 
         start = s.get("session_start")
         end = s.get("session_end")
-        if start is not None and end is not None:
-            duration = float(end) - float(start)
-        else:
-            duration = -1.0
+        # Prefer the actual trigger-ON duration stamped by the completion
+        # handler (issue #335). session_end - session_start brackets the whole
+        # pipeline lifetime — pre-trigger setup + post-trigger USB drain — which
+        # runs ~3 s longer than the laser-on window, so the raw delta reads e.g.
+        # "2:03" for a 2:00 scan. Old rows lack the key; fall back to wall-clock.
+        actual = meta.get("actual_duration_sec")
+        duration = None
+        if actual is not None:
+            try:
+                duration = float(actual)
+            except (TypeError, ValueError):
+                duration = None
+        if duration is None:
+            if start is not None and end is not None:
+                duration = float(end) - float(start)
+            else:
+                duration = -1.0
 
         return {
             "sessionId": int(s.get("id")),
@@ -2917,11 +2934,20 @@ class MotionConnector(QObject):
         if self._scan_notes_session_label:
             self._persist_scan_notes(self._scan_notes_session_label)
 
-    def _persist_scan_notes(self, session_label: str) -> bool:
+    def _persist_scan_notes(
+        self, session_label: str, actual_duration_sec: float | None = None
+    ) -> bool:
         """Write the in-memory notes buffer to sessions.session_notes of the
         scan DB session whose session_label matches. Returns True on success.
         ScanDBSink (critical) creates the session at scan start, so every scan
-        that ran has a row to update."""
+        that ran has a row to update.
+
+        When ``actual_duration_sec`` is given, merge it into session_meta as
+        ``actual_duration_sec`` so History reports the actual trigger-ON scan
+        time rather than the pipeline wall-clock (issue #335). This runs from
+        the app's _CompletionSink, which fires *after* the SDK's ScanDBSink has
+        finalised session_end + any diagnostics meta, so a read-modify-write
+        here is race-free and preserves the existing meta."""
         db_path = getattr(self._interface, "scan_db_path", None)
         if not db_path or not session_label:
             return False
@@ -2935,8 +2961,14 @@ class MotionConnector(QObject):
                         "Scan notes: no DB session with label %r", session_label
                     )
                     return False
-                db.update_session(session["id"],
-                                  session_notes=self._scan_notes.strip())
+                update_kwargs: dict = {
+                    "session_notes": self._scan_notes.strip()
+                }
+                if actual_duration_sec is not None:
+                    meta = _sdk_meta_dict(session)
+                    meta["actual_duration_sec"] = float(actual_duration_sec)
+                    update_kwargs["session_meta"] = meta
+                db.update_session(session["id"], **update_kwargs)
                 logger.info("Scan notes saved to DB session %r",
                             session_label)
                 return True
@@ -3604,7 +3636,10 @@ class MotionConnector(QObject):
             scan_id = getattr(meta, "scan_id", "") if meta else ""
             session_label = f"{scan_id}_{subject_id}" if scan_id else ""
             self._scan_notes_session_label = session_label
-            self._persist_scan_notes(session_label)
+            # Stamp the actual trigger-ON duration (same value as the notes
+            # line above) so History shows the real scan time, not the pipeline
+            # wall-clock session_end - session_start (issue #335).
+            self._persist_scan_notes(session_label, actual_duration_sec=elapsed)
 
             # Interrupted-scan outcome. An interrupted scan loses its open
             # interval; one that ends before any interval closes saves

--- a/tests/test_history_sessions.py
+++ b/tests/test_history_sessions.py
@@ -103,6 +103,67 @@ def test_get_scan_sessions_rows_and_sort(tmp_path):
     assert top["dateTime"] == "2026-06-12 09:31:00"
 
 
+# ── Issue #335 — History duration must be the actual trigger-ON scan time ──
+# session_end - session_start brackets the whole pipeline lifetime (pre-trigger
+# setup + post-trigger USB drain), ~3 s longer than the laser-on window. The
+# completion handler stamps the trigger-ON duration into
+# session_meta.actual_duration_sec; _session_to_row must prefer it.
+
+
+def test_session_to_row_prefers_actual_duration_from_meta(tmp_path):
+    c = _connector(tmp_path, str(tmp_path / "scans.db"))
+    # Wall-clock window is 123.2 s (renders "2:03"); the actual trigger-ON
+    # duration the app recorded is 120.02 s ("2:00").
+    session = {
+        "id": 1,
+        "session_label": "20260708_114526_ow2P964L",
+        "session_start": 1000.0,
+        "session_end": 1123.2,
+        "session_notes": None,
+        "session_meta": {
+            "subject_id": "ow2P964L",
+            "actual_duration_sec": 120.02,
+            "sdk_flags": {"reduced_mode": True,
+                          "left_camera_mask": 0x66, "right_camera_mask": 0x66},
+        },
+    }
+    row = c._session_to_row(session)
+    assert row["durationSec"] == pytest.approx(120.02)
+
+
+def test_session_to_row_falls_back_to_wall_clock_without_actual_duration(tmp_path):
+    """Old rows written before the fix have no actual_duration_sec, so
+    _session_to_row keeps the wall-clock delta (backward compatible)."""
+    c = _connector(tmp_path, str(tmp_path / "scans.db"))
+    session = {
+        "id": 1, "session_label": "20260101_000000_s",
+        "session_start": 1000.0, "session_end": 1015.0,
+        "session_notes": None, "session_meta": {"sdk_flags": {}},
+    }
+    row = c._session_to_row(session)
+    assert row["durationSec"] == 15.0
+
+
+def test_persist_scan_notes_stamps_actual_duration(tmp_path):
+    """The completion handler passes the trigger-ON elapsed to
+    _persist_scan_notes, which merges actual_duration_sec into session_meta
+    without clobbering the existing meta (sdk_flags, diagnostics)."""
+    db_path = str(tmp_path / "scans.db")
+    _make_session(db_path, "20260708_114526_ow2P964L", 1000.0, 1123.2,
+                  0x66, 0x66, subject="ow2P964L")
+    c = _connector(tmp_path, db_path)
+    c._scan_notes = "some notes"
+    assert c._persist_scan_notes("20260708_114526_ow2P964L",
+                                 actual_duration_sec=120.02) is True
+
+    # Read back through the History row: it must now show the actual duration,
+    # and the pre-existing sdk_flags must survive the merge.
+    row = c.get_scan_sessions()[0]
+    assert row["durationSec"] == pytest.approx(120.02)
+    assert row["leftMask"] == 0x66 and row["rightMask"] == 0x66
+    assert row["notes"] == "some notes"
+
+
 def test_get_scan_sessions_interrupted_open_session(tmp_path):
     db_path = str(tmp_path / "scans.db")
     _make_session(db_path, "20260612_100000_subjC", 300.0, None, 0xFF, 0xFF)


### PR DESCRIPTION
## Problem

History's **Duration** column reads ~3 s longer than the actual scan (e.g. `2:03` for a 2:00 scan) — issue #335.

## Root cause

Two independent duration measurements exist, and History used the wrong one:

| Measurement | Source | Value in the reporter's log |
|---|---|---|
| Notes line (`Scan completed — duration: …`) | Trigger-ON clock (`_TriggerStateSink` → `_trigger_cumulative_s`, #201) = actual laser-on time | **00:02:00** ✅ |
| History **Duration** column | `session_end − session_start` from the DB | **≈123.2 s → "2:03"** ❌ |

`session_start`/`session_end` are stamped by the SDK's `ScanDBSink` as `time.time()` at pipeline `on_scan_start` and `on_complete`. That window brackets the **whole pipeline lifetime** — pre-trigger setup (trigger-config command + first-frame arrival) plus post-trigger USB drain/teardown — which is ~3 s wider than the trigger-ON window. `HistoryModal.formatDuration(123.2)` → `2` + `round(3.2)` = `"2:03"`.

The reporter's log confirms it exactly: scan started `11:46:33.766`, ended `11:48:37.014` (Δ≈123.2 s), while the trigger-based notes line correctly reads `00:02:00`.

## Fix

Persist the app's authoritative trigger-ON duration (the same value already written to the notes line) into `session_meta.actual_duration_sec` at completion, and prefer it in `_session_to_row`. Old rows without the key fall back to the wall-clock delta (backward compatible).

**Race-free:** verified the SDK's `ScanDBSink.on_complete` (which finalises `session_end` + any diagnostics meta) runs *before* the app's `_CompletionSink` (`all_sinks = default_sinks + request.sinks`, dispatched in order). So the read-modify-write in `_persist_scan_notes` runs last and preserves the existing meta (sdk_flags, diagnostics).

## Changes
- `_session_to_row`: prefer `session_meta.actual_duration_sec`, fall back to `session_end − session_start`.
- `_persist_scan_notes(...)`: optional `actual_duration_sec` merged into `session_meta` (extracted a `_sdk_meta_dict` helper reused by `_sdk_flags_from_session`).
- `_on_pipeline_complete`: pass the trigger-ON `elapsed` through.

## Tests
- `test_session_to_row_prefers_actual_duration_from_meta` — 123.2 s window + 120.02 s actual → reports 120.02.
- `test_session_to_row_falls_back_to_wall_clock_without_actual_duration` — old rows unchanged.
- `test_persist_scan_notes_stamps_actual_duration` — DB round-trip: History shows the actual duration, sdk_flags survive the merge.

Full unit suite: **451 passed**. Not bench-verified — the running app has no no-hardware mock mode; the tests exercise the exact DB round-trip against the real `ScanDatabase`.

Refs #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)