### PR TITLE
fix: give the error modal's footer buttons one shared width

### DIFF
--- a/components/CriticalErrorModal.qml
+++ b/components/CriticalErrorModal.qml
@@ -33,6 +33,23 @@ Item {
     property var _queue: []
     property bool _detailExpanded: false
 
+    // One width for all three footer buttons. Left to size themselves they
+    // came out 119 / 142 / 92 px (label + Material 3's 24px-a-side padding),
+    // which made the primary action the narrowest thing in the row and gave
+    // each button a different padding-to-label ratio. Must stay >= the
+    // longest label plus _footerButtonPad*2 ("Contact Support" is 94px at
+    // 13px Segoe UI, so 118 is the floor); 132 leaves slack for a wider
+    // system font. Every other modal footer in the app sets explicit button
+    // widths the same way (HistoryModal, LogsModal).
+    readonly property int _footerButtonWidth: 132
+    // Material 3's default 24 is sized for standalone buttons; halved here so
+    // the label isn't squeezed inside the fixed width above (at 24 the
+    // longest label overflowed its content box and only stayed legible
+    // because the centred Text spilled into the padding). Must be set as
+    // left/rightPadding — the Material style assigns those directly, so a
+    // horizontalPadding override is silently ignored.
+    readonly property int _footerButtonPad: 12
+
     function _enqueue(code, title, message, action, detail) {
         var q = root._queue.slice()
         q.push({code: code, title: title, message: message,
@@ -105,11 +122,13 @@ Item {
         // minimum was ~466px when the middle one read "Send Bug Report to
         // Openwater", so a clamp that shrinks the card below ~514px made the
         // row overflow the card and clip (verified: fine at 640px, broken at
-        // 560px). The #340 rename to "Contact Support" bought ~85px of that
-        // back, but the fixed 520 stays: it has the room at every window size
-        // the clamp would have shrunk for. The icon-bar inset is unnecessary
-        // too — at z:100000 this modal is above ButtonPanel, so the bar sits
-        // dimmed behind the backdrop rather than overlapping the card.
+        // 560px). The #340 rename to "Contact Support" and the fixed button
+        // widths below bought that back — the row now needs 416px (3 × 132
+        // + 2 × 10 spacing) inside 472px of content — but the fixed 520
+        // stays: it has the room at every window size the clamp would have
+        // shrunk for. The icon-bar inset is unnecessary too — at z:100000
+        // this modal is above ButtonPanel, so the bar sits dimmed behind the
+        // backdrop rather than overlapping the card.
         width: 520
         height: contentCol.implicitHeight + 48
         radius: 12
@@ -244,8 +263,12 @@ Item {
                 spacing: 10
 
                 Button {
+                    objectName: "errCopyDetailsBtn"
                     text: "Copy details"
+                    Layout.preferredWidth: root._footerButtonWidth
                     Layout.preferredHeight: 32
+                    leftPadding: root._footerButtonPad
+                    rightPadding: root._footerButtonPad
                     // Confirm the copy — copyToClipboard succeeds silently, so
                     // without a toast this button is indistinguishable from a
                     // dead one. The tag keeps repeat clicks from stacking.
@@ -269,8 +292,12 @@ Item {
                 }
 
                 Button {
+                    objectName: "errContactSupportBtn"
                     text: "Contact Support"
+                    Layout.preferredWidth: root._footerButtonWidth
                     Layout.preferredHeight: 32
+                    leftPadding: root._footerButtonPad
+                    rightPadding: root._footerButtonPad
                     onClicked: MotionInterface.sendBugReport(root.code)
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13
@@ -288,8 +315,12 @@ Item {
                 Item { Layout.fillWidth: true }
 
                 Button {
+                    objectName: "errDismissBtn"
                     text: "Dismiss"
+                    Layout.preferredWidth: root._footerButtonWidth
                     Layout.preferredHeight: 32
+                    leftPadding: root._footerButtonPad
+                    rightPadding: root._footerButtonPad
                     onClicked: root.dismiss()
                     contentItem: Text {
                         text: parent.text; font.pixelSize: 13

--- a/tests/test_critical_error_modal_footer.py
+++ b/tests/test_critical_error_modal_footer.py
@@ -1,0 +1,212 @@
+"""Unit tests for the footer button row in components/CriticalErrorModal.qml.
+
+Left to size themselves, the three footer buttons came out 119 / 142 / 92 px
+(label width plus the Material style's 24px-a-side padding), which made the
+primary action the narrowest control in the row and gave the longest label a
+content box smaller than the label itself. These tests pin the geometry
+contract that replaced that: one shared width for all three, and a row that
+still fits inside the card's fixed 520px.
+
+Assertions are deliberately font-independent — the offscreen platform
+resolves a fallback font whose metrics are ~2x the real Segoe UI ones, so
+anything compared against a measured label width would be meaningless here.
+
+Unit-marked: no app launch, no hardware, offscreen Qt platform.
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+# A QGuiApplication must exist before any QML Quick item is created, and it
+# must be constructed before conftest's session-scoped autouse fixture
+# instantiates a bare QCoreApplication. Module import runs at collection
+# time — ahead of every fixture — so create it here. The offscreen platform
+# is passed via argv, NOT via QT_QPA_PLATFORM, so the process environment is
+# untouched (see test_logs_modal_filters.py).
+from PyQt6.QtCore import (  # noqa: E402
+    QCoreApplication,
+    QObject,
+    QUrl,
+    pyqtProperty,
+    pyqtSignal,
+    pyqtSlot,
+)
+from PyQt6.QtGui import QGuiApplication  # noqa: E402
+
+if QCoreApplication.instance() is None:
+    _qt_app = QGuiApplication([sys.argv[0], "-platform", "offscreen"])
+else:
+    _qt_app = QCoreApplication.instance()
+
+import pytest  # noqa: E402
+from PyQt6.QtQml import (  # noqa: E402
+    QQmlComponent,
+    QQmlEngine,
+    qmlRegisterSingletonInstance,
+    qmlRegisterSingletonType,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ERROR_MODAL_QML = REPO_ROOT / "components" / "CriticalErrorModal.qml"
+APP_THEME_QML = REPO_ROOT / "components" / "AppTheme.qml"
+
+FOOTER_BUTTONS = ("errCopyDetailsBtn", "errContactSupportBtn",
+                  "errDismissBtn")
+
+# Mirrors the panel geometry in CriticalErrorModal.qml: a fixed 520px card
+# with 24px content margins and 10px between footer buttons.
+CARD_WIDTH = 520
+CARD_MARGIN = 24
+FOOTER_SPACING = 10
+
+
+class _StubMotionInterface(QObject):
+    """Minimal MotionInterface stand-in covering every member
+    CriticalErrorModal.qml (and AppTheme.qml) references."""
+
+    criticalErrorRaised = pyqtSignal(str, str, str, str, str)
+    _neverEmitted = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.dismissed_count = 0
+
+    @pyqtProperty("QVariantMap", notify=_neverEmitted)
+    def appConfig(self):
+        return {"darkMode": True}
+
+    @pyqtSlot()
+    def criticalErrorsDismissed(self):
+        self.dismissed_count += 1
+
+    @pyqtSlot(str)
+    def copyToClipboard(self, _text):
+        pass
+
+    @pyqtSlot(str)
+    def sendBugReport(self, _code):
+        pass
+
+    @pyqtSlot(str, str, int, bool, str)
+    def notify(self, *_args):
+        pass
+
+
+@contextlib.contextmanager
+def _basic_controls_style():
+    """Temporarily force the always-available Basic Controls style (the
+    platform-native style plugin fails to load in a bare offscreen test
+    process; restore right after so HIL subprocesses can't inherit it)."""
+    prev = os.environ.get("QT_QUICK_CONTROLS_STYLE")
+    os.environ["QT_QUICK_CONTROLS_STYLE"] = "Basic"
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("QT_QUICK_CONTROLS_STYLE", None)
+        else:
+            os.environ["QT_QUICK_CONTROLS_STYLE"] = prev
+
+
+@pytest.fixture(scope="module")
+def modal():
+    """Compile CriticalErrorModal.qml once and raise one error into it."""
+    stub = _StubMotionInterface()
+    qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", stub)
+    qmlRegisterSingletonType(
+        QUrl.fromLocalFile(str(APP_THEME_QML)), "OpenMotion", 1, 0,
+        "AppTheme",
+    )
+    engine = QQmlEngine()
+    with _basic_controls_style():
+        component = QQmlComponent(
+            engine, QUrl.fromLocalFile(str(ERROR_MODAL_QML))
+        )
+    if component.isError():
+        raise RuntimeError(
+            "CriticalErrorModal.qml failed to compile:\n"
+            + "\n".join(e.toString() for e in component.errors())
+        )
+    obj = component.create()
+    if obj is None:
+        raise RuntimeError(
+            "CriticalErrorModal.qml failed to instantiate:\n"
+            + "\n".join(e.toString() for e in component.errors())
+        )
+    # Populate it the way the connector does. (root.visible still reads
+    # False afterwards — the item is parentless in a bare engine, so it has
+    # no effective visibility; the layout below is computed regardless.)
+    stub.criticalErrorRaised.emit(
+        "E-304", "Device disconnected during scan",
+        "A console or sensor was disconnected while the scan was running.",
+        "Check the USB cables and power, then start a new scan.",
+        "ConnectionError: sensor LEFT vanished from USB",
+    )
+
+    yield obj
+
+    obj.deleteLater()
+    del engine
+    del stub
+
+
+def _button(modal_obj, object_name):
+    btn = modal_obj.findChild(QObject, object_name)
+    assert btn is not None, f"footer button {object_name!r} not found"
+    return btn
+
+
+def test_all_footer_buttons_share_one_width(modal):
+    """The row reads as a set, and the primary action is never the runt."""
+    natural = {
+        name: _button(modal, name).property("implicitWidth")
+        for name in FOOTER_BUTTONS
+    }
+    # Sanity check that the test isn't tautological: the labels differ in
+    # length, so left to themselves these buttons would be ragged.
+    assert len(set(natural.values())) == len(FOOTER_BUTTONS), (
+        f"expected three different natural widths, got {natural}"
+    )
+
+    laid_out = {
+        name: _button(modal, name).property("width")
+        for name in FOOTER_BUTTONS
+    }
+    expected = float(modal.property("_footerButtonWidth"))
+    assert set(laid_out.values()) == {expected}, (
+        f"footer buttons must all be {expected}px, got {laid_out}"
+    )
+
+
+def test_footer_row_fits_inside_the_fixed_card(modal):
+    """Guards the clipping mode that forced the card's fixed 520px width:
+    three buttons plus their spacing must fit the card's content box."""
+    width = modal.property("_footerButtonWidth")
+    assert width is not None, "_footerButtonWidth missing from the modal"
+    row_width = 3 * width + 2 * FOOTER_SPACING
+    content_width = CARD_WIDTH - 2 * CARD_MARGIN
+    assert row_width <= content_width, (
+        f"footer row needs {row_width}px but the card only offers "
+        f"{content_width}px — it will clip"
+    )
+
+
+def test_footer_padding_is_applied_as_left_and_right(modal):
+    """The Material style assigns leftPadding/rightPadding directly, so a
+    horizontalPadding override is silently ignored — assert the padding
+    actually landed, and that the label keeps a usable content box."""
+    pad = modal.property("_footerButtonPad")
+    assert pad is not None, "_footerButtonPad missing from the modal"
+    for name in FOOTER_BUTTONS:
+        btn = _button(modal, name)
+        assert btn.property("leftPadding") == pad, name
+        assert btn.property("rightPadding") == pad, name
+    content_box = modal.property("_footerButtonWidth") - 2 * pad
+    assert content_box >= 100, (
+        f"only {content_box}px left for the label — the longest "
+        f'("Contact Support") needs ~94px at 13px Segoe UI'
+    )


### PR DESCRIPTION
Refs #410

## Problem

The footer of `CriticalErrorModal.qml` was the only modal footer in the app that set no explicit button width, so each button was sized by its label plus the Material style's 24px-a-side padding:

| Button | Label | Rendered width |
|---|---|---|
| Copy details | 71 px | 119 px |
| Contact Support | 94 px | 142 px |
| Dismiss (primary) | 44 px | 92 px |

The primary action ended up the narrowest control in the row, and the padding-to-label ratio ranged 40–52%, so the three didn't read as a set.

## Fix

- One shared width (132 px) for all three buttons, matching how every other modal footer in the app is built (`HistoryModal` 132/128/200, `LogsModal` 110/80/118).
- Horizontal padding halved to 12. **This has to be set as `leftPadding`/`rightPadding`** — the Material style assigns those directly, so a `horizontalPadding` override is silently ignored. At the stock 24 a 132px button leaves only 84px for a 94px label; it stayed legible purely because the centred `Text` spilled out into the padding.
- Refreshed the load-bearing comment above `width: 520` with the new footer minimum (416px inside 472px of content).

## Verification

Rendered the real QML with the app's Material style and Segoe UI, before and after — buttons now measure 132 / 132 / 132 with 108px content boxes for labels of 71 / 94 / 44.

Added `tests/test_critical_error_modal_footer.py` (3 unit-marked tests, no hardware): widths all equal, row fits the card's fixed 520px, padding lands on left/right. Assertions are font-independent, since the offscreen platform resolves a fallback font whose metrics are ~2x Segoe UI's.

```
651 passed, 1 skipped, 121 deselected in 34.54s     # pytest tests/ -m unit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)