### PR TITLE
feat: warn that sensor debug logging raises camera-dropout risk (#408)

### DIFF
--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -1010,6 +1010,29 @@ Item {
                         Item { Layout.fillWidth: true }
                     }
 
+                    // Sensor debug log sets DEBUG_FLAG_USB_PRINTF on both
+                    // sensors. On firmware without sensor-fw#115, the
+                    // firmware's own "HISTO enqueue fail: queue full" message
+                    // has to be transmitted over the COMM endpoint; if the
+                    // host stops draining COMM the send busy-waits the
+                    // firmware main loop for up to 500 ms, which starves the
+                    // 25 ms camera DMA re-arm and kills the camera for the
+                    // rest of the session. Bench: 6/6 scans lost a camera with
+                    // this on, 0/6 with it off, under the same induced stall.
+                    // Shown only when enabled — this is a live hazard, not a
+                    // general note about the setting.
+                    Text {
+                        visible: MotionInterface.appConfig.sensorDebugLogging === true
+                        Layout.fillWidth: true
+                        Layout.leftMargin: 4
+                        Layout.bottomMargin: 6
+                        wrapMode: Text.WordWrap
+                        font.pixelSize: 11
+                        color: AppTheme.accentYellow
+                        text: qsTr("Raises camera-dropout risk during acquisition. "
+                                   + "Turn off before clinical scans.")
+                    }
+
                     // Console USB-printf debug log — persisted to config AND
                     // pushed live to a connected console via
                     // setConsoleDebugLogging. Re-applied on connect (RAM-only

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -4217,6 +4217,19 @@ class MotionConnector(QObject):
                 subject_id, duration_sec, left_camera_mask, right_camera_mask,
                 "off" if disable_laser else "on",
             )
+            if self._sensor_debug_logging:
+                # DEBUG_FLAG_USB_PRINTF is set, so this scan carries an
+                # elevated camera-dropout risk on firmware without
+                # sensor-fw#115: the firmware's queue-full diagnostic is
+                # transmitted over COMM, and if the host stops draining COMM
+                # that send busy-waits the firmware main loop, starving the
+                # 25 ms camera DMA re-arm. Logged at WARNING so a scan taken
+                # in this state is identifiable after the fact.
+                logger.warning(
+                    "Scan started with sensor debug logging ENABLED "
+                    "(DEBUG_FLAG_USB_PRINTF) — elevated camera-dropout risk; "
+                    "not recommended for clinical acquisition"
+                )
             # Bind the live source's DB tail to THIS scan's session row by its
             # exact label (set synchronously inside start_scan), so a later
             # pan-into-past resolves the right session instead of guessing the


### PR DESCRIPTION
## What

Settings → Engineering → **"Sensor debug log"** sets `DEBUG_FLAG_USB_PRINTF` on
both sensors. On firmware without openmotion-sensor-fw#115, that one bit is the
difference between a healthy scan and a dead camera.

Bench, identical induced 300 ms whole-host USB stall, **interleaved** A/B so
thermal or coupling drift cannot masquerade as an arm effect:

| `sensorDebugLogging` | flags | scans that lost a camera |
|---|---|---|
| ON | `0xC1` | **6/6** |
| OFF | `0xC0` | **0/6** |

Zero void trials — every trial verified all four requested cameras per module
were delivering before the injection.

### Mechanism

The firmware's own `HISTO enqueue fail: queue full` message must be transmitted
over the COMM endpoint. If the host stops draining COMM, the send busy-waits the
firmware **main loop** for up to `TX_TIMEOUT` = 500 ms. The per-camera DMA
re-arm lives in that loop and the frame period is 25 ms, so one such wait costs
the camera — and per openmotion-sensor-fw#102 it stays lost until the next
`configure_camera_sensors`, i.e. across scans, not just the rest of one.

**The irony is the point:** enabling sensor debug logging to investigate camera
dropouts substantially increases the chance of one. Anyone debugging this class
of fault walks straight into it.

## Changes

- **`SettingsModal.qml`** — inline warning under the toggle, shown only while it
  is enabled. This is a live hazard, not a general note about the setting, so it
  appears when it applies rather than as permanent chrome.
- **`motion_connector.py`** — log at `WARNING` on scan start when the flag is
  set, so a scan taken in this state is identifiable after the fact.

## Scope

The shipping default is already `sensorDebugLogging: false`, so a **default
clinical build is unaffected** and this changes no default behaviour.

This is a guard-rail, not the fix. The defect is openmotion-sensor-fw#115
(fixed, hardware-validated, PR openmotion-sensor-fw#117) and
openmotion-sensor-fw#116 (the re-arm's placement, which needs per-camera double
buffering and is left as a designed change).

## Verification

- App launched from this branch with the flag enabled: no QML errors, warning
  renders in the Engineering section, override applied correctly
  (`Setting debug flags 0xc1 ... debug_logging=True`).
- Layout: the new `Text` sits in the same `ColumnLayout` as the surrounding
  `FieldRow`s, which already use `Layout.fillWidth` in that block.
- Visually reviewed in the running app.

Refs #408

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
