### PR TITLE
ci: build and release a macOS DMG artifact

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -200,3 +200,116 @@ jobs:
             resources/OpenMotionDriver-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    runs-on: macos-15   # Apple Silicon runner
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install libusb
+        run: brew install libusb
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+
+          # SDK selection — mirrors the Windows job above (see the comment
+          # there for the full rationale).
+          if [[ "$GITHUB_REF" == refs/tags/*-dev.* ]] || [[ "$GITHUB_REF" == refs/heads/next ]]; then
+            echo "Dev/next-branch ($GITHUB_REF) — installing SDK from openmotion-sdk@next"
+            pip install "git+https://github.com/OpenwaterHealth/openmotion-sdk.git@next"
+          elif [[ "$GITHUB_REF" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "Production/RC tag detected ($GITHUB_REF) — installing latest openmotion-sdk from PyPI"
+            pip install --upgrade openmotion-sdk
+          else
+            WHL_URL=$(python -c "import json,urllib.request as ur,sys; d=json.load(ur.urlopen('https://api.github.com/repos/OpenwaterHealth/openmotion-sdk/releases/latest')); w=[a['browser_download_url'] for a in d.get('assets',[]) if a['name'].endswith('.whl')]; print(w[0] if w else '')" 2>/dev/null || true)
+
+            if [ -n "$WHL_URL" ]; then
+              echo "Installing pylib wheel: $WHL_URL"
+              pip install "$WHL_URL"
+            else
+              echo "No wheel found – falling back to source install"
+              pip install git+https://github.com/OpenwaterHealth/openmotion-sdk.git
+            fi
+          fi
+
+          pip install -r requirements.txt
+
+          # requirements.txt pins PyInstaller 6.11.1 for the Windows build.
+          # 6.11 has a macOS bug that creates Qt framework symlinks twice
+          # (FileExistsError on Versions/Current/* during assemble); fixed
+          # in later 6.x. Override the pin for this job only.
+          pip install --upgrade "pyinstaller>=6.13"
+
+      - name: Stamp version from git tag
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            VER="${TAG#v}"
+          else
+            VER=$(git describe --tags --dirty --always --long 2>/dev/null || echo "dev-${GITHUB_SHA::8}")
+          fi
+          echo "Stamping version: $VER"
+          # BSD sed needs an explicit (empty) backup suffix with -i
+          sed -i '' "s/^_FALLBACK_VERSION = .*/_FALLBACK_VERSION = \"${VER}\"/" version.py
+
+      - name: Determine version tag
+        id: meta
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG=$(git describe --tags --dirty --always 2>/dev/null || echo "dev-${GITHUB_SHA::8}")
+          fi
+          echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          if [[ "$TAG" == *-dev.* ]] || [[ "$TAG" == *-rc.* ]]; then
+            echo "PRERELEASE=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PRERELEASE=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "::notice ::Version tag resolved to: ${TAG}"
+
+      - name: Build .app + DMG
+        shell: bash
+        run: ./build_macos.sh   # CI env var is set by Actions → Finder styling and `open` are skipped
+
+      - name: Locate DMG
+        id: dmg
+        shell: bash
+        run: |
+          DMG_PATH=$(ls dist/Open-Motion-*-macOS.dmg | head -1)
+          echo "DMG_PATH=${DMG_PATH}" >> "$GITHUB_OUTPUT"
+          echo "DMG_NAME=$(basename "$DMG_PATH" .dmg)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.dmg.outputs.DMG_NAME }}
+          path: ${{ steps.dmg.outputs.DMG_PATH }}
+
+      # Attach the DMG to the same release the Windows job creates. Both
+      # jobs target the same tag; action-gh-release appends assets to an
+      # existing release rather than clobbering it, so ordering is safe.
+      - name: Attach DMG to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.TAG }}
+          prerelease: ${{ steps.meta.outputs.PRERELEASE == 'true' }}
+          files: ${{ steps.dmg.outputs.DMG_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -168,6 +168,11 @@ app = BUNDLE(
 )
 SPEC_EOF
 
+# Clear previous output first: PyInstaller's -y overwrite can trip over
+# framework symlinks left by an earlier build (FileExistsError on
+# Versions/Current/* inside Qt .frameworks).
+rm -rf "${DIST_DIR}/${APP_NAME}" "${DIST_DIR}/${APP_NAME}.app"
+
 python -m PyInstaller --noconfirm --clean "$SPEC_FILE" 2>&1 | tail -5
 echo "  ✓ Built ${DIST_DIR}/${APP_NAME}.app"
 
@@ -266,7 +271,10 @@ MOUNT_POINT="/Volumes/${APP_NAME}"
 hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
 hdiutil attach "$DMG_TEMP" -mountpoint "$MOUNT_POINT" >/dev/null 2>&1
 
-# Use AppleScript to set Finder window appearance
+# Use AppleScript to set Finder window appearance. Skipped in CI: headless
+# runners have no Finder session / automation permission, and the styling is
+# cosmetic — the DMG is fully functional without it.
+if [ -z "${CI:-}" ]; then
 osascript << APPLESCRIPT
 tell application "Finder"
     tell disk "$APP_NAME"
@@ -291,6 +299,9 @@ tell application "Finder"
     end tell
 end tell
 APPLESCRIPT
+else
+    echo "  (CI: skipping Finder window styling)"
+fi
 
 # Unmount
 sync
@@ -319,5 +330,7 @@ echo "║  DMG:  ${DMG_FINAL}                                         "
 echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 
-# Open the DMG so the user can see it
-open "$DMG_FINAL"
+# Open the DMG so the user can see it (interactive runs only)
+if [ -z "${CI:-}" ]; then
+    open "$DMG_FINAL"
+fi


### PR DESCRIPTION
## Summary

Adds a `build-macos` job to `release-build.yml` so every release (and branch push) also produces a macOS DMG, attached to the GitHub Release alongside the Windows zips/installers.

- **Runner:** `macos-15` (Apple Silicon). SDK selection, version stamping, and prerelease detection mirror the existing Windows job.
- **Build:** `brew install libusb` + `./build_macos.sh` (existing script). The DMG uploads as a workflow artifact on every run and attaches to the release on tag pushes — `softprops/action-gh-release` appends assets to whichever job creates the release first, and both jobs set the prerelease flag, so job ordering doesn't matter.
- **`build_macos.sh` CI-proofing:** the AppleScript Finder window styling and the final `open` are skipped when `$CI` is set (headless runners have no Finder session; the styling is cosmetic). The script also clears `dist/Open-Motion*` before PyInstaller — a leftover tree makes assemble fail with `FileExistsError` on Qt framework symlinks.
- **PyInstaller version:** the mac job upgrades past the `requirements.txt` pin (6.11.1, unchanged for Windows). 6.11 has a macOS bug that creates Qt framework symlinks twice during assemble; verified fixed on 6.21.

## Verification

Ran the exact CI path locally (`CI=1 ./build_macos.sh`, Python 3.12, Apple Silicon):
- DMG builds: `Open-Motion-1.5.0-dev.0+dirty-macOS.dmg` (112 MB), ad-hoc signed, with Applications-symlink drag-install layout.
- The packaged `.app` launches and connects to real hardware — console + both sensor modules enumerate and complete init with zero errors.

## Caveats

- Functional macOS device I/O requires the SDK fixes in OpenwaterHealth/openmotion-sdk#152. Dev builds (SDK from `@next`) pick them up as soon as that PR merges; prod/rc builds get them with the next PyPI SDK release. The DMG builds fine either way.
- The `.app` is ad-hoc signed, not notarized — first launch needs the right-click → Open dance (already documented in the README's Gatekeeper note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)