### PR TITLE
fix: pre-scan CQ check evaluates every physically-present camera

### DIFF
--- a/pages/BloodFlow.qml
+++ b/pages/BloodFlow.qml
@@ -531,20 +531,19 @@ Rectangle {
     // ===== SCAN RUNNER (check mode) =====
     // Shares flash + trigger/laser plumbing with scanRunner; final stage is
     // the contact-quality check instead of capture. Always flashes 0xFF so
-    // every physically-present camera participates (lets the live CQ view
-    // show a dot for every camera) — absent cameras are skipped by the
-    // configure workflow. The pass/fail *evaluation* is narrower: only the
-    // user's currently configured scan mask (evalLeftMask/evalRightMask)
-    // is required to pass — a camera set to "None" in scan settings is
-    // flashed/shown but never blocks the check.
+    // every physically-present camera participates — absent cameras are
+    // skipped by the configure workflow. Every physically-present camera is
+    // also EVALUATED and gates pass/fail (issue #420, reversing #277's
+    // scan-mask narrowing): the preflight is a whole-module seating check,
+    // so an unmeasured camera must never render as good contact. Known
+    // trade-off, accepted: a dead camera fails every preflight even when
+    // it's excluded from the scan mask.
     ScanRunner {
         id: qualityCheckRunner
         mode: "check"
         connector: MotionInterface
         leftMask: MotionInterface.leftSensorConnected  ? 0xFF : 0x00
         rightMask: MotionInterface.rightSensorConnected ? 0xFF : 0x00
-        evalLeftMask: bloodFlow.leftMask
-        evalRightMask: bloodFlow.rightMask
         laserOn: true
         laserPower: 50
         // See note on the scanRunner triggerConfig above — same here.

--- a/pages/scan/ScanRunner.qml
+++ b/pages/scan/ScanRunner.qml
@@ -23,16 +23,6 @@ QtObject {
     property int leftMask: 0x5A
     property int rightMask: 0x5A
 
-    // "check" mode only: the mask actually evaluated for contact-quality
-    // pass/fail. Defaults to leftMask/rightMask (the flash mask) so
-    // existing callers are unaffected; a caller that flashes every
-    // physically-present camera (leftMask/rightMask = 0xFF) but only
-    // wants to require contact on the user's *configured* scan cameras
-    // sets these explicitly — a camera the user set to "None" then never
-    // needs to pass contact quality.
-    property int evalLeftMask: leftMask
-    property int evalRightMask: rightMask
-
     property int durationSec: 60
     property string subjectId: ""
     property bool disableLaser: false
@@ -181,8 +171,8 @@ QtObject {
 
     property ContactQualityCheckTask checkTask: ContactQualityCheckTask {
         connector: runner.connector
-        leftCameraMask: runner.evalLeftMask
-        rightCameraMask: runner.evalRightMask
+        leftCameraMask: runner.leftMask
+        rightCameraMask: runner.rightMask
 
         onStarted: {
             runner._stage = "check"


### PR DESCRIPTION
Refs #420

Field observation: lifting a sensor off the phantom during the pre-scan contact-quality check turned only the far/outer cameras orange (the scan-mask set — clinical 0xC3 = cams 1,2,7,8) while the near cameras stayed green despite having no contact.

Root cause: 84771d9 (#277) narrowed the CQ *evaluation* to the configured scan mask, and the modal has no 'not evaluated' state — unmeasured cameras render green, indistinguishable from measured-and-passed.

Fix (per Ethan's decision — deliberately reverses #277): the check task now evaluates the runner's flash mask (0xFF per connected side), so **all 8 cameras per side are measured and gate pass/fail** in both the clinical Start preflight and the research Check button. The `evalLeftMask`/`evalRightMask` plumbing is removed; the check-runner comment documents the accepted trade-off (a known-dead camera fails every preflight even when excluded from the scan mask). `runContactQualityCheck(left_mask, right_mask)` API unchanged. The ContactQualityModal binding comment ('pre-scan check always evaluates all physically-present cameras') is accurate again.

Tests: unit suite 655 passed / 1 skipped (QML-only change; no pytest surface). Needs a hand check: lift a sensor during preflight → all 8 dots of that module go orange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)