### PR TITLE
fix: CQ modal camera-to-mask-bit mapping matches the SDK convention

### DIFF
--- a/components/ContactQualityModal.qml
+++ b/components/ContactQualityModal.qml
@@ -207,8 +207,12 @@ Item {
     }
 
     function cameraEnabled(side, camIndex1) {
-        // Camera 1 maps to bit 7 ... camera 8 maps to bit 0.
-        var bit = 8 - camIndex1
+        // Camera N maps to bit N-1, matching every data-side consumer:
+        // the SDK's `mask & (1 << cam_id)` and the connector's
+        // `cam_id + 1` labels. Only the non-palindromic masks (the
+        // Left/Right presets) can distinguish this from the reversed
+        // mapping — see #384.
+        var bit = camIndex1 - 1
         var mask = (side === "left") ? root.leftMask : root.rightMask
         return ((mask >> bit) & 1) === 1
     }


### PR DESCRIPTION
Refs #384

## What

One-line fix in `ContactQualityModal.cameraEnabled`: camera N now maps to mask bit **N-1** (`camIndex1 - 1`), replacing the reversed `8 - camIndex1` mapping. Comment updated to state the convention and why only Left/Right presets could expose the mismatch.

## Why

The live CQ modal believed camera 1 = bit 7 while the SDK (`_cams_from_masks`: `mask & (1 << cam_id)`), `MotionSensor` (`1 << camera_id`), and the connector's labels (`cam_id + 1`) all use camera 1 = bit 0. Every shipped preset except **Left** (`0x0F`) and **Right** (`0xF0`) is a bit-palindrome, so the two conventions agreed by luck. With Left selected, the modal grayed out L1–L4 (the cameras actually under evaluation) and showed L5–L8 as good, while warning rows correctly named L1–L4.

## Scope

The other reversed-bit sites flagged in #384 — `BloodFlow.maskToArray`, `ScanSettingsModal.maskFromArray` + its hard-coded preset patterns, and `SensorView`'s dot indexing (dot "Sensor ID: 1" reads `sensorActive[7]`) — form a closed **double reversal that cancels out** and renders correctly today. Verified concretely: the Left preset lights preview dots 1–4, matching what the SDK evaluates. Deliberately untouched here; unwinding that intermediate representation is a zero-behavior-change refactor for a separate ticket.

## Verification

No QML test infra — needs eyes-on with a non-palindromic preset (a palindromic mask cannot distinguish the conventions):
1. Research build, Scan Settings → **Left** preset, start a scan.
2. Cover L1: the warning row and the reddened dot must both say L1 (previously: row said L1, dot L1 was gray/inactive, L5–L8 sat green).
3. Mirror-check with **Right**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)