### PR TITLE
fix: restore ft_min_mean_per_camera to [50, 70, ..., 70, 50]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | `deferHistoSend` | `true` | Defer the per-frame histogram send out of the FSIN ISR into the firmware main loop (firmware `DEBUG_FLAG_SEND_DEFER`, bit `0x80`; sensor-fw#68). Config-only (no Settings UI); pushed to connected sensors at connect via `_compute_sensor_debug_flags`. Requires the PR-branch sensor firmware — stock firmware ignores bit 7. |
 | `scanDataStallTimeoutSec` | `15` | Whole-scan data-stall watchdog (#248): abort the scan with the E-303 critical modal when NO camera delivers a frame for this long while the trigger is ON. `<= 0` disables. Per-camera dropouts (`cameraDropoutThresholdSec`, default 2 s, code-only key) stay fail-soft — only total loss aborts. |
 | `tecTripTempC` | `40` | Console over-temp trip (°C) pushed to the console user config on connect via `motion_config.ensure_tec_trip` (read-modify-write, preserves calibration + OPT/EE keys). Validated to 1–60 °C; absent/invalid values leave the device's existing trip untouched (never writes `0`, which would disable the firmware trip). |
-| `ft_min_mean_per_camera` | `[40,40,…]` | Calibration pass threshold — min pixel mean per camera (8-element array). |
+| `ft_min_mean_per_camera` | `[50,70,…,70,50]` | Calibration pass threshold — min pixel mean per camera (8-element array). Cameras 1 and 8 (far) get a lower bar than the middle six. |
 | `calibration_scan_duration_sec` | `15` | Calibration runtime. |
 | `test_scan_duration_sec` | `5` | "Test" scan runtime (feature #132). |
 | `cq_dark_threshold_per_camera` | `[3.0,…]` | Contact-quality dark threshold. |

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -35,14 +35,14 @@
     "test_scan_duration_sec": 5,
     "calibration_scan_delay_sec": 1,
     "ft_min_mean_per_camera": [
-        40,
-        40,
-        40,
-        40,
-        40,
-        40,
-        40,
-        40
+        50,
+        70,
+        70,
+        70,
+        70,
+        70,
+        70,
+        50
     ],
     "ft_min_contrast_per_camera": [
         0.25,


### PR DESCRIPTION
Restores the per-camera minimum light mean — the Test/Calibrate pass gate shown as `light_mean` vs `min_mean` (`motion_connector.py:5379`) — from the flat `[40] * 8` back to `[50, 70, 70, 70, 70, 70, 70, 50]`.

## Why

`a0dd680` (2026-05-26) is titled *"refactor: consolidate dataDirectory; drop output_path + triggerConfig"* and its long commit message says nothing about thresholds — but it flattened this array. It rode along with a batch of other local working-copy values swept in by the same commit: `bviMin` 1.0 -> 0.0, `dataDirectory` repointed to a personal path, `rawCsvDurationSec` 60 -> null, `reducedMode` true -> false. That reads as a developer's local config landing in the repo, not a considered threshold change.

`3a97472` reverted it on 2026-06-01, but the 40s came back through the next-next merge two days later (`5186fc5` / `b9f5cdb`) and have stuck since.

The restored array also carries information the flat 40 discarded: cameras 1 and 8 (the far cameras) get a lower bar (50) than the middle six (70), matching the known far/near illumination difference. Value last set deliberately in `2c6af4f` ("config: lower mean thresholds", 2026-05-02).

## Changes

- `config/app_config.json` — `ft_min_mean_per_camera` -> `[50, 70, 70, 70, 70, 70, 70, 50]`
- `CLAUDE.md` — config table updated to match (it documented the `[40,40,…]` regression as the intended default)

## Verification

- JSON parses, no BOM introduced, 65 keys unchanged
- Diff is values-only — no structural or key changes
- Not bench-verified: this raises a pass/fail bar, so the real check is a Test/Calibrate run on hardware confirming cameras still pass at the stricter threshold. Worth doing before this ships in a full release.

## Follow-up (not in this PR)

`main.py:106` registers the code-side default for this key as `[0] * 8`, so a missing config key makes the light check pass unconditionally — a silent-pass fallback on a pass/fail gate.

Refs #379