### PR TITLE
fix: surface the camera over-temp alert as a toast (Refs #424)

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -473,6 +473,11 @@ class _LivePlotSink:
         n = batch.bfi_live.shape[0]
         connector = self._connector
         threshold = connector._camera_temp_alert_threshold_c
+        # Over-temp toast is Research-only: a clinical operator has no action
+        # to take on a chip-temperature reading and shouldn't get a mid-scan
+        # popup for one. Clinical builds still get the capture-log + app-log
+        # line below, so the event stays in the record either way.
+        temp_toast_enabled = not connector._app_config.get("clinicalMode", False)
         now_mono = time.monotonic()
 
         low_light_rt = getattr(batch, "low_light_rt", None)
@@ -558,6 +563,20 @@ class _LivePlotSink:
                         )
                         connector.captureLog.emit(msg)
                         logger.warning(msg)
+                        # captureLog only reaches the app log (its QML
+                        # terminus is console.log), so the operator sees
+                        # nothing on screen without this. notify() is safe
+                        # from this runner thread — it emits a signal that
+                        # is delivered queued onto the GUI thread, same as
+                        # _on_camera_dropout_recovered below.
+                        if temp_toast_enabled:
+                            connector.notify(
+                                f"Camera {side.upper()} {cam_id + 1} temperature "
+                                f"{temp_c:.1f}°C — above {threshold:.0f}°C threshold",
+                                type_="warning",
+                                duration_ms=5000,
+                                tag=f"temp_{side}_{cam_id}",
+                            )
 
                 # Non-finite BFI/BVI: row-addressed LIGHT rows are appended
                 # anyway (issue #418) — an unlit (covered / off-target)

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -34,18 +34,25 @@ class _RecorderLiveSource:
         self.dropped.append({"side": side, "cam_id": cam_id, "t": t})
 
 
-def _connector():
+def _connector(clinical_mode=False):
     conn = SimpleNamespace(
         _camera_temp_alert_threshold_c=100.0,
         _camera_dropped=set(),
         _camera_last_seen={},
         _camera_last_temp={},
+        _app_config={"clinicalMode": clinical_mode},
         captureLog=_Signal(),
         recovered=[],
+        notified=[],
     )
     # Called by the sink when a dropped camera's frames resume.
     conn._on_camera_dropout_recovered = (
         lambda side, cam_id: conn.recovered.append((side, cam_id)))
+    # Toast surface — records the kwargs the sink fires it with.
+    conn.notify = (
+        lambda text, type_="info", duration_ms=4000, dismissible=True, tag="":
+        conn.notified.append({"text": text, "type": type_, "tag": tag,
+                              "durationMs": duration_ms}))
     return conn
 
 
@@ -252,6 +259,83 @@ def test_live_plot_sink_passes_temp_for_light_frames():
 
     assert len(src.appended) == 1
     assert src.appended[0]["temp"] == pytest.approx(54.3, abs=1e-4)
+
+
+def _over_temp_batch(temp_c=112.0, frame_type="light"):
+    """One row from LEFT camera 3 (cam_id 2) at ``temp_c``."""
+    batch = SimpleNamespace(
+        bfi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        bvi_live=np.zeros((1, 2, 8), dtype=np.float32),
+        mean_dc_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        contrast_sn_rt=np.zeros((1, 2, 8), dtype=np.float32),
+        temperature_c=np.full((1, 2, 8), temp_c, dtype=np.float32),
+        frame_type=np.array([frame_type], dtype="<U8"),
+        timestamp_s=np.array([0.5], dtype=np.float64),
+        abs_frame_ids=np.array([1], dtype=np.int64),
+        side_ids=np.array([0], dtype=np.int8),
+        cam_ids=np.array([2], dtype=np.int8),
+    )
+    batch.bfi_live[0, 0, 2] = 0.3
+    batch.bvi_live[0, 0, 2] = 5.0
+    return batch
+
+
+def test_over_temp_fires_a_toast_not_just_a_log_line():
+    """Crossing cameraTempAlertThresholdC must raise an on-screen toast.
+    captureLog alone only reaches the app log (its QML terminus is
+    console.log), so the operator saw nothing during the scan."""
+    conn = _connector()
+    sink, _ = _make_sink(conn)
+
+    sink.consume("live", _over_temp_batch(temp_c=112.0))
+
+    assert len(conn.notified) == 1
+    toast = conn.notified[0]
+    assert toast["type"] == "warning"
+    assert toast["tag"] == "temp_left_2"
+    assert toast["durationMs"] == 5000   # auto-dismiss, not sticky
+    assert "LEFT 3" in toast["text"]
+    assert "112.0" in toast["text"]
+    # The log line is unchanged — the toast is additive.
+    assert len(conn.captureLog.calls) == 1
+
+
+def test_over_temp_toast_suppressed_in_clinical_mode():
+    """Clinical builds get the log line but no mid-scan popup."""
+    conn = _connector(clinical_mode=True)
+    sink, _ = _make_sink(conn)
+
+    sink.consume("live", _over_temp_batch(temp_c=112.0))
+
+    assert conn.notified == []
+    assert len(conn.captureLog.calls) == 1
+
+
+def test_over_temp_toast_fires_once_per_camera_per_scan():
+    """The _temp_alerted latch must gate the toast too — at 40 Hz an
+    unlatched toast would re-fire on every frame."""
+    conn = _connector()
+    sink, _ = _make_sink(conn)
+
+    for _ in range(5):
+        sink.consume("live", _over_temp_batch(temp_c=112.0))
+
+    assert len(conn.notified) == 1
+
+    # A new scan re-arms the latch.
+    sink.on_scan_start(None)
+    sink.consume("live", _over_temp_batch(temp_c=112.0))
+    assert len(conn.notified) == 2
+
+
+def test_no_over_temp_toast_below_threshold():
+    conn = _connector()
+    sink, _ = _make_sink(conn)
+
+    sink.consume("live", _over_temp_batch(temp_c=99.0))
+
+    assert conn.notified == []
+    assert conn.captureLog.calls == []
 
 
 def test_live_plot_sink_no_temp_for_dark_frames():


### PR DESCRIPTION
Refs #424

## Problem

With `cameraTempAlertThresholdC` lowered to reproduce, the over-temp alert
fires and lands in the app log — but nothing appears on screen during the
scan.

## Root cause — missing feature, not a regression

The alert in `_LivePlotSink.consume` has only ever done:

```python
connector.captureLog.emit(msg)
logger.warning(msg)
```

`captureLog` dead-ends in `console.log`:

`captureLog` → `CaptureDataTask._onLog` → `ScanRunner.messageOut` →
`BloodFlow.qml:512` → `console.log(line)` → Qt message handler → app log.

Checked whether a toast was dropped at some point — it wasn't:

- Introduced in `e724515` (Feb 18) already log-only.
- `git log --all -S 'notify(...[Tt]emperature'` returns nothing across every branch.
- `6d3420a` removed a *second, redundant* `console.log` forwarder, not a visible view.

Every sibling alert (camera dropout, device disconnect, laser safety) calls
`notify()`. Temperature was the odd one out.

## Change

Add `notify()` alongside the existing log emissions, following the
camera-dropout toast's conventions:

| | |
|---|---|
| type | `warning` |
| duration | 5 s auto-dismiss |
| tag | `temp_{side}_{cam_id}` — a repeat replaces rather than stacks |

Thread-safety matches the neighbouring `_on_camera_dropout_recovered`: the
sink runs on the pipeline runner thread and `notify()` emits a signal
delivered queued onto the GUI thread.

**Gated to Research builds** (`not clinicalMode`) — a clinical operator has
no action to take on a chip-temperature reading and shouldn't get a mid-scan
popup. Clinical builds keep the capture-log + app-log line, so the event
stays in the record either way.

The existing `_temp_alerted` latch gates the toast too, so it fires once per
camera per scan rather than at 40 Hz.

## Testing

4 unit tests in `tests/test_live_plot_sink.py`:

- toast fires with the right type / tag / duration / text
- suppressed in clinical mode (log line still emitted)
- once per camera per scan, re-armed by `on_scan_start`
- silent below threshold

`python -m pytest tests/ -m unit -q` → **659 passed, 1 skipped**.

⚠️ **Bench hand-test pending** — the unit tests cover the `notify()` emit,
not the QML actually painting the toast. Verifying on the rig with the
threshold lowered before this merges.

## Follow-on (not in this PR)

The toast latches once per camera per scan and never clears — if the camera
cools back below threshold it just ages out after 5 s with no "recovered"
signal, unlike the dropout toast which has `_on_camera_dropout_recovered`
replace it in place. Left matching the pre-existing latch semantics rather
than inventing new behavior; worth its own ticket if we want symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
