### PR TITLE
feat: E-304 modal + disconnect toast when a device is unplugged mid-scan

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -92,6 +92,19 @@ data-stall watchdog when no camera has delivered a frame for
 **What to do:** Check the sensor cables and power, then reconnect and start a
 new scan. If it happens repeatedly, send a bug report.
 
+### E-304 — Device disconnected during scan
+A console or sensor was disconnected while the scan was running, so the scan was
+stopped. Any data captured before the disconnection was saved. Fired when a
+device participating in the running scan — the console, or a sensor whose camera
+mask was non-zero at scan start — drops off USB during the trigger-on capture
+phase. Distinct from E-303: a physical unplug rarely trips the data-stall
+watchdog (the SDK tears the scan down first), so this is the coded modal for a
+device being removed mid-scan. Unplugging an idle / masked-out sensor, or any
+device while not scanning, does not raise this.
+
+**What to do:** Check the USB cables and power, reconnect the system, and start a
+new scan. If it keeps happening, send a bug report.
+
 ## Startup warnings (connection watchdog)
 
 A one-shot check armed at app launch flags expected devices that never showed

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -94,10 +94,10 @@ new scan. If it happens repeatedly, send a bug report.
 
 ### E-304 — Device disconnected during scan
 A console or sensor was disconnected while the scan was running, so the scan was
-stopped. Any data captured before the disconnection was saved. Fired when a
-device participating in the running scan — the console, or a sensor whose camera
-mask was non-zero at scan start — drops off USB during the trigger-on capture
-phase. Distinct from E-303: a physical unplug rarely trips the data-stall
+stopped. Some data loss may have occurred — data captured before the
+disconnection is not guaranteed to have been saved. Fired when a device
+participating in the running scan — the console, or a sensor whose camera mask
+was non-zero at scan start — drops off USB during the trigger-on capture phase. Distinct from E-303: a physical unplug rarely trips the data-stall
 watchdog (the SDK tears the scan down first), so this is the coded modal for a
 device being removed mid-scan. Unplugging an idle / masked-out sensor, or any
 device while not scanning, does not raise this.

--- a/error_codes.py
+++ b/error_codes.py
@@ -138,7 +138,8 @@ _SCAN = [
         "E-304", "scan",
         "Device disconnected during scan",
         "A console or sensor was disconnected while the scan was running, so "
-        "the scan was stopped. Any data captured before the disconnection was "
+        "the scan was stopped. Some data loss may have occurred — data "
+        "captured before the disconnection is not guaranteed to have been "
         "saved.",
         "Check the USB cables and power, reconnect the system, and start a "
         "new scan. If it keeps happening, send a bug report.",

--- a/error_codes.py
+++ b/error_codes.py
@@ -134,6 +134,15 @@ _SCAN = [
         "Check the sensor cables and power, then reconnect and start a new "
         "scan. If it happens repeatedly, send a bug report.",
     ),
+    _e(
+        "E-304", "scan",
+        "Device disconnected during scan",
+        "A console or sensor was disconnected while the scan was running, so "
+        "the scan was stopped. Any data captured before the disconnection was "
+        "saved.",
+        "Check the USB cables and power, reconnect the system, and start a "
+        "new scan. If it keeps happening, send a bug report.",
+    ),
 ]
 
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -378,6 +378,18 @@ def _should_abort_on_disconnect(
     return bool(capture_running) and name in active_sides
 
 
+def _disconnect_toast_text(name: str) -> str:
+    """Toast copy for a device that dropped off USB (issue #387). Used for the
+    low-key notice when the drop does NOT abort a running scan (idle, or a
+    non-participating device)."""
+    label = {
+        "console": "Console",
+        "left": "Left sensor",
+        "right": "Right sensor",
+    }.get(name, name)
+    return f"{label} disconnected"
+
+
 _SIDE_NAMES = ("left", "right")
 
 
@@ -2052,17 +2064,14 @@ class MotionConnector(QObject):
                 self.configFinished.emit(
                     False, f"Device disconnected during sensor configuration ({name})"
                 )
-            # Unplugged mid-scan (issue #387): a device participating in the
-            # running scan dropped — raise the E-304 critical modal and abort.
-            # The SDK's own mid-scan disconnect subscription is already tearing
-            # the scan down; this adds the operator-facing modal the app would
-            # otherwise omit (a real unplug rarely trips the E-303 stall
-            # watchdog). An idle / masked-out sensor is not in
-            # _capture_active_sides, so unplugging it won't abort a good scan.
-            if _should_abort_on_disconnect(
-                name, self._capture_running, self._capture_active_sides
-            ):
-                self._abort_scan_device_disconnect(name)
+            # A device dropped off USB (issue #387). If it's a device taking
+            # part in a running scan, raise the E-304 critical modal and abort;
+            # otherwise (idle, or a non-participating device) show a low-key
+            # disconnect toast. The SDK's own mid-scan disconnect subscription
+            # is already tearing a running scan down; the E-304 modal is the
+            # operator-facing notice the app would otherwise omit (a real
+            # unplug rarely trips the E-303 stall watchdog).
+            self._surface_disconnect(name)
         # CONNECTING / DISCONNECTING are intermediate; UI doesn't need to
         # fire a connect/disconnect signal for those, and emitting
         # connectionStatusChanged on every intermediate transition would
@@ -4804,6 +4813,23 @@ class MotionConnector(QObject):
             detail=f"{name} disconnected mid-scan (scan elapsed {elapsed_str})",
         )
         self.stopCapture()
+
+    def _surface_disconnect(self, name: str) -> None:
+        """Surface a device dropping off USB (issue #387). If the drop aborts a
+        running scan (a participating device lost mid-scan), raise the E-304
+        modal; otherwise show a low-key toast (an idle disconnect, or a
+        non-participating device). Exactly one notification per event."""
+        if _should_abort_on_disconnect(
+            name, self._capture_running, self._capture_active_sides
+        ):
+            self._abort_scan_device_disconnect(name)
+        else:
+            self.notify(
+                _disconnect_toast_text(name),
+                type_="warning",
+                duration_ms=6000,
+                tag=f"disconnect_{name}",
+            )
 
     def _emit_or_defer_scan_notes(self) -> None:
         """Open the end-of-scan notes modal, or defer it if a critical-error

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -361,6 +361,23 @@ def _scan_data_stall_decision(
     return stalled if stalled > timeout_sec else None
 
 
+def _should_abort_on_disconnect(
+    name: str,
+    capture_running: bool,
+    active_sides: set,
+) -> bool:
+    """Decide whether losing device ``name`` must abort the scan (issue #387).
+
+    A device unplugged mid-scan aborts with the E-304 critical modal only
+    when a capture is actually running AND the dropped device is part of
+    THIS scan — the console (always; it drives the trigger/laser) or a
+    sensor whose camera mask was non-zero at scan start (``active_sides``,
+    snapshotted in startCapture). An idle / masked-out sensor unplugged
+    mid-scan, or any disconnect while not capturing, must not abort.
+    """
+    return bool(capture_running) and name in active_sides
+
+
 _SIDE_NAMES = ("left", "right")
 
 
@@ -1002,9 +1019,17 @@ class MotionConnector(QObject):
         self._camera_last_seen: dict[tuple[str, int], float] = {}
         self._camera_last_temp: dict[tuple[str, int], float] = {}
         self._camera_dropped: set[tuple[str, int]] = set()
-        # One-shot guard for the all-camera stall abort (issue #248) —
-        # set when E-303 fires, cleared at the next startCapture.
-        self._scan_stall_abort_fired = False
+        # Shared one-shot guard for a scan-ending abort modal — set when the
+        # all-camera stall fires E-303 (issue #248) OR a participating device
+        # is unplugged mid-scan and fires E-304 (issue #387). Whichever fires
+        # first wins so the two can't stack two modals. Cleared at the next
+        # startCapture.
+        self._scan_abort_notified = False
+        # Sides participating in the CURRENT scan — {"console"} plus any
+        # sensor with a non-zero camera mask at scan start. Snapshotted in
+        # startCapture; consulted by the disconnect handler so unplugging an
+        # idle / masked-out sensor doesn't abort a good scan (issue #387).
+        self._capture_active_sides: set[str] = set()
 
         # NaN-gap tracker — replaced with a fresh instance at each scan
         # start. Kept on the instance for debugging/introspection only;
@@ -1026,6 +1051,15 @@ class MotionConnector(QObject):
         self._error_led_timer.setInterval(_ERROR_LED_BLINK_MS)
         self._error_led_timer.timeout.connect(self._on_error_led_tick)
         self._error_led_on = False  # True while the blue half-period is lit
+        # Critical-error modal coordination (issue #387). While a critical
+        # modal is on screen, the end-of-scan notes modal must not pop under
+        # it (it opens seconds after an abort, once the scan unwinds, and
+        # would steal keyboard focus behind the error modal). _raise_critical
+        # sets _critical_modal_active; _emit_or_defer_scan_notes defers the
+        # open when it is set; criticalErrorsDismissed clears it and flushes
+        # any deferred open so the notes modal appears once the error is gone.
+        self._critical_modal_active = False
+        self._scan_notes_pending = False
         self._plot_t0: float = 0.0  # set at scan start; scan-start monotonic anchor
 
         # Trigger-ON clock (issue #201) — the single scan-time source of
@@ -2018,6 +2052,17 @@ class MotionConnector(QObject):
                 self.configFinished.emit(
                     False, f"Device disconnected during sensor configuration ({name})"
                 )
+            # Unplugged mid-scan (issue #387): a device participating in the
+            # running scan dropped — raise the E-304 critical modal and abort.
+            # The SDK's own mid-scan disconnect subscription is already tearing
+            # the scan down; this adds the operator-facing modal the app would
+            # otherwise omit (a real unplug rarely trips the E-303 stall
+            # watchdog). An idle / masked-out sensor is not in
+            # _capture_active_sides, so unplugging it won't abort a good scan.
+            if _should_abort_on_disconnect(
+                name, self._capture_running, self._capture_active_sides
+            ):
+                self._abort_scan_device_disconnect(name)
         # CONNECTING / DISCONNECTING are intermediate; UI doesn't need to
         # fire a connect/disconnect signal for those, and emitting
         # connectionStatusChanged on every intermediate transition would
@@ -3767,7 +3812,15 @@ class MotionConnector(QObject):
         self._camera_last_seen = {}
         self._camera_last_temp = {}
         self._camera_dropped = set()
-        self._scan_stall_abort_fired = False
+        self._scan_abort_notified = False
+        # Snapshot the devices participating in THIS scan for the mid-scan
+        # disconnect abort (issue #387): the console always participates;
+        # a sensor participates only when its gated camera mask is non-zero.
+        self._capture_active_sides = (
+            {"console"}
+            | ({"left"} if left_camera_mask else set())
+            | ({"right"} if right_camera_mask else set())
+        )
         self._dropout_timer.start()
 
         # NaN-gap tracker — fresh per scan (same lifecycle as the watchdog).
@@ -3896,7 +3949,12 @@ class MotionConnector(QObject):
                 "outcome": _outcome_kind,
             })
             self.captureFinished.emit(True, "", "", "")
-            self.scanNotesReady.emit()
+            # Open the notes modal now, UNLESS a critical-error modal is on
+            # screen (e.g. an E-304 device-disconnect abort raised it seconds
+            # ago): defer the open until the error is dismissed so the error
+            # modal stays on top and doesn't lose focus to the notes field
+            # behind it (issue #387).
+            self._emit_or_defer_scan_notes()
 
         # Issue #43: telemetry CSVs are engineering diagnostics — clinical
         # users must not get them. Default False (fail closed). Raw
@@ -4680,7 +4738,7 @@ class MotionConnector(QObject):
         # is NOT fail-soft: if no camera has delivered a frame for
         # scanDataStallTimeoutSec the scan is dead air — abort it and
         # tell the user instead of counting down to a hollow "complete".
-        if not self._scan_stall_abort_fired:
+        if not self._scan_abort_notified:
             stalled_s = _scan_data_stall_decision(
                 now,
                 self._trigger_on_mono,
@@ -4699,7 +4757,7 @@ class MotionConnector(QObject):
         data files and emits captureFinished, returning the QML scan flow
         (and the state machine) to idle exactly like a user Stop.
         """
-        self._scan_stall_abort_fired = True
+        self._scan_abort_notified = True
         elapsed_str = self._scan_elapsed_str()
         msg = (
             f"[{elapsed_str}] No data from any camera for "
@@ -4717,6 +4775,58 @@ class MotionConnector(QObject):
             ),
         )
         self.stopCapture()
+
+    def _abort_scan_device_disconnect(self, name: str) -> None:
+        """Abort the running scan because a participating device was
+        unplugged mid-scan (issue #387). Runs on the main thread from the
+        connection handler. Twin of _abort_scan_data_stall: it shares the
+        one-shot guard (so a disconnect + a stall — or two devices dropping
+        — can't stack two modals), writes a capture-log line, raises the
+        E-304 critical modal, then stopCapture(). The SDK is already tearing
+        the scan down via its own mid-scan disconnect subscription; the
+        stopCapture() here cancels it app-side too and, by marking the scan
+        canceled, suppresses the redundant end-of-scan outcome toast — the
+        modal is the notification.
+        """
+        if self._scan_abort_notified:
+            return
+        self._scan_abort_notified = True
+        elapsed_str = self._scan_elapsed_str()
+        msg = (
+            f"[{elapsed_str}] {name} disconnected during the scan — "
+            f"stopping the scan; data captured before the disconnection "
+            f"is saved."
+        )
+        logger.error(msg)
+        self.captureLog.emit(msg)
+        self._raise_critical(
+            "E-304",
+            detail=f"{name} disconnected mid-scan (scan elapsed {elapsed_str})",
+        )
+        self.stopCapture()
+
+    def _emit_or_defer_scan_notes(self) -> None:
+        """Open the end-of-scan notes modal, or defer it if a critical-error
+        modal is currently on screen (issue #387).
+
+        On an E-304 device-disconnect abort (and E-303 / E-202) the critical
+        modal is raised, then the scan unwinds for a second or two before
+        this completion handler runs. The notes modal opening now would pop
+        UNDER the error modal and steal keyboard focus. Deferring holds the
+        open until criticalErrorsDismissed() flushes it, so the error modal
+        stays on top and only one modal is on screen at a time.
+
+        Called from the pipeline completion handler (worker thread). The
+        re-check after setting the pending flag closes the tiny race where
+        the modal is dismissed between the check and the set.
+        """
+        if not self._critical_modal_active:
+            self.scanNotesReady.emit()
+            return
+        self._scan_notes_pending = True
+        if not self._critical_modal_active:
+            self._scan_notes_pending = False
+            self.scanNotesReady.emit()
 
     def _on_camera_dropout_recovered(self, side: str, cam_id: int) -> None:
         """Frames resumed for a camera the watchdog had flagged Connection
@@ -5168,6 +5278,9 @@ class MotionConnector(QObject):
                          f" ({detail})" if detail else "")
             self.criticalErrorRaised.emit(
                 code, err.title, err.message, err.suggested_action, detail)
+            # A critical modal is now on screen; hold back the end-of-scan
+            # notes modal until it is dismissed (issue #387).
+            self._critical_modal_active = True
             self._errorLedBlinkRequested.emit()
         except Exception:
             logger.exception("Failed to raise critical error %s", code)
@@ -5213,9 +5326,17 @@ class MotionConnector(QObject):
     @pyqtSlot()
     def criticalErrorsDismissed(self):
         """Called from CriticalErrorModal when the last queued error is
-        dismissed: stop the error blink and restore the idle green LED
-        (issue #257). No-op if the blink never started (e.g. the console
-        was never reachable)."""
+        dismissed: release the notes modal deferred behind it (issue #387),
+        then stop the error blink and restore the idle green LED (issue
+        #257)."""
+        # The error modal is gone — open the notes modal if a scan finished
+        # behind it (E-304 device disconnect, or E-303 / E-202). Must run
+        # before the LED early-return below, which returns when no blink was
+        # ever started (e.g. the console itself was the disconnected device).
+        self._critical_modal_active = False
+        if self._scan_notes_pending:
+            self._scan_notes_pending = False
+            self.scanNotesReady.emit()
         if not self._error_led_timer.isActive() and not self._error_led_on:
             return
         self._error_led_timer.stop()

--- a/tests/test_dropout_marker_time_axis.py
+++ b/tests/test_dropout_marker_time_axis.py
@@ -69,7 +69,7 @@ def _watchdog_self(src, *, plot_t0, last_seen, threshold=2.0):
         cameraDropoutDetected=_Signal(),
         # All-camera stall watchdog (issue #248) — armed but far from
         # tripping; these tests exercise the per-camera marker path.
-        _scan_stall_abort_fired=False,
+        _scan_abort_notified=False,
         _scan_data_stall_timeout_sec=15.0,
         _trigger_on_mono=plot_t0,
     )

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -50,7 +50,7 @@ def test_expected_catalog_codes_present():
     expected = {
         "E-101", "E-102", "E-103", "E-105",
         "E-201", "E-202",
-        "E-301", "E-302", "E-303",
+        "E-301", "E-302", "E-303", "E-304",
     }
     # E-104/E-106 are intentionally absent: the connection watchdog surfaces
     # them as warning toasts, not via this critical-modal registry.

--- a/tests/test_scan_disconnect_abort.py
+++ b/tests/test_scan_disconnect_abort.py
@@ -43,6 +43,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from motion_connector import (  # noqa: E402
     MotionConnector,
     _should_abort_on_disconnect,
+    _disconnect_toast_text,
 )
 
 pytestmark = pytest.mark.unit
@@ -81,6 +82,64 @@ def test_disconnect_while_not_capturing_does_not_abort():
         name="console", capture_running=False,
         active_sides={"console", "left"},
     ) is False
+
+
+# ── _disconnect_toast_text ──────────────────────────────────────────────
+
+
+def test_disconnect_toast_text_names_the_device():
+    assert _disconnect_toast_text("console") == "Console disconnected"
+    assert _disconnect_toast_text("left") == "Left sensor disconnected"
+    assert _disconnect_toast_text("right") == "Right sensor disconnected"
+
+
+# ── MotionConnector._surface_disconnect (unbound, fake) ─────────────────
+#
+# Routes a device drop to EITHER the E-304 modal (participating device lost
+# mid-scan) OR a low-key toast (idle, or a non-participating device) — never
+# both, so the operator gets exactly one notification per event.
+
+
+class _FakeSurface:
+    def __init__(self, capture_running, active_sides):
+        self._capture_running = capture_running
+        self._capture_active_sides = active_sides
+        self.aborted = []
+        self.toasts = []
+
+    def _abort_scan_device_disconnect(self, name):
+        self.aborted.append(name)
+
+    def notify(self, text, type_="info", duration_ms=4000,
+               dismissible=True, tag=""):
+        self.toasts.append((text, type_, tag))
+
+
+def test_surface_disconnect_mid_scan_participating_aborts_no_toast():
+    fake = _FakeSurface(capture_running=True, active_sides={"console", "left"})
+    MotionConnector._surface_disconnect(fake, "console")
+    assert fake.aborted == ["console"]
+    assert fake.toasts == []
+
+
+def test_surface_disconnect_idle_shows_toast_no_abort():
+    fake = _FakeSurface(capture_running=False, active_sides=set())
+    MotionConnector._surface_disconnect(fake, "left")
+    assert fake.aborted == []
+    assert len(fake.toasts) == 1
+    text, type_, tag = fake.toasts[0]
+    assert text == "Left sensor disconnected"
+    assert type_ == "warning"
+    assert tag == "disconnect_left"
+
+
+def test_surface_disconnect_nonparticipating_sensor_mid_scan_toasts():
+    # Scan on left only; the idle right sensor drops → toast, not an abort.
+    fake = _FakeSurface(capture_running=True, active_sides={"console", "left"})
+    MotionConnector._surface_disconnect(fake, "right")
+    assert fake.aborted == []
+    assert len(fake.toasts) == 1
+    assert fake.toasts[0][0] == "Right sensor disconnected"
 
 
 # ── MotionConnector._abort_scan_device_disconnect (unbound, fake) ───────

--- a/tests/test_scan_disconnect_abort.py
+++ b/tests/test_scan_disconnect_abort.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for the mid-scan device-disconnect abort (issue #387).
+
+What this exercises
+-------------------
+When a device participating in a running scan (the console, or a sensor
+whose camera mask was non-zero at scan start) is physically unplugged, the
+app must raise the big critical-error modal with code E-304 — not merely the
+end-of-scan toast the SDK's own disconnect teardown would leave behind.
+
+Three seams:
+
+  - ``_should_abort_on_disconnect`` — the pure decision the connection
+    handler consults: abort only when a scan is capturing AND the dropped
+    device is part of THIS scan. An idle / masked-out sensor being
+    unplugged must NOT abort a good scan.
+
+  - ``MotionConnector._abort_scan_device_disconnect`` — the abort path,
+    twin of ``_abort_scan_data_stall``: one-shot guard shared with the
+    stall watchdog (so a disconnect + a stall can't stack two modals),
+    capture-log line, E-304 critical modal, then stopCapture().
+
+  - ``_emit_or_defer_scan_notes`` / ``criticalErrorsDismissed`` — the
+    notes-modal deferral: the notes modal opens seconds after the abort
+    (once the scan finishes unwinding), so it must be held back until the
+    critical-error modal is dismissed, keeping the error modal on top.
+
+Marker
+------
+``pytest.mark.unit`` — pure Python, no QApplication, no hardware; the
+conftest autouse fixtures short-circuit on this marker.
+
+Run with:  pytest tests/test_scan_disconnect_abort.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from motion_connector import (  # noqa: E402
+    MotionConnector,
+    _should_abort_on_disconnect,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── _should_abort_on_disconnect ─────────────────────────────────────────
+
+
+def test_console_loss_while_capturing_aborts():
+    # The console always participates — it drives the trigger/laser.
+    assert _should_abort_on_disconnect(
+        name="console", capture_running=True,
+        active_sides={"console", "left"},
+    ) is True
+
+
+def test_participating_sensor_loss_while_capturing_aborts():
+    assert _should_abort_on_disconnect(
+        name="right", capture_running=True,
+        active_sides={"console", "left", "right"},
+    ) is True
+
+
+def test_idle_sensor_loss_does_not_abort():
+    """A connected-but-masked-out sensor (not part of this scan) being
+    unplugged must NOT abort a scan running on the other side."""
+    assert _should_abort_on_disconnect(
+        name="right", capture_running=True,
+        active_sides={"console", "left"},
+    ) is False
+
+
+def test_disconnect_while_not_capturing_does_not_abort():
+    """Idle (not-scanning) unplug stays low-key — no modal."""
+    assert _should_abort_on_disconnect(
+        name="console", capture_running=False,
+        active_sides={"console", "left"},
+    ) is False
+
+
+# ── MotionConnector._abort_scan_device_disconnect (unbound, fake) ───────
+
+
+class _Signal:
+    def __init__(self):
+        self.calls = []
+
+    def emit(self, *args):
+        self.calls.append(args)
+
+
+class _FakeConnector:
+    """Just the attributes _abort_scan_device_disconnect touches."""
+
+    def __init__(self):
+        self._scan_abort_notified = False
+        self.captureLog = _Signal()
+        self.criticals = []
+        self.stop_calls = 0
+
+    def _scan_elapsed_str(self):
+        return "00:02:05"
+
+    def _raise_critical(self, code, detail=""):
+        self.criticals.append((code, detail))
+
+    def stopCapture(self):
+        self.stop_calls += 1
+
+
+def test_abort_raises_e304_and_stops_capture():
+    fake = _FakeConnector()
+    MotionConnector._abort_scan_device_disconnect(fake, "right")
+
+    assert fake._scan_abort_notified is True
+    assert fake.stop_calls == 1
+    # E-304 critical modal, detail names the device + scan-elapsed.
+    assert len(fake.criticals) == 1
+    code, detail = fake.criticals[0]
+    assert code == "E-304"
+    assert "right" in detail
+    assert "00:02:05" in detail
+    # Capture-log line names the disconnected device and the elapsed stamp.
+    assert len(fake.captureLog.calls) == 1
+    (msg,) = fake.captureLog.calls[0]
+    assert "right" in msg
+    assert "[00:02:05]" in msg
+    assert "disconnected" in msg.lower()
+
+
+def test_abort_is_one_shot_shared_with_stall_guard():
+    """If a scan-ending abort was already notified (e.g. the stall watchdog
+    fired E-303 first, or a prior disconnect), a later disconnect must not
+    stack a second modal."""
+    fake = _FakeConnector()
+    fake._scan_abort_notified = True
+
+    MotionConnector._abort_scan_device_disconnect(fake, "console")
+
+    assert fake.criticals == []
+    assert fake.stop_calls == 0
+    assert fake.captureLog.calls == []
+
+
+# ── Notes-modal deferral (unbound, fake) ────────────────────────────────
+
+
+class _FakeTimer:
+    def __init__(self, active=False):
+        self._active = active
+        self.stopped = 0
+
+    def isActive(self):
+        return self._active
+
+    def stop(self):
+        self.stopped += 1
+
+
+class _FakeNotesConnector:
+    """Attributes the notes-deferral seams touch."""
+
+    def __init__(self):
+        self._critical_modal_active = False
+        self._scan_notes_pending = False
+        self.scanNotesReady = _Signal()
+        # LED bits criticalErrorsDismissed also touches — inert here.
+        self._error_led_timer = _FakeTimer(active=False)
+        self._error_led_on = False
+        self.led_writes = []
+
+    def _set_console_led(self, state):
+        self.led_writes.append(state)
+        return True
+
+
+def test_notes_emit_immediately_when_no_modal_active():
+    fake = _FakeNotesConnector()
+    MotionConnector._emit_or_defer_scan_notes(fake)
+
+    assert len(fake.scanNotesReady.calls) == 1
+    assert fake._scan_notes_pending is False
+
+
+def test_notes_deferred_while_critical_modal_active():
+    fake = _FakeNotesConnector()
+    fake._critical_modal_active = True
+
+    MotionConnector._emit_or_defer_scan_notes(fake)
+
+    # Held back — the error modal must stay on top of the notes modal.
+    assert fake.scanNotesReady.calls == []
+    assert fake._scan_notes_pending is True
+
+
+def test_dismiss_flushes_deferred_notes():
+    fake = _FakeNotesConnector()
+    fake._critical_modal_active = True
+    fake._scan_notes_pending = True
+
+    MotionConnector.criticalErrorsDismissed(fake)
+
+    assert fake._critical_modal_active is False
+    assert fake._scan_notes_pending is False
+    assert len(fake.scanNotesReady.calls) == 1
+
+
+def test_dismiss_without_pending_notes_does_not_emit():
+    fake = _FakeNotesConnector()
+    fake._critical_modal_active = True
+
+    MotionConnector.criticalErrorsDismissed(fake)
+
+    assert fake._critical_modal_active is False
+    assert fake.scanNotesReady.calls == []

--- a/tests/test_scan_stall_watchdog.py
+++ b/tests/test_scan_stall_watchdog.py
@@ -136,7 +136,7 @@ class _FakeConnector:
     """Just the attributes _abort_scan_data_stall touches."""
 
     def __init__(self):
-        self._scan_stall_abort_fired = False
+        self._scan_abort_notified = False
         self._scan_data_stall_timeout_sec = 15.0
         self.captureLog = _Signal()
         self.criticals = []
@@ -156,7 +156,7 @@ def test_abort_raises_e303_and_stops_capture():
     fake = _FakeConnector()
     MotionConnector._abort_scan_data_stall(fake, 16.2)
 
-    assert fake._scan_stall_abort_fired is True
+    assert fake._scan_abort_notified is True
     assert fake.stop_calls == 1
     # E-303 critical modal with the stall duration + elapsed in the detail.
     assert len(fake.criticals) == 1


### PR DESCRIPTION
## What & why
When a device (the console, or a sensor in use) is unplugged **mid-scan**, the app now raises the big **E-304 "Device disconnected during scan"** critical modal and stops the scan — instead of the old behavior where a genuine USB unplug was torn down by the SDK and surfaced only as an end-of-scan toast (E-303's data-stall watchdog rarely trips on a real unplug). Per system-design guidance: mid-scan unplug → modal; idle unplug → low-key toast.

Refs #387

## Behavior
- **Unplugged mid-scan** (a participating device — the console, or a sensor whose camera mask was non-zero at scan start): E-304 critical modal, scan stopped, the redundant end-of-scan outcome toast suppressed.
- **Unplugged while not scanning**, or a **non-participating / masked-out sensor** dropped mid-scan: a low-key warning toast naming the device (“Console disconnected” / “Left sensor disconnected” / “Right sensor disconnected”). A good scan is never aborted by an idle device dropping.
- **Error modal above the notes modal**: the end-of-scan Session Notes modal is deferred (connector-side) until the critical modal is dismissed, so the error stays on top and doesn’t lose keyboard focus to the notes field opening behind it.

## Implementation (all app-side, twin of the E-303 stall abort)
- New `E-304` in `error_codes.py` + `docs/ERROR_CODES.md`.
- Pure decisions `_should_abort_on_disconnect` / `_disconnect_toast_text`; `_capture_active_sides` snapshot at scan start.
- `_abort_scan_device_disconnect` mirrors `_abort_scan_data_stall`; the stall one-shot generalizes to a shared `_scan_abort_notified` so a disconnect + a stall (or a device cascade) can’t stack two modals.
- `_surface_disconnect` routes each drop to modal-or-toast — exactly one notification per event.
- Notes deferral via `_emit_or_defer_scan_notes` / `criticalErrorsDismissed`.
- No QML changes: `CriticalErrorModal` is already hosted top-level (z:100000) above the page-nested notes modal; the only real gap was keyboard-focus timing, fixed by the connector-side deferral.

## Testing
- **Unit**: 592 unit tests pass, incl. new `tests/test_scan_disconnect_abort.py` (14 tests: participating-vs-idle scoping, abort + one-shot guard, toast text/routing, notes deferral).
- **Hand-tested on hardware** (bench, both sensors + console):
  - Idle sensor unplug → “Right sensor disconnected” toast, no modal ✓
  - Mid-scan sensor unplug → E-304 modal on top of the dimmed scan; scan ended “stopped” ✓
  - Softened data-loss wording rendered ✓
  - Dismiss E-304 → Session Notes modal surfaces ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)