### PR TITLE
fix: record a disconnected sensor's scan mask as None (0x00)

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -3476,6 +3476,22 @@ class MotionConnector(QObject):
             f"disable_laser={disable_laser})"
         )
 
+        # Issue #352: a disconnected side's mask must be recorded as 0x00
+        # ("None"), not the UI's pending selection — the SDK persists the
+        # ScanRequest masks verbatim into session_meta.sdk_flags, which
+        # History and the replay grid trust (#175), so an ungated mask shows
+        # a phantom config and empty panes for hardware that was never
+        # there. The UI keeps the pending selection (it applies if the
+        # sensor is plugged in before scanning; zeroing it would regress the
+        # #127 preserve-across-power-cycle behavior), so the gate lives
+        # here — mirroring runContactQualityCheck and calibration/test.
+        left_camera_mask = (
+            int(left_camera_mask) if self._leftSensorConnected else 0x00
+        )
+        right_camera_mask = (
+            int(right_camera_mask) if self._rightSensorConnected else 0x00
+        )
+
         if duration_sec <= 0:
             logger.warning("duration_sec was %s, clamping to 3600", duration_sec)
             duration_sec = 3600

--- a/tests/test_scan_mask_disconnected_gate.py
+++ b/tests/test_scan_mask_disconnected_gate.py
@@ -1,0 +1,92 @@
+"""Issue #352: a disconnected sensor's camera mask must be recorded as
+0x00 ("None"), not the UI's pending selection.
+
+The UI deliberately keeps showing the mask a disconnected side *would*
+use if the sensor were plugged in before scanning (and zeroing UI state
+would regress the #127 preserve-selection-across-power-cycle behavior),
+so the gate lives at scan start: ``startCapture`` must zero the mask for
+any side whose sensor isn't connected — mirroring the existing pattern
+in ``runContactQualityCheck`` and the calibration/test flows. The SDK
+records the ScanRequest masks verbatim into ``session_meta.sdk_flags``,
+which History and the replay grid trust (per #175), so an ungated mask
+shows a phantom config and empty panes for hardware that was never there.
+
+These tests mock the hardware seam (``interface.start_scan``) and assert
+on the captured ``ScanRequest`` — no hardware, no app launch.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _make_connector(tmp_path, *, left_connected, right_connected):
+    iface = MagicMock()
+    iface.console = MagicMock()
+    iface.left = MagicMock()
+    iface.right = MagicMock()
+    iface.is_device_connected.return_value = (
+        True, left_connected, right_connected
+    )
+    iface.scan_workflow = MagicMock()
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.start_scan.return_value = True
+    # LiveScanSource treats scan_db_path as an optional path string; a
+    # bare MagicMock attribute would leak into os.path calls.
+    iface.scan_db_path = None
+
+    c = MotionConnector(
+        interface=iface,
+        app_config={"engineeringMode": False},
+        data_dir=str(tmp_path),
+        config_dir="config",
+    )
+    c._consoleConnected = True
+    c._leftSensorConnected = left_connected
+    c._rightSensorConnected = right_connected
+    return c
+
+
+def _captured_request(connector, left_mask, right_mask):
+    ok = connector.startCapture("subj", 5, left_mask, right_mask, False)
+    assert ok is True
+    connector._interface.start_scan.assert_called_once()
+    return connector._interface.start_scan.call_args.args[0]
+
+
+def test_disconnected_left_mask_recorded_as_none(tmp_path):
+    """Right-only scan (the #352 repro): the Left UI default (0x99
+    "Outer") must not reach the ScanRequest — History would show a
+    phantom Left config and replay would lay out empty Left panes."""
+    connector = _make_connector(
+        tmp_path, left_connected=False, right_connected=True
+    )
+    req = _captured_request(connector, 0x99, 0xFF)
+    assert req.left_camera_mask == 0x00
+    assert req.right_camera_mask == 0xFF
+
+
+def test_disconnected_right_mask_recorded_as_none(tmp_path):
+    """Mirror of the repro: left-only scan zeroes the right mask."""
+    connector = _make_connector(
+        tmp_path, left_connected=True, right_connected=False
+    )
+    req = _captured_request(connector, 0x66, 0xC3)
+    assert req.left_camera_mask == 0x66
+    assert req.right_camera_mask == 0x00
+
+
+def test_both_connected_masks_pass_through_unchanged(tmp_path):
+    """Guard against over-gating: with both sensors connected the user's
+    configured masks reach the SDK untouched."""
+    connector = _make_connector(
+        tmp_path, left_connected=True, right_connected=True
+    )
+    req = _captured_request(connector, 0x99, 0xC3)
+    assert req.left_camera_mask == 0x99
+    assert req.right_camera_mask == 0xC3


### PR DESCRIPTION
## Summary

Fixes the [#352](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/issues/352) History bug: a scan taken with one sensor unplugged recorded the disconnected side's pending UI mask (0x99 "Outer" default, or 0xC3 "Far" in clinical mode) as if it were scanned. History then showed a phantom camera config for hardware that was never there, and replaying the scan laid out a grid of empty panes for it (the replay viewer deliberately trusts the recorded `sdk_flags` masks per #175, so the fix belongs at record time).

`startCapture` now gates each side's mask on its sensor's connected state (`mask if connected else 0x00`) before building the `ScanRequest` — the exact pattern `runContactQualityCheck` and the calibration/test flows already use. `_config_name(0x00)` renders as **None** in History, and the replay viewer's `_masks_from_flags` accepts a one-side-zero pair, so replay lays out only the side that actually scanned.

Deliberately **not** changed:
- The UI keeps showing the pending selection for a disconnected side — it applies if the user plugs the sensor in before scanning, and zeroing UI state on disconnect would regress the #127 preserve-selection-across-power-cycle behavior.
- Mid-scan disconnects still render their configured panes empty — that's the #175-intended dropout signal; masks are gated against connection state at scan start.

## Testing

- New unit suite `tests/test_scan_mask_disconnected_gate.py` (3 tests, written red-first): left-disconnected repro from #352, the right-disconnected mirror, and a both-connected pass-through guard against over-gating.
- Full `-m unit` suite: 455 passed.

Refs #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)