### PR TITLE
fix: name the CI-built DMG from the release tag, not git describe

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -285,6 +285,11 @@ jobs:
 
       - name: Build .app + DMG
         shell: bash
+        env:
+          # The version-stamp sed above dirties the checkout, so letting
+          # build_macos.sh derive the version from `git describe --dirty`
+          # would name the DMG "<tag>+dirty". Pass the clean tag instead.
+          OPENMOTION_VERSION: ${{ steps.meta.outputs.TAG }}
         run: ./build_macos.sh   # CI env var is set by Actions → Finder styling and `open` are skipped
 
       - name: Locate DMG

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -15,8 +15,11 @@ SPEC_FILE="openwater_macos.spec"
 DIST_DIR="dist"
 BUILD_DIR="build"
 
-# Resolve version from git
-VERSION="$(python version.py 2>/dev/null || echo "0.0.0")"
+# Resolve version: explicit override first (CI passes the release tag —
+# the version-stamp sed dirties the checkout, so git describe would
+# report "+dirty"), then git describe, then a placeholder.
+VERSION="${OPENMOTION_VERSION:-$(python version.py 2>/dev/null || echo "0.0.0")}"
+export OPENMOTION_VERSION="${VERSION}"   # let the spec's Info.plist use the same value
 DMG_NAME="Open-Motion-${VERSION}-macOS.dmg"
 
 echo "╔══════════════════════════════════════════════════════════════╗"
@@ -156,8 +159,10 @@ app = BUNDLE(
     bundle_identifier="com.openwaterhealth.bloodflow",
     info_plist={
         "CFBundleDisplayName": APP_NAME,
-        "CFBundleShortVersionString": os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
-        "CFBundleVersion": os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
+        "CFBundleShortVersionString": os.environ.get("OPENMOTION_VERSION")
+            or os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
+        "CFBundleVersion": os.environ.get("OPENMOTION_VERSION")
+            or os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
         "NSHighResolutionCapable": True,
         "LSMinimumSystemVersion": "12.0",
         "NSPrincipalClass": "NSApplication",


### PR DESCRIPTION
The version-stamp sed in the `build-macos` job dirties the checkout, so `build_macos.sh`'s git-describe-based version resolved to `<tag>+dirty` — the 1.4.1-dev.0 release shipped `Open-Motion-1.4.1-dev.0+dirty-macOS.dmg`.

This adds an `OPENMOTION_VERSION` override consumed by the DMG name and the bundle's `CFBundleShortVersionString`/`CFBundleVersion`, and passes the clean tag from the workflow. Local builds without the override keep the existing git-describe behavior. (The version shown *inside* the frozen app was already clean — it uses the sed-stamped `_FALLBACK_VERSION` since the bundle has no git.)

Verified locally: `OPENMOTION_VERSION=9.9.9-test CI=1 ./build_macos.sh` → `Open-Motion-9.9.9-test-macOS.dmg` with matching Info.plist version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)