### PR TITLE
chore: retune ft_min_mean_per_camera calibration defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Debug flags that are still useful when hardware **is** attached (`config/app_con
 | `deferHistoSend` | `true` | Defer the per-frame histogram send out of the FSIN ISR into the firmware main loop (firmware `DEBUG_FLAG_SEND_DEFER`, bit `0x80`; sensor-fw#68). Config-only (no Settings UI); pushed to connected sensors at connect via `_compute_sensor_debug_flags`. Requires the PR-branch sensor firmware — stock firmware ignores bit 7. |
 | `scanDataStallTimeoutSec` | `15` | Whole-scan data-stall watchdog (#248): abort the scan with the E-303 critical modal when NO camera delivers a frame for this long while the trigger is ON. `<= 0` disables. Per-camera dropouts (`cameraDropoutThresholdSec`, default 2 s, code-only key) stay fail-soft — only total loss aborts. |
 | `tecTripTempC` | `40` | Console over-temp trip (°C) pushed to the console user config on connect via `motion_config.ensure_tec_trip` (read-modify-write, preserves calibration + OPT/EE keys). Validated to 1–60 °C; absent/invalid values leave the device's existing trip untouched (never writes `0`, which would disable the firmware trip). |
-| `ft_min_mean_per_camera` | `[50,70,…,70,50]` | Calibration pass threshold — min pixel mean per camera (8-element array). Cameras 1 and 8 (far) get a lower bar than the middle six. |
+| `ft_min_mean_per_camera` | `[40,80,…,80,40]` | Calibration pass threshold — min pixel mean per camera (8-element array). Cameras 1 and 8 (far) get a lower bar than the middle six. |
 | `calibration_scan_duration_sec` | `15` | Calibration runtime. |
 | `test_scan_duration_sec` | `5` | "Test" scan runtime (feature #132). |
 | `cq_dark_threshold_per_camera` | `[3.0,…]` | Contact-quality dark threshold. |

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -35,14 +35,14 @@
     "test_scan_duration_sec": 5,
     "calibration_scan_delay_sec": 1,
     "ft_min_mean_per_camera": [
-        50,
-        70,
-        70,
-        70,
-        70,
-        70,
-        70,
-        50
+        40,
+        80,
+        80,
+        80,
+        80,
+        80,
+        80,
+        40
     ],
     "ft_min_contrast_per_camera": [
         0.25,


### PR DESCRIPTION
Retunes the default calibration pass thresholds (`ft_min_mean_per_camera`, min pixel mean per camera) in `config/app_config.json`:

- Far cameras (1 and 8): 50 -> 40
- Middle six cameras (2-7): 70 -> 80

The far-cameras-get-a-lower-bar pattern is preserved; only the values change. Also updates the stale documented values in the CLAUDE.md config table. JSON verified to parse (`json.load` returns `[40, 80, 80, 80, 80, 80, 80, 40]`). No code paths change — `main.py`'s config_store whitelist entry is a `[0] * 8` placeholder and no tests pin these values.

Refs #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)