### PR TITLE
fix: install + verify the encryption deps at build time

### DIFF
--- a/openwater.spec
+++ b/openwater.spec
@@ -103,6 +103,36 @@ try:
 except Exception:
     pass
 
+# Fail the BUILD, not the field, when a clinical package is missing its crypto.
+# PyInstaller can only bundle what is installed in the build environment, so an
+# env without these silently produces a clinical app that dies with
+# ModuleNotFoundError on first launch. build_and_zip.ps1 does not install
+# requirements.txt, so a local build inherits whatever happens to be in the
+# conda env - which is exactly how this shipped broken once. Research builds do
+# not need them, so only gate on clinicalMode.
+import json as _json
+try:
+    with open(os.path.join(os.path.dirname(os.path.abspath(SPEC)), "config",
+                           "app_config.json"), encoding="utf-8") as _f:
+        _is_clinical = bool(_json.load(_f).get("clinicalMode", False))
+except Exception:
+    _is_clinical = False
+if _is_clinical:
+    _missing = []
+    for _mod in ("keyring", "sqlcipher3"):
+        try:
+            __import__(_mod)
+        except ImportError:
+            _missing.append(_mod)
+    if _missing:
+        raise SystemExit(
+            "\n*** BUILD ABORTED: clinicalMode=true but these encryption packages "
+            f"are not installed in the build environment: {', '.join(_missing)}.\n"
+            "    PyInstaller cannot bundle what is not installed, so this build "
+            "would produce a clinical app that fails on first launch.\n"
+            "    Fix:  pip install -r requirements.txt\n"
+        )
+
 # Optional: if you also have a separate 'libusb' wheel installed, this won't hurt
 try:
     binaries += collect_dynamic_libs("libusb")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,10 @@ pyusb==1.3.1
 libusb1==3.3.1
 keyboard==0.13.5
 pyinstaller==6.11.1
+# Scan-database encryption (clinical builds). These MUST be installed in the
+# build environment even though the SDK declares them in its [encryption]
+# extra: PyInstaller can only bundle packages that are actually installed, so
+# omitting them produces a packaged app that dies with ModuleNotFoundError on
+# first launch. See omotion/db_key.py and db_open.py.
+keyring==25.6.0
+sqlcipher3==0.6.2


### PR DESCRIPTION
## What

Fixes `ModuleNotFoundError: No module named 'keyring'` in the packaged clinical app.

**Root cause:** neither `keyring` nor `sqlcipher3` was in `requirements.txt`, and CI installs the SDK *without* its `[encryption]` extra. PyInstaller can only bundle packages that are **actually installed in the build environment**, so a clean build env produced an app that died on first launch.

It went unnoticed because my local dev environment happened to have both — a textbook works-on-my-machine miss on my part.

Refs #394

## Changes

- **`requirements.txt`** — pin `keyring==25.6.0` and `sqlcipher3==0.6.2` (the versions the HIL runs used). Both CI build jobs already install `requirements.txt`, so this fixes them, and the pins match the file's existing convention.
- **`openwater.spec`** — **fail the build, not the field.** `build_and_zip.ps1` does *not* install `requirements.txt`, so a local build inherits whatever is in the conda env — exactly how this shipped broken. The spec now aborts when `clinicalMode=true` and either package is missing:

  ```
  *** BUILD ABORTED: clinicalMode=true but these encryption packages are not
      installed in the build environment: sqlcipher3.
      PyInstaller cannot bundle what is not installed, so this build would
      produce a clinical app that fails on first launch.
      Fix:  pip install -r requirements.txt
  ```

  Research builds are unaffected — they never touch the keystore, so the deps stay genuinely optional there.

## Testing

- **Verified the guard for real**: uninstalled `sqlcipher3`, ran the actual build, confirmed it aborts with the message above rather than producing a broken package. Reinstalled and confirmed the build proceeds.
- App unit suite: **628 passed**.

Pairs with **OpenwaterHealth/openmotion-sdk#188**, which converts the bare `ModuleNotFoundError` into an `EncryptionUnavailable` naming the same fix — so if this ever regresses, the runtime error is diagnosable instead of cryptic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)