### PR TITLE
feat: warm Claude-style light theme (paper surfaces, terracotta accent)

### DIFF
--- a/components/AppTheme.qml
+++ b/components/AppTheme.qml
@@ -13,36 +13,50 @@ import OpenMotion 1.0
  *
  *  All tokens react to MotionInterface.appConfig.darkMode so the
  *  entire UI flips live when the toggle is changed.
+ *
+ *  Light mode is a warm "paper" palette (cream surfaces, warm-gray
+ *  ink, terracotta interactive accent) modeled on the Claude desktop
+ *  light theme. When tuning, keep each group's relative ordering —
+ *  e.g. light-mode borders run darkest→lightest hover < subtle <
+ *  strong < soft ("subtle"/"strong" are named for their dark-mode
+ *  roles).
  */
 QtObject {
     // ── convenience alias ──────────────────────────────────────────
     readonly property bool dark: MotionInterface.appConfig.darkMode !== false
 
     // ── backgrounds (lightest → darkest in dark mode) ─────────────
-    readonly property color bgBase:       dark ? "#1C1C1E" : "#D5D5DA"
-    readonly property color bgPanel:      dark ? "#1A1A1C" : "#C5C5CB"
-    readonly property color bgContainer:  dark ? "#1E1E20" : "#E0E0E4"
-    readonly property color bgElevated:   dark ? "#252528" : "#C8C8CE"
-    readonly property color bgInput:      dark ? "#2E2E33" : "#C0C0C6"
-    readonly property color bgPlot:       dark ? "#141417" : "#E7E7EC"
-    readonly property color bgHover:      dark ? "#2E2E33" : "#BABAC0"
-    readonly property color bgCard:       dark ? "#262630" : "#E4E4E8"
-    readonly property color bgCardAlt:    dark ? "#232329" : "#DADADE"
+    readonly property color bgBase:       dark ? "#1C1C1E" : "#F0EEE6"
+    readonly property color bgPanel:      dark ? "#1A1A1C" : "#E8E4D8"
+    readonly property color bgContainer:  dark ? "#1E1E20" : "#F7F5EE"
+    readonly property color bgElevated:   dark ? "#252528" : "#EBE7DB"
+    readonly property color bgInput:      dark ? "#2E2E33" : "#FDFCF8"
+    readonly property color bgPlot:       dark ? "#141417" : "#F5F3EB"
+    readonly property color bgHover:      dark ? "#2E2E33" : "#E3DFD1"
+    readonly property color bgCard:       dark ? "#262630" : "#FAF9F4"
+    readonly property color bgCardAlt:    dark ? "#232329" : "#F1EEE5"
 
     // ── borders ───────────────────────────────────────────────────
-    readonly property color borderStrong: dark ? "#2A2A2E" : "#AAAAB0"
-    readonly property color borderSubtle: dark ? "#3E4E6F" : "#9AA2B2"
-    readonly property color borderHover:  dark ? "#5A6B8C" : "#687890"
-    readonly property color borderSoft:   dark ? "#333340" : "#B8B8C0"
+    readonly property color borderStrong: dark ? "#2A2A2E" : "#CFC9BB"
+    readonly property color borderSubtle: dark ? "#3E4E6F" : "#C6C0B0"
+    readonly property color borderHover:  dark ? "#5A6B8C" : "#8F8877"
+    readonly property color borderSoft:   dark ? "#333340" : "#D8D3C5"
 
     // ── text ──────────────────────────────────────────────────────
-    readonly property color textPrimary:   dark ? "#FFFFFF" : "#1C1C1E"
-    readonly property color textSecondary: dark ? "#BDC3C7" : "#48484A"
-    readonly property color textTertiary:  dark ? "#7F8C8D" : "#8E8E93"
-    readonly property color textDisabled:  dark ? "#555555" : "#AEAEB2"
+    readonly property color textPrimary:   dark ? "#FFFFFF" : "#1F1E1B"
+    readonly property color textSecondary: dark ? "#BDC3C7" : "#57544A"
+    readonly property color textTertiary:  dark ? "#7F8C8D" : "#8A867A"
+    readonly property color textDisabled:  dark ? "#555555" : "#B6B1A4"
     readonly property color textLink:      dark ? "#4A90E2" : "#2060C0"
 
-    // ── accent colours (same in both modes) ───────────────────────
+    // ── interactive accent ────────────────────────────────────────
+    // Hover fills, focus rings, toggle-on, selected rows, CTA chips.
+    // Terracotta on the light paper palette; unchanged blue in dark
+    // mode. Semantic blues (info toasts, active-camera dots, status
+    // chips) stay on accentBlue in both modes — do not swap those.
+    readonly property color accentInteractive: dark ? "#4A90E2" : "#D97757"
+
+    // ── semantic accent colours (same in both modes) ──────────────
     readonly property color accentBlue:          "#4A90E2"
     readonly property color accentGreen:         "#2ECC71"
     readonly property color accentRed:           "#E74C3C"
@@ -55,12 +69,12 @@ QtObject {
     readonly property color statusGreen:  "#2ECC71"
     readonly property color statusBlue:   "#3498DB"
     readonly property color statusYellow: "#F1C40F"
-    readonly property color statusGrey:   dark ? "#7F8C8D" : "#AEAEB2"
+    readonly property color statusGrey:   dark ? "#7F8C8D" : "#A8A399"
 
     // ── chart / plot specific ─────────────────────────────────────
-    readonly property color plotGrid:     dark ? "#333333" : "#C0C0C5"
-    readonly property color plotLabel:    dark ? "#999999" : "#555555"
-    readonly property color plotText:     dark ? "#C9D1D9" : "#2A2A2A"
+    readonly property color plotGrid:     dark ? "#333333" : "#CFC9BA"
+    readonly property color plotLabel:    dark ? "#999999" : "#6B675C"
+    readonly property color plotText:     dark ? "#C9D1D9" : "#33312B"
     // Plot cell / scrubber track surface. In dark mode this matches the
     // old bgPanel value (no visual change); in light mode it is white so
     // cells read as raised paper on the recessed bgPlot surface instead
@@ -69,11 +83,13 @@ QtObject {
 
     // ── floating overlays (pills, popups, tooltips over the plot) ──
     // Translucent in both modes; dark values match the previous
-    // hard-coded Qt.rgba constants so dark mode is unchanged.
+    // hard-coded Qt.rgba constants so dark mode is unchanged. Light
+    // values are warm-tinted whites so overlays sit on the paper
+    // palette without going clinical-white.
     readonly property color overlayBg:      dark ? Qt.rgba(0.10, 0.10, 0.12, 0.82)
-                                                 : Qt.rgba(1.0, 1.0, 1.0, 0.90)
+                                                 : Qt.rgba(0.99, 0.98, 0.95, 0.90)
     readonly property color overlayBgSolid: dark ? Qt.rgba(0.12, 0.12, 0.14, 0.96)
-                                                 : Qt.rgba(1.0, 1.0, 1.0, 0.97)
+                                                 : Qt.rgba(0.99, 0.985, 0.96, 0.97)
 
     // Guard a user-configured accent (e.g. trace colors) for legibility
     // against the current plot background: colors too light to read in
@@ -82,7 +98,7 @@ QtObject {
     function readableInk(c) {
         var col = (typeof c === "string") ? Qt.color(c) : c
         var lum = 0.299 * col.r + 0.587 * col.g + 0.114 * col.b
-        if (!dark && lum > 0.62) return Qt.color("#26262B")
+        if (!dark && lum > 0.62) return Qt.color("#2B2925")
         if (dark && lum < 0.16) return Qt.color("#E8E8EC")
         return col
     }

--- a/components/ButtonPanel.qml
+++ b/components/ButtonPanel.qml
@@ -229,7 +229,7 @@ Rectangle {
         property string iconText: ""
         property string label: ""
         property bool highlighted: false
-        property color highlightColor: "#4A90E2"
+        property color highlightColor: AppTheme.accentInteractive
         Layout.preferredWidth: 68
         Layout.preferredHeight: 68
         Layout.alignment: Qt.AlignHCenter

--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -487,8 +487,8 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
-                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentInteractive : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.dismissed() }
                 }
@@ -503,8 +503,8 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
-                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentInteractive : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.retestRequested() }
                 }
@@ -567,10 +567,10 @@ Item {
                     }
                     background: Rectangle {
                         color: !parent.enabled ? AppTheme.bgCard
-                              : (parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput)
+                              : (parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput)
                         radius: 4
                         border.color: !parent.enabled ? AppTheme.borderSubtle
-                                    : (parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft)
+                                    : (parent.hovered ? AppTheme.accentInteractive : AppTheme.borderSoft)
                         border.width: 1
                     }
                     onClicked: { root.continueRequested(); root.close(); root.dismissed() }
@@ -588,8 +588,8 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
-                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentInteractive : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.dismissed() }
                 }
@@ -604,8 +604,8 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
-                        radius: 4; border.color: parent.hovered ? AppTheme.accentBlue : AppTheme.borderSoft; border.width: 1
+                        color: parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput
+                        radius: 4; border.color: parent.hovered ? AppTheme.accentInteractive : AppTheme.borderSoft; border.width: 1
                     }
                     onClicked: { root.close(); root.retestRequested() }
                 }

--- a/components/FirmwareUpdateBanner.qml
+++ b/components/FirmwareUpdateBanner.qml
@@ -20,7 +20,7 @@ Rectangle {
     property bool _dismissed: false
     visible: _devMode && MotionInterface.anyFirmwareUpdateAvailable && !_dismissed
 
-    color: AppTheme.accentBlue
+    color: AppTheme.accentInteractive
     radius: 0
     Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
 
@@ -45,7 +45,7 @@ Rectangle {
                 id: viewBtn
                 anchors.centerIn: parent
                 text: "View"
-                color: AppTheme.accentBlue
+                color: AppTheme.accentInteractive
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
             }

--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -295,7 +295,7 @@ Item {
                     verticalAlignment: TextInput.AlignVCenter
                     background: Rectangle {
                         color: AppTheme.bgInput; radius: 6
-                        border.color: searchField.activeFocus ? AppTheme.accentBlue : AppTheme.borderSubtle
+                        border.color: searchField.activeFocus ? AppTheme.accentInteractive : AppTheme.borderSubtle
                         border.width: 1
                     }
                     onTextChanged: root.searchText = text
@@ -573,8 +573,8 @@ Item {
                     background: Rectangle {
                         radius: 6
                         color: !loadBtn.enabled ? AppTheme.bgInput
-                               : (loadBtn.hovered ? Qt.lighter(AppTheme.accentBlue, 1.12)
-                                                  : AppTheme.accentBlue)
+                               : (loadBtn.hovered ? Qt.lighter(AppTheme.accentInteractive, 1.12)
+                                                  : AppTheme.accentInteractive)
                     }
                     onClicked: {
                         root.loadingPlot = true

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -90,7 +90,7 @@ Item {
             color: AppTheme.bgInput
             radius: 4
             border.color: !ff.validDate ? "#C0392B"
-                          : ff.activeFocus ? AppTheme.accentBlue
+                          : ff.activeFocus ? AppTheme.accentInteractive
                                            : AppTheme.borderSubtle
             border.width: 1
         }
@@ -153,7 +153,7 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        color: parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput
                         border.color: parent.hovered ? AppTheme.textPrimary : AppTheme.textSecondary; radius: 4
                     }
                     onClicked: {
@@ -171,7 +171,7 @@ Item {
                         horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? AppTheme.accentBlue : AppTheme.bgInput
+                        color: parent.hovered ? AppTheme.accentInteractive : AppTheme.bgInput
                         border.color: parent.hovered ? AppTheme.textPrimary : AppTheme.textSecondary; radius: 4
                     }
                     onClicked: root.refresh()
@@ -217,7 +217,7 @@ Item {
                     background: Rectangle {
                         color: AppTheme.bgInput; radius: 4
                         border.color: typeCombo.activeFocus
-                                      ? AppTheme.accentBlue : AppTheme.borderSubtle
+                                      ? AppTheme.accentInteractive : AppTheme.borderSubtle
                         border.width: 1
                     }
                     indicator: Text {
@@ -254,7 +254,7 @@ Item {
                             leftPadding: 8
                         }
                         background: Rectangle {
-                            color: highlighted ? AppTheme.accentBlue : "transparent"
+                            color: highlighted ? AppTheme.accentInteractive : "transparent"
                         }
                     }
                 }
@@ -297,7 +297,7 @@ Item {
                     }
                     background: Rectangle {
                         color: parent.enabled && parent.hovered
-                               ? AppTheme.accentBlue : AppTheme.bgInput
+                               ? AppTheme.accentInteractive : AppTheme.bgInput
                         border.color: parent.enabled && parent.hovered
                                       ? AppTheme.textPrimary : AppTheme.borderSubtle
                         radius: 4

--- a/components/PasswordPromptModal.qml
+++ b/components/PasswordPromptModal.qml
@@ -105,7 +105,7 @@ Item {
                 background: Rectangle {
                     color: AppTheme.bgInput
                     radius: 4
-                    border.color: pwField.activeFocus ? AppTheme.accentBlue : AppTheme.borderSoft
+                    border.color: pwField.activeFocus ? AppTheme.accentInteractive : AppTheme.borderSoft
                     border.width: 1
                 }
                 onAccepted: root._submit()
@@ -152,7 +152,7 @@ Item {
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? Qt.lighter(AppTheme.accentBlue, 1.1) : AppTheme.accentBlue
+                        color: parent.hovered ? Qt.lighter(AppTheme.accentInteractive, 1.1) : AppTheme.accentInteractive
                         radius: 4
                     }
                 }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -1190,9 +1190,9 @@ Rectangle {
             height: 36
             radius: 18
             color: settingsPopup.opened
-                   ? Qt.rgba(0.29, 0.56, 0.89, 0.85)
+                   ? Qt.alpha(AppTheme.accentInteractive, 0.85)
                    : AppTheme.overlayBg
-            border.color: settingsPopup.opened ? "#4A90E2" : AppTheme.borderSubtle
+            border.color: settingsPopup.opened ? AppTheme.accentInteractive : AppTheme.borderSubtle
             border.width: 1
 
             Text {
@@ -1231,7 +1231,7 @@ Rectangle {
                 }
 
                 // Mini Switch styled to match SettingsModal's PillSwitch —
-                // blue-background pill with white thumb when on, dark
+                // accent-background pill with white thumb when on, plain
                 // background when off. Animated thumb glide on toggle.
                 component PopupPillSwitch: Switch {
                     id: psCtrl
@@ -1240,8 +1240,8 @@ Rectangle {
                         x:      psCtrl.leftPadding
                         y:      (psCtrl.height - height) / 2
                         width:  44; height: 24; radius: 12
-                        color:  psCtrl.checked ? AppTheme.accentBlue : AppTheme.bgInput
-                        border.color: psCtrl.checked ? AppTheme.accentBlue : AppTheme.borderSoft
+                        color:  psCtrl.checked ? AppTheme.accentInteractive : AppTheme.bgInput
+                        border.color: psCtrl.checked ? AppTheme.accentInteractive : AppTheme.borderSoft
                         border.width: 1
                         Behavior on color { ColorAnimation { duration: 120 } }
 

--- a/components/ScanSettingsModal.qml
+++ b/components/ScanSettingsModal.qml
@@ -255,7 +255,7 @@ Item {
                     color: AppTheme.textPrimary
                     background: Rectangle {
                         color: AppTheme.bgInput; radius: 4
-                        border.color: userLabelField.activeFocus ? AppTheme.accentBlue : AppTheme.borderSubtle
+                        border.color: userLabelField.activeFocus ? AppTheme.accentInteractive : AppTheme.borderSubtle
                         border.width: 1
                     }
                     onEditingFinished: {
@@ -319,7 +319,7 @@ Item {
                         delegate: ItemDelegate {
                             width: leftSelector.width; height: 32
                             contentItem: Text { text: model.name; font.pixelSize: 13; color: AppTheme.textPrimary; verticalAlignment: Text.AlignVCenter; leftPadding: 8 }
-                            background: Rectangle { color: highlighted ? AppTheme.accentBlue : "transparent" }
+                            background: Rectangle { color: highlighted ? AppTheme.accentInteractive : "transparent" }
                             highlighted: leftSelector.highlightedIndex === index
                         }
                         popup: Popup {
@@ -371,7 +371,7 @@ Item {
                         delegate: ItemDelegate {
                             width: rightSelector.width; height: 32
                             contentItem: Text { text: model.name; font.pixelSize: 13; color: AppTheme.textPrimary; verticalAlignment: Text.AlignVCenter; leftPadding: 8 }
-                            background: Rectangle { color: highlighted ? AppTheme.accentBlue : "transparent" }
+                            background: Rectangle { color: highlighted ? AppTheme.accentInteractive : "transparent" }
                             highlighted: rightSelector.highlightedIndex === index
                         }
                         popup: Popup {
@@ -406,7 +406,7 @@ Item {
 
                 Text {
                     text: "Timed"
-                    color: !root.freeRun ? AppTheme.accentBlue : AppTheme.textSecondary
+                    color: !root.freeRun ? AppTheme.accentInteractive : AppTheme.textSecondary
                     font.pixelSize: 14
                     font.weight: !root.freeRun ? Font.Bold : Font.Normal
                 }
@@ -418,8 +418,8 @@ Item {
                     indicator: Rectangle {
                         x: modeSwitch.leftPadding; y: (modeSwitch.height - height) / 2
                         width: 44; height: 24; radius: 12
-                        color: modeSwitch.checked ? AppTheme.accentBlue : AppTheme.bgInput
-                        border.color: modeSwitch.checked ? AppTheme.accentBlue : AppTheme.borderSubtle; border.width: 1
+                        color: modeSwitch.checked ? AppTheme.accentInteractive : AppTheme.bgInput
+                        border.color: modeSwitch.checked ? AppTheme.accentInteractive : AppTheme.borderSubtle; border.width: 1
                         Behavior on color { ColorAnimation { duration: 120 } }
                         Rectangle {
                             x: modeSwitch.checked ? parent.width - width - 3 : 3
@@ -431,7 +431,7 @@ Item {
 
                 Text {
                     text: "Continuous"
-                    color: root.freeRun ? AppTheme.accentBlue : AppTheme.textSecondary
+                    color: root.freeRun ? AppTheme.accentInteractive : AppTheme.textSecondary
                     font.pixelSize: 14
                     font.weight: root.freeRun ? Font.Bold : Font.Normal
                 }

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -63,7 +63,7 @@ Item {
     readonly property color colBgInput:    AppTheme.bgInput
     readonly property color colBorder:     AppTheme.borderStrong
     readonly property color colBorderSoft: AppTheme.borderSoft
-    readonly property color colAccent:     AppTheme.accentBlue
+    readonly property color colAccent:     AppTheme.accentInteractive
     readonly property color colTextPri:    AppTheme.textPrimary
     readonly property color colTextSec:    AppTheme.textSecondary
     readonly property color colTextMuted:  AppTheme.textTertiary
@@ -1217,7 +1217,7 @@ Item {
                         property string label: "Update"
                         property bool chipEnabled: true
                         width: chipText.implicitWidth + 18; height: 24; radius: 4
-                        color: chipArea.containsMouse ? Qt.lighter(AppTheme.accentBlue, 1.1) : AppTheme.accentBlue
+                        color: chipArea.containsMouse ? Qt.lighter(AppTheme.accentInteractive, 1.1) : AppTheme.accentInteractive
                         opacity: chipEnabled ? 1.0 : 0.6
                         Text {
                             id: chipText

--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -27,7 +27,7 @@ Rectangle {
     property bool updating: false
     property string statusText: "Update"
 
-    color: AppTheme.accentBlue
+    color: AppTheme.accentInteractive
     radius: 0
 
     Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
@@ -62,7 +62,7 @@ Rectangle {
                 id: downloadBtn
                 anchors.centerIn: parent
                 text: banner.updating ? banner.statusText : "Update"
-                color: AppTheme.accentBlue
+                color: AppTheme.accentInteractive
                 font.pixelSize: 12
                 font.weight: Font.DemiBold
             }


### PR DESCRIPTION
Refs #369

## What changed

Light mode drops the cool blue-gray palette for a warm cream/ivory "paper" look modeled on the Claude desktop light theme.

- **`AppTheme.qml`** — every light-side token retoned: cream surfaces (`bgBase #F0EEE6`, panels `#E8E4D8`, cards `#FAF9F4`), white input chips (`bgInput #FDFCF8` — was recessed gray), warm near-black ink (`#1F1E1B`), warm taupe borders, warm plot grid/labels, warm-tinted overlays, warm `readableInk()` fallback ink (thresholds unchanged — traces still draw on white cells).
- **New `accentInteractive` token** (`dark ? #4A90E2 : #D97757`) for affordances: hover fills, focus rings, toggle-on, selected combo rows, CTA chips, the icon-rail highlight. Swapped in ContactQualityModal, HistoryModal, LogsModal, PasswordPromptModal, PlotViewer, ScanSettingsModal, SettingsModal (`colAccent`), FirmwareUpdateBanner, UpdateBanner, ButtonPanel.
- **Two hardcoded accents tokenized**: PlotViewer's popup-open ring/fill (`#4A90E2` / `Qt.rgba(...)` → token via `Qt.alpha`) and ButtonPanel's rail `highlightColor`.

## Invariants

- **Dark mode is pixel-identical**: dark-side values byte-identical; `accentInteractive`'s dark side equals `accentBlue`, so swapped call sites render exactly as before. Verified by screenshot after the change.
- **Semantic blues stay blue in both modes**: NotificationCenter "info" severity, SensorView active-camera dots, CriticalErrorModal detail arrow.
- **Clinical/safety colors untouched**: CQ dot colors, warning oranges, status greens/reds/yellows, E-3xx modal styling.
- No Python changes, no config keys, no behavior changes.

## Verification

- Visual pass from source (Research mode, no-hardware sample-scan replay boot): main plot page, Scan Settings, Settings, History, hover readout overlay — at 1200×800 and maximized 3440×1392. Terracotta shows on "Timed" selection, toggles, rail highlight; camera-mask dots correctly stay blue. Before/after screenshots shared with Ethan.
- Dark-mode relaunch screenshot: unchanged (no terracotta, blues where blues were).
- `python -m pytest -m unit`: **572 passed**, 121 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)