### PR TITLE
fix: give Qt a window-class icon so the taskbar can't fall back to generic (Refs #223)

### DIFF
--- a/main.py
+++ b/main.py
@@ -250,18 +250,20 @@ def _app_icon() -> QIcon:
 
 
 def main():
-    # Set the Windows AppUserModelID as the very first thing, before any
-    # QApplication (and thus any HWND) is created. Windows binds the taskbar
-    # button to the process identity when the first window appears; setting
-    # this after QApplication() races the shell and intermittently leaves the
-    # taskbar showing the generic Windows icon (Explorer caches one icon per
-    # AUMID). This must run before check_single_instance()'s message box too.
+    # Set the Windows AppUserModelID before any QApplication (and thus any
+    # HWND) exists: Windows binds the taskbar button to the process identity
+    # when the first window appears, so this has to be settled first. It must
+    # run before check_single_instance()'s message box too.
     #
-    # The ".1" suffix retires the original "Openwater.OpenMotion" AUMID:
-    # machines that ever ran a pre-1.4.0-dev.1 build (which set the AUMID
-    # after QApplication and could lose the race) have the generic icon
-    # cached under the old ID, and Explorer keeps serving that cached icon
-    # to fixed builds forever. A new AUMID gets a fresh cache entry.
+    # DO NOT bump this string again. It was bumped once ("Openwater.OpenMotion"
+    # -> ".1") on the theory that Explorer caches an icon per AUMID and that a
+    # fresh ID would clear a poisoned entry. That theory did not hold up: the
+    # generic-icon bug reproduced under a brand-new AUMID and a clean relaunch
+    # under the *same* AUMID showed the correct icon, so the AUMID was never
+    # what was broken. The real cause was the Win32 window-class icon (see the
+    # #223 note further down, and utils/win_taskbar_icon.py). Changing the
+    # AUMID only mints a new identity and strands every taskbar pin users have
+    # made since 1.4.0 — a one-way cost with no benefit.
     # Keep in sync with the ShortcutProperty in installer/app.wxs.
     if sys.platform == "win32":
         try:
@@ -427,6 +429,21 @@ def main():
     if not engine.rootObjects():
         logger.error("Error: Failed to load QML file")
         sys.exit(-1)
+
+    # Pin the Win32 window-class icon (issue #223). Qt answers Explorer's
+    # WM_GETICON probe with the icon set above, but the shell asks with
+    # SMTO_ABORTIFHUNG and falls back to the *class* icon when the GUI thread
+    # is busy — and Qt leaves that at the generic IDI_APPLICATION, because its
+    # LoadImage(hInst, L"IDI_ICON1", ...) lookup finds nothing in a PyInstaller
+    # build. Frozen builds get the resource from openwater.spec's build hook;
+    # this makes the fallback correct at runtime too, including from source.
+    if sys.platform == "win32":
+        from utils.win_taskbar_icon import apply_window_class_icon
+
+        apply_window_class_icon(
+            int(engine.rootObjects()[0].winId()),
+            resource_path("assets", "images", "favicon.ico"),
+        )
 
     # wait=False: the QML window is already visible at this point (main.qml's
     # ApplicationWindow is `visible: true`) and Qt's event loop hasn't started

--- a/openwater.spec
+++ b/openwater.spec
@@ -9,17 +9,39 @@ from PyInstaller.building.build_main import Analysis, PYZ, EXE, COLLECT
 
 APP_NAME = "Open-Motion"
 ENTRY = "main.py"
-ICON_FILE = os.path.abspath("assets/images/favicon.ico")
+
+# Anchor to the spec's own directory rather than the build-time CWD:
+# os.path.abspath("assets/...") silently resolved against wherever PyInstaller
+# happened to be invoked from, so a build launched from another directory got a
+# nonexistent icon path.
+ICON_FILE = os.path.join(SPECPATH, "assets", "images", "favicon.ico")
+if not os.path.exists(ICON_FILE):
+    raise SystemExit(f"[spec] FATAL: app icon missing: {ICON_FILE}")
 
 datas = []
 hidden = []
 binaries = []
 
-# --- your existing resource folders (keep what you already had) ---
+# --- resource folders ---
+# These are hard failures, not silent skips. The source paths below are still
+# CWD-relative, so skipping a missing one would quietly produce a build with no
+# QML and no assets at all — strictly worse than the wrong-CWD icon bug that
+# motivated anchoring ICON_FILE above.
 for item in ("main.qml",):
-    if os.path.exists(item):
-        datas.append((item, "."))
-for folder in ("pages", "components", "assets", "models", "config", "models", "processing"):
+    if not os.path.exists(item):
+        raise SystemExit(
+            f"[spec] FATAL: {item!r} not found in {os.getcwd()} — "
+            f"run PyInstaller from the repo root ({SPECPATH})."
+        )
+    datas.append((item, "."))
+for folder in ("pages", "components", "assets", "config", "processing"):
+    if not os.path.isdir(folder):
+        raise SystemExit(
+            f"[spec] FATAL: required resource folder {folder!r} not found in "
+            f"{os.getcwd()} — run PyInstaller from the repo root ({SPECPATH})."
+        )
+    datas.append((folder, folder))
+for folder in ("models",):  # optional
     if os.path.isdir(folder):
         datas.append((folder, folder))
 
@@ -30,9 +52,10 @@ _SAMPLE_SCAN = os.path.join("resources", "sample_scan.csv")
 if os.path.exists(_SAMPLE_SCAN):
     datas.append((_SAMPLE_SCAN, "resources"))
 
-# Ensure the icon is explicitly included
-if os.path.exists(ICON_FILE):
-    datas.append((ICON_FILE, "assets/images"))
+# Ensure the icon is explicitly included (also reachable via the `assets` tree
+# above; the runtime class-icon hardening in utils/win_taskbar_icon.py loads it
+# from disk, so a missing copy would be a silent downgrade).
+datas.append((ICON_FILE, "assets/images"))
 
 # --- PyQt6 (keep as before) ---
 qt_datas, qt_bins, qt_hidden = collect_all("PyQt6")
@@ -192,6 +215,25 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 
+# ---------- Qt window-class icon (issue #223) ----------
+# Qt sets the Win32 *window-class* icon with LoadImage(hInst, L"IDI_ICON1", ...)
+# and falls back to the generic IDI_APPLICATION when that name isn't found.
+# PyInstaller publishes the icon group under the *integer* id 1, which a name
+# lookup never matches — so the class icon is generic in every PyInstaller+Qt
+# build. The shell falls back to the class icon whenever its WM_GETICON probe
+# of a freshly shown window times out (SMTO_ABORTIFHUNG), which is why the
+# generic taskbar icon showed up intermittently and only on slower machines.
+#
+# The hook makes PyInstaller publish a second, *named* group alongside its own.
+# It must be installed before EXE() runs: EXE.assemble() embeds resources
+# before appending the PKG archive and before fixing up the PE checksum, and
+# rewriting resources after that point truncates the appended archive and
+# produces an exe that cannot start.
+if sys.platform == "win32":
+    sys.path.insert(0, os.path.join(SPECPATH, "scripts"))
+    from win_icon_resource import install_pyinstaller_hook, has_named_group_icon
+    install_pyinstaller_hook()
+
 exe_gui = EXE(
     pyz, a.scripts, [],
     exclude_binaries=True,
@@ -207,3 +249,16 @@ coll = COLLECT(
     strip=False, upx=False, upx_exclude=[],
     name=APP_NAME
 )
+
+# Verify on the artifact that actually ships. This also catches a warm build/
+# tree: PyInstaller's EXE cache compares the icon *path*, not its contents, so
+# a cached exe can silently carry stale resources — fail loudly instead.
+if sys.platform == "win32":
+    _dist_exe = os.path.join(DISTPATH, APP_NAME, APP_NAME + ".exe")
+    if not has_named_group_icon(_dist_exe):
+        raise SystemExit(
+            f"[spec] FATAL: {_dist_exe} has no 'IDI_ICON1' icon resource — Qt "
+            f"would register its window classes with the generic Windows icon "
+            f"(#223). Rebuild with --clean."
+        )
+    print(f"[spec] verified 'IDI_ICON1' window-class icon in {_dist_exe}")

--- a/scripts/make_app_icon.py
+++ b/scripts/make_app_icon.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 """Regenerate assets/images/favicon.ico from assets/images/favicon.png.
 
-Windows shell components (exe-resource icon extraction, shortcut icons,
-the taskbar icon cache) only reliably support PNG-compressed frames at
-256x256; every smaller frame must be a classic BMP/DIB frame or the
-shell can fall back to the generic default icon (issue #223). Pillow's
-default ICO writer emits PNG-compressed frames at *every* size, so do
-not regenerate the icon with a plain `Image.save(..., format="ICO")` —
-run this script instead. It writes BMP frames for 16..128 px and a
-single PNG-compressed 256 px frame, matching Microsoft's icon guidance.
+Writes classic BMP/DIB frames for 16..128 px and a single PNG-compressed
+256 px frame, which is the conventional layout Microsoft's icon guidance
+describes. Run this rather than a plain `Image.save(..., format="ICO")`:
+Pillow's default ICO writer emits PNG-compressed frames at *every* size,
+so a casual regen silently changes the frame encoding of a shipped asset.
+
+Note on history: this script was written for issue #223 on the theory
+that the all-PNG icon was why the taskbar showed the generic Windows
+icon. That theory was wrong — Windows 10/11 loads PNG frames fine at
+every size, and the real cause was the Win32 window-class icon (see
+scripts/win_icon_resource.py). The BMP layout is kept because it is what
+now ships and is byte-for-byte reproducible from this script, not
+because the shell requires it. Regenerating the icon is not a fix for
+any icon bug; don't reach for it as one.
 
 Usage:  python scripts/make_app_icon.py
 """

--- a/scripts/win_icon_resource.py
+++ b/scripts/win_icon_resource.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Publish the frozen exe's icon group under the name Qt looks for.
+
+Qt's ``QWindowsContext::registerWindowClass`` sets the Win32 *window-class*
+icon with ``LoadImage(hInstance, L"IDI_ICON1", ...)`` and falls back to
+``LoadIcon(NULL, IDI_APPLICATION)`` — the generic Windows icon — when that
+lookup fails. (The literal is in qwindows.dll; Qt's own qmake/CMake RC
+template names the icon ``IDI_ICON1``, which is why Qt looks for it.)
+
+PyInstaller writes the icon group under the *integer* resource id 1
+(``PyInstaller/utils/win32/icon.py::CopyIcons_FromIco`` →
+``UpdateResource(hdst, RT_GROUP_ICON, i + 1, data)``). A name lookup never
+matches an integer id, so **every** PyInstaller-frozen Qt app registers its
+window classes with the generic Windows icon.
+
+That is normally invisible, because Qt also sets a per-window icon via
+``WM_SETICON`` and the shell prefers it. But the shell asks for the
+per-window icon with ``SendMessageTimeout(..., SMTO_ABORTIFHUNG)``: if the
+GUI thread is busy when Explorer probes a freshly shown window, the shell
+gives up and paints the *window-class* icon instead — the generic one — and
+it sticks for the life of that window. That is the intermittent,
+machine-dependent taskbar failure in issue #223: it only bites on machines
+slow enough to blow Explorer's probe budget during startup.
+
+The fix is to write a *second* ``RT_GROUP_ICON`` directory, named
+``IDI_ICON1``, pointing at the ``RT_ICON`` images PyInstaller already wrote.
+The integer group #1 is left untouched, so the icon Explorer shows for the
+.exe file itself — and every shortcut that inherits it — is unchanged.
+
+Build-time entry point is :func:`install_pyinstaller_hook`, called from
+``openwater.spec``. It patches ``CopyIcons`` rather than post-processing the
+finished exe on purpose: PyInstaller embeds resources *before* appending the
+PKG archive and *before* computing the PE checksum (``EXE.assemble``
+steps 1-3), so rewriting resources afterwards would rewrite a PE whose
+overlay and checksum are already final.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+from ctypes import wintypes
+
+RT_ICON = 3
+RT_GROUP_ICON = 14
+
+#: The resource name Qt hard-codes in QWindowsContext::registerWindowClass.
+QT_ICON_NAME = "IDI_ICON1"
+
+_LOAD_LIBRARY_AS_DATAFILE = 0x0002
+_LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x0020
+_IMAGE_ICON = 1
+_LR_DEFAULTSIZE = 0x0040
+
+
+def add_named_group_icon(exe_path, ico_path, name=QT_ICON_NAME, first_icon_id=1):
+    """Alias an already-embedded icon group under the string ``name``.
+
+    Assumes PyInstaller has just written the ``RT_ICON`` images with
+    consecutive ids starting at ``first_icon_id`` (it does — see
+    ``CopyIcons_FromIco``). Only the group *directory* is duplicated, so
+    this costs a few dozen bytes, not a second copy of the images.
+
+    Returns the number of bytes written.
+    """
+    # Imported lazily: only the build machine has PyInstaller, and the
+    # runtime/test paths in this module must not require it.
+    from PyInstaller.compat import win32api
+    from PyInstaller.utils.win32.icon import IconFile
+
+    icon_file = IconFile(str(ico_path))
+    data = icon_file.grp_icon_dir() + icon_file.grp_icondir_entries(first_icon_id)
+
+    handle = win32api.BeginUpdateResource(str(exe_path), 0)
+    win32api.UpdateResource(handle, RT_GROUP_ICON, name, data)
+    win32api.EndUpdateResource(handle, 0)
+    return len(data)
+
+
+def has_named_group_icon(exe_path, name=QT_ICON_NAME) -> bool:
+    """True if Qt's exact class-icon lookup would succeed against this exe.
+
+    Deliberately replicates ``LoadImage(hInst, L"IDI_ICON1", IMAGE_ICON, 0,
+    0, LR_DEFAULTSIZE)`` rather than merely enumerating resource names, so a
+    pass here means Qt itself will find the icon.
+    """
+    if sys.platform != "win32":
+        return False
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+
+    kernel32.LoadLibraryExW.restype = wintypes.HMODULE
+    kernel32.LoadLibraryExW.argtypes = [
+        wintypes.LPCWSTR, wintypes.HANDLE, wintypes.DWORD
+    ]
+    kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
+    user32.LoadImageW.restype = wintypes.HANDLE
+    user32.LoadImageW.argtypes = [
+        wintypes.HMODULE, wintypes.LPCWSTR, wintypes.UINT,
+        ctypes.c_int, ctypes.c_int, wintypes.UINT,
+    ]
+    user32.DestroyIcon.argtypes = [wintypes.HANDLE]
+
+    hmod = kernel32.LoadLibraryExW(
+        os.path.abspath(str(exe_path)),
+        None,
+        _LOAD_LIBRARY_AS_DATAFILE | _LOAD_LIBRARY_AS_IMAGE_RESOURCE,
+    )
+    if not hmod:
+        return False
+    try:
+        hicon = user32.LoadImageW(
+            hmod, str(name), _IMAGE_ICON, 0, 0, _LR_DEFAULTSIZE
+        )
+        if hicon:
+            user32.DestroyIcon(hicon)
+            return True
+        return False
+    finally:
+        kernel32.FreeLibrary(hmod)
+
+
+def group_icon_names(exe_path):
+    """List the exe's RT_GROUP_ICON resource names, for diagnostics/tests.
+
+    Returns a list of ``("INT", n)`` / ``("STR", "NAME")`` tuples. Used to
+    assert that adding the named group did not disturb PyInstaller's
+    integer group #1, which is what Explorer shows for the file itself.
+    """
+    if sys.platform != "win32":
+        return []
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.LoadLibraryExW.restype = wintypes.HMODULE
+    kernel32.LoadLibraryExW.argtypes = [
+        wintypes.LPCWSTR, wintypes.HANDLE, wintypes.DWORD
+    ]
+    kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
+
+    # Both the type and the name are passed as raw pointers, because an
+    # integer resource id is MAKEINTRESOURCE-encoded *into* the pointer
+    # value. Declaring them as LPCWSTR makes ctypes try to marshal those
+    # ints as strings and crash.
+    ENUMRESNAMEPROC = ctypes.WINFUNCTYPE(
+        wintypes.BOOL, wintypes.HMODULE, ctypes.c_void_p,
+        ctypes.c_void_p, ctypes.c_void_p,
+    )
+    kernel32.EnumResourceNamesW.restype = wintypes.BOOL
+    kernel32.EnumResourceNamesW.argtypes = [
+        wintypes.HMODULE, ctypes.c_void_p, ENUMRESNAMEPROC, ctypes.c_void_p
+    ]
+
+    found = []
+
+    def _collect(_hmod, _typ, name_ptr, _param):
+        as_int = name_ptr or 0
+        if as_int < 0x10000:
+            found.append(("INT", as_int))
+        else:
+            found.append(("STR", ctypes.wstring_at(as_int)))
+        return True
+
+    hmod = kernel32.LoadLibraryExW(
+        os.path.abspath(str(exe_path)),
+        None,
+        _LOAD_LIBRARY_AS_DATAFILE | _LOAD_LIBRARY_AS_IMAGE_RESOURCE,
+    )
+    if not hmod:
+        return []
+    try:
+        kernel32.EnumResourceNamesW(
+            hmod, ctypes.c_void_p(RT_GROUP_ICON), ENUMRESNAMEPROC(_collect), None
+        )
+    finally:
+        kernel32.FreeLibrary(hmod)
+    return found
+
+
+def install_pyinstaller_hook(name=QT_ICON_NAME):
+    """Make PyInstaller also publish the icon group under ``name``.
+
+    Wraps ``PyInstaller.utils.win32.icon.CopyIcons``, which ``EXE.assemble``
+    calls in its resource-embedding step — before the PKG archive is
+    appended and before the PE checksum is fixed up. Call this from the spec
+    *before* constructing ``EXE(...)``.
+
+    Returns True if the hook was installed.
+    """
+    if sys.platform != "win32":
+        return False
+
+    from PyInstaller.utils.win32 import icon as _pyi_icon
+
+    if getattr(_pyi_icon.CopyIcons, "_openwater_named_group", False):
+        return True  # already hooked (spec re-entry)
+
+    _original = _pyi_icon.CopyIcons
+
+    def _copy_icons_with_named_group(dstpath, srcpath):
+        _original(dstpath, srcpath)
+        # Only the plain single-.ico form is aliased. The multi-icon and
+        # "file.exe,N" forms don't have a predictable RT_ICON id layout, and
+        # this app doesn't use them — better to skip than to write a group
+        # pointing at ids that may not exist.
+        sources = [srcpath] if isinstance(srcpath, (str, os.PathLike)) else list(srcpath)
+        if len(sources) != 1 or not str(sources[0]).lower().endswith(".ico"):
+            print(
+                "[icon] not a single .ico source — skipping the %s alias; "
+                "Qt will fall back to the generic window-class icon" % name
+            )
+            return
+        written = add_named_group_icon(dstpath, sources[0], name=name)
+        print(
+            "[icon] published RT_GROUP_ICON %r (%d bytes) so Qt's "
+            "window-class lookup resolves (#223)" % (name, written)
+        )
+
+    _copy_icons_with_named_group._openwater_named_group = True
+    _pyi_icon.CopyIcons = _copy_icons_with_named_group
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 3 and sys.argv[1] == "check":
+        exe = sys.argv[2]
+        ok = has_named_group_icon(exe)
+        print(f"{exe}")
+        print(f"  RT_GROUP_ICON names : {group_icon_names(exe)}")
+        print(f"  {QT_ICON_NAME:<19} : {'FOUND' if ok else 'MISSING'}")
+        sys.exit(0 if ok else 1)
+    if len(sys.argv) >= 3:
+        print("wrote", add_named_group_icon(sys.argv[1], sys.argv[2]), "bytes")
+        sys.exit(0)
+    print(__doc__)
+    print("usage: win_icon_resource.py check <exe>")
+    print("       win_icon_resource.py <exe> <ico>")
+    sys.exit(2)

--- a/tests/test_app_icon_resources.py
+++ b/tests/test_app_icon_resources.py
@@ -1,0 +1,149 @@
+"""Guards for the app icon (issue #223).
+
+The taskbar showed the generic Windows icon intermittently because Qt
+registers its window classes with ``LoadImage(hInst, L"IDI_ICON1", ...)`` and
+falls back to ``IDI_APPLICATION`` when that name is absent — which it always
+was, since PyInstaller publishes the icon group under an *integer* id. These
+tests lock down both halves of the fix: the icon asset itself, and the build
+wiring that publishes the named resource.
+"""
+
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ICO_PATH = REPO_ROOT / "assets" / "images" / "favicon.ico"
+SPEC_PATH = REPO_ROOT / "openwater.spec"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _parse_ico(data: bytes):
+    """Return [(width, height, n_bytes, offset, is_png), ...]."""
+    reserved, kind, count = struct.unpack("<HHH", data[:6])
+    assert reserved == 0 and kind == 1, "not an ICO file"
+    frames = []
+    for i in range(count):
+        entry = data[6 + i * 16: 6 + (i + 1) * 16]
+        w, h, _colors, _rsv, _planes, _bpp, size, offset = struct.unpack(
+            "<BBBBHHII", entry
+        )
+        blob = data[offset:offset + size]
+        frames.append(
+            (w or 256, h or 256, size, offset, blob[:8] == b"\x89PNG\r\n\x1a\n")
+        )
+    return frames
+
+
+@pytest.mark.unit
+def test_favicon_ico_is_structurally_valid():
+    data = ICO_PATH.read_bytes()
+    frames = _parse_ico(data)
+
+    assert {f[0] for f in frames} == {16, 24, 32, 48, 64, 128, 256}
+    for width, height, size, offset, _is_png in frames:
+        assert width == height, f"non-square {width}x{height} frame"
+        assert size > 0
+        assert offset + size <= len(data), "frame runs past EOF"
+    # The last frame must end exactly at EOF — a short file is the classic
+    # symptom of a binary mangled by CRLF translation on checkout.
+    assert max(o + s for _w, _h, s, o, _p in frames) == len(data)
+
+
+@pytest.mark.unit
+def test_favicon_ico_is_reproducible_from_the_generator(tmp_path):
+    """scripts/make_app_icon.py must still reproduce the committed bytes.
+
+    The generator hand-splices the ICO directory; this catches a regression in
+    that arithmetic, and catches someone regenerating the asset with a plain
+    Pillow ``Image.save(..., format="ICO")``.
+    """
+    pytest.importorskip("PIL")
+
+    work = tmp_path / "repo"
+    (work / "assets" / "images").mkdir(parents=True)
+    (work / "scripts").mkdir()
+    for rel in ("assets/images/favicon.png", "scripts/make_app_icon.py"):
+        (work / rel).write_bytes((REPO_ROOT / rel).read_bytes())
+
+    subprocess.run(
+        [sys.executable, str(work / "scripts" / "make_app_icon.py")],
+        check=True, capture_output=True,
+    )
+
+    assert (work / "assets" / "images" / "favicon.ico").read_bytes() == \
+        ICO_PATH.read_bytes(), (
+            "regenerating favicon.ico no longer reproduces the committed file"
+        )
+
+
+@pytest.mark.unit
+def test_spec_anchors_icon_to_specpath_not_cwd():
+    """ICON_FILE must not resolve against the build-time CWD.
+
+    ``os.path.abspath("assets/images/favicon.ico")`` silently produced a
+    nonexistent path when PyInstaller was invoked from another directory.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    assert 'os.path.abspath("assets/images/favicon.ico")' not in spec
+    assert "SPECPATH" in spec.split("ICON_FILE =")[1].split("\n")[0]
+
+
+@pytest.mark.unit
+def test_spec_installs_the_named_group_icon_hook():
+    """The build must publish the icon group under Qt's "IDI_ICON1" name.
+
+    Without this, Qt registers every window class with the generic Windows
+    icon and a slow startup strands it on the taskbar button (#223).
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    assert "install_pyinstaller_hook()" in spec
+    assert "has_named_group_icon" in spec, "the post-build assertion was dropped"
+
+
+@pytest.mark.unit
+def test_spec_fails_loudly_on_missing_resources():
+    """Missing QML/assets must abort the build, not ship a broken artifact."""
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    assert spec.count("raise SystemExit") >= 3
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows resource APIs")
+def test_named_group_icon_probe_rejects_a_stock_python_exe():
+    """The probe must actually discriminate, not just return True.
+
+    python.exe has icon resources but not one named "IDI_ICON1", so it is a
+    true negative — if this ever passes, the probe is broken and the build
+    assertion it backs is worthless.
+    """
+    from win_icon_resource import group_icon_names, has_named_group_icon
+
+    assert has_named_group_icon(sys.executable) is False
+    # ...and the enumerator still sees python.exe's own icon group, proving we
+    # are reading real resources rather than failing to open the file at all.
+    assert group_icon_names(sys.executable), "no RT_GROUP_ICON found at all"
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows resource APIs")
+def test_built_exe_has_both_icon_groups():
+    """If a build is present, it must carry the named *and* numeric groups.
+
+    The numeric group #1 is what Explorer shows for the file itself; the named
+    one is what Qt looks up for the window class. Losing either is a bug.
+    """
+    from win_icon_resource import group_icon_names, has_named_group_icon
+
+    exe = REPO_ROOT / "dist" / "Open-Motion" / "Open-Motion.exe"
+    if not exe.exists():
+        pytest.skip("no build in dist/ — run PyInstaller first")
+
+    names = group_icon_names(exe)
+    assert ("STR", "IDI_ICON1") in names, f"missing Qt class icon; got {names}"
+    assert ("INT", 1) in names, f"PyInstaller's file icon was clobbered: {names}"
+    assert has_named_group_icon(exe)

--- a/tests/test_win_class_icon.py
+++ b/tests/test_win_class_icon.py
@@ -1,0 +1,119 @@
+"""Guards for the runtime window-class icon hardening (issue #223).
+
+See utils/win_taskbar_icon.py for why the class icon matters: it is what the
+shell paints when its WM_GETICON probe of a freshly shown window times out.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ICO_PATH = REPO_ROOT / "assets" / "images" / "favicon.ico"
+
+from utils.win_taskbar_icon import apply_window_class_icon  # noqa: E402
+
+
+@pytest.mark.unit
+def test_apply_is_fail_soft_on_a_bad_hwnd():
+    """A cosmetic icon must never take down a clinical app's startup."""
+    assert apply_window_class_icon(0, ICO_PATH) is False
+    assert apply_window_class_icon(None, ICO_PATH) is False
+    assert apply_window_class_icon("not-a-handle", ICO_PATH) is False
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform != "win32", reason="Win32 class icons")
+def test_apply_is_fail_soft_on_a_missing_icon_file(tmp_path):
+    # Non-null but bogus HWND: LoadImage fails first, so nothing is installed
+    # and we still return False rather than raising.
+    assert apply_window_class_icon(1, tmp_path / "nope.ico") is False
+
+
+# Run in a subprocess: this needs a real GUI QApplication, and the session-wide
+# QCoreApplication that conftest installs cannot host a QWidget and cannot be
+# replaced in-process.
+_CLASS_ICON_PROBE = r'''
+import ctypes, sys
+from ctypes import wintypes
+from PyQt6.QtWidgets import QApplication, QWidget
+
+sys.path.insert(0, sys.argv[1])
+from utils.win_taskbar_icon import apply_window_class_icon
+
+GCLP_HICON = -14
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+user32.LoadIconW.restype = wintypes.HANDLE
+user32.LoadIconW.argtypes = [wintypes.HMODULE, wintypes.LPCWSTR]
+get_class = getattr(user32, "GetClassLongPtrW", None) or user32.GetClassLongW
+get_class.restype = ctypes.c_size_t
+get_class.argtypes = [wintypes.HWND, ctypes.c_int]
+
+app = QApplication([])
+widget = QWidget()
+hwnd = int(widget.winId())
+
+generic = user32.LoadIconW(None, wintypes.LPCWSTR(32512))  # IDI_APPLICATION
+before = get_class(wintypes.HWND(hwnd), GCLP_HICON)
+ok = apply_window_class_icon(hwnd, sys.argv[2])
+after = get_class(wintypes.HWND(hwnd), GCLP_HICON)
+
+print(f"applied={ok} generic={generic} before={before} after={after}")
+assert ok is True, "apply_window_class_icon returned False"
+assert after not in (0, generic), "class icon is still the generic Windows icon"
+assert after != before, "class icon was not changed"
+print("OK")
+'''
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform != "win32", reason="Win32 class icons")
+def test_apply_replaces_the_generic_class_icon(tmp_path):
+    """The whole point: the class icon must stop being IDI_APPLICATION.
+
+    Also asserts the *before* state is the generic icon, which is the bug
+    itself — Qt registers the class with IDI_APPLICATION because its
+    "IDI_ICON1" lookup finds nothing.
+    """
+    pytest.importorskip("PyQt6.QtWidgets")
+
+    script = tmp_path / "probe.py"
+    script.write_text(_CLASS_ICON_PROBE, encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(script), str(REPO_ROOT), str(ICO_PATH)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"probe failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout, result.stdout
+
+
+@pytest.mark.unit
+def test_aumid_matches_the_installer_shortcuts():
+    """A one-sided AUMID bump silently breaks Start-menu/pinned icons.
+
+    Both MSI shortcuts must carry the same System.AppUserModel.ID the app sets
+    at startup.
+    """
+    main_py = (REPO_ROOT / "main.py").read_text(encoding="utf-8")
+    wxs = (REPO_ROOT / "installer" / "app.wxs").read_text(encoding="utf-8")
+
+    import re
+    app_ids = re.findall(
+        r"SetCurrentProcessExplicitAppUserModelID\(\s*[\"']([^\"']+)[\"']",
+        main_py,
+    )
+    assert len(app_ids) == 1, f"expected one AUMID in main.py, got {app_ids}"
+
+    shortcut_ids = re.findall(
+        r'Key="System\.AppUserModel\.ID"\s+Value="([^"]+)"', wxs
+    )
+    assert len(shortcut_ids) == 2, (
+        f"expected both MSI shortcuts to set an AUMID, got {shortcut_ids}"
+    )
+    assert set(shortcut_ids) == set(app_ids), (
+        f"AUMID drift: main.py {app_ids} vs installer/app.wxs {shortcut_ids}"
+    )

--- a/utils/win_taskbar_icon.py
+++ b/utils/win_taskbar_icon.py
@@ -1,0 +1,118 @@
+"""Pin the Win32 window-class icon to the app icon (issue #223).
+
+Windows resolves the icon for a taskbar button in this order:
+
+    WM_GETICON(ICON_SMALL2 / ICON_SMALL / ICON_BIG)  ->  GCLP_HICONSM
+                                                     ->  GCLP_HICON
+
+Qt answers the ``WM_GETICON`` messages from ``QWindow::setIcon`` /
+``QGuiApplication::setWindowIcon``, so the first step normally wins. The catch
+is that the shell asks with ``SendMessageTimeout(..., SMTO_ABORTIFHUNG)``: if
+the GUI thread is busy when Explorer probes a freshly shown window — a slow
+disk, a VM, an RDP session, an antivirus scanning a ~400 MB one-folder dist —
+the probe times out and the shell paints the *window-class* icon instead, where
+it sticks for the life of that window.
+
+Qt registers those classes with ``LoadImage(hInstance, L"IDI_ICON1", ...)`` and
+falls back to ``LoadIcon(NULL, IDI_APPLICATION)`` — the generic Windows icon —
+when the lookup fails, which it always does in a PyInstaller build (PyInstaller
+publishes the icon group under an integer id, not that name). So the fallback
+target is the generic icon, and blowing the probe budget strands it.
+
+``scripts/win_icon_resource.py`` fixes that at build time for frozen builds by
+also publishing the group under ``IDI_ICON1``. This module is the belt-and-
+braces half: it overwrites the class icon at runtime, which additionally covers
+running from source (``python.exe`` has no such resource either) and any future
+build path that loses the resource.
+
+Everything here is best-effort. A clinical app must never fail to start over a
+cosmetic icon, so every failure is logged and swallowed.
+"""
+
+import ctypes
+import logging
+import sys
+from ctypes import wintypes
+
+# Handlers are attached to the "openmotion.bloodflow-app" logger in main.py,
+# not to the root logger, so a __name__-based logger would never reach the app
+# log file. Match utils/single_instance.py.
+logger = logging.getLogger("openmotion.bloodflow-app")
+
+GCLP_HICON = -14
+GCLP_HICONSM = -34
+
+IMAGE_ICON = 1
+LR_LOADFROMFILE = 0x0010
+
+SM_CXICON = 11
+SM_CXSMICON = 49
+
+# HICONs installed on a window class must outlive it — the class holds a raw
+# handle and never takes a reference. Keeping them here (and never calling
+# DestroyIcon) is the documented way to do this.
+_class_icons = []
+
+
+def apply_window_class_icon(hwnd, ico_path) -> bool:
+    """Set the window-class icon for ``hwnd``'s class to ``ico_path``.
+
+    Affects every window of that class in this process, present and future.
+    Returns True if at least one of the two class icons was installed.
+    """
+    if sys.platform != "win32":
+        return False
+    try:
+        hwnd = int(hwnd)
+    except (TypeError, ValueError):
+        logger.warning("Window-class icon: unusable HWND %r", hwnd)
+        return False
+    if not hwnd:
+        logger.warning("Window-class icon: null HWND")
+        return False
+
+    try:
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+
+        user32.LoadImageW.restype = wintypes.HANDLE
+        user32.LoadImageW.argtypes = [
+            wintypes.HMODULE, wintypes.LPCWSTR, wintypes.UINT,
+            ctypes.c_int, ctypes.c_int, wintypes.UINT,
+        ]
+        user32.GetSystemMetrics.restype = ctypes.c_int
+        user32.GetSystemMetrics.argtypes = [ctypes.c_int]
+
+        # SetClassLongPtrW only exists on 64-bit; on 32-bit it is a macro for
+        # SetClassLongW and the symbol is absent from user32.
+        set_class = getattr(user32, "SetClassLongPtrW", None) or user32.SetClassLongW
+        set_class.restype = ctypes.c_size_t
+        set_class.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_size_t]
+
+        installed = []
+        for metric, index, label in (
+            (SM_CXICON, GCLP_HICON, "large"),
+            (SM_CXSMICON, GCLP_HICONSM, "small"),
+        ):
+            extent = user32.GetSystemMetrics(metric)
+            hicon = user32.LoadImageW(
+                None, str(ico_path), IMAGE_ICON, extent, extent, LR_LOADFROMFILE
+            )
+            if not hicon:
+                logger.warning(
+                    "Window-class icon: LoadImage(%s, %dpx) failed (err %d)",
+                    ico_path, extent, ctypes.get_last_error(),
+                )
+                continue
+            _class_icons.append(hicon)
+            set_class(wintypes.HWND(hwnd), index, ctypes.c_size_t(hicon))
+            installed.append(f"{label}={extent}px")
+
+        if installed:
+            logger.info("Window-class icon set (%s)", ", ".join(installed))
+            return True
+        logger.warning("Window-class icon NOT set — taskbar may show the "
+                       "generic Windows icon on a slow start (#223)")
+        return False
+    except Exception:
+        logger.warning("Window-class icon hardening failed", exc_info=True)
+        return False


### PR DESCRIPTION
## Problem

The taskbar intermittently shows the generic Windows icon on some machines. Two prior fixes missed the actual fallback path:

- `ecfc877` — set the AUMID before `QApplication` (ordering)
- `235e516` — bumped the AUMID, regenerated `favicon.ico` with BMP frames, added shortcut AUMIDs

## Root cause

Qt registers **every top-level window class** with:

```c
LoadImage(hInstance, L"IDI_ICON1", IMAGE_ICON, 0, 0, LR_DEFAULTSIZE)
```

and falls back to `LoadIcon(NULL, IDI_APPLICATION)` — the generic Windows icon — when that name isn't found. (The UTF-16 literal is in `qwindows.dll`; Qt's own qmake/CMake RC template names the icon `IDI_ICON1`.)

PyInstaller publishes the icon group under the **integer** resource id 1 — `PyInstaller/utils/win32/icon.py`: `UpdateResource(hdst, RT_GROUP_ICON, i + 1, data)`. A *name* lookup never matches an *integer* id, so the window-class icon is the generic Windows icon in **every** PyInstaller + Qt build.

That's normally invisible, because Qt answers `WM_GETICON` per window and the shell prefers it. But the shell asks with `SendMessageTimeout(..., SMTO_ABORTIFHUNG)`. When the GUI thread is busy as Explorer probes a freshly shown window, the probe times out and the shell paints the **window-class** icon — the generic one — where it sticks for the life of the window.

That's the intermittency: it only bites on machines slow enough to blow Explorer's probe budget during startup (VMs, RDP, cold disks, AV scanning a ~400 MB one-folder dist). `1f76757` narrowed that window by not blocking on device connect, but the fallback target itself was still generic.

Measured on a live Qt window before this change:

```
generic = LoadIcon(NULL, IDI_APPLICATION) = 65579
GCLP_HICON of a real Qt window          = 65579   <-- identical
```

## Fix

**1. Build time (corrective)** — `scripts/win_icon_resource.py` publishes a second, *named* `RT_GROUP_ICON` (`"IDI_ICON1"`) that aliases the `RT_ICON` images PyInstaller already wrote, so Qt's lookup resolves. PyInstaller's integer group #1 is untouched, so the icon Explorer shows for the .exe — and every shortcut that inherits it — is unchanged.

The hook wraps PyInstaller's `CopyIcons` rather than post-processing the built exe, and that detail matters: `EXE.assemble()` embeds resources **before** appending the PKG archive and before fixing the PE checksum. Rewriting resources afterwards truncates the archive — measured on a real onedir exe, **22,801,431 → 344,576 bytes**, MEI cookie gone, exe won't start.

`openwater.spec` asserts the resource is present on the artifact that actually ships, which also catches a warm `build/` tree (PyInstaller's EXE cache compares the icon *path*, not its contents).

**2. Runtime (defensive)** — `utils/win_taskbar_icon.py` sets the class icon explicitly after the QML window exists. Covers running from source (`python.exe` has no such resource either) and any future build path that loses it. Fail-soft throughout — a cosmetic icon must never block a clinical app's startup.

**3. Build hygiene** — `ICON_FILE` now anchors to `SPECPATH` instead of the build-time CWD, and the QML/asset guards are hard failures instead of silent skips. These are paired deliberately: anchoring the icon *without* hard-failing would trade a loud error for a silent build shipping no assets at all.

**4. Comment corrections** — two comments would have invited a fourth wrong fix:
- the AUMID has no per-ID icon cache; bumping it again only mints a new identity and strands every taskbar pin made since 1.4.0
- Windows 10/11 loads PNG ico frames at every size, so regenerating `favicon.ico` is not a fix for any icon bug

## Verification

Done on this machine:

- Full `python -m PyInstaller --clean -y openwater.spec` build succeeds; hook fires; post-build assertion passes.
- Shipped exe carries **both** groups: `[('STR','IDI_ICON1'), ('INT',1)]`. The two directories are byte-identical (104 B, same sha), reference RT_ICON ids 1–7 at 16/24/32/48/64/128/256 px, no dangling references. Explorer's file icon is unregressed.
- Minimal PyInstaller app built through the same hook **runs** — confirming the archive survives, unlike post-processing.
- Live probe: class icon before = `65579` (= `IDI_APPLICATION`), after = a real icon handle.
- `pytest -m unit tests/` → **639 passed**.

New regression tests: `tests/test_app_icon_resources.py`, `tests/test_win_class_icon.py` — including a true-negative probe test (stock `python.exe` must report the resource missing) so the build assertion can't silently degrade to always-true, and an AUMID cross-file consistency check between `main.py` and `installer/app.wxs`.

Still needs a clean/slow machine (cannot be proved here):

- That QA's specific failures were this mechanism. Worth asking the reporter one question: was the generic icon on a **freshly extracted, freshly launched** copy, or on an existing pinned/desktop shortcut? A stale pin at an old install path would look identical and would not be fixed by this.
- Behaviour on machines that actually blow the probe budget. This dev box's post-show window is milliseconds, so a pass here doesn't exercise the failing population — the fix removes the *dependence* on that timing, but only a slow machine confirms it in situ.
- I did not launch the packaged GUI on the bench (that needs your go-ahead).

## Not done here

The Burn bootstrapper `Open-Motion-Setup-*.exe` ships WiX's stub icon, and Add/Remove Programs inherits it via Burn's `DisplayIcon`. Real defect, but deterministic and on installer-only surfaces — separate from this intermittent app-icon bug, so I left it out. Happy to do it as a follow-up.

Refs #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
