### PR TITLE
feat: hide History scan-status dot outside engineering mode

### DIFF
--- a/components/HistoryModal.qml
+++ b/components/HistoryModal.qml
@@ -33,6 +33,13 @@ Item {
     // Async "Load in viewer" busy state (issue #152 pattern).
     property bool loadingPlot: false
 
+    // The completed/interrupted status dot is a diagnostic with no column
+    // header and no legend — clinical users only see an unexplained mark.
+    // Interrupted rows already announce themselves on export ("Interrupted
+    // scans can't be exported."), so hide the column outside engineering.
+    readonly property bool engineeringMode:
+        MotionInterface.appConfig.engineeringMode === true
+
     // Left-edge space to keep clear of the icon bar (BloodFlow's
     // ButtonPanel — 80px wide + 8px margin, pinned left at z:10000, which
     // is ABOVE this modal's z:9998). The card is centered in the region to
@@ -356,7 +363,10 @@ Item {
                         activeSort: root.sortKey; ascending: root.sortAsc
                         onSortRequested: function(name) { root.setSort(name) }
                     }
-                    Item { Layout.preferredWidth: col.status }
+                    Item {
+                        visible: root.engineeringMode
+                        Layout.preferredWidth: col.status
+                    }
                 }
             }
 
@@ -431,6 +441,7 @@ Item {
                                 verticalAlignment: Text.AlignVCenter
                             }
                             Text {
+                                visible: root.engineeringMode
                                 Layout.preferredWidth: col.status
                                 text: modelData.interrupted ? "⚠" : "●"
                                 color: modelData.interrupted ? "#E6A23C" : "#3EC97A"


### PR DESCRIPTION
Refs #374

## What

The History table's last column rendered a per-scan completion mark — green `●`
for a normally-completed scan, amber `⚠` for an interrupted one. Its column
header is deliberately blank and there's no tooltip or legend, so a clinical
user just sees an unexplained dot on every row.

This gates the column on `engineeringMode`. Engineering mode is unchanged.

## Why it's safe to hide

`interrupted` (`end is None` on the session row) still drives every behavior it
gated — it's only the silent visual that goes away:

- single export refuses with "Interrupted scans can't be exported."
- batch export drops interrupted rows into the skip count
- the detail-pane action button stays disabled for them

So a clinical user still finds out a scan is unusable at the moment it matters.

## Implementation

Both halves of the column — the blank header spacer and the delegate `Text` —
bind to the same new `root.engineeringMode`, so they hide together and the
header stays aligned with the body. Hidden items drop out of a `RowLayout`, so
the remaining columns reclaim the 28 px.

Uses the same `MotionInterface.appConfig.engineeringMode === true` pattern as
the CQ per-camera dots, the profiling HUD, and the firmware-update banner, so
the runtime `EngineeringUnlockModal` unlock brings the dot back without a
restart.

## Testing

- QML parse check: file loads through `QQmlComponent` offscreen with no syntax
  errors (only the expected unresolved local type when loaded outside
  `components/`).
- **Not yet visually verified in the running app** — wants a screenshot of the
  History modal with rows, in both clinical and engineering mode, before merge.
