### PR TITLE
Unify update gating: block firmware/app updates in clinical builds; engineering-gated beta for both (#386)

### DIFF
--- a/components/FirmwareUpdateBanner.qml
+++ b/components/FirmwareUpdateBanner.qml
@@ -4,8 +4,9 @@ import QtQuick.Layouts 6.0
 import OpenMotion 1.0
 
 /*  FirmwareUpdateBanner — slides in below the header when newer device
- *  firmware is available. engineeringMode-gated (technician task). The "View"
- *  button asks the host to open the Settings overlay (firmware card).
+ *  firmware is available. Shown in Research builds; never in Clinical — the
+ *  connector never flags a firmware update in a clinical build (#386). The
+ *  "View" button asks the host to open the Settings overlay (firmware card).
  */
 Rectangle {
     id: banner
@@ -16,9 +17,11 @@ Rectangle {
 
     signal viewRequested()
 
-    readonly property bool _devMode: MotionInterface.appConfig.engineeringMode === true
+    // Clinical builds never flag a firmware update (the connector skips the
+    // check), but gate the banner on !clinicalMode too for defence in depth.
+    readonly property bool _clinical: MotionInterface.appConfig.clinicalMode === true
     property bool _dismissed: false
-    visible: _devMode && MotionInterface.anyFirmwareUpdateAvailable && !_dismissed
+    visible: !_clinical && MotionInterface.anyFirmwareUpdateAvailable && !_dismissed
 
     color: AppTheme.accentInteractive
     radius: 0

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -1405,12 +1405,12 @@ Item {
                         label: "Beta Updates"
                         visible: MotionInterface.appConfig.engineeringMode === true
                         PillSwitch {
-                            checked: MotionInterface.appConfig.downloadBetaFirmware === true
-                            onToggled: MotionInterface.setConfig("downloadBetaFirmware", checked)
+                            checked: MotionInterface.appConfig.downloadBetaUpdates === true
+                            onToggled: MotionInterface.setConfig("downloadBetaUpdates", checked)
                         }
                         Text {
-                            text: MotionInterface.appConfig.downloadBetaFirmware === true ? "On" : "Off"
-                            color: MotionInterface.appConfig.downloadBetaFirmware === true ? root.colAccent : root.colTextMuted
+                            text: MotionInterface.appConfig.downloadBetaUpdates === true ? "On" : "Off"
+                            color: MotionInterface.appConfig.downloadBetaUpdates === true ? root.colAccent : root.colTextMuted
                             font.pixelSize: 12
                         }
                         Item { Layout.fillWidth: true }

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -1338,13 +1338,15 @@ Item {
                         }
                         Item { Layout.fillWidth: true }
                         Text {
-                            visible: connected && !updateAvailable
+                            // Clinical never runs the firmware check, so it must
+                            // not claim "Up to date" — show the version only (#386).
+                            visible: !root.clinicalMode && connected && !updateAvailable
                             text: "Up to date"
                             color: AppTheme.statusGreen
                             font.pixelSize: 12
                         }
                         UpdateChip {
-                            visible: connected && updateAvailable
+                            visible: !root.clinicalMode && connected && updateAvailable
                             onChipClicked: fwConfirm.openFor(label, dev)
                         }
                     }
@@ -1392,11 +1394,11 @@ Item {
                         }
                     }
 
-                    // Beta firmware: when on, the autoupdater targets the
+                    // Beta Updates: when on (engineering mode only), BOTH the
+                    // app self-updater and the device firmware check target the
                     // most-recently-published release (incl. dev/rc), not just
-                    // full releases. Plain config flag — the connector re-runs
-                    // the firmware check when it toggles (setConfig hook).
-                    // Engineering (engineering mode) only.
+                    // full releases. The connector re-checks on toggle and when
+                    // engineering mode changes (_refresh_update_checks). (#386)
                     Rectangle {
                         Layout.fillWidth: true; height: 1; color: root.colBorderSoft
                         visible: MotionInterface.appConfig.engineeringMode === true

--- a/components/UpdateBanner.qml
+++ b/components/UpdateBanner.qml
@@ -120,6 +120,12 @@ Rectangle {
             banner.downloadUrl = url
             banner.shown = true
         }
+        // Withdraw a stale offer: a re-check (e.g. after engineering mode is
+        // turned off, dropping beta back to stable) that finds nothing hides
+        // the banner. The initial up-to-date launch is a no-op — never shown.
+        function onUpdateNotAvailable() {
+            banner.shown = false
+        }
         // Reflect download/install progress on the button.
         function onUpdateProgress(message) {
             banner.statusText = message

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -127,7 +127,7 @@
         15.0
     ],
     "engineeringMode": false,
-    "downloadBetaFirmware": false,
+    "downloadBetaUpdates": false,
     "forceLaserFail": false,
     "cameraFakeData": false,
     "cameraTempAlertThresholdC": 110,

--- a/main.py
+++ b/main.py
@@ -85,6 +85,12 @@ def _load_app_config() -> dict:
         # the releases-latest endpoint (used by the local update-test server).
         "updateRepo": None,
         "updateApiUrl": None,
+        # Beta/prerelease update channel for BOTH updaters (app self-update
+        # + device firmware). Effective only in a Research build with
+        # engineering mode unlocked — see MotionConnector._beta_enabled().
+        # Must be registered here or config_store drops it (silently
+        # non-persistent). Renamed from downloadBetaFirmware (#386).
+        "downloadBetaUpdates": False,
         "cameraTempAlertThresholdC": 105,
         # Whole-scan data-stall watchdog (issue #248): abort the scan with
         # E-303 when no camera delivers a frame for this many seconds while

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2089,7 +2089,7 @@ class MotionConnector(QObject):
 
     def _firmware_check_worker(self, kind: FirmwareKind, generation: int | None = None) -> None:
         try:
-            beta = self._app_config.get("downloadBetaFirmware", False)
+            beta = self._app_config.get("downloadBetaUpdates", False)
             info = check_latest(kind, include_prerelease=beta)
         except Exception:                           # defensive; check_latest is fail-soft
             info = None
@@ -2112,7 +2112,7 @@ class MotionConnector(QObject):
         kind = self._kind_for_device(name)
         installed = self._firmware_versions.get(name, "")
         latest = self._firmware_latest_by_kind.get(kind.value, "")
-        beta = self._app_config.get("downloadBetaFirmware", False)
+        beta = self._app_config.get("downloadBetaUpdates", False)
         avail = (bool(installed) and bool(latest)
                  and is_update_available(installed, latest, prerelease=beta))
         self._firmware_latest[name] = latest
@@ -2125,7 +2125,7 @@ class MotionConnector(QObject):
 
     def _refresh_firmware_update_check(self) -> None:
         """Invalidate the firmware-latest caches and re-run detection for every
-        connected device — called when downloadBetaFirmware toggles so the
+        connected device — called when downloadBetaUpdates toggles so the
         banner/Settings card reflect the new release pool immediately."""
         self._firmware_latest_by_kind.clear()
         self._firmware_checking_kinds.clear()
@@ -2173,7 +2173,7 @@ class MotionConnector(QObject):
             kind = self._kind_for_device(device_key)
             self.firmwareUpdateProgress.emit(
                 device_key, "check", -1, "Checking latest release…")
-            beta = self._app_config.get("downloadBetaFirmware", False)
+            beta = self._app_config.get("downloadBetaUpdates", False)
             info = check_latest(kind, include_prerelease=beta)
             if info is None:
                 raise RuntimeError("Could not reach GitHub to fetch firmware.")
@@ -2957,7 +2957,7 @@ class MotionConnector(QObject):
         if old != value:
             self._audit.log("settings_changed",
                             {"changes": {key: {"old": old, "new": value}}})
-        if key == "downloadBetaFirmware" and old != value:
+        if key == "downloadBetaUpdates" and old != value:
             self._refresh_firmware_update_check()
 
     @pyqtSlot('QVariantMap')
@@ -2974,7 +2974,7 @@ class MotionConnector(QObject):
         logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
         if changes:
             self._audit.log("settings_changed", {"changes": changes})
-        if "downloadBetaFirmware" in changes:
+        if "downloadBetaUpdates" in changes:
             self._refresh_firmware_update_check()
 
     # Sensor debug-flag config keys surfaced as live Settings → Engineering

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2065,6 +2065,15 @@ class MotionConnector(QObject):
     def _devices_for_kind(kind: FirmwareKind) -> list[str]:
         return ["console"] if kind == FirmwareKind.CONSOLE else ["left", "right"]
 
+    def _beta_enabled(self) -> bool:
+        """Prerelease (beta) channel is active only for a Research build with
+        engineering mode unlocked and the beta toggle on. Clinical never opts
+        in; disabling engineering mode drops back to stable. Shared by the
+        firmware updater and the app self-updater (#386)."""
+        return (not self._app_config.get("clinicalMode", False)
+                and self._app_config.get("engineeringMode", False)
+                and self._app_config.get("downloadBetaUpdates", False))
+
     def _maybe_check_firmware_update(self, name: str) -> None:
         """If engineeringMode, ensure this device's firmware-update availability
         is computed — reusing a cached 'latest' for the kind, or kicking one
@@ -2089,7 +2098,7 @@ class MotionConnector(QObject):
 
     def _firmware_check_worker(self, kind: FirmwareKind, generation: int | None = None) -> None:
         try:
-            beta = self._app_config.get("downloadBetaUpdates", False)
+            beta = self._beta_enabled()
             info = check_latest(kind, include_prerelease=beta)
         except Exception:                           # defensive; check_latest is fail-soft
             info = None
@@ -2112,7 +2121,7 @@ class MotionConnector(QObject):
         kind = self._kind_for_device(name)
         installed = self._firmware_versions.get(name, "")
         latest = self._firmware_latest_by_kind.get(kind.value, "")
-        beta = self._app_config.get("downloadBetaUpdates", False)
+        beta = self._beta_enabled()
         avail = (bool(installed) and bool(latest)
                  and is_update_available(installed, latest, prerelease=beta))
         self._firmware_latest[name] = latest
@@ -2173,7 +2182,7 @@ class MotionConnector(QObject):
             kind = self._kind_for_device(device_key)
             self.firmwareUpdateProgress.emit(
                 device_key, "check", -1, "Checking latest release…")
-            beta = self._app_config.get("downloadBetaUpdates", False)
+            beta = self._beta_enabled()
             info = check_latest(kind, include_prerelease=beta)
             if info is None:
                 raise RuntimeError("Could not reach GitHub to fetch firmware.")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2172,6 +2172,11 @@ class MotionConnector(QObject):
         and both banners drop the old offer if it no longer qualifies."""
         self._refresh_firmware_update_check()
         if not self._app_config.get("clinicalMode", False):
+            # Withdraw any currently-shown app-update offer synchronously (it may
+            # be a now-ineligible beta), mirroring the firmware side; the
+            # re-check re-offers only if a valid update still exists, so a failed
+            # re-check leaves the stale offer withdrawn rather than clickable.
+            self.updateNotAvailable.emit()
             self.checkForUpdates()
 
     @pyqtSlot(str, result=bool)
@@ -5745,9 +5750,12 @@ class MotionConnector(QObject):
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read().decode())
 
-            # Stable: /releases/latest returns one release object. Beta:
-            # /releases returns a newest-first list -> pick the newest non-draft.
-            release = _select_release(data, include_prerelease=True) if beta else data
+            # Select by RESPONSE SHAPE, not the beta flag: the beta channel hits
+            # the /releases LIST endpoint (newest-first) -> pick newest non-draft;
+            # stable /releases/latest returns one object. An updateApiUrl override
+            # may return a single object even on beta, so handle both (#386).
+            release = (_select_release(data, include_prerelease=True)
+                       if isinstance(data, list) else data)
             if not release:
                 self.updateNotAvailable.emit()
                 return

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -5809,9 +5809,20 @@ class MotionConnector(QObject):
 
         if r_parts != l_parts:
             return r_parts > l_parts
-        # Same base version: non-pre > pre
+        # Same numeric base.
         if l_pre and not r_pre:
-            return True
+            return True   # local prerelease, remote full -> remote is newer
+        if r_pre and l_pre:
+            # Both prereleases of the same base (rc.1 -> rc.2, dev.0 -> dev.1,
+            # dev -> rc): order by PEP 440 prerelease precedence. Only the beta
+            # channel ever compares pre-vs-pre (#386). packaging parses the
+            # project's rc.N/dev.N tags; if it can't, keep the old not-newer
+            # behavior so a weird tag never triggers a spurious "update".
+            try:
+                from packaging.version import Version
+                return Version(remote) > Version(local)
+            except Exception:
+                return False
         return False
 
     @pyqtSlot(str)

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2148,6 +2148,17 @@ class MotionConnector(QObject):
             if self._firmware_versions.get(name):
                 self._maybe_check_firmware_update(name)
 
+    def _refresh_update_checks(self) -> None:
+        """Re-evaluate BOTH updaters after a change to the beta channel or
+        engineering mode. Firmware re-detects for connected devices; the app
+        self-updater re-checks — but only in a Research build, so a Clinical
+        build makes no outbound GitHub call (#96, #386). Also withdraws a stale
+        beta offer: the re-check runs on the now-current (post-change) channel,
+        and both banners drop the old offer if it no longer qualifies."""
+        self._refresh_firmware_update_check()
+        if not self._app_config.get("clinicalMode", False):
+            self.checkForUpdates()
+
     @pyqtSlot(str, result=bool)
     def startFirmwareUpdate(self, device_key: str) -> bool:
         """Download the latest firmware for device_key and flash it over DFU.
@@ -2968,8 +2979,8 @@ class MotionConnector(QObject):
         if old != value:
             self._audit.log("settings_changed",
                             {"changes": {key: {"old": old, "new": value}}})
-        if key == "downloadBetaUpdates" and old != value:
-            self._refresh_firmware_update_check()
+        if old != value and key in ("downloadBetaUpdates", "engineeringMode"):
+            self._refresh_update_checks()
 
     @pyqtSlot('QVariantMap')
     def saveConfigs(self, configs: dict):
@@ -2985,8 +2996,8 @@ class MotionConnector(QObject):
         logger.debug(f"[Connector] Config saved: {sorted(configs.keys())}")
         if changes:
             self._audit.log("settings_changed", {"changes": changes})
-        if "downloadBetaUpdates" in changes:
-            self._refresh_firmware_update_check()
+        if any(k in changes for k in ("downloadBetaUpdates", "engineeringMode")):
+            self._refresh_update_checks()
 
     # Sensor debug-flag config keys surfaced as live Settings → Engineering
     # toggles, mapped to the runtime cache attribute that

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -5724,19 +5724,33 @@ class MotionConnector(QObject):
         from version import get_version
 
         # ``updateRepo`` points the check at a staging/mirror repo; the broader
-        # ``updateApiUrl`` fully overrides the releases-latest endpoint (used by
+        # ``updateApiUrl`` fully overrides the single-release endpoint (used by
         # the local fake-releases server for offline end-to-end update testing).
-        # Both absent => the production GitHub repo.
+        # Both absent => the production GitHub repo. On the beta channel we hit
+        # the /releases LIST endpoint and pick the newest published (incl.
+        # prerelease); otherwise the stable /releases/latest single object (#386).
         repo = self._app_config.get("updateRepo") or self._GITHUB_REPO
-        api_url = self._app_config.get("updateApiUrl") or (
-            f"https://api.github.com/repos/{repo}/releases/latest"
-        )
+        beta = self._beta_enabled()
+        override = self._app_config.get("updateApiUrl")
+        if override:
+            api_url = override.replace("/releases/latest", "/releases") if beta else override
+        else:
+            base = f"https://api.github.com/repos/{repo}/releases"
+            api_url = base if beta else base + "/latest"
         try:
-            req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github+json"})
+            req = urllib.request.Request(
+                api_url, headers={"Accept": "application/vnd.github+json"})
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read().decode())
 
-            remote_tag = data.get("tag_name", "").lstrip("v")
+            # Stable: /releases/latest returns one release object. Beta:
+            # /releases returns a newest-first list -> pick the newest non-draft.
+            release = _select_release(data, include_prerelease=True) if beta else data
+            if not release:
+                self.updateNotAvailable.emit()
+                return
+
+            remote_tag = release.get("tag_name", "").lstrip("v")
             if not remote_tag:
                 self.updateCheckFailed.emit("Could not determine latest release tag.")
                 return
@@ -5744,33 +5758,28 @@ class MotionConnector(QObject):
             # Find the Setup bundle matching this build's variant.
             # clinicalMode True = clinical build; False = Research/full build.
             is_research = not bool(self._app_config.get("clinicalMode", False))
-            download_url = _select_update_asset(data.get("assets", []), is_research)
+            download_url = _select_update_asset(release.get("assets", []), is_research)
 
-            local_version = get_version()
-            # Strip local metadata for comparison (e.g. "+3.gabc1234.dirty")
-            local_base = local_version.split("+")[0]
+            # Strip local metadata for comparison (e.g. "+3.gabc1234.dirty").
+            local_base = get_version().split("+")[0]
 
             if not self._version_newer(remote_tag, local_base):
-                logger.info(f"App is up to date ({local_base} >= {remote_tag})")
+                logger.info("App is up to date (%s >= %s)", local_base, remote_tag)
                 self.updateNotAvailable.emit()
             elif not _is_bundle_url(download_url):
                 # Newer release exists but has no matching installer asset
                 # (e.g. assets still uploading) -- don't offer an in-place
                 # update we can't actually perform.
                 logger.warning(
-                    "Update %s available but no installer asset found",
-                    remote_tag,
-                )
+                    "Update %s available but no installer asset found", remote_tag)
                 self.updateNotAvailable.emit()
             else:
                 logger.info(
-                    "Update available: %s (current: %s)",
-                    remote_tag, local_base,
-                )
+                    "Update available: %s (current: %s)", remote_tag, local_base)
                 self.updateAvailable.emit(remote_tag, download_url)
 
         except Exception as e:
-            logger.warning(f"Update check failed: {e}")
+            logger.warning("Update check failed: %s", e)
             self.updateCheckFailed.emit(str(e))
 
     @staticmethod

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -2075,11 +2075,12 @@ class MotionConnector(QObject):
                 and self._app_config.get("downloadBetaUpdates", False))
 
     def _maybe_check_firmware_update(self, name: str) -> None:
-        """If engineeringMode, ensure this device's firmware-update availability
-        is computed — reusing a cached 'latest' for the kind, or kicking one
-        background GitHub check per kind per session."""
-        if not self._app_config.get("engineeringMode", False):
-            return
+        """In a Research build, ensure this device's firmware-update
+        availability is computed — reusing a cached 'latest' for the kind, or
+        kicking one background GitHub check per kind per session. Clinical
+        builds never check, even with engineering mode unlocked (#386)."""
+        if self._app_config.get("clinicalMode", False):
+            return   # firmware updates are disabled in clinical builds (#386)
         if name not in self._firmware_versions or not self._firmware_versions[name]:
             return
         kind = self._kind_for_device(name)
@@ -2150,11 +2151,12 @@ class MotionConnector(QObject):
     @pyqtSlot(str, result=bool)
     def startFirmwareUpdate(self, device_key: str) -> bool:
         """Download the latest firmware for device_key and flash it over DFU.
-        engineeringMode-only; refused during a scan or while another update runs."""
+        Research-only (blocked in clinical builds); refused during a scan or
+        while another update runs (#386)."""
         if device_key not in ("console", "left", "right"):
             return False
-        if not self._app_config.get("engineeringMode", False):
-            return False
+        if self._app_config.get("clinicalMode", False):
+            return False   # firmware updates are disabled in clinical builds (#386)
         if self._state == RUNNING or self._running:
             self.firmwareUpdateFinished.emit(
                 device_key, False, "Cannot update firmware during a scan.")

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -126,6 +126,21 @@ def _select_update_asset(assets: list, is_research: bool):
     return None
 
 
+def _select_release(releases, include_prerelease):
+    """Pick the newest published release from a GitHub /releases list.
+
+    GitHub returns releases newest-first. Drafts are never installable and are
+    always skipped. When include_prerelease is False, prereleases are skipped
+    too. Returns the chosen release dict, or None if nothing is eligible (#386)."""
+    for rel in releases or []:
+        if rel.get("draft"):
+            continue
+        if rel.get("prerelease") and not include_prerelease:
+            continue
+        return rel
+    return None
+
+
 def _authenticode_status(path: str) -> str:
     """Return the Authenticode signature status of ``path``.
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -5720,6 +5720,8 @@ class MotionConnector(QObject):
         t.start()
 
     def _check_for_updates_worker(self):
+        if self._app_config.get("clinicalMode", False):
+            return   # clinical builds never check for app updates (#96, #386)
         import urllib.request
         from version import get_version
 
@@ -5838,6 +5840,8 @@ class MotionConnector(QObject):
         Guarded against re-entry so repeated clicks can't spawn racing
         download threads against the same file.
         """
+        if self._app_config.get("clinicalMode", False):
+            return   # clinical builds never install app updates (#96, #386)
         if getattr(self, "_update_in_progress", False):
             logger.info("Update already in progress; ignoring repeat request")
             return

--- a/scripts/fake_release_server.py
+++ b/scripts/fake_release_server.py
@@ -24,19 +24,25 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 def build_handler(bundle_path: str, tag: str, host_port: str):
     asset_name = os.path.basename(bundle_path)
     download_url = f"http://{host_port}/{asset_name}"
-    latest_json = json.dumps(
-        {
-            "tag_name": tag,
-            "name": tag,
-            "html_url": f"http://{host_port}/",
-            "assets": [
-                {
-                    "name": asset_name,
-                    "browser_download_url": download_url,
-                }
-            ],
-        }
-    ).encode()
+    release_obj = {
+        "tag_name": tag,
+        "name": tag,
+        "draft": False,
+        # A dash marks a prerelease tag (e.g. 1.3.1-rc.2 / -dev.0); the beta
+        # channel (#386) selects the newest non-draft from the /releases list.
+        "prerelease": "-" in tag,
+        "html_url": f"http://{host_port}/",
+        "assets": [
+            {
+                "name": asset_name,
+                "browser_download_url": download_url,
+            }
+        ],
+    }
+    # Stable channel hits /releases/latest (one object); beta hits /releases
+    # (a newest-first list). Serve both so either channel is testable.
+    latest_json = json.dumps(release_obj).encode()
+    releases_json = json.dumps([release_obj]).encode()
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, fmt, *args):
@@ -50,6 +56,12 @@ def build_handler(bundle_path: str, tag: str, host_port: str):
                 self.send_header("Content-Length", str(len(latest_json)))
                 self.end_headers()
                 self.wfile.write(latest_json)
+            elif path.endswith("/releases"):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(releases_json)))
+                self.end_headers()
+                self.wfile.write(releases_json)
             elif path == f"/{asset_name}":
                 size = os.path.getsize(bundle_path)
                 self.send_response(200)
@@ -84,8 +96,9 @@ def main():
     handler = build_handler(args.bundle, args.tag, host_port)
     server = ThreadingHTTPServer((args.host, args.port), handler)
     print(f"[fake-release] serving tag {args.tag} ({os.path.basename(args.bundle)})")
-    print(f"[fake-release]   releases/latest -> http://{host_port}/releases/latest")
-    print(f"[fake-release]   set the old build's updateApiUrl to that URL")
+    print(f"[fake-release]   releases/latest -> http://{host_port}/releases/latest  (stable)")
+    print(f"[fake-release]   releases        -> http://{host_port}/releases         (beta)")
+    print(f"[fake-release]   set the old build's updateApiUrl to the /releases/latest URL")
     print("[fake-release] Ctrl+C to stop")
     try:
         server.serve_forever()

--- a/scripts/fake_release_server.py
+++ b/scripts/fake_release_server.py
@@ -98,7 +98,7 @@ def main():
     print(f"[fake-release] serving tag {args.tag} ({os.path.basename(args.bundle)})")
     print(f"[fake-release]   releases/latest -> http://{host_port}/releases/latest  (stable)")
     print(f"[fake-release]   releases        -> http://{host_port}/releases         (beta)")
-    print(f"[fake-release]   set the old build's updateApiUrl to the /releases/latest URL")
+    print("[fake-release]   set the old build's updateApiUrl to the /releases/latest URL")
     print("[fake-release] Ctrl+C to stop")
     try:
         server.serve_forever()

--- a/tests/test_app_config_defaults.py
+++ b/tests/test_app_config_defaults.py
@@ -185,3 +185,27 @@ def test_shipped_config_connection_timeout_is_twelve_seconds():
     shipped = json.loads(
         (REPO_ROOT / "config" / "app_config.json").read_text(encoding="utf-8"))
     assert shipped["connectionTimeoutSec"] == 12
+
+
+def test_beta_updates_default_is_registered(tmp_path, monkeypatch):
+    """downloadBetaUpdates must be in the in-code defaults whitelist or
+    _load_app_config silently drops it and the beta toggle never persists."""
+    _patch_config_path(monkeypatch, tmp_path / "app_config.json")
+    cfg = app_main._load_app_config()
+    assert cfg["downloadBetaUpdates"] is False
+
+    config_path = tmp_path / "app_config.json"
+    config_path.write_text(json.dumps({"downloadBetaUpdates": True}), encoding="utf-8")
+    _patch_config_path(monkeypatch, config_path)
+    cfg = app_main._load_app_config()
+    assert cfg["downloadBetaUpdates"] is True
+
+
+def test_beta_updates_present_in_shipped_config():
+    """Shipped config carries downloadBetaUpdates (default off); the old
+    downloadBetaFirmware key is fully retired."""
+    shipped = app_main.resource_path("config", "app_config.json")
+    with open(shipped, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["downloadBetaUpdates"] is False
+    assert "downloadBetaFirmware" not in data

--- a/tests/test_firmware_update_beta.py
+++ b/tests/test_firmware_update_beta.py
@@ -58,6 +58,7 @@ def test_toggle_invalidates_and_rechecks(tmp_path):
     c._firmware_update_available["left"] = True
     called = []
     c._maybe_check_firmware_update = lambda name: called.append(name)
+    c.checkForUpdates = lambda: None   # avoid the app-update network thread (#386)
 
     c.setConfig("downloadBetaUpdates", True)
 

--- a/tests/test_firmware_update_beta.py
+++ b/tests/test_firmware_update_beta.py
@@ -1,4 +1,4 @@
-"""downloadBetaFirmware flows into the SDK check + a toggle re-checks."""
+"""downloadBetaUpdates flows into the SDK check + a toggle re-checks."""
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,7 +19,7 @@ def _connector(tmp_path, dev_mode=True, beta=False):
     iface.get_sdk_version.return_value = "9.9.9"
     return MotionConnector(
         interface=iface,
-        app_config={"engineeringMode": dev_mode, "downloadBetaFirmware": beta},
+        app_config={"engineeringMode": dev_mode, "downloadBetaUpdates": beta},
         data_dir=str(tmp_path), config_dir="config",
     )
 
@@ -59,7 +59,7 @@ def test_toggle_invalidates_and_rechecks(tmp_path):
     called = []
     c._maybe_check_firmware_update = lambda name: called.append(name)
 
-    c.setConfig("downloadBetaFirmware", True)
+    c.setConfig("downloadBetaUpdates", True)
 
     assert c._firmware_latest_by_kind == {}      # cache invalidated
     assert "left" in called                      # re-check for the connected device

--- a/tests/test_firmware_update_detection.py
+++ b/tests/test_firmware_update_detection.py
@@ -12,7 +12,7 @@ from omotion.firmware_update import FirmwareKind, LatestInfo
 pytestmark = pytest.mark.unit
 
 
-def _connector(tmp_path, dev_mode):
+def _connector(tmp_path, dev_mode=False, clinical=False):
     iface = MagicMock()
     iface.is_device_connected.return_value = (False, False, False)
     iface.scan_workflow.running = False
@@ -20,18 +20,38 @@ def _connector(tmp_path, dev_mode):
     iface.scan_db_path = str(tmp_path / "scans.db")
     iface.get_sdk_version.return_value = "9.9.9"
     return MotionConnector(
-        interface=iface, app_config={"engineeringMode": dev_mode},
+        interface=iface,
+        app_config={"engineeringMode": dev_mode, "clinicalMode": clinical},
         data_dir=str(tmp_path), config_dir="config",
     )
 
 
-def test_no_check_when_developer_mode_off(tmp_path, monkeypatch):
-    called = []
-    monkeypatch.setattr(motion_connector, "check_latest", lambda k: called.append(k))
-    c = _connector(tmp_path, dev_mode=False)
+def test_no_check_in_clinical_mode(tmp_path, monkeypatch):
+    """Clinical build must never spawn a firmware check — even with
+    engineering mode unlocked (#386)."""
+    monkeypatch.setattr(motion_connector, "check_latest", lambda k, **_: None)
+    c = _connector(tmp_path, dev_mode=True, clinical=True)   # eng ON, clinical
     c._firmware_versions["left"] = "v1.0.0"
+    spawned = []
+    monkeypatch.setattr(
+        motion_connector.threading, "Thread",
+        lambda **k: MagicMock(start=lambda: spawned.append(1)))
     c._maybe_check_firmware_update("left")
-    assert called == [], "must not hit GitHub when engineeringMode is off"
+    assert spawned == [], "clinical build must not check firmware, even with eng mode on"
+
+
+def test_check_runs_in_research_without_eng(tmp_path, monkeypatch):
+    """Research build checks firmware on the stable channel with no
+    engineering mode required (#386)."""
+    monkeypatch.setattr(motion_connector, "check_latest", lambda k, **_: None)
+    c = _connector(tmp_path, dev_mode=False, clinical=False)  # research, eng OFF
+    c._firmware_versions["left"] = "v1.0.0"
+    spawned = []
+    monkeypatch.setattr(
+        motion_connector.threading, "Thread",
+        lambda **k: MagicMock(start=lambda: spawned.append(k.get("args"))))
+    c._maybe_check_firmware_update("left")
+    assert spawned, "research build must check firmware even with eng mode off"
 
 
 def test_worker_flags_update_and_emits(tmp_path, monkeypatch):

--- a/tests/test_firmware_update_orchestration.py
+++ b/tests/test_firmware_update_orchestration.py
@@ -20,7 +20,7 @@ def _no_network_check(monkeypatch):
     monkeypatch.setattr(motion_connector, "check_latest", lambda kind, **_: None)
 
 
-def _connector(tmp_path, dev_mode=True):
+def _connector(tmp_path, dev_mode=True, clinical=False):
     iface = MagicMock()
     iface.is_device_connected.return_value = (True, True, True)
     iface.scan_workflow.running = False
@@ -28,7 +28,8 @@ def _connector(tmp_path, dev_mode=True):
     iface.scan_db_path = str(tmp_path / "scans.db")
     iface.get_sdk_version.return_value = "9.9.9"
     return MotionConnector(
-        interface=iface, app_config={"engineeringMode": dev_mode},
+        interface=iface,
+        app_config={"engineeringMode": dev_mode, "clinicalMode": clinical},
         data_dir=str(tmp_path), config_dir="config",
     )
 
@@ -39,10 +40,33 @@ def _finished(c):
     return out
 
 
-def test_refuses_when_not_developer_mode(tmp_path):
-    c = _connector(tmp_path, dev_mode=False)
+def test_refuses_in_clinical_mode(tmp_path, monkeypatch):
+    """Clinical build refuses to flash firmware even with engineering mode
+    unlocked and an update available (#386)."""
+    c = _connector(tmp_path, dev_mode=True, clinical=True)   # eng ON, clinical
+    c._state = READY
     c._firmware_update_available["left"] = True
+    # Defensive: if the gate were wrong, this stops a real DFU flash from a test.
+    monkeypatch.setattr(c, "_firmware_update_worker", lambda dev: None)
+    monkeypatch.setattr(
+        motion_connector.threading, "Thread",
+        lambda **k: MagicMock(start=lambda: k["target"](*k["args"])))
     assert c.startFirmwareUpdate("left") is False
+
+
+def test_allowed_in_research_without_eng(tmp_path, monkeypatch):
+    """Research build flashes firmware with no engineering mode required (#386)."""
+    c = _connector(tmp_path, dev_mode=False, clinical=False)  # research, eng OFF
+    c._state = READY
+    c._firmware_update_available["left"] = True
+    started = []
+    monkeypatch.setattr(c, "_firmware_update_worker", lambda dev: started.append(dev))
+    monkeypatch.setattr(
+        motion_connector.threading, "Thread",
+        lambda **k: MagicMock(start=lambda: k["target"](*k["args"])))
+    assert c.startFirmwareUpdate("left") is True
+    assert c._firmware_update_in_progress == "left"
+    assert started == ["left"]
 
 
 def test_refuses_during_scan(tmp_path):

--- a/tests/test_update_gating.py
+++ b/tests/test_update_gating.py
@@ -164,3 +164,64 @@ def test_apply_update_refused_in_clinical(tmp_path, monkeypatch):
         lambda **k: MagicMock(start=lambda: started.append(1)))
     c.applyUpdate("https://x/Open-Motion-Research-Setup-1.6.0-rc.1.exe")
     assert started == [], "clinical build must not start an app-update install"
+
+
+# ── Withdraw an offered beta when engineering mode is turned OFF ──────────
+
+def test_eng_off_withdraws_app_offer_synchronously(tmp_path):
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=True,
+                   downloadBetaUpdates=True)
+    c.checkForUpdates = lambda: None   # don't spawn the real re-check thread
+    withdrawn = []
+    c.updateNotAvailable.connect(lambda: withdrawn.append(1))
+    c.setConfig("engineeringMode", False)
+    assert withdrawn == [1], "app offer must be withdrawn synchronously on eng-off"
+
+
+def test_eng_off_withdraws_firmware_offer(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_check(kind, *, include_prerelease=False):
+        seen["beta"] = include_prerelease
+        return None
+
+    monkeypatch.setattr(motion_connector, "check_latest", fake_check)
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=True,
+                   downloadBetaUpdates=True)
+    c.checkForUpdates = lambda: None
+    c._firmware_versions["left"] = "1.8.0"
+    c._firmware_latest_by_kind["sensor"] = "1.8.1-dev.5"
+    c._firmware_update_available["left"] = True
+    monkeypatch.setattr(
+        motion_connector.threading, "Thread",
+        lambda **k: MagicMock(start=lambda: k["target"](*k["args"])))
+    c.setConfig("engineeringMode", False)
+    assert c._firmware_update_available["left"] is False   # stale beta withdrawn
+    assert seen.get("beta") is False                       # re-checked on stable
+
+
+def test_saveconfigs_refreshes_both_updaters(tmp_path):
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=False,
+                   downloadBetaUpdates=False)
+    fw, app = [], []
+    c._refresh_firmware_update_check = lambda: fw.append(1)
+    c.checkForUpdates = lambda: app.append(1)
+    c.saveConfigs({"engineeringMode": True})
+    assert fw == [1]
+    assert app == [1]
+
+
+def test_app_beta_override_single_object_does_not_crash(tmp_path, monkeypatch):
+    # An updateApiUrl override that returns a single release object (not a list)
+    # on the beta channel must be handled by shape, not crash _select_release.
+    obj = {"tag_name": "1.6.0-rc.1", "draft": False, "prerelease": True,
+           "assets": [{"name": "Open-Motion-Research-Setup-1.6.0-rc.1.exe",
+                       "browser_download_url": "https://x/rc.exe"}]}
+    cap = {}
+    _patch_http(monkeypatch, obj, cap)
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=True,
+                   downloadBetaUpdates=True, updateApiUrl="http://localhost:9/custom")
+    out = []
+    c.updateAvailable.connect(lambda v, u: out.append((v, u)))
+    c._check_for_updates_worker()
+    assert out == [("1.6.0-rc.1", "https://x/rc.exe")]

--- a/tests/test_update_gating.py
+++ b/tests/test_update_gating.py
@@ -1,0 +1,34 @@
+"""Unified update gating (#386): _beta_enabled, _select_release, app beta path,
+and the refresh/withdraw hook that ties engineering mode to the beta channel."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from motion_connector import MotionConnector
+
+pytestmark = pytest.mark.unit
+
+
+def _connector(tmp_path, **cfg):
+    iface = MagicMock()
+    iface.is_device_connected.return_value = (False, False, False)
+    iface.scan_workflow.running = False
+    iface.scan_workflow.config_running = False
+    iface.scan_db_path = str(tmp_path / "scans.db")
+    iface.get_sdk_version.return_value = "9.9.9"
+    return MotionConnector(
+        interface=iface, app_config=cfg,
+        data_dir=str(tmp_path), config_dir="config",
+    )
+
+
+@pytest.mark.parametrize("clinical,eng,beta,expected", [
+    (False, True,  True,  True),    # research + eng + toggle -> beta
+    (False, True,  False, False),   # toggle off
+    (False, False, True,  False),   # eng off -> no beta even if toggle on
+    (True,  True,  True,  False),   # clinical never opts in
+])
+def test_beta_enabled_matrix(tmp_path, clinical, eng, beta, expected):
+    c = _connector(tmp_path, clinicalMode=clinical,
+                   engineeringMode=eng, downloadBetaUpdates=beta)
+    assert c._beta_enabled() is expected

--- a/tests/test_update_gating.py
+++ b/tests/test_update_gating.py
@@ -32,3 +32,27 @@ def test_beta_enabled_matrix(tmp_path, clinical, eng, beta, expected):
     c = _connector(tmp_path, clinicalMode=clinical,
                    engineeringMode=eng, downloadBetaUpdates=beta)
     assert c._beta_enabled() is expected
+
+
+# ── Refresh / withdraw on engineering-mode or beta-toggle change ──────────
+
+def test_eng_mode_change_refreshes_both_updaters_in_research(tmp_path):
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=False,
+                   downloadBetaUpdates=False)
+    fw, app = [], []
+    c._refresh_firmware_update_check = lambda: fw.append(1)
+    c.checkForUpdates = lambda: app.append(1)
+    c.setConfig("engineeringMode", True)
+    assert fw == [1], "firmware detection must re-run on engineering-mode change"
+    assert app == [1], "app updater must re-check on engineering-mode change"
+
+
+def test_eng_mode_change_makes_no_network_call_in_clinical(tmp_path):
+    c = _connector(tmp_path, clinicalMode=True, engineeringMode=False,
+                   downloadBetaUpdates=False)
+    fw, app = [], []
+    c._refresh_firmware_update_check = lambda: fw.append(1)
+    c.checkForUpdates = lambda: app.append(1)
+    c.setConfig("engineeringMode", True)
+    assert fw == [1], "the refresh hook must fire on engineering-mode change"
+    assert app == [], "clinical build must not make an outbound app-update call"

--- a/tests/test_update_gating.py
+++ b/tests/test_update_gating.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import motion_connector
 import version as version_mod
 from motion_connector import MotionConnector
 
@@ -138,3 +139,28 @@ def test_app_stable_uses_latest_endpoint(tmp_path, monkeypatch):
     c._check_for_updates_worker()
     assert cap["url"].endswith("/releases/latest")
     assert seen == ["uptodate"]                      # 1.5.0 == local 1.5.0
+
+
+# ── Clinical hard-block for the APP self-updater (Python backstop) ────────
+
+def test_app_check_no_network_in_clinical(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: calls.append(1))
+    # Clinical + engineering unlocked + beta on: still no outbound call.
+    c = _connector(tmp_path, clinicalMode=True, engineeringMode=True,
+                   downloadBetaUpdates=True)
+    emitted = []
+    c.updateAvailable.connect(lambda v, u: emitted.append((v, u)))
+    c._check_for_updates_worker()
+    assert calls == [], "clinical build must make no outbound update request"
+    assert emitted == []
+
+
+def test_apply_update_refused_in_clinical(tmp_path, monkeypatch):
+    c = _connector(tmp_path, clinicalMode=True)
+    started = []
+    monkeypatch.setattr(
+        motion_connector.threading, "Thread",
+        lambda **k: MagicMock(start=lambda: started.append(1)))
+    c.applyUpdate("https://x/Open-Motion-Research-Setup-1.6.0-rc.1.exe")
+    assert started == [], "clinical build must not start an app-update install"

--- a/tests/test_update_gating.py
+++ b/tests/test_update_gating.py
@@ -1,9 +1,12 @@
 """Unified update gating (#386): _beta_enabled, _select_release, app beta path,
 and the refresh/withdraw hook that ties engineering mode to the beta channel."""
+import json as _json
+import urllib.request
 from unittest.mock import MagicMock
 
 import pytest
 
+import version as version_mod
 from motion_connector import MotionConnector
 
 pytestmark = pytest.mark.unit
@@ -80,3 +83,58 @@ def test_select_release_empty_is_none():
     from motion_connector import _select_release
     assert _select_release([], include_prerelease=True) is None
     assert _select_release([_DRAFT], include_prerelease=True) is None
+
+
+# ── App self-updater beta channel (conditional /releases endpoint) ────────
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._p = payload
+
+    def read(self):
+        return _json.dumps(self._p).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _patch_http(monkeypatch, payload, capture):
+    def fake_urlopen(req, timeout=0):
+        capture["url"] = req.full_url
+        return _FakeResp(payload)
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(version_mod, "get_version", lambda: "1.5.0")
+
+
+def test_app_beta_offers_newest_prerelease(tmp_path, monkeypatch):
+    releases = [
+        {"tag_name": "1.6.0-rc.1", "draft": False, "prerelease": True,
+         "assets": [{"name": "Open-Motion-Research-Setup-1.6.0-rc.1.exe",
+                     "browser_download_url": "https://x/rc.exe"}]},
+        {"tag_name": "1.5.0", "draft": False, "prerelease": False, "assets": []},
+    ]
+    cap = {}
+    _patch_http(monkeypatch, releases, cap)
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=True,
+                   downloadBetaUpdates=True)
+    out = []
+    c.updateAvailable.connect(lambda v, u: out.append((v, u)))
+    c._check_for_updates_worker()
+    assert cap["url"].endswith("/releases")          # list endpoint, not /latest
+    assert out == [("1.6.0-rc.1", "https://x/rc.exe")]
+
+
+def test_app_stable_uses_latest_endpoint(tmp_path, monkeypatch):
+    latest = {"tag_name": "1.5.0", "draft": False, "prerelease": False, "assets": []}
+    cap = {}
+    _patch_http(monkeypatch, latest, cap)
+    c = _connector(tmp_path, clinicalMode=False, engineeringMode=False,
+                   downloadBetaUpdates=False)
+    seen = []
+    c.updateNotAvailable.connect(lambda: seen.append("uptodate"))
+    c._check_for_updates_worker()
+    assert cap["url"].endswith("/releases/latest")
+    assert seen == ["uptodate"]                      # 1.5.0 == local 1.5.0

--- a/tests/test_update_gating.py
+++ b/tests/test_update_gating.py
@@ -56,3 +56,27 @@ def test_eng_mode_change_makes_no_network_call_in_clinical(tmp_path):
     c.setConfig("engineeringMode", True)
     assert fw == [1], "the refresh hook must fire on engineering-mode change"
     assert app == [], "clinical build must not make an outbound app-update call"
+
+
+# ── _select_release: newest non-draft from a GitHub /releases list ────────
+
+_STABLE = {"tag_name": "1.5.0", "draft": False, "prerelease": False, "assets": []}
+_RC = {"tag_name": "1.6.0-rc.1", "draft": False, "prerelease": True, "assets": []}
+_DRAFT = {"tag_name": "1.7.0", "draft": True, "prerelease": False, "assets": []}
+
+
+def test_select_release_beta_takes_newest_non_draft():
+    from motion_connector import _select_release
+    # GitHub lists newest-first; the draft is skipped, the rc is taken.
+    assert _select_release([_DRAFT, _RC, _STABLE], include_prerelease=True) is _RC
+
+
+def test_select_release_stable_skips_prerelease():
+    from motion_connector import _select_release
+    assert _select_release([_DRAFT, _RC, _STABLE], include_prerelease=False) is _STABLE
+
+
+def test_select_release_empty_is_none():
+    from motion_connector import _select_release
+    assert _select_release([], include_prerelease=True) is None
+    assert _select_release([_DRAFT], include_prerelease=True) is None

--- a/tests/test_version_newer.py
+++ b/tests/test_version_newer.py
@@ -55,3 +55,17 @@ def test_inline_pre_suffix():
 def test_rc_suffix_counts_as_prerelease():
     assert newer("1.5.8", "1.5.8-rc.2") is True
     assert newer("1.5.8-rc.2", "1.5.8") is False
+
+
+def test_newer_prerelease_of_same_base():
+    # Beta channel (#386): a newer rc/dev of the SAME numeric base must be
+    # offered, or the app self-updater never advances rc.1 -> rc.2.
+    assert newer("1.5.8-rc.2", "1.5.8-rc.1") is True
+    assert newer("1.5.8-dev.1", "1.5.8-dev.0") is True
+    assert newer("1.5.8-rc.1", "1.5.8-dev.0") is True   # rc outranks dev
+
+
+def test_not_newer_same_or_older_prerelease():
+    assert newer("1.5.8-rc.1", "1.5.8-rc.2") is False
+    assert newer("1.5.8-rc.1", "1.5.8-rc.1") is False
+    assert newer("1.5.8-dev.0", "1.5.8-rc.1") is False  # dev below rc


### PR DESCRIPTION
Refs #386

## Summary

Reworks update gating for both the **app self-updater** and the **device firmware updater** onto two clean axes:

- **`clinicalMode`** (build-time) — hard-blocks **both** updaters: no network check, no banner, no start, **regardless of engineering mode**. Previously the firmware updater had **no clinical gate at all** — a clinical build could unlock engineering mode (double-click logo → password) and flash firmware. That's the safety gap this closes.
- **`engineeringMode`** (runtime) — now purely the **beta/prerelease** gate.

### Behavior matrix

| Build | Eng mode | Beta toggle | App self-updater | Firmware updater |
|---|---|---|---|---|
| Clinical | any | any | ❌ blocked | ❌ blocked |
| Research | off | (ignored) | ✅ stable | ✅ stable |
| Research | on | off | ✅ stable | ✅ stable |
| Research | on | on | ✅ beta | ✅ beta |

- Research enables both updaters on the **stable** channel with **no** engineering mode required.
- Beta active iff `Research AND engineeringMode AND downloadBetaUpdates` (shared `_beta_enabled()`), and turning engineering mode **off withdraws** any offered beta (synchronously) for both updaters.
- Renamed `downloadBetaFirmware` → `downloadBetaUpdates` and **registered it in `main.py` defaults** (it was missing → previously silently non-persistent).

## Key changes
- Firmware gate flipped `engineeringMode` → `clinicalMode` (`_maybe_check_firmware_update`, `startFirmwareUpdate`, `FirmwareUpdateBanner.qml`).
- App self-updater gains a prerelease channel (conditional `/releases` endpoint + pure `_select_release`), plus a **Python clinical guard** in `_check_for_updates_worker`/`applyUpdate` (defense-in-depth, mirroring firmware).
- `_refresh_update_checks()` re-checks both updaters + withdraws stale offers on eng/beta change; no outbound call in clinical.
- `_version_newer` now orders same-base prereleases (rc.1 → rc.2) via `packaging` — without it the beta channel would never advance between rc's.
- Settings: Clinical shows FW **version only** (no unchecked "Up to date"); beta toggle stays engineering-gated.

## Verification
- **601 unit tests pass** (`-m unit`); new suite `tests/test_update_gating.py` + migrated firmware-update tests cover the full matrix, clinical hard-block, app beta selection, both withdraw directions, and the config-key whitelist.
- Ran a 4-lens adversarial review (clinical-safety / correctness / regression / test-coverage); **all 6 confirmed findings fixed** in this PR (prerelease ordering, app clinical Python-guard, synchronous withdraw, override-shape robustness, withdraw-direction + saveConfigs test gaps).
- flake8 clean across changed regions.

## Still needs
- **Manual GUI check** (Research vs Clinical launch) — logic is fully unit-tested; the QML changes are visibility-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)