### PR TITLE
fix: keep the live plot scrolling through contact loss

### DIFF
--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -153,13 +153,17 @@ Item {
         ctx.beginPath()
         ctx.lineWidth = 1.5
         ctx.strokeStyle = color
+        // Pen-up at non-finite samples: a NaN run (unlit camera during a
+        // contact loss) must render as a blank gap, not a straight line
+        // bridging the last point before the gap to the first one after.
+        var penDown = false
         for (var i = 0; i < pts.length; i++) {
             var t = pts[i][0]
             var v = pts[i][1]
-            if (!isFinite(v)) continue
+            if (!isFinite(v)) { penDown = false; continue }
             var x = ((t - tLo) / dt) * w
             var y = h - ((v - yMinVal) / dy) * h
-            if (i === 0) ctx.moveTo(x, y)
+            if (!penDown) { ctx.moveTo(x, y); penDown = true }
             else ctx.lineTo(x, y)
         }
         ctx.stroke()

--- a/components/PlotCell.qml
+++ b/components/PlotCell.qml
@@ -428,7 +428,8 @@ Item {
                 var dt = (dx / cell.width) * cell.windowSeconds
                 cell.panZoomTarget.setWindow(
                     panZoomArea._dragStartWindowStartT - dt,
-                    cell.windowSeconds
+                    cell.windowSeconds,
+                    "drag-pan"
                 )
             } else {
                 // Hover: broadcast cursor time to the viewer.
@@ -459,7 +460,7 @@ Item {
             var anchorT = tLoNow + ratio * cell.windowSeconds
             var newSec = cell.windowSeconds * factor
             var newStart = anchorT - ratio * newSec
-            cell.panZoomTarget.setWindow(newStart, newSec)
+            cell.panZoomTarget.setWindow(newStart, newSec, "wheel-zoom")
             wheel.accepted = true
         }
     }
@@ -498,7 +499,8 @@ Item {
                           + pinchZoom._anchorRatio * pinchZoom._baseWindowSeconds
             cell.panZoomTarget.setWindow(
                 anchorT - pinchZoom._anchorRatio * newSec,
-                newSec
+                newSec,
+                "pinch-zoom"
             )
         }
     }

--- a/components/PlotViewer.qml
+++ b/components/PlotViewer.qml
@@ -51,7 +51,7 @@ Rectangle {
             viewer._kbReset()
             event.accepted = true
         } else if (event.key === Qt.Key_Home) {
-            viewer.setWindow(0, viewer.windowSeconds)
+            viewer.setWindow(0, viewer.windowSeconds, "keyboard")
             event.accepted = true
         } else if (event.key === Qt.Key_End) {
             viewer._kbEnd()
@@ -288,7 +288,7 @@ Rectangle {
     readonly property real _minWindowSeconds: 0.5
     readonly property real _maxWindowSeconds: 600.0
 
-    function _ensureFrozen() {
+    function _ensureFrozen(cause) {
         // Capture the currently-visible window start so pan/zoom from
         // followLive transitions smoothly (no visual jump). After this
         // the caller mutates windowStartT/windowSeconds freely.
@@ -297,12 +297,16 @@ Rectangle {
             // than re-reading source.liveEdge — avoids a one-frame jump
             // at the moment of pan/zoom on a fast source.
             viewer.windowStartT = Math.max(0, viewer.liveEdgeSnapshot - viewer.windowSeconds)
+            // One line per live→paused edge — the recovery already logs
+            // as "[Plot] back-to-live" — so a debug bundle can show WHEN
+            // the view stopped following live and what input did it.
+            console.info("[Plot] live-follow paused (" + (cause || "pan/zoom") + ")")
         }
         viewer.followLive = false
     }
 
-    function setWindow(startT, seconds) {
-        _ensureFrozen()
+    function setWindow(startT, seconds, cause) {
+        _ensureFrozen(cause)
         viewer.windowSeconds = Math.max(_minWindowSeconds, Math.min(_maxWindowSeconds, seconds))
         // Cap startT so the window can't extend past the live edge —
         // otherwise the scrubber inset slides off into empty future
@@ -325,17 +329,17 @@ Rectangle {
     readonly property real _defaultWindowSeconds: 15
 
     function _kbPan(seconds) {
-        _ensureFrozen()
-        setWindow(viewer.windowStartT + seconds, viewer.windowSeconds)
+        _ensureFrozen("keyboard")
+        setWindow(viewer.windowStartT + seconds, viewer.windowSeconds, "keyboard")
     }
 
     function _kbZoom(factor) {
-        _ensureFrozen()
+        _ensureFrozen("keyboard")
         // Zoom around the center of the currently-visible window so the
         // operator's mental anchor stays put on the screen.
         var center = viewer.windowStartT + viewer.windowSeconds / 2
         var newSec = viewer.windowSeconds * factor
-        setWindow(center - newSec / 2, newSec)
+        setWindow(center - newSec / 2, newSec, "keyboard")
     }
 
     function _kbEnd() {
@@ -347,7 +351,8 @@ Rectangle {
         } else {
             setWindow(
                 Math.max(0, viewer.liveEdgeSnapshot - viewer.windowSeconds),
-                viewer.windowSeconds
+                viewer.windowSeconds,
+                "keyboard"
             )
         }
     }
@@ -850,7 +855,7 @@ Rectangle {
             followLive: viewer.followLive
 
             onPanRequested: function(startT) {
-                viewer.setWindow(startT, viewer.windowSeconds)
+                viewer.setWindow(startT, viewer.windowSeconds, "scrubber")
                 console.info("[Plot] scrubber pan → " + startT.toFixed(2) + " s")
             }
         }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -559,13 +559,19 @@ class _LivePlotSink:
                         connector.captureLog.emit(msg)
                         logger.warning(msg)
 
-                # Skip NaN samples for the plot — Qt would otherwise render
-                # them as a spike from baseline to wherever NaN lands in the
-                # y-mapping. Common causes: warmup before the first dark
-                # observation, and unlit frames (the dark stage suppresses
-                # realtime emission — see low_light_rt above).
+                # Non-finite BFI/BVI: row-addressed LIGHT rows are appended
+                # anyway (issue #418) — an unlit (covered / off-target)
+                # camera must keep advancing its buffers and the source's
+                # liveEdge so the time axis scrolls through a contact loss;
+                # PlotCell breaks the trace at NaN so the run renders as a
+                # blank gap. Dark rows keep the finite gate (a NaN append at
+                # every scheduled dark would notch the trace ~each 15 s),
+                # and legacy fan-out batches keep it too — without
+                # side_ids/cam_ids a finite BFI is the only evidence this
+                # camera actually produced the row.
                 if not (math.isfinite(bfi) and math.isfinite(bvi)):
-                    continue
+                    if is_dark or not row_addressed:
+                        continue
 
                 mean_for_source: Optional[float] = None
                 contrast_for_source: Optional[float] = None

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -111,6 +111,28 @@ def test_camera_buffer_mark_dropped_sets_timestamp_once():
     assert buf.dropped_at == 1.5
 
 
+def test_camera_buffer_window_decimated_preserves_nan_gap():
+    """A NaN run (contact-loss gap, issue #418) must survive decimation:
+    a bin whose samples are all NaN comes out NaN (np.nanmean semantics),
+    so the renderer keeps the gap blank at zoomed-out windows instead of
+    bridging it with mean-binned neighbors."""
+    buf = _CameraBuffer(initial_capacity=64)
+    # 40 samples at 40 Hz: 10 finite, 20 NaN (the gap), 10 finite.
+    for i in range(40):
+        v = float("nan") if 10 <= i < 30 else 1.0
+        buf.append(t=i * 0.025, v=v, frame_id=i)
+
+    # (t_hi - t_lo) * 40 Hz = 40 expected samples; max_points=10 gives
+    # stride 4 — each output is the nanmean of 4 consecutive samples, so
+    # bins fully inside the 20-sample gap are all-NaN and must stay NaN.
+    t_arr, v_arr = buf.window_decimated(0.0, 1.0, 10)
+
+    assert len(v_arr) >= 3
+    assert np.isfinite(v_arr[0])       # leading finite region intact
+    assert np.isnan(v_arr).any()       # the gap survives as NaN bins
+    assert np.isfinite(v_arr[-1])      # trailing finite region intact
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # ScanDataSource (base)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -1,3 +1,4 @@
+import math
 from types import SimpleNamespace
 
 import numpy as np
@@ -328,9 +329,9 @@ def test_live_plot_sink_records_every_arrival_into_gap_tracker():
         side_ids=np.array([0, 0, 0], dtype=np.int8),
         cam_ids=np.array([1, 1, 1], dtype=np.int8),
     )
-    # Middle sample is NaN → skipped for the PLOT, but still recorded in
-    # the tracker (the frame arrived). The only gap is the genuine
-    # delivery silence between t=0.125 and t=3.0.
+    # Middle sample is NaN → recorded in the tracker (the frame arrived)
+    # AND appended to the plot as a gap sample (issue #418). The only
+    # delivery gap is the genuine silence between t=0.125 and t=3.0.
     batch.bfi_live[:] = 7.0
     batch.bvi_live[:] = 4.0
     batch.bfi_live[1, 0, 1] = np.nan
@@ -340,16 +341,21 @@ def test_live_plot_sink_records_every_arrival_into_gap_tracker():
     assert tracker.merged_gaps() == [
         (pytest.approx(0.125), pytest.approx(3.0))
     ]
-    # Plot behavior unchanged: NaN sample not appended to the live source.
+    # The NaN light row is appended too (blank-gap sample) — the plot's
+    # buffers advance on every arriving light frame.
     assert [r["t"] for r in src.appended] == [
-        pytest.approx(0.1), pytest.approx(3.0)
+        pytest.approx(0.1), pytest.approx(0.125), pytest.approx(3.0)
     ]
+    assert math.isnan(src.appended[1]["bfi"])
 
 
-def test_live_plot_sink_covered_camera_stays_alive_and_unplotted():
+def test_live_plot_sink_covered_camera_appends_nan_gap_samples():
     """A covered / off-target camera streams light-typed frames whose
-    BFI/BVI are NaN. It must keep feeding the heartbeat and the gap
-    tracker (it is connected), while appending nothing to the plot."""
+    BFI/BVI are NaN. It keeps feeding the heartbeat and the gap tracker,
+    and (issue #418) the NaN sample IS appended — buffers and liveEdge
+    keep advancing so the time axis scrolls through a contact loss; the
+    renderer draws NaN runs as a blank gap. mean/contrast stay None
+    (non-finite); chip temperature is real and keeps flowing."""
     from nan_gap_tracker import NanGapTracker
 
     conn = _connector()
@@ -374,9 +380,89 @@ def test_live_plot_sink_covered_camera_stays_alive_and_unplotted():
 
     assert ("left", 2) in conn._camera_last_seen   # alive
     assert tracker.t0 == pytest.approx(0.1)        # delivery recorded
-    assert src.appended == []                      # nothing plottable
-    # Chip temperature is real even when the camera sees no light.
+    assert [(r["side"], r["cam_id"], r["frame_id"]) for r in src.appended] == [
+        ("left", 2, 10),
+        ("left", 2, 11),
+    ]
+    assert all(math.isnan(r["bfi"]) and math.isnan(r["bvi"])
+               for r in src.appended)
+    assert all(r["mean"] is None and r["contrast"] is None
+               for r in src.appended)
+    # Chip temperature is real even when the camera sees no light — the
+    # temp trace keeps updating through the gap.
+    assert [r["temp"] for r in src.appended] == [
+        pytest.approx(55.0, abs=1e-4), pytest.approx(55.0, abs=1e-4)]
     assert conn._camera_last_temp[("left", 2)] == pytest.approx(55.0, abs=1e-4)
+
+
+def test_live_plot_sink_dark_frame_nan_still_skipped():
+    """Scheduled dark frames with NaN BFI/BVI stay unappended — appending
+    them would notch every trace with a one-frame blank at each ~15 s
+    dark now that the renderer breaks the line at NaN samples (issue #418)."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        bvi_live=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        mean_dc_rt=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        contrast_sn_rt=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["dark"], dtype="<U8"),
+        timestamp_s=np.array([0.5], dtype=np.float64),
+        abs_frame_ids=np.array([20], dtype=np.int64),
+        side_ids=np.array([0], dtype=np.int8),
+        cam_ids=np.array([1], dtype=np.int8),
+    )
+
+    sink.consume("live", batch)
+
+    assert src.appended == []
+
+
+def test_live_plot_sink_warmup_and_stale_nan_still_skipped():
+    """Warmup and stale frames are skipped before the NaN gate — the
+    relaxed append (issue #418) must not resurrect them."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        bvi_live=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        mean_dc_rt=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        contrast_sn_rt=np.full((2, 2, 8), np.nan, dtype=np.float32),
+        temperature_c=np.full((2, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["warmup", "stale"], dtype="<U8"),
+        timestamp_s=np.array([0.1, 0.125], dtype=np.float64),
+        abs_frame_ids=np.array([10, 11], dtype=np.int64),
+        side_ids=np.array([0, 0], dtype=np.int8),
+        cam_ids=np.array([2, 2], dtype=np.int8),
+    )
+
+    sink.consume("live", batch)
+
+    assert src.appended == []
+
+
+def test_live_plot_sink_legacy_batch_nan_still_skipped():
+    """Batches without side_ids/cam_ids fan every row out to all 16
+    cameras; a finite BFI is the only evidence a camera produced the
+    row. NaN rows must stay unappended there or every camera's buffer
+    would collect 16-way NaN garbage (issue #418)."""
+    conn = _connector()
+    sink, src = _make_sink(conn)
+    batch = SimpleNamespace(
+        bfi_live=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        bvi_live=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        mean_dc_rt=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        contrast_sn_rt=np.full((1, 2, 8), np.nan, dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), 35.0, dtype=np.float32),
+        frame_type=np.array(["light"], dtype="<U8"),
+        timestamp_s=np.array([0.5], dtype=np.float64),
+        abs_frame_ids=np.array([1], dtype=np.int64),
+    )
+
+    sink.consume("live", batch)
+
+    assert src.appended == []
 
 
 def test_live_plot_sink_rearms_dropped_camera_on_frame_arrival():


### PR DESCRIPTION
Refs #418

Two fixes + observability for the field-reported plot freeze around contact-quality events (debug-bundle-20260729_092613):

- **Axis continuity:** `_LivePlotSink` now appends unlit light-frames as NaN (row-addressed path only), so buffers and `liveEdge` keep advancing and the grid scrolls through a total contact loss instead of freezing and leaping. Dark rows and legacy fan-out batches keep the finite-only gate.
- **Blank gaps:** `PlotCell._drawTrace` pens up at non-finite samples — a contact-loss gap renders blank instead of a straight line bridging the points before/after the loss. Also fixes the clinical side-average trace, which already received NaNs and bridged them.
- **Pause observability:** the DVR `followLive` true→false edge now logs `[Plot] live-follow paused (<cause>)` (drag-pan / wheel-zoom / pinch-zoom / keyboard / scrubber), matching the existing back-to-live recovery line.

Tests: sink NaN-append rules + decimation gap-survival guard (`-m unit`, no hardware) — full unit suite 655 passed / 1 skipped. QML changes (gap rendering, logging) verified by review; visual check on hardware pending Ethan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)