### PR TITLE
fix: rename error-modal labels to "ERROR" / "Contact Support" (Refs #340)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Edit `config/app_config.json` to customize behavior:
 | `bviMin` / `bviMax` | `4.0` / `8.0` | Manual BVI plot bounds (when autoscale is off) |
 | `meanMin` / `meanMax` | `0` / `200` | Manual mean plot bounds |
 | `contrastMin` / `contrastMax` | `0.0` / `0.7` | Manual contrast plot bounds |
-| `support_email` | `support@openwater.health` | Destination for the critical-error modal's **Send Bug Report** button |
+| `support_email` | `support@openwater.health` | Destination for the error modal's **Contact Support** button |
 | `bug_report_smtp` | _(absent)_ | Optional `{host, port, username, password, from_addr, use_tls}` block. When set, bug reports are emailed automatically with the session log attached; otherwise the app opens your mail client for manual send |
 | `connectionTimeoutSec` | `12` | Startup connection watchdog grace period before warning about missing devices (E-104/E-106, yellow toast); `0` disables it |
 | `requireConsole` | `true` | Watchdog warns (E-104) if no console connected at startup |

--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -102,10 +102,12 @@ Item {
         // Fixed width, centred on the full window — deliberately NOT the
         // Math.min(parent.width - iconBarInset - 40, …) clamp the other modals
         // use. This modal's footer carries three buttons whose combined
-        // minimum is ~466px, so a clamp that shrinks the card below ~514px
-        // makes the row overflow the card and clip (verified: fine at 640px,
-        // broken at 560px). A fixed 520 has the room at every window size the
-        // clamp would have shrunk for. The icon-bar inset is unnecessary here
+        // minimum was ~466px when the middle one read "Send Bug Report to
+        // Openwater", so a clamp that shrinks the card below ~514px made the
+        // row overflow the card and clip (verified: fine at 640px, broken at
+        // 560px). The #340 rename to "Contact Support" bought ~85px of that
+        // back, but the fixed 520 stays: it has the room at every window size
+        // the clamp would have shrunk for. The icon-bar inset is unnecessary
         // too — at z:100000 this modal is above ButtonPanel, so the bar sits
         // dimmed behind the backdrop rather than overlapping the card.
         width: 520
@@ -150,7 +152,10 @@ Item {
                 }
 
                 Text {
-                    text: "CRITICAL ERROR"
+                    // "ERROR", not "CRITICAL ERROR" (#340) — the internal
+                    // documentation calls these errors, and the extra word
+                    // escalated conditions that are often recoverable.
+                    text: "ERROR"
                     color: AppTheme.textTertiary
                     font.pixelSize: 11
                     font.letterSpacing: 0.5
@@ -264,7 +269,7 @@ Item {
                 }
 
                 Button {
-                    text: "Send Bug Report to Openwater"
+                    text: "Contact Support"
                     Layout.preferredHeight: 32
                     onClicked: MotionInterface.sendBugReport(root.code)
                     contentItem: Text {

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -2,7 +2,7 @@
 
 When the BloodFlow app hits a showstopper condition it raises a **critical-error
 modal** carrying a stable code (e.g. `E-101`). The modal is dismissible and
-offers **Copy details** and **Send Bug Report to Openwater**.
+offers **Copy details** and **Contact Support**.
 
 Codes are the single source of truth in [`error_codes.py`](../error_codes.py);
 this document is generated from that registry. They are grouped by subsystem:
@@ -26,7 +26,7 @@ camera, or an FPGA) did not respond during the firmware's power-on self-check.
 The system cannot scan reliably in this state.
 
 **What to do:** Power-cycle the sensor and reconnect. If it persists, the sensor
-hardware needs service — send a bug report.
+hardware needs service — contact support.
 
 ### E-102 — Sensor self-check unreadable
 The sensor connected but did not return its power-on self-check result, so its
@@ -34,14 +34,14 @@ internal device health is unknown (typically older firmware, or the status
 command was rejected).
 
 **What to do:** Power-cycle the sensor and reconnect. If it persists, update the
-sensor firmware or send a bug report.
+sensor firmware or contact support.
 
 ### E-103 — Console initialization failed
 The console connected but its laser-power configuration could not be applied.
 The laser may not operate correctly until this is resolved.
 
-**What to do:** Power-cycle the console and reconnect. If it persists, send a bug
-report — the console firmware or config may need attention.
+**What to do:** Power-cycle the console and reconnect. If it persists, contact
+support — the console firmware or config may need attention.
 
 ### E-105 — Camera power-on failed
 The sensor could not power on its cameras during initialization, so camera
@@ -58,14 +58,14 @@ the allowed transient window, so laser safety cannot be confirmed. The laser was
 shut off as a precaution.
 
 **What to do:** Power-cycle the system and reconnect. Do not scan until this
-clears — send a bug report if it persists; the safety I2C link may be failing.
+clears — contact support if it persists; the safety I2C link may be failing.
 
 ### E-202 — Laser safety trip
 The laser-safety monitor tripped during a scan and the laser was shut off. The
 scan was stopped.
 
 **What to do:** Remove any obstruction, let the system settle, and start a new
-scan. If it trips repeatedly, stop and send a bug report.
+scan. If it trips repeatedly, stop and contact support.
 
 ## E-3xx — Scan / capture
 
@@ -90,7 +90,7 @@ data-stall watchdog when no camera has delivered a frame for
 `scanDataStallTimeoutSec` (default 3 s) while the trigger is ON.
 
 **What to do:** Check the sensor cables and power, then reconnect and start a
-new scan. If it happens repeatedly, send a bug report.
+new scan. If it happens repeatedly, contact support.
 
 ### E-304 — Device disconnected during scan
 A console or sensor was disconnected while the scan was running, so the scan was
@@ -103,7 +103,7 @@ device being removed mid-scan. Unplugging an idle / masked-out sensor, or any
 device while not scanning, does not raise this.
 
 **What to do:** Check the USB cables and power, reconnect the system, and start a
-new scan. If it keeps happening, send a bug report.
+new scan. If it keeps happening, contact support.
 
 ## Startup warnings (connection watchdog)
 
@@ -133,10 +133,10 @@ Tunable in [`config/app_config.json`](../config/app_config.json):
 Disconnects that happen *after* startup are handled by the normal connection
 status UI, not by this watchdog.
 
-## Sending a bug report
+## Contacting support
 
-The **Send Bug Report to Openwater** button packages the current session log plus
-the error context for support.
+The **Contact Support** button packages the current session log plus the error
+context for support.
 
 - By default it opens your mail client with a pre-filled message to
   `support@openwater.health`, copies the report to your clipboard, and reveals

--- a/error_codes.py
+++ b/error_codes.py
@@ -51,7 +51,7 @@ _STARTUP = [
         "a camera, or an FPGA) did not respond during its power-on self-check. "
         "The system cannot scan reliably in this state.",
         "Power-cycle the sensor and reconnect. If it persists, the sensor "
-        "hardware needs service — send a bug report.",
+        "hardware needs service — contact support.",
     ),
     _e(
         "E-102", "startup",
@@ -59,15 +59,15 @@ _STARTUP = [
         "The sensor connected but did not return its power-on self-check "
         "result, so its internal device health is unknown.",
         "Power-cycle the sensor and reconnect. If it persists, update the "
-        "sensor firmware or send a bug report.",
+        "sensor firmware or contact support.",
     ),
     _e(
         "E-103", "startup",
         "Console initialization failed",
         "The console connected but its laser-power configuration could not be "
         "applied. The laser may not operate correctly until this is resolved.",
-        "Power-cycle the console and reconnect. If it persists, send a bug "
-        "report — the console firmware or config may need attention.",
+        "Power-cycle the console and reconnect. If it persists, contact "
+        "support — the console firmware or config may need attention.",
     ),
     _e(
         "E-105", "startup",
@@ -94,7 +94,7 @@ _SAFETY = [
         "longer than the allowed transient window, so laser safety cannot be "
         "confirmed. The laser was shut off as a precaution.",
         "Power-cycle the system and reconnect. Do not scan until this clears "
-        "— send a bug report if it persists; the safety I2C link may be "
+        "— contact support if it persists; the safety I2C link may be "
         "failing.",
     ),
     _e(
@@ -103,7 +103,7 @@ _SAFETY = [
         "The laser-safety monitor tripped during a scan and the laser was shut "
         "off. The scan was stopped.",
         "Remove any obstruction, let the system settle, and start a new scan. "
-        "If it trips repeatedly, stop and send a bug report.",
+        "If it trips repeatedly, stop and contact support.",
     ),
 ]
 
@@ -132,7 +132,7 @@ _SCAN = [
         "continue, so the scan was stopped. Data captured before the loss "
         "was saved.",
         "Check the sensor cables and power, then reconnect and start a new "
-        "scan. If it happens repeatedly, send a bug report.",
+        "scan. If it happens repeatedly, contact support.",
     ),
     _e(
         "E-304", "scan",
@@ -142,7 +142,7 @@ _SCAN = [
         "captured before the disconnection is not guaranteed to have been "
         "saved.",
         "Check the USB cables and power, reconnect the system, and start a "
-        "new scan. If it keeps happening, send a bug report.",
+        "new scan. If it keeps happening, contact support.",
     ),
 ]
 
@@ -165,7 +165,7 @@ def lookup(code: str) -> CriticalError:
     return CriticalError(
         code=code,
         category="startup",
-        title="Critical error",
-        message="A critical error occurred.",
-        suggested_action="Send a bug report with the session log attached.",
+        title="Error",
+        message="An error occurred.",
+        suggested_action="Contact support with the session log attached.",
     )


### PR DESCRIPTION
Refs #340

Two label changes on the coded error modal, plus the wording elsewhere that names them. **Scoped to the renames only** — the stepped export-log/email-support flow also described on #340 is not in this PR.

## What changed

| | Before | After |
|---|---|---|
| Eyebrow label | `CRITICAL ERROR` | `ERROR` |
| Footer button | `Send Bug Report to Openwater` | `Contact Support` |

## Why the change spans more than two strings

The seven `"send a bug report"` suggested-action strings in `error_codes.py` render **inside this same modal**, in the callout directly above that button — leaving them would have the modal advise "send a bug report" next to a button labelled Contact Support. They now read "contact support", and `docs/ERROR_CODES.md` (hand-mirrored from the registry) plus the README config table follow, since both name the button explicitly. The unknown-code fallback entry titled `"Critical error"` is `"Error"` for the same reason.

The `width: 520` comment justified rejecting the responsive clamp by citing the old button's width (~466px combined footer minimum). The rename buys ~85px of that back, so the comment was updated to keep the measurement matching the code it justifies. **The width itself is unchanged** — 520 still clears the clamp's failure range.

## Reviewer notes

- **No behaviour change.** The button still calls `sendBugReport(code)`; queueing, backdrop/Esc dismissal, `criticalErrorsDismissed()` and the console error-LED paths are untouched.
- **The "no red" half of the second comment on #340 was already done** by a16b8ae (Jul 23), which rebuilt this modal on the house card shell and removed every `accentRed` reference. Only the label needed changing here.
- No test asserted on either label, so nothing needed updating; `error_codes.py` has no string-content tests either.

## Verification

- `flake8 error_codes.py` — clean
- `pytest tests/ -m unit` — **628 passed**, 121 deselected
- QML parse check on `CriticalErrorModal.qml` — no syntax errors (only the expected unresolved `OpenMotion` import, which `main.py` registers at runtime)
- **Not yet checked on screen** — visual confirmation of the modal is still pending.

## Left alone (flag if wanted)

1. `docs/ERROR_CODES.md` is still titled "Critical Error Codes" and its intro still says "critical-error modal" — renaming the doc ripples into anchors and inbound links.
2. Support address is inconsistent repo-wide: `support_email` defaults to `support@openwater.health` (main.py, README, ERROR_CODES.md) while the debug-bundle toast hardcodes `support@openwater.cc`, which is also what #340 specifies. Best settled alongside the export/email flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
