### PR TITLE
fix: escalate and name pre-scan contact-quality failures

### DIFF
--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -44,6 +44,12 @@ Item {
     property bool preScanMode: false
     // Live-scan modal is only dismissable when no CQ issues remain active.
     property bool liveScanDismissable: false
+    // The SDK's pass/fail verdict for the last completed check (#390). It
+    // used to be emitted and dropped, so nothing downstream could tell a
+    // passing check from one where a whole sensor side was dark. Defaults
+    // true: a modal that has not run a check yet has nothing to report.
+    // Consumed by the acknowledgement gate in #406.
+    property bool checkPassed: true
     // ModalManager opt-out: don't allow click-outside / icon-bar clicks to
     // close this modal while a check is in flight, while it is gating a
     // pre-scan Start, or while a live scan is running. The user must use

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -76,6 +76,14 @@ SCALE_I = 0.25
 _CQ_DEFAULT_DARK_THRESHOLD_DN = 3.0
 _CQ_DEFAULT_LIGHT_THRESHOLD_DN = 15.0
 _CQ_DEFAULT_ROLLING_WINDOW = 10
+# Preflight verdict severity (#390). Total optical loss is a hardware fault,
+# not an operator-technique note, so it outranks the reposition-the-headset
+# reasons. Anything absent here (i.e. "ok") stays at INFO.
+_CQ_REASON_LOG_LEVEL = {
+    "no_signal": logging.ERROR,
+    "poor_contact": logging.WARNING,
+    "ambient_light": logging.WARNING,
+}
 # Asymmetric live debounce (#364): RAISE fast, CLEAR slow.
 _CQ_DEFAULT_LIVE_ACTIVATE_FRAMES = 10
 _CQ_DEFAULT_LIVE_CLEAR_FRAMES = 80
@@ -4566,6 +4574,11 @@ class MotionConnector(QObject):
         return {
             "ambient_light": "Ambient light detected",
             "poor_contact": "Poor sensor contact",
+            # Distinct from poor_contact on purpose (#390): a dark fiber and
+            # a loose headband used to read identically, so the operator was
+            # told to reposition the headset when the fix was to reseat a
+            # connector.
+            "no_signal": "No signal — check fiber and sensor seating",
         }.get(type_key, type_key)
 
     @staticmethod
@@ -4718,16 +4731,15 @@ class MotionConnector(QObject):
             time.monotonic() - self._cq_t0 if self._cq_t0 is not None else 0.0
         )
         if result is None:
-            logger.info(
-                "=== Contact-quality check ended: failed after %.1fs ===",
+            # Third state, not a failed verdict: the SDK workflow threw and
+            # we have no per-camera data at all. Keep it distinguishable from
+            # "ran, and the cameras failed" (#390).
+            logger.error(
+                "=== Contact-quality check ended: errored after %.1fs ===",
                 elapsed_s,
             )
             self.contactQualityCheckFinished.emit(False, "CQ check failed", [])
             return
-        logger.info(
-            "=== Contact-quality check ended: completed after %.1fs ===",
-            elapsed_s,
-        )
 
         # Convert CamCQResult.reason → (typeKey, warning dict) that the QML
         # ContactQualityModal expects.
@@ -4763,13 +4775,18 @@ class MotionConnector(QObject):
                     }
                     warn_tags.append("ambient_light")
                 elif reason in ("poor_contact", "no_signal"):
-                    warnings_by_key[(camera, "poor_contact")] = {
+                    # Keep the two apart (#390). They used to collapse into
+                    # "poor_contact", so a decoupled fiber told the operator
+                    # to reposition the headset. NB the live monitor keeps
+                    # mapping to poor_contact — the SDK guarantees no_signal
+                    # is preflight-only (omotion/contact_quality.py:20).
+                    warnings_by_key[(camera, reason)] = {
                         "camera": camera,
-                        "typeKey": "poor_contact",
-                        "typeText": self._warning_text("poor_contact"),
+                        "typeKey": reason,
+                        "typeText": self._warning_text(reason),
                         "value": float(light_avg_dn) if light_avg_dn == light_avg_dn else 0.0,
                     }
-                    warn_tags.append("poor_contact")
+                    warn_tags.append(reason)
 
                 table_rows.append({
                     "camera": camera,
@@ -4789,7 +4806,12 @@ class MotionConnector(QObject):
             "|--------|----------|---------|---------|----------|----------------|----------|"
         )
         for row in table_rows:
-            logger.info(
+            # Escalate the row itself, not just an aggregate (#390): the row
+            # carries the numbers, and the documented triage grep is
+            # WARNING|ERROR|FAIL|aborted — an INFO-only hardware fault is
+            # invisible to log review.
+            logger.log(
+                _CQ_REASON_LOG_LEVEL.get(row["reason"], logging.INFO),
                 "| %-6s | %8s | %7s | %7.2f | %8.2f | %-14s | %-8s |",
                 row["camera"],
                 row["light_avg_dn"],
@@ -4800,9 +4822,29 @@ class MotionConnector(QObject):
                 row["warnings"],
             )
 
+        # One greppable summary line per fault class, so a whole-side
+        # blackout does not have to be reconstructed from eight rows.
+        for reason, level in _CQ_REASON_LOG_LEVEL.items():
+            affected = [r["camera"] for r in table_rows if r["reason"] == reason]
+            if affected:
+                logger.log(
+                    level,
+                    "CQ %s on %d camera(s): %s",
+                    reason, len(affected), ", ".join(affected),
+                )
+
         warning_list = list(warnings_by_key.values())
         ok = result.passed
         err_msg = "" if ok else "Contact quality check failed"
+
+        # State the verdict (#390). This used to say "completed" over eight
+        # dead cameras, and it was emitted before the table was even built.
+        logger.log(
+            logging.INFO if ok else logging.ERROR,
+            "=== Contact-quality check ended: %s after %.1fs ===",
+            "passed" if ok else "FAILED",
+            elapsed_s,
+        )
         self.contactQualityCheckFinished.emit(ok, err_msg, warning_list)
 
     def _on_cq_transition(self, side, cam_id, reason, value, active):

--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -635,11 +635,21 @@ Rectangle {
                 // user can explicitly Continue into the main scan.
                 contactQualityModal.liveScan = true
             }
+            // Record the verdict before branching (#390). It used to be
+            // dropped on every path: the warnings branch returns early, so
+            // `ok` was never read, and a check where an entire sensor side
+            // reported no signal was indistinguishable downstream from a
+            // clean one.
+            contactQualityModal.checkPassed = ok
             if (warnings.length > 0) {
                 for (var i = 0; i < warnings.length; ++i) {
                     var w = warnings[i]
                     contactQualityModal.addWarning(w.camera, w.typeKey, w.typeText, w.value)
                 }
+                // Still returns, deliberately: the per-camera warnings are
+                // the specific, actionable view of a failed verdict, and
+                // falling through to showError would replace them with a
+                // generic message (8b7892c).
                 return
             }
             if (!ok) {

--- a/tests/test_contact_quality_escalation.py
+++ b/tests/test_contact_quality_escalation.py
@@ -1,0 +1,203 @@
+"""Unit tests for pre-scan contact-quality escalation (#390).
+
+During the 725-cycle reliability campaign the preflight check detected total
+loss of optical signal on up to all 8 cameras of a sensor side, logged the
+whole verdict at INFO inside a table, announced itself as "completed", and
+described the fault to the operator as "Poor sensor contact" — the same
+words a loose headband gets.
+
+These tests pin the three halves of that:
+
+* the verdict rows and the end banner must escalate when a camera reports
+  ``no_signal`` (the documented triage grep is WARNING|ERROR|FAIL|aborted,
+  so an INFO-only fault is invisible to log review);
+* the banner must state the verdict rather than always saying "completed";
+* ``no_signal`` must carry its own typeKey and operator string, because
+  "reposition the headset" is the wrong instruction for a dark fiber.
+
+No hardware — the connector fixture fakes the interface and runs the CQ
+worker synchronously.
+"""
+import logging
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def connector():
+    from motion_connector import MotionConnector
+
+    fake_iface = MagicMock()
+    fake_iface.console = MagicMock()
+    fake_iface.left = MagicMock()
+    fake_iface.right = MagicMock()
+    fake_iface.is_device_connected.return_value = (True, True, True)
+    fake_iface.scan_workflow = MagicMock()
+    fake_iface.scan_workflow.running = False
+    fake_iface.scan_workflow.config_running = False
+    fake_iface.contact_quality_workflow = MagicMock()
+
+    c = MotionConnector(
+        interface=fake_iface,
+        app_config={"engineeringMode": False},
+        data_dir=".",
+        config_dir="config",
+    )
+    c._consoleConnected = True
+    c._leftSensorConnected = True
+    c._rightSensorConnected = True
+    return c
+
+
+def _cam(reason, light_avg_dn=float("nan"), dark_max_dn=float("nan")):
+    """A CamCQResult-alike. A bare MagicMock crashes the per-camera loop."""
+    return SimpleNamespace(
+        light_avg_dn=light_avg_dn, dark_max_dn=dark_max_dn, reason=reason,
+    )
+
+
+def _result(per_camera, passed):
+    return SimpleNamespace(per_camera=per_camera, passed=passed)
+
+
+def _dark_side_result():
+    """The campaign's signature failure: the whole right side dark."""
+    per_camera = {("left", i): _cam("ok", 67.8, -0.7) for i in range(8)}
+    per_camera.update({("right", i): _cam("no_signal") for i in range(8)})
+    return _result(per_camera, passed=False)
+
+
+def _emitted(connector):
+    box = {}
+    connector.contactQualityCheckFinished.connect(
+        lambda ok, err, warnings: box.update(ok=ok, err=err, warnings=warnings)
+    )
+    return box
+
+
+# --- (a) log level -------------------------------------------------------
+
+def test_no_signal_camera_escalates_above_info(connector, caplog):
+    """A dark camera must be findable by the documented triage grep."""
+    caplog.set_level(logging.DEBUG)
+
+    connector._on_cq_result_ready(_dark_side_result())
+
+    escalated = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert escalated, "total optical loss produced no record above INFO"
+    assert any("R1" in r.getMessage() for r in escalated), (
+        "no escalated record names an affected camera"
+    )
+
+
+def test_all_ok_result_stays_quiet(connector, caplog):
+    """Regression fence: a clean check must not cry wolf."""
+    caplog.set_level(logging.DEBUG)
+    per_camera = {(side, i): _cam("ok", 67.8, -0.7)
+                  for side in ("left", "right") for i in range(8)}
+
+    connector._on_cq_result_ready(_result(per_camera, passed=True))
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+# --- (b) end banner ------------------------------------------------------
+
+def test_end_banner_states_a_failed_verdict(connector, caplog):
+    """The banner said "completed" over eight dead cameras."""
+    caplog.set_level(logging.DEBUG)
+
+    connector._on_cq_result_ready(_dark_side_result())
+
+    banners = [r.getMessage() for r in caplog.records
+               if "Contact-quality check ended" in r.getMessage()]
+    assert len(banners) == 1, f"expected one end banner, got {banners}"
+    assert "completed" not in banners[0], (
+        "a failing check still announces itself as completed"
+    )
+
+
+def test_end_banner_still_reports_a_passing_check(connector, caplog):
+    caplog.set_level(logging.DEBUG)
+    per_camera = {(side, i): _cam("ok", 67.8, -0.7)
+                  for side in ("left", "right") for i in range(8)}
+
+    connector._on_cq_result_ready(_result(per_camera, passed=True))
+
+    banners = [r.getMessage() for r in caplog.records
+               if "Contact-quality check ended" in r.getMessage()]
+    assert len(banners) == 1
+    assert "passed" in banners[0].lower()
+
+
+def test_sdk_throw_is_still_distinguishable_from_a_failed_verdict(connector, caplog):
+    """result is None means the workflow errored — a third state, not a
+    failed verdict. Collapsing the two loses the distinction."""
+    caplog.set_level(logging.DEBUG)
+
+    connector._on_cq_result_ready(None)
+
+    banners = [r.getMessage() for r in caplog.records
+               if "Contact-quality check ended" in r.getMessage()]
+    assert len(banners) == 1
+    assert "passed" not in banners[0].lower()
+
+
+# --- (c) operator vocabulary ---------------------------------------------
+
+def test_no_signal_gets_its_own_type_key(connector):
+    """"Poor sensor contact" sends the operator to reposition the headset
+    for ten minutes instead of plugging a fiber back in."""
+    box = _emitted(connector)
+
+    connector._on_cq_result_ready(_dark_side_result())
+
+    keys = {w["typeKey"] for w in box["warnings"] if w["camera"].startswith("R")}
+    assert keys == {"no_signal"}, f"no_signal collapsed into {keys}"
+
+
+def test_no_signal_text_differs_from_poor_contact(connector):
+    box = _emitted(connector)
+    per_camera = {("left", 0): _cam("poor_contact", 14.5, -0.7),
+                  ("right", 0): _cam("no_signal")}
+
+    connector._on_cq_result_ready(_result(per_camera, passed=False))
+
+    texts = {w["camera"]: w["typeText"] for w in box["warnings"]}
+    assert texts["L1"] != texts["R1"], "both faults describe themselves identically"
+    assert "signal" in texts["R1"].lower()
+
+
+def test_poor_contact_is_unchanged(connector):
+    """Regression fence: the normal reposition-the-headset path is the one
+    the clinical loop is built around. Do not disturb it."""
+    box = _emitted(connector)
+    per_camera = {("left", 5): _cam("poor_contact", 14.49, -0.7)}
+
+    connector._on_cq_result_ready(_result(per_camera, passed=False))
+
+    assert box["warnings"] == [{
+        "camera": "L6",
+        "typeKey": "poor_contact",
+        "typeText": "Poor sensor contact",
+        "value": pytest.approx(14.49),
+    }]
+
+
+def test_no_signal_value_is_not_a_nan(connector):
+    """NaN crosses into QML as a value that renders as "nan"; the existing
+    code already floors it to 0.0. Keep that when the key splits."""
+    box = _emitted(connector)
+
+    connector._on_cq_result_ready(_result({("right", 0): _cam("no_signal")}, False))
+
+    assert not math.isnan(box["warnings"][0]["value"])

--- a/tests/test_contact_quality_modal.py
+++ b/tests/test_contact_quality_modal.py
@@ -1,18 +1,74 @@
+"""Source-text guards on the pre-scan contact-quality result handler.
+
+QML is not instantiated here — these read pages/BloodFlow.qml as text, which
+is the cheapest thing that still catches the two regressions this handler has
+actually suffered.
+
+History worth keeping: the original guard asserted only that the warnings
+branch appeared at a lower string offset than ``if (!ok)``. That expressed
+"show the specific warnings, not a generic error" (8b7892c), but the way it
+was written was also satisfied by the warnings branch returning
+unconditionally — which is exactly what made ``ok`` unreachable and left the
+preflight verdict discarded for the whole reliability campaign (#390). The
+assertion and its intent had drifted apart, and the defect lived in the gap.
+Both properties are now pinned explicitly.
+"""
 from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.unit
 
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _handler() -> str:
+    """The handler body with // comments stripped.
+
+    Stripping matters: these assertions look for identifiers, and a comment
+    explaining why a call is *not* made would otherwise read as the call
+    itself.
+    """
+    text = (_REPO / "pages" / "BloodFlow.qml").read_text(encoding="utf-8")
+    start = text.index("function onContactQualityCheckFinished")
+    end = text.index("// Live-scan warnings", start)
+    return "\n".join(
+        line.split("//")[0] for line in text[start:end].splitlines()
+    )
+
 
 def test_contact_quality_warnings_take_precedence_over_generic_failure():
-    qml = Path(__file__).resolve().parents[1] / "pages" / "BloodFlow.qml"
-    text = qml.read_text(encoding="utf-8")
-    handler_start = text.index("function onContactQualityCheckFinished")
-    handler_end = text.index("// Live-scan warnings", handler_start)
-    handler = text[handler_start:handler_end]
+    """A failing check with per-camera detail must show that detail, not
+    replace it with "Quick check failed" (8b7892c)."""
+    handler = _handler()
 
     warning_branch = handler.index("warnings.length")
     generic_failure_branch = handler.index("if (!ok)")
 
     assert warning_branch < generic_failure_branch
+    assert "showError" not in handler[warning_branch:generic_failure_branch], (
+        "the warnings branch falls through into the generic error, which "
+        "would replace the per-camera detail with 'Quick check failed'"
+    )
+
+
+def test_preflight_verdict_is_not_discarded():
+    """``ok`` is the SDK's pass/fail verdict. It reached QML and was dropped
+    on every path — the whole of #390. It must be recorded on the modal."""
+    handler = _handler()
+
+    assert "checkPassed = ok" in handler, (
+        "the contact-quality verdict is computed, emitted, and then thrown "
+        "away — nothing downstream can tell a passing check from a failing "
+        "one (#390)"
+    )
+
+
+def test_modal_exposes_the_verdict():
+    """The property the handler writes has to exist, and default to the
+    safe value for a modal that has not run a check yet."""
+    modal = (_REPO / "components" / "ContactQualityModal.qml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "property bool checkPassed" in modal


### PR DESCRIPTION
Refs #390

The **legibility** half of #390. The acknowledgement gate is split out into #406 — this PR deliberately does not change whether a scan can start.

## What was broken

A whole sensor side dark, clinical build, today on `next`:

```
=== Contact-quality check ended: completed after 3.0s ===      <- INFO, and says "completed"
CQ Final Compare (DN, pedestal-subtracted; ...)                <- INFO
| R1     |      n/a |     n/a |    3.00 |    15.00 | no_signal      | poor_contact |
| R2     |      n/a |     n/a |    3.00 |    15.00 | no_signal      | poor_contact |
...
```

Every line INFO. The banner says *completed*, and it was emitted **before** the table was built, so it could not have reflected the verdict even in principle. The operator's tooltip reads **"Poor sensor contact"** — the same words a loose headband gets. And `result.passed == False` reached QML and was dropped.

Fifteen non-`ok` checks occurred across the campaign; **zero** changed a scan outcome.

## What this changes

| Sub-defect | Fix |
|---|---|
| Whole verdict at INFO | `no_signal` -> ERROR, `poor_contact` / `ambient_light` -> WARNING, `ok` stays INFO. **The row itself escalates**, not just an aggregate — the row carries the numbers, and the documented triage grep is `WARNING\|ERROR\|FAIL\|aborted`. Plus one greppable summary line per fault class, so a whole-side blackout needn't be reconstructed from eight rows. |
| Banner always "completed" | Now `passed` / `FAILED`, emitted **after** the table, at a level matching the outcome. The `result is None` branch becomes `errored`, keeping an SDK throw distinguishable from a check that ran and failed — three states that were collapsing into two. |
| `no_signal` indistinguishable from `poor_contact` | Its own `typeKey` and string: **"No signal — check fiber and sensor seating"**. This is the operator-facing point of the whole PR: the old text sent someone to reposition a headset for ten minutes when the fix was to reseat a connector. |
| `ok` discarded | Recorded on the modal as `checkPassed` before branching. |

The **live-monitor** mapping is deliberately untouched — the SDK guarantees `no_signal` is preflight-only (`omotion/contact_quality.py:20`).

The warnings branch **still returns early**, on purpose. Per-camera warnings are the specific, actionable view of a failed verdict; falling through to `showError` would replace them with "Quick check failed" (that was `8b7892c`'s point). The fix is to stop *discarding* `ok`, not to change which view is shown. `checkPassed` is the property #406's gate binds to.

## Note on the test that was already there

`tests/test_contact_quality_modal.py` asserted only that the warnings branch appeared at a lower string offset than `if (!ok)`. That expressed "show warnings, not a generic error" — but it was equally satisfied by the warnings branch returning **unconditionally**, which is precisely what made `ok` unreachable. Assertion and intent had drifted apart, and #390 lived in the gap.

Both properties are now pinned explicitly. `//` comments are stripped before matching — while writing this I added a comment containing the word `showError` and my own assertion failed on the prose, which is exactly the failure mode source-text tests invite.

## Verification

- `tests/test_contact_quality_escalation.py` — 9 new connector tests driving `_on_cq_result_ready` with a real-shaped result. **5 fail against `next`**, all 9 pass here. Includes fences for the quiet path (a clean check must not cry wolf) and for `poor_contact` being byte-for-byte unchanged.
- `tests/test_contact_quality_modal.py` — 3 tests, **2 fail against `next`**.
- Full unit suite: **649 passed, 1 skipped**.
- `flake8` on every added line: clean.
- Both touched QML files parse offscreen via `QQmlComponent` (only the expected `module "OpenMotion" is not installed`). I confirmed that check is meaningful by injecting a deliberate syntax error and watching it trip.

No hardware was driven.

## Not in scope

- **The gate** -> #406. Depends on this PR's `typeKey` split: a gate whose dialog says "Poor sensor contact" gives the wrong instruction.
- **Clinical preflight now evaluates 4 cameras per side, not 8.** `84771d9` (#277) made preflight take the scan mask, and `clinicalModeLeftMask` is `0xC3` = cams 1, 2, 7, 8. The campaign's 8-row all-`no_signal` table is not reproducible on current code — the detection surface got *narrower*. Whether a safety preflight should evaluate every physically present camera regardless of scan mask is a clinical decision, not a code cleanup. Flagged on #390.
- **The reliability-harness half of #390.** `tests/Reliability_Test_Script.py` exists only on `origin/test/test-fixes`, has one `_CYCLE_RESULTS.append` hardcoding `"status": "PASS"`, and its only failure path is a `pytest.fail` that aborts the whole run. No mainline commit can close that half.
- **A possible modal hang** found while tracing: `ScanRunner.qml:88-95`'s 30 s `checkWatchdog` calls `_finish(false, ...)`, but the modal only leaves `"checking"` on `contactQualityCheckFinished`, where the footer is hidden and `dismissable` is false. Wants bench confirmation before filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)