### PR TITLE
fix: make toasts and dropdown popups near-opaque in the Liquid Glass theme

### DIFF
--- a/components/AppTheme.qml
+++ b/components/AppTheme.qml
@@ -134,6 +134,20 @@ QtObject {
                                                    : (dark ? Qt.rgba(0.12, 0.12, 0.14, 0.96)
                                                            : Qt.rgba(0.99, 0.985, 0.96, 0.97))
 
+    // ── toast surface ─────────────────────────────────────────────
+    // Transient chrome that must stay readable over whatever it lands on,
+    // including the busy ambient. In glass mode it can't inherit
+    // bgElevated: that token is a 12% *white* wash, which would leave the
+    // white body text sitting on bright frost. So toasts go dark-dominant
+    // and near-opaque here (same trick as sheetBg / plotCellBg), a touch
+    // lighter than a modal sheet so they still read as floating chrome
+    // rather than a focused task surface. Solid-theme values are
+    // byte-identical to bgElevated so turning glass off is a perfect
+    // revert.
+    readonly property color toastBg: glass ? (dark ? Qt.rgba(0.12,0.12,0.16,0.94)
+                                                    : Qt.rgba(1,1,1,0.94))
+                                            : (dark ? "#252528" : "#EBE7DB")
+
     // ── modal sheet surface ───────────────────────────────────────
     // Modal panels (Settings, History, Contact Quality, …) need a much
     // heavier frost than chrome like the header: a focused task sheet

--- a/components/AppTheme.qml
+++ b/components/AppTheme.qml
@@ -130,7 +130,14 @@ QtObject {
     readonly property color overlayBg:      glass ? (dark ? Qt.rgba(0.10,0.10,0.14,0.60) : Qt.rgba(1,1,1,0.62))
                                                    : (dark ? Qt.rgba(0.10, 0.10, 0.12, 0.82)
                                                            : Qt.rgba(0.99, 0.98, 0.95, 0.90))
-    readonly property color overlayBgSolid: glass ? (dark ? Qt.rgba(0.12,0.12,0.16,0.80) : Qt.rgba(1,1,1,0.82))
+    // overlayBgSolid is the "you are reading something off this" tier —
+    // the hover tooltip, the window-length menu, the ⋯ settings popup. In
+    // glass it therefore carries the same near-opaque weight as menuBg /
+    // toastBg: these float over live traces, and a readout you can see the
+    // plot through is a readout you have to squint at. (overlayBg above
+    // stays airy — it backs pills and chips, which are chrome, not text
+    // you stop to read.)
+    readonly property color overlayBgSolid: glass ? (dark ? Qt.rgba(0.12,0.12,0.16,0.94) : Qt.rgba(1,1,1,0.94))
                                                    : (dark ? Qt.rgba(0.12, 0.12, 0.14, 0.96)
                                                            : Qt.rgba(0.99, 0.985, 0.96, 0.97))
 
@@ -147,6 +154,17 @@ QtObject {
     readonly property color toastBg: glass ? (dark ? Qt.rgba(0.12,0.12,0.16,0.94)
                                                     : Qt.rgba(1,1,1,0.94))
                                             : (dark ? "#252528" : "#EBE7DB")
+
+    // ── menu / dropdown surface ───────────────────────────────────
+    // The list panel a ComboBox drops open. Same reasoning as toastBg,
+    // and more urgent: these popups previously took bgCard, which in
+    // glass+dark is only 8% white — an open dropdown all but vanished
+    // into the ambient, and its options are a list you have to read to
+    // click. Solid-theme values are byte-identical to bgCard so turning
+    // glass off is a perfect revert.
+    readonly property color menuBg: glass ? (dark ? Qt.rgba(0.12,0.12,0.16,0.94)
+                                                   : Qt.rgba(1,1,1,0.94))
+                                           : (dark ? "#262630" : "#FAF9F4")
 
     // ── modal sheet surface ───────────────────────────────────────
     // Modal panels (Settings, History, Contact Quality, …) need a much

--- a/components/LogsModal.qml
+++ b/components/LogsModal.qml
@@ -238,7 +238,8 @@ Item {
                             ScrollBar.vertical: ScrollBar {}
                         }
                         background: Rectangle {
-                            color: AppTheme.bgCard; radius: 4
+                            // menuBg — readable over the glass ambient (#398).
+                            color: AppTheme.menuBg; radius: 4
                             border.color: AppTheme.borderSubtle; border.width: 1
                         }
                     }

--- a/components/NotificationCenter.qml
+++ b/components/NotificationCenter.qml
@@ -248,7 +248,9 @@ Item {
                     implicitHeight: contentRow.implicitHeight + 24
                     height: implicitHeight
                     radius: 10
-                    color: AppTheme.bgElevated
+                    // Dedicated token, not bgElevated — a toast has to stay
+                    // readable over the Liquid Glass ambient (#396).
+                    color: AppTheme.toastBg
                     border.color: AppTheme.borderSubtle
                     border.width: 1
 

--- a/components/ScanSettingsModal.qml
+++ b/components/ScanSettingsModal.qml
@@ -325,7 +325,8 @@ Item {
                         popup: Popup {
                             y: leftSelector.height; width: leftSelector.width; implicitHeight: contentItem.implicitHeight + 2; padding: 1
                             contentItem: ListView { clip: true; implicitHeight: contentHeight; model: leftSelector.delegateModel; ScrollIndicator.vertical: ScrollIndicator {} }
-                            background: Rectangle { color: AppTheme.bgCard; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
+                            // menuBg — readable over the glass ambient (#398).
+                            background: Rectangle { color: AppTheme.menuBg; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
                         }
                         Component.onCompleted: {
                             var defMask = MotionInterface.appConfig.leftMask !== undefined
@@ -377,7 +378,8 @@ Item {
                         popup: Popup {
                             y: rightSelector.height; width: rightSelector.width; implicitHeight: contentItem.implicitHeight + 2; padding: 1
                             contentItem: ListView { clip: true; implicitHeight: contentHeight; model: rightSelector.delegateModel; ScrollIndicator.vertical: ScrollIndicator {} }
-                            background: Rectangle { color: AppTheme.bgCard; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
+                            // menuBg — readable over the glass ambient (#398).
+                            background: Rectangle { color: AppTheme.menuBg; radius: 4; border.color: AppTheme.borderSubtle; border.width: 1 }
                         }
                         Component.onCompleted: {
                             var defMask = MotionInterface.appConfig.rightMask !== undefined

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -60,6 +60,7 @@ Item {
     // ── Theme tokens (aliased from AppTheme) ──────────────────────────────
     readonly property color colBgPanel:    AppTheme.sheetBg
     readonly property color colBgCard:     AppTheme.bgCard
+    readonly property color colMenuBg:     AppTheme.menuBg
     readonly property color colBgInput:    AppTheme.bgInput
     readonly property color colBorder:     AppTheme.borderStrong
     readonly property color colBorderSoft: AppTheme.borderSoft
@@ -294,7 +295,9 @@ Item {
                 ScrollIndicator.vertical: ScrollIndicator {}
             }
             background: Rectangle {
-                color: root.colBgCard
+                // menuBg, not bgCard — an open dropdown has to be readable
+                // over the Liquid Glass ambient (#398).
+                color: root.colMenuBg
                 radius: 4
                 border.color: root.colBorderSoft
                 border.width: 1


### PR DESCRIPTION
Refs #396, Refs #398

## What

Floating surfaces — toasts, dropdown popups, and the plot's menu/popup/tooltip overlays — go near-opaque in the Liquid Glass theme, via two new `AppTheme` tokens and one alpha bump.

| Surface | Before (glass+dark) | After |
|---|---|---|
| Notification toasts | `bgElevated` — `rgba(1,1,1,0.12)` | `toastBg` — `rgb(31,31,41)` a=0.94 |
| ComboBox popups (Settings ×5, ScanSettings ×2, Logs ×1) | `bgCard` — `rgba(1,1,1,0.08)` | `menuBg` — `rgb(31,31,41)` a=0.94 |
| PlotViewer window-length menu, `⋯` popup, hover tooltip | `overlayBgSolid` — a=0.80 | `overlayBgSolid` — a=0.94 |

## Why

Both `bgElevated` and `bgCard` are **white** washes in glass mode — 12% and 8% alpha respectively. Over the `AmbientBackground` a toast was easy to miss entirely, and an open dropdown all but vanished, which is worse: its contents are a list of options you have to read in order to click the right one.

Raising those tokens' alpha is not the fix. They are white overlays, so more alpha means a near-white panel under white `textPrimary`; and both tokens also back non-floating surfaces (cards, panels) that read fine as they are. So each floating role gets its own dark-dominant token instead — the same approach `sheetBg` and `plotCellBg` already take for surfaces that must stay legible over the ambient.

0.94 is deliberately a touch lighter than a modal sheet's 0.97: these are floating chrome, not focused task surfaces.

## Reviewer notes

**Dark and Light mode are provably unchanged.** Each new token's solid branch is byte-identical to the token it replaces, and `overlayBgSolid`'s solid branches weren't touched — that is the revert invariant `AppTheme.qml`'s header comment asks for. From the probe:

| token | Dark Mode | Light Mode | Liquid Glass | Glass + light |
|---|---|---|---|---|
| `toastBg` | `rgb(37,37,40)` a=1.00 | `rgb(235,231,219)` a=1.00 | `rgb(31,31,41)` a=0.94 | `rgb(255,255,255)` a=0.94 |
| `bgElevated` (was) | `rgb(37,37,40)` a=1.00 | `rgb(235,231,219)` a=1.00 | white **a=0.12** | white a=0.64 |
| `menuBg` | `rgb(38,38,48)` a=1.00 | `rgb(250,249,244)` a=1.00 | `rgb(31,31,41)` a=0.94 | `rgb(255,255,255)` a=0.94 |
| `bgCard` (was) | `rgb(38,38,48)` a=1.00 | `rgb(250,249,244)` a=1.00 | white **a=0.08** | white a=0.58 |
| `overlayBgSolid` | `rgb(31,31,36)` a=0.96 | `rgb(252,251,245)` a=0.97 | `rgb(31,31,41)` a=0.94 | `rgb(255,255,255)` a=0.94 |

Deliberately left alone:

- **`bgCard` / `bgElevated` themselves** — they still back cards and panels (`ContactQualityModal`, `TestResultsWindow`, the header strip) where translucency is the point.
- **`overlayBg`** (a=0.60) — backs pills and chips, which are chrome, not text you stop to read.
- **`bgInput`** (a=0.86) — already deliberately near-opaque; it is shared by every text field, so bumping it would move far more than dropdowns.
- **Borders** — `borderSubtle` in glass+dark is a bright hairline (`rgba(1,1,1,0.22)`) and reads correctly against the darker fills.

One rider beyond the dropdowns: `overlayBgSolid` also backs the plot hover tooltip (`PlotViewer.qml:880`), so that readout firms up too. Same "floating readout over live traces" role, where see-through costs the most — but calling it out since it wasn't strictly a menu.

## Verification

Offscreen QML harness: stub `MotionInterface` + the real `AppTheme.qml` registered as a singleton, probe Rectangles bound exactly the way the real call sites bind them, resolved fill read back for all four theme combinations — that is the table above. Every touched QML file also compile-checks clean (`QT_QUICK_CONTROLS_STYLE=Basic`; the default Windows style plugin DLL is unloadable in that Python env, unrelated to this change).

Also run from source in Liquid Glass (research variant) off this branch — `1.5.0-dev.3+2.g0f2a235` — and eyeballed by @boringethan on the bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
