### PR TITLE
feat: engineering-mode dark-correction bypass toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | `bfiClampLow` / `bfiClampHigh` | `0.0` / `10.0` | Display clamps (values outside show `--`). |
 | `bviLowPassEnabled` | `true` | 1-pole LPF on BVI (cutoff 40 Hz). |
 | `writeRawCsv` | `false` | Opt-in raw histogram CSVs (`{scan_id}_(left\|right)_mask*_raw.csv`). Settings → Engineering toggle; additionally gated on `engineeringMode` — flipping engineering mode off stops raw output even if the toggle was left on. `rawCsvDurationSec` caps seconds written (`null` = whole scan). |
+| `darkCorrectionBypass` | `false` | Engineering bench toggle (Settings → Engineering, #345): scans bypass the whole dark subsystem — realtime + batch use raw − pedestal (SDK `ScanRequest.dark_correction_bypass`), dark-frame warnings off, terminal interval always closes, `session_meta` marks the session `dark_correction: bypassed`. Gated on `engineeringMode` at scan start (fail closed, #43 pattern); an amber badge on the scan page shows while armed. For continuous illumination sources that never turn off. |
 | `writeCorrectedCsv` | `false` | Opt-in corrected per-cam CSV (`{scan_id}.csv`) — redundant now that per-cam BFI/BVI lands in `scans.db`. Config-only, no Settings UI. |
 | `dataDirectory` | `null` | Single output root — `logs/` and `data/` (`scans.db`, calibrations) live under it. `null` = `app_paths.writable_root()`: cwd for dev runs, exe-adjacent or `%PROGRAMDATA%\Openwater` per `portableMode` when frozen. |
 

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -935,6 +935,35 @@ Item {
                         Item { Layout.fillWidth: true }
                     }
 
+                    // Dark-correction bypass (#345) — persisted config only
+                    // (no firmware flag); read engineering-gated at scan
+                    // start. onToggled (not onCheckedChanged) so the
+                    // appConfig rebind can't feed back into the slot.
+                    FieldRow {
+                        label: "Bypass dark correction"
+                        PillSwitch {
+                            checked: MotionInterface.appConfig.darkCorrectionBypass === true
+                            onToggled: MotionInterface.setConfig("darkCorrectionBypass", checked)
+                        }
+                        Text {
+                            text: MotionInterface.appConfig.darkCorrectionBypass === true ? "On" : "Off"
+                            color: MotionInterface.appConfig.darkCorrectionBypass === true ? root.colAccent : root.colTextMuted
+                            font.pixelSize: 12
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+                    Text {
+                        text: "For bench illumination sources that never turn off: scans "
+                              + "skip realtime + interval dark subtraction and all dark-frame "
+                              + "warnings. Recorded values become raw − pedestal and the "
+                              + "session is marked as bypassed. Only applies while "
+                              + "engineering mode is on."
+                        color: root.colTextMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
                     // ── Calibration / Test (moved here from the former
                     //    standalone Calibration card; now engineering-only) ──
                     Rectangle { Layout.fillWidth: true; height: 1; color: root.colBorderSoft }

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -3,6 +3,7 @@
     "dataDirectory": null,
     "writeRawCsv": false,
     "rawCsvDurationSec": null,
+    "darkCorrectionBypass": false,
     "leftMask": 102,
     "rightMask": 102,
     "clinicalMode": true,

--- a/main.py
+++ b/main.py
@@ -130,6 +130,12 @@ def _load_app_config() -> dict:
         "dataDirectory": None,
         "writeRawCsv": True,
         "rawCsvDurationSec": None,
+        # Engineering bench toggle (#345): bypass the scan pipeline's dark
+        # subsystem for continuous illumination sources that never turn
+        # off. Gated on engineeringMode at scan start (fail closed). Must
+        # be listed here — config_store filters both the shipped config
+        # and the writable overrides to keys present in these defaults.
+        "darkCorrectionBypass": False,
         # Corrected per-cam CSV ({scan_id}.csv) is redundant now that
         # per-cam BFI/BVI lands in scans.db (the new viewer + past replay
         # read from there). Default off; set true to keep exporting it

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -3506,10 +3506,20 @@ class MotionConnector(QObject):
         self.scanNotesChanged.emit()
         self._capture_running = True
         self._capture_start_time = time.time()
+        # Dark-correction bypass (engineering bench sources that never turn
+        # off, issue #345): engineering-gated the same way as raw CSV /
+        # telemetry (#43 — fail closed for clinical use even if the
+        # persisted toggle was left on). Computed before the audit entry so
+        # the compliance trail records whether this scan ran bypassed.
+        dark_correction_bypass = bool(
+            self._app_config.get("engineeringMode", False)
+            and self._app_config.get("darkCorrectionBypass", False)
+        )
         self._audit.log("scan_started", {
             "label": subject_id,
             "left_mask": int(left_camera_mask),
             "right_mask": int(right_camera_mask),
+            "dark_correction_bypass": dark_correction_bypass,
         })
         # Per-scan monotonic zero for plot timestamps. sample.timestamp_s comes
         # from each sensor's firmware clock, which resets on sensor reboot — so
@@ -3710,6 +3720,9 @@ class MotionConnector(QObject):
             # must be explicitly gated on engineeringMode here. The original
             # gate was dropped in the sink-refactor follow-up (93c2feb).
             write_telemetry_csv=engineering_mode,
+            # Engineering bench toggle (#345), gated at the top of this
+            # slot next to the audit entry.
+            dark_correction_bypass=dark_correction_bypass,
             # Raw CSV duration forwarded to the pipeline's Tee("raw") gate
             # via raw_save_max_duration_s. None means unbounded (write entire
             # scan); 0 omits raw tee entirely. The writeRawCsv toggle lives
@@ -3739,9 +3752,9 @@ class MotionConnector(QObject):
         if started:
             logger.info(
                 "=== Full scan started: subject=%s duration=%ss "
-                "left=0x%02X right=0x%02X laser=%s ===",
+                "left=0x%02X right=0x%02X laser=%s dark_bypass=%s ===",
                 subject_id, duration_sec, left_camera_mask, right_camera_mask,
-                "off" if disable_laser else "on",
+                "off" if disable_laser else "on", dark_correction_bypass,
             )
             # Bind the live source's DB tail to THIS scan's session row by its
             # exact label (set synchronously inside start_scan), so a later

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -325,6 +325,35 @@ Rectangle {
         }
     }
 
+    // Engineering bench indicator (#345) — dark-correction bypass is armed
+    // (Settings → Engineering → "Bypass dark correction"). Shown whenever
+    // the next scan will run bypassed (engineering mode AND the toggle),
+    // not just mid-scan, so a forgotten toggle is visible before Start.
+    // z above the plot, below modals (9998) and ButtonPanel (10000).
+    Rectangle {
+        visible: MotionInterface.appConfig.engineeringMode === true
+                 && MotionInterface.appConfig.darkCorrectionBypass === true
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 14
+        anchors.rightMargin: 20
+        z: 5000
+        radius: height / 2
+        height: 24
+        width: bypassBadgeText.implicitWidth + 24
+        color: "#B45309"
+        border.color: "#F59E0B"
+        border.width: 1
+        Text {
+            id: bypassBadgeText
+            anchors.centerIn: parent
+            text: "DARK CORRECTION BYPASSED"
+            color: "#FFFFFF"
+            font.pixelSize: 11
+            font.weight: Font.DemiBold
+        }
+    }
+
     // ===== MODALS =====
     ScanSettingsModal {
         id: scanSettingsModal

--- a/tests/test_app_config_defaults.py
+++ b/tests/test_app_config_defaults.py
@@ -163,3 +163,18 @@ def test_tec_trip_temp_present_in_shipped_config():
     with open(shipped, "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data["tecTripTempC"] == 40
+
+
+def test_dark_correction_bypass_key_survives_whitelist(tmp_path, monkeypatch):
+    """#345: darkCorrectionBypass must be registered in the in-code
+    defaults — config_store filters both the shipped config and the
+    writable overrides to those keys, so a missing registration makes
+    the Settings toggle silently non-persistent (and the badge/scan gate
+    never see the flag)."""
+    config_path = tmp_path / "app_config.json"
+    config_path.write_text(
+        json.dumps({"darkCorrectionBypass": True}), encoding="utf-8",
+    )
+    _patch_config_path(monkeypatch, config_path)
+    cfg = app_main._load_app_config()
+    assert cfg["darkCorrectionBypass"] is True

--- a/tests/test_dark_bypass_dev_gate.py
+++ b/tests/test_dark_bypass_dev_gate.py
@@ -1,0 +1,66 @@
+"""Issue #345: the dark-correction bypass must be engineering-gated.
+
+The persisted ``darkCorrectionBypass`` toggle only takes effect while
+``engineeringMode`` is also true at scan start (fail closed for clinical
+use, same pattern as writeRawCsv / telemetry in issue #43). These tests
+mock the hardware seam (``interface.start_scan``) and assert on the
+captured ``ScanRequest`` — no hardware, no app launch.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _make_connector(tmp_path, app_config):
+    iface = MagicMock()
+    iface.console = MagicMock()
+    iface.left = MagicMock()
+    iface.right = MagicMock()
+    iface.is_device_connected.return_value = (True, True, True)
+    iface.scan_workflow = MagicMock()
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.start_scan.return_value = True
+    # LiveScanSource treats scan_db_path as an optional path string; a
+    # bare MagicMock attribute would leak into os.path calls.
+    iface.scan_db_path = None
+
+    c = MotionConnector(
+        interface=iface,
+        app_config=app_config,
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._rightSensorConnected = True
+    return c
+
+
+def _captured_request(connector):
+    ok = connector.startCapture("subj", 5, 0x66, 0x66, False)
+    assert ok is True
+    connector._interface.start_scan.assert_called_once()
+    return connector._interface.start_scan.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        ({"engineeringMode": True, "darkCorrectionBypass": True}, True),
+        ({"engineeringMode": True, "darkCorrectionBypass": False}, False),
+        ({"engineeringMode": True}, False),                   # key missing
+        ({"engineeringMode": False, "darkCorrectionBypass": True}, False),
+        ({"darkCorrectionBypass": True}, False),              # eng key missing
+        ({}, False),
+    ],
+)
+def test_dark_bypass_requires_engineering_mode(tmp_path, config, expected):
+    connector = _make_connector(tmp_path, dict(config))
+    req = _captured_request(connector)
+    assert req.dark_correction_bypass is expected


### PR DESCRIPTION
Settings → Engineering toggle "Bypass dark correction" for bench illumination sources that never turn off (Refs #345).

- Persisted `darkCorrectionBypass` config key (registered in the main.py defaults whitelist — config_store filters to those keys); PillSwitch row + explainer in the password-gated Engineering card.
- Fail-closed gating at scan start (same as writeRawCsv/telemetry, #43): the flag reaches `ScanRequest.dark_correction_bypass` only while `engineeringMode` is true. Audit log records it per scan; scan-start log line shows `dark_bypass=`.
- Amber "DARK CORRECTION BYPASSED" badge on the scan page whenever armed (engineering mode AND toggle), visible before Start.
- Unit tests: 6-case gating matrix on the mocked `start_scan` seam + a config-whitelist regression test. Full unit suite: 458 passed.
- Visual check from source: badge renders top-right; Engineering card shows the row + explainer with no layout overflow; boot log clean of QML errors.

**Depends on** OpenwaterHealth/openmotion-sdk#135 (`ScanRequest.dark_correction_bypass`) — merge that first; running this branch against an older SDK raises TypeError at scan start.

To bench-test from source: switch `../openmotion-sdk` to `feature/134-dark-correction-bypass` (or launch with `PYTHONPATH=C:\Users\ethan\Projects\.worktrees\sdk-dark-bypass`), enable engineering mode, flip Settings → Engineering → "Bypass dark correction".

🤖 Generated with [Claude Code](https://claude.com/claude-code)