### PR TITLE
feat: restyle critical error modal to house style with blue trim

### DIFF
--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -86,7 +86,7 @@ Item {
     // Backdrop — click outside dismisses.
     Rectangle {
         anchors.fill: parent
-        color: "#000000C0"
+        color: "#000000AA"
         // Capture ALL pointer input so scroll/hover can't fall through to
         // the interactive plot viewer behind the modal (issue #214).
         MouseArea {
@@ -99,51 +99,50 @@ Item {
 
     // Panel
     Rectangle {
+        // Fixed width, centred on the full window — deliberately NOT the
+        // Math.min(parent.width - iconBarInset - 40, …) clamp the other modals
+        // use. This modal's footer carries three buttons whose combined
+        // minimum is ~466px, so a clamp that shrinks the card below ~514px
+        // makes the row overflow the card and clip (verified: fine at 640px,
+        // broken at 560px). A fixed 520 has the room at every window size the
+        // clamp would have shrunk for. The icon-bar inset is unnecessary here
+        // too — at z:100000 this modal is above ButtonPanel, so the bar sits
+        // dimmed behind the backdrop rather than overlapping the card.
         width: 520
-        height: contentCol.implicitHeight + headerBar.height + 16 + 20
-        radius: 14
+        height: contentCol.implicitHeight + 48
+        radius: 12
         color: AppTheme.sheetBg
-        border.color: AppTheme.accentRed
-        border.width: 1
+        border.color: AppTheme.borderSubtle
+        border.width: 2
         anchors.centerIn: parent
 
         // Absorb clicks so they don't reach the backdrop.
         MouseArea { anchors.fill: parent }
 
-        // Red header bar with code badge.
-        Rectangle {
-            id: headerBar
-            anchors.top: parent.top
-            anchors.left: parent.left
-            anchors.right: parent.right
-            height: 44
-            radius: 14
-            color: AppTheme.accentRed
-            // square off the bottom corners so only the top is rounded
-            Rectangle {
-                anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                height: parent.radius
-                color: AppTheme.accentRed
-            }
+        ColumnLayout {
+            id: contentCol
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 16
 
+            // Eyebrow row — code badge, label, queued-error counter. Replaces
+            // the old solid header bar: a coloured header bar is not a pattern
+            // used anywhere else in the app, and the saturated red read as an
+            // alarm for conditions that are often recoverable.
             RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 16
-                anchors.rightMargin: 16
-                spacing: 10
+                Layout.fillWidth: true
+                spacing: 9
 
                 Rectangle {
                     Layout.preferredHeight: 24
                     Layout.preferredWidth: codeText.implicitWidth + 16
                     radius: 4
-                    color: "#FFFFFF"
+                    color: AppTheme.accentInteractive
                     Text {
                         id: codeText
                         anchors.centerIn: parent
                         text: root.code
-                        color: AppTheme.accentRed
+                        color: "#FFFFFF"
                         font.pixelSize: 13
                         font.weight: Font.Bold
                         font.family: "Consolas, monospace"
@@ -151,36 +150,25 @@ Item {
                 }
 
                 Text {
-                    text: "Critical Error"
-                    color: "#FFFFFF"
-                    font.pixelSize: 15
-                    font.weight: Font.DemiBold
+                    text: "CRITICAL ERROR"
+                    color: AppTheme.textTertiary
+                    font.pixelSize: 11
+                    font.letterSpacing: 0.5
                     Layout.fillWidth: true
                 }
 
                 Text {
                     visible: root._queue.length > 0
                     text: root._queue.length + " more"
-                    color: "#FFFFFFCC"
+                    color: AppTheme.textTertiary
                     font.pixelSize: 12
                 }
             }
-        }
-
-        ColumnLayout {
-            id: contentCol
-            anchors.top: headerBar.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.topMargin: 16
-            anchors.leftMargin: 20
-            anchors.rightMargin: 20
-            spacing: 12
 
             Text {
                 text: root.title
                 color: AppTheme.textPrimary
-                font.pixelSize: 17
+                font.pixelSize: 18
                 font.weight: Font.DemiBold
                 wrapMode: Text.WordWrap
                 Layout.fillWidth: true
@@ -253,7 +241,15 @@ Item {
                 Button {
                     text: "Copy details"
                     Layout.preferredHeight: 32
-                    onClicked: MotionInterface.copyToClipboard(root._reportText())
+                    // Confirm the copy — copyToClipboard succeeds silently, so
+                    // without a toast this button is indistinguishable from a
+                    // dead one. The tag keeps repeat clicks from stacking.
+                    onClicked: {
+                        MotionInterface.copyToClipboard(root._reportText())
+                        MotionInterface.notify(
+                            "Error details copied to clipboard.",
+                            "success", 3000, true, "critical-error-copy")
+                    }
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
                         color: AppTheme.textSecondary
@@ -297,7 +293,8 @@ Item {
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: parent.hovered ? Qt.lighter(AppTheme.accentRed, 1.1) : AppTheme.accentRed
+                        color: parent.hovered ? Qt.lighter(AppTheme.accentInteractive, 1.1)
+                                              : AppTheme.accentInteractive
                         radius: 4
                     }
                 }


### PR DESCRIPTION
Refs #382

## Why

`CriticalErrorModal` was the only modal in the app that did not follow the house style: a 44px solid `accentRed` header bar, an `accentRed` card border, and an `accentRed` primary button. Nothing else in the UI has a coloured header bar at all — `HistoryModal`, `NotesModal` and `SampleScanOfferModal` all use a plain `sheetBg` card with a `borderSubtle` 2px edge and the title as ordinary text in the content column.

Beyond the inconsistency, the saturated red read as an alarm. For a clinical operator, a recoverable condition like E-303 — whose own message says "Data captured before the loss was saved" — presented with more visual urgency than the situation warranted.

## What changed

All in `components/CriticalErrorModal.qml`. 44 insertions, 47 deletions.

- Header bar removed entirely; its code badge, label and queue counter re-homed as an eyebrow row at the top of the content column
- Card shell brought onto the house pattern: radius 14 → 12, border `accentRed` 1px → `borderSubtle` 2px, uniform 24px margins, spacing 12 → 16, backdrop `#000000C0` → `#000000AA`
- Title 17 → 18px
- All trim moved from `AppTheme.accentRed` to `AppTheme.accentInteractive`, so it tracks the theme like every other primary button — blue in dark mode, terracotta in light. Zero `accentRed` references remain.

### Also fixes a pre-existing defect

Hand-testing surfaced "the Copy details button does not work". It did work — verified by priming the clipboard with a sentinel, clicking programmatically, and reading back the full report text. The real defect is that `copyToClipboard` succeeds **silently**: no toast, no log line, no state change. Both siblings give feedback (Send Bug Report toasts, Dismiss closes the modal), so a working button was indistinguishable from a dead one.

It now raises a success toast, following the precedent already set by `_send_bug_report_fallback`. This is pre-existing — `git diff` confirms the button block was untouched by the restyle.

## Reviewer notes

**Width and centering are deliberately unchanged.** Adopting the other modals responsive clamp (`Math.min(parent.width - iconBarInset - 40, 520)`) plus their `iconBarInset` offset was tried and reverted. This modal footer carries three buttons with a ~466px combined minimum, so the clamp overflowed and clipped the row on narrow windows:

| Window width | With clamp | Fixed 520 (shipped) |
|---|---|---|
| 1200px | fine | fine |
| 640px | fits, right margin eaten (4px vs 24px) | fine |
| 560px | **contents overflow, Dismiss clipped** | **all three buttons visible, correct margins** |

The previous fixed-520 layout handled 560px correctly, so the clamp was a strict regression. A comment on the `width` line records why it is not used, so the inconsistency is not "fixed" back later. The inset bought nothing here anyway: at `z: 100000` this modal is above `ButtonPanel` (`z: 10000`), so the icon bar sits dimmed behind the backdrop rather than overlapping the card.

**Worth a second opinion:** in light mode `accentInteractive` resolves to terracotta `#D97757`, so the badge and Dismiss button read as a warm orange-red — visibly warmer than the "blue, not red" framing that motivated the ticket. This was a deliberate choice (theme-tracking over a fixed `accentBlue`), but it is the one thing I would want a second pair of eyes on. Switching just those two to `accentBlue` is a two-line change; the trade is that the modal would then diverge from other modals primary buttons in light mode.

**Two things noted but deliberately not changed:**
1. `NotificationCenter` is `z: 99999` and this modal is `z: 100000`, so the new confirmation toast renders behind the `#000000AA` backdrop, slightly dimmed. Still legible, so left alone — but a future modal with a more opaque backdrop would hide its own toasts.
2. "Copy details" uses `borderSoft` while its sibling uses `borderSubtle`, making it noticeably fainter. That is the house pattern for low-emphasis buttons (`SampleScanOfferModal` "Not now"), so it was left as deliberate hierarchy.

## Verification

- QML parses clean — 0 syntax/structural errors via headless `QQmlComponent`. The checker was itself validated: an untouched control file passes, a deliberately corrupted copy is caught.
- `test_critical_error_signal.py`, `test_console_led_error_blink.py`, `test_scan_db_readonly_e301.py` — **24 passed**. These cover the connector signals, not the QML, so they prove no behavior regression but cannot catch a styling one.
- Rendered on hardware (console 1.8.1-rc.1, right sensor attached) with synthetic E-201/E-102/E-303 injected via an out-of-tree launcher — no repo files touched. Checked in dark mode, light mode, the queued "N more" state, and at 560px after the revert. Full session log shows zero QML warnings.

Behavior otherwise untouched: queueing, `criticalErrorsDismissed()` on drain (#257), backdrop/Esc dismissal, `copyToClipboard`, `sendBugReport`, and the `criticalErrorRaised` connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)