### PR TITLE
feat: encrypt scans.db at rest on clinical builds (app wiring)

### DIFF
--- a/audit_log.py
+++ b/audit_log.py
@@ -129,10 +129,17 @@ class AuditLog:
             )
             return
         try:
-            conn = sqlite3.connect(str(db_path), check_same_thread=False)
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA busy_timeout=5000")
-            self._conn = conn
+            # Open through the SDK helper, not stdlib sqlite3. On a clinical
+            # build scans.db is SQLCipher-encrypted, and a stdlib connection
+            # raises "file is not a database" — which the fail-soft handler
+            # below would swallow, silently disabling the audit log on exactly
+            # the builds that need it. db_open picks the driver from the
+            # process encryption policy, applies the key, and sets the same
+            # WAL/busy_timeout PRAGMAs this used to set by hand. AuditLog
+            # itself never sees the key.
+            from omotion import db_open
+
+            self._conn = db_open.connect(db_path)
             self._init_schema()
         except Exception:
             logger.warning(

--- a/main.py
+++ b/main.py
@@ -347,11 +347,44 @@ def main():
     _scan_data_dir = os.path.join(_data_dir, app_paths.DATA_DIRNAME)
     os.makedirs(_scan_data_dir, exist_ok=True)
     _scan_db_path = os.path.join(_scan_data_dir, "scans.db")
+    # Clinical builds encrypt scans.db at rest (SQLCipher, key in the Windows
+    # Credential Manager). The flag is the SIGNED build config, so the encrypt
+    # decision cannot be independently forgotten. Constructing MotionInterface
+    # sets the SDK's process-wide policy exactly once.
+    _clinical = bool(app_config.get("clinicalMode", False))
     motion_interface = MotionInterface(
         data_dir=_scan_data_dir,
         scan_db_path=_scan_db_path,
         operator_id="bloodflow-app",
+        require_encrypted_db=_clinical,
     )
+
+    # An existing PLAINTEXT scans.db must be encrypted before anything opens it:
+    # under the policy the SDK refuses to open plaintext (it never silently
+    # appends PHI in the clear), and AuditLog opens the same file inside
+    # MotionConnector below. So this has to happen here — after the policy is
+    # set, before the connector exists.
+    if _clinical:
+        from omotion import db_migrate
+
+        try:
+            if db_migrate.migrate_plaintext_to_encrypted(_scan_db_path):
+                logger.warning(
+                    "scans.db was plaintext and has been encrypted in place. A "
+                    "backup of the original remains at %s.pre-encryption.bak — "
+                    "remove it per SOP once this build is confirmed.",
+                    _scan_db_path,
+                )
+        except Exception:
+            # Fail loudly but let the app start: the SDK's own pre-flight will
+            # refuse the scan before the laser fires, which is a far clearer
+            # failure than a dead splash screen.
+            logger.exception(
+                "scans.db encryption migration FAILED — scanning will be "
+                "refused until this is resolved. The original database is "
+                "untouched."
+            )
+
     motion_interface.log_system_info()
 
     qInstallMessageHandler(qt_message_handler)

--- a/openwater.spec
+++ b/openwater.spec
@@ -74,6 +74,35 @@ hidden += [
     "base58",
 ]
 
+# --- scan-DB encryption stack (clinical builds) ---
+# Belt-and-braces, NOT a fix for a known break: a frozen build was verified to
+# pick these up already, because PyInstaller's bytecode scan finds the lazy
+# `import sqlcipher3` / `import keyring` inside omotion.db_open/db_key, and
+# PyInstaller ships its own keyring hook for the entry-point-discovered
+# backends. Listing them explicitly means a refactor of those import sites (or
+# a hook change) cannot silently produce a clinical build that crashes on the
+# first scan or, worse, cannot open its own encrypted database.
+hidden += [
+    "sqlcipher3",
+    "sqlcipher3.dbapi2",
+    "keyring",
+    "keyring.backends",
+    "keyring.backends.Windows",          # WinVaultKeyring - found via entry points
+    "win32ctypes.core",                  # backs the Windows keyring backend
+    "win32ctypes.pywin32.win32cred",
+    "win32ctypes.pywin32.pywintypes",
+]
+try:
+    # sqlcipher3 is a single native extension with OpenSSL statically linked,
+    # so there are no side-car DLLs to chase - collect_all still future-proofs
+    # against that changing.
+    _sc_datas, _sc_bins, _sc_hidden = collect_all("sqlcipher3")
+    datas += _sc_datas
+    binaries += _sc_bins
+    hidden += _sc_hidden
+except Exception:
+    pass
+
 # Optional: if you also have a separate 'libusb' wheel installed, this won't hurt
 try:
     binaries += collect_dynamic_libs("libusb")

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -31,11 +31,15 @@
       ],
       "supplier": {
         "name": "Openwater Inc.",
-        "url": ["https://www.openwater.cc"]
+        "url": [
+          "https://www.openwater.cc"
+        ]
       },
       "manufacturer": {
         "name": "Openwater Inc.",
-        "url": ["https://www.openwater.cc"]
+        "url": [
+          "https://www.openwater.cc"
+        ]
       },
       "properties": [
         {
@@ -435,7 +439,9 @@
       ],
       "supplier": {
         "name": "Openwater Inc.",
-        "url": ["https://www.openwater.cc"]
+        "url": [
+          "https://www.openwater.cc"
+        ]
       },
       "externalReferences": [
         {
@@ -544,6 +550,114 @@
         {
           "name": "ow:scope-note",
           "value": "Development/linting dependency only. Not included in deployed application binary."
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:pypi/sqlcipher3@0.6.2",
+      "name": "sqlcipher3",
+      "version": "0.6.2",
+      "description": "DB-API 2.0 binding bundling SQLCipher; encrypts scans.db at rest on clinical builds",
+      "purl": "pkg:pypi/sqlcipher3@0.6.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "supplier": {
+        "name": "Charles Leifer"
+      },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/coleifer/sqlcipher3"
+        },
+        {
+          "type": "distribution",
+          "url": "https://pypi.org/project/sqlcipher3/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:generic/sqlcipher@4.12.0",
+      "name": "SQLCipher",
+      "version": "4.12.0",
+      "description": "AES-256-CBC + per-page HMAC-SHA512 encryption layer for SQLite (Community Edition; statically linked into the sqlcipher3 wheel)",
+      "purl": "pkg:generic/sqlcipher@4.12.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause License"
+          }
+        }
+      ],
+      "supplier": {
+        "name": "Zetetic LLC"
+      },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://www.zetetic.net/sqlcipher/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:generic/openssl@3.6.0",
+      "name": "OpenSSL",
+      "version": "3.6.0",
+      "description": "Cryptographic provider backing SQLCipher (statically linked into the sqlcipher3 wheel); CVE-tracked",
+      "purl": "pkg:generic/openssl@3.6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "supplier": {
+        "name": "OpenSSL Project"
+      },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://www.openssl.org/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:pypi/keyring@25.6.0",
+      "name": "keyring",
+      "version": "25.6.0",
+      "description": "OS keystore access; holds the scans.db encryption key in the Windows Credential Manager",
+      "purl": "pkg:pypi/keyring@25.6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "supplier": {
+        "name": "Jason R. Coombs"
+      },
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/jaraco/keyring"
+        },
+        {
+          "type": "distribution",
+          "url": "https://pypi.org/project/keyring/"
         }
       ]
     }


### PR DESCRIPTION
## What

App-side wiring for scan-database encryption. On **clinical builds only**,
`scans.db` is encrypted at rest with SQLCipher (AES-256-CBC + HMAC-SHA512),
keyed from the Windows Credential Manager. Research builds are byte-identical
to today.

Refs #394

> **Blocked on OpenwaterHealth/openmotion-sdk#187** — this consumes the SDK's
> `db_open` / `db_key` / `db_migrate`. Merge that first.

## Changes

- **`main.py`** — `MotionInterface(require_encrypted_db=clinicalMode)` sets the
  SDK's process-wide encryption policy exactly once, from the **signed** build
  config, so the encrypt decision cannot be independently forgotten.
- **`main.py`** — run `db_migrate` **before** `MotionConnector` exists. Under the
  policy the SDK refuses to open a plaintext `scans.db` (it never silently
  appends PHI in the clear), and `AuditLog` opens that same file inside the
  connector — so an existing plaintext DB has to be encrypted in that window.
  Migration failure logs loudly but does not block startup; the SDK pre-flight
  then refuses the scan before the laser fires, which is a clearer failure than
  a dead splash screen.
- **`audit_log.py`** — open via `db_open.connect()` instead of stdlib `sqlite3`.

  **The audit log stays in `scans.db`.** Same file, same `logs` table, same rows —
  the Logs viewer and CSV export are untouched. Only the driver changes:

  ```python
  conn = sqlite3.connect(str(db_path), check_same_thread=False)  # before
  conn = db_open.connect(db_path)                                # after
  ```

  It matters because on a clinical build that file is ciphertext: stdlib
  `sqlite3` raises, `AuditLog` is fail-soft by contract, and the audit trail
  silently disables itself on exactly the builds that need it. `AuditLog` never
  sees the key.
- **`openwater.spec`** — explicit hiddenimports for the encryption stack.
- **`sbom.cdx.json`** — `sqlcipher3` + `keyring`, plus **SQLCipher 4.12.0** and
  **OpenSSL 3.6.0**, which are *statically linked inside the sqlcipher3 wheel*.
  They are the actual cryptographic implementation and need CVE tracking even
  though they are not separate installs.

## Verification

- Both startup orderings simulated end to end: research and clinical each
  produce a working `AuditLog` writing to `scans.db`; clinical is encrypted and
  blocks stdlib `sqlite3`, research is unchanged.
- **PyInstaller: the predicted packaging gap does not exist.** A frozen build
  with *no* encryption entries in the spec still resolved sqlcipher3's native
  extension and the real `WinVaultKeyring`, and wrote + read an encrypted DB
  inside the frozen app. PyInstaller's bytecode scan finds the lazy imports
  inside `omotion.db_open`/`db_key`, and it ships its own keyring hook.
  sqlcipher3 is a single 5.9 MB `.pyd` with OpenSSL statically linked, so there
  are no side-car DLLs to chase. The spec entries here are **belt-and-braces,
  not a fix** — they stop a future refactor of those import sites from silently
  shipping a clinical build that cannot open its own database.
- App unit suite: **628 passed** (4 consecutive runs).

## Operational note for commissioning

The encryption key is **never** written to the disk it protects — a recovery
file beside the encrypted DB would defeat the stolen-disk threat model. First
key provisioning logs a WARNING with the exact command:

```
python -m omotion.db_key export <path>
```

Commissioning must run it to secure storage **off** the machine. Without it, a
rebuilt profile or reimaged machine makes every scan in that database
permanently unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
