### PR TITLE
fix: resolve the frozen data root per-platform instead of via %PROGRAMDATA%

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,10 +27,21 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-import pyautogui
 import psutil
-import pygetwindow as gw
-from pywinauto import Desktop as UiaDesktop
+
+# The GUI-automation stack drives the HIL suite only, and pywinauto is
+# Windows-only — importing it unconditionally made conftest unimportable on
+# macOS, which took the platform-independent `unit` tests down with it. Import
+# them optionally; every consumer lives inside a HIL fixture or helper, which
+# a `unit`-marked run never reaches.
+try:
+    import pyautogui
+    import pygetwindow as gw
+    from pywinauto import Desktop as UiaDesktop
+except ImportError:  # non-Windows dev machine — HIL tests can't run here anyway
+    pyautogui = None
+    gw = None
+    UiaDesktop = None
 
 
 # ─────────────────────────────────────────────
@@ -54,8 +65,9 @@ def _qcoreapplication():
 # ─────────────────────────────────────────────
 # pyautogui defaults
 # ─────────────────────────────────────────────
-pyautogui.FAILSAFE = True
-pyautogui.PAUSE = 0.5
+if pyautogui is not None:
+    pyautogui.FAILSAFE = True
+    pyautogui.PAUSE = 0.5
 
 # ─────────────────────────────────────────────
 # Constants

--- a/tests/test_app_paths.py
+++ b/tests/test_app_paths.py
@@ -56,6 +56,18 @@ def test_frozen_portable_uses_exe_folder(tmp_path, monkeypatch):
     assert root == exe_dir
 
 
+def _fake_home(monkeypatch, home):
+    """Point Path.home() at a temp dir, portably.
+
+    Setting $HOME is not enough: on Windows Path.home() resolves via
+    %USERPROFILE%, so a HOME-only stub leaks these darwin-simulating tests out
+    into the developer's real home directory (and then fails there). Patching
+    the method itself is what actually holds on every platform the suite is
+    collected on.
+    """
+    monkeypatch.setattr(app_paths.Path, "home", classmethod(lambda cls: home))
+
+
 @pytest.mark.unit
 def test_frozen_macos_uses_application_support(tmp_path, monkeypatch):
     """A frozen macOS build has no %PROGRAMDATA%; it must land in the standard
@@ -64,7 +76,7 @@ def test_frozen_macos_uses_application_support(tmp_path, monkeypatch):
     monkeypatch.delenv("PROGRAMDATA", raising=False)
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _fake_home(monkeypatch, tmp_path)
 
     root = app_paths.writable_root(portable=False)
 
@@ -77,15 +89,21 @@ def test_frozen_macos_never_yields_a_windows_path(tmp_path, monkeypatch):
     """Regression: PROGRAMDATA is unset off Windows, and the r'C:\\ProgramData'
     default was taken literally — creating a directory actually named
     'C:\\ProgramData' relative to the cwd (inside the .app bundle, or a hard
-    failure when Finder launches with cwd='/')."""
+    failure when Finder launches with cwd='/').
+
+    Asserted as "no ProgramData component" rather than "no 'C:' substring",
+    because tmp_path is itself a C:\\... path when the suite runs on Windows.
+    """
     monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
     monkeypatch.delenv("PROGRAMDATA", raising=False)
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _fake_home(monkeypatch, tmp_path)
 
     for portable in (True, False):
-        assert "C:" not in str(app_paths.writable_root(portable=portable))
+        root = app_paths.writable_root(portable=portable)
+        assert "ProgramData" not in str(root)
+        assert root == tmp_path / "Library" / "Application Support" / "Openwater"
 
 
 @pytest.mark.unit
@@ -95,7 +113,7 @@ def test_frozen_macos_portable_stays_outside_the_app_bundle(tmp_path, monkeypatc
     monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _fake_home(monkeypatch, tmp_path)
     bundle = tmp_path / "Open-Motion.app" / "Contents" / "MacOS"
     bundle.mkdir(parents=True)
     monkeypatch.setattr(sys, "executable", str(bundle / "Open-Motion"), raising=False)
@@ -112,7 +130,7 @@ def test_falls_back_to_documents_when_root_mkdir_denied(tmp_path, monkeypatch):
     os.access check is ever reached."""
     monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
     monkeypatch.setattr(sys, "frozen", False, raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _fake_home(monkeypatch, tmp_path)
     denied = tmp_path / "readonly_cwd"
     denied.mkdir()
     monkeypatch.chdir(denied)

--- a/tests/test_app_paths.py
+++ b/tests/test_app_paths.py
@@ -33,6 +33,7 @@ def test_dev_root_is_cwd_when_not_frozen(tmp_path, monkeypatch):
 def test_frozen_non_portable_uses_program_data(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")  # %PROGRAMDATA% is Windows-only
     monkeypatch.setenv("PROGRAMDATA", str(tmp_path))
 
     root = app_paths.writable_root(portable=False)
@@ -45,6 +46,7 @@ def test_frozen_non_portable_uses_program_data(tmp_path, monkeypatch):
 def test_frozen_portable_uses_exe_folder(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")  # portable zips are Windows-only
     exe_dir = tmp_path / "install_dir"
     exe_dir.mkdir()
     monkeypatch.setattr(sys, "executable", str(exe_dir / "Open-Motion.exe"), raising=False)
@@ -52,6 +54,82 @@ def test_frozen_portable_uses_exe_folder(tmp_path, monkeypatch):
     root = app_paths.writable_root(portable=True)
 
     assert root == exe_dir
+
+
+@pytest.mark.unit
+def test_frozen_macos_uses_application_support(tmp_path, monkeypatch):
+    """A frozen macOS build has no %PROGRAMDATA%; it must land in the standard
+    per-user data location, not a directory named after a Windows path."""
+    monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
+    monkeypatch.delenv("PROGRAMDATA", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    root = app_paths.writable_root(portable=False)
+
+    assert root == tmp_path / "Library" / "Application Support" / "Openwater"
+    assert root.is_dir()
+
+
+@pytest.mark.unit
+def test_frozen_macos_never_yields_a_windows_path(tmp_path, monkeypatch):
+    """Regression: PROGRAMDATA is unset off Windows, and the r'C:\\ProgramData'
+    default was taken literally — creating a directory actually named
+    'C:\\ProgramData' relative to the cwd (inside the .app bundle, or a hard
+    failure when Finder launches with cwd='/')."""
+    monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
+    monkeypatch.delenv("PROGRAMDATA", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    for portable in (True, False):
+        assert "C:" not in str(app_paths.writable_root(portable=portable))
+
+
+@pytest.mark.unit
+def test_frozen_macos_portable_stays_outside_the_app_bundle(tmp_path, monkeypatch):
+    """Writing inside Open-Motion.app invalidates its code signature, so the
+    portable layout cannot apply on macOS."""
+    monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    bundle = tmp_path / "Open-Motion.app" / "Contents" / "MacOS"
+    bundle.mkdir(parents=True)
+    monkeypatch.setattr(sys, "executable", str(bundle / "Open-Motion"), raising=False)
+
+    root = app_paths.writable_root(portable=True)
+
+    assert ".app" not in str(root)
+
+
+@pytest.mark.unit
+def test_falls_back_to_documents_when_root_mkdir_denied(tmp_path, monkeypatch):
+    """The unwritable-root fallback must survive mkdir itself being refused —
+    on a read-only parent (Finder launch, cwd='/') mkdir raises before the
+    os.access check is ever reached."""
+    monkeypatch.delenv("OPENWATER_DATA_ROOT", raising=False)
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    denied = tmp_path / "readonly_cwd"
+    denied.mkdir()
+    monkeypatch.chdir(denied)
+
+    real_mkdir = app_paths.Path.mkdir
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == denied:
+            raise PermissionError(13, "Read-only file system")
+        return real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(app_paths.Path, "mkdir", fake_mkdir)
+
+    root = app_paths.writable_root()
+
+    assert root == tmp_path / "Documents" / "Open-Motion"
+    assert root.is_dir()
 
 
 @pytest.mark.unit

--- a/tests/test_calibration_target_isolation.py
+++ b/tests/test_calibration_target_isolation.py
@@ -55,6 +55,9 @@ import numpy as np
 import psutil
 import pyautogui
 import pytest
+# Windows-only UI automation; this whole module is a HIL test. Skip the module
+# rather than fail collection on a non-Windows dev machine.
+pytest.importorskip("pywinauto", reason="pywinauto is Windows-only (HIL test)")
 from pywinauto import findwindows
 
 from conftest import (

--- a/tests/test_calibration_ui.py
+++ b/tests/test_calibration_ui.py
@@ -40,6 +40,9 @@ This test verifies the UI plumbing, not acceptance criteria.
 import time
 
 import pytest
+# Windows-only UI automation; this whole module is a HIL test. Skip the module
+# rather than fail collection on a non-Windows dev machine.
+pytest.importorskip("pywinauto", reason="pywinauto is Windows-only (HIL test)")
 from pywinauto import findwindows
 
 from conftest import SLEEP, ensure_visible, log, uia_window

--- a/utils/app_paths.py
+++ b/utils/app_paths.py
@@ -40,16 +40,30 @@ def writable_root(portable: bool = False) -> Path:
         return root
 
     if getattr(sys, "frozen", False):
-        if portable:
+        if sys.platform == "darwin":
+            # macOS has no %PROGRAMDATA% (the literal r"C:\ProgramData" default
+            # got taken at face value, creating a directory actually *named*
+            # that), and the portable layout can't apply either: writing inside
+            # Open-Motion.app invalidates its code signature. Both variants use
+            # the standard per-user data location.
+            root = Path.home() / "Library" / "Application Support" / _APP_DIRNAME
+        elif portable:
             root = Path(sys.executable).resolve().parent
         else:
             base = os.environ.get("PROGRAMDATA", r"C:\ProgramData")
             root = Path(base) / _APP_DIRNAME
     else:
         root = Path.cwd()
-    root.mkdir(parents=True, exist_ok=True)
 
-    if not os.access(root, os.W_OK):
+    # A read-only parent (Finder launches the app with cwd="/") makes mkdir
+    # itself raise, before the os.access check below could ever redirect us.
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        writable = os.access(root, os.W_OK)
+    except OSError:
+        writable = False
+
+    if not writable:
         root = Path.home() / "Documents" / "Open-Motion"
         root.mkdir(parents=True, exist_ok=True)
     return root


### PR DESCRIPTION
Refs #427

## What

Three changes, all macOS-portability:

1. **`utils/app_paths.py`** — resolve the frozen root per-platform. On darwin both variants use `~/Library/Application Support/Openwater`.
2. **`utils/app_paths.py`** — wrap `mkdir` + the writability probe in `try/except OSError` so a refused `mkdir` falls through to `~/Documents/Open-Motion`.
3. **`tests/conftest.py`** — make the Windows-only GUI-automation imports optional so the suite is collectable on macOS.

## Why

`os.environ.get("PROGRAMDATA", r"C:\ProgramData")` is unset off Windows, so the fallback string was taken at face value — creating a directory *actually named* `C:\ProgramData` relative to the cwd, or failing hard on a Finder launch (cwd = `/`). The portable layout is no good on macOS either: writing inside `Open-Motion.app` invalidates its code signature, so both variants have to land outside the bundle.

The `mkdir` ordering was a separate latent bug: `os.access` was checked *after* `root.mkdir()`, so on a read-only parent `mkdir` raised before the fallback could ever be reached.

`conftest.py` imported `pywinauto` unconditionally, which made it unimportable on macOS — taking the platform-independent `unit` tests down with it. Every consumer lives inside a HIL fixture that a `unit`-marked run never reaches, so the imports can be optional; the two HIL modules that import `pywinauto` at module scope get `pytest.importorskip`.

## Testing

`tests/test_app_paths.py` — 10 passed. Full unit suite: **659 passed, 1 skipped, 121 deselected**. Whole suite collects: 781 tests.

The third commit fixes the new macOS tests so they pass **on Windows** too. They stubbed `$HOME`, but `Path.home()` resolves via `%USERPROFILE%` on Windows — so they escaped `tmp_path`, asserted against the developer's real home directory, and failed. One of them also created a stray `~/Library/Application Support/Openwater` on a Windows box. Now `Path.home` itself is patched, and the "no Windows path" assertion checks for a `ProgramData` component rather than a `"C:"` substring — the latter can never hold when `tmp_path` *is* a `C:\...` path.

## Notes

Branch was pushed 2026-07-30 during a macOS functionality pass; PR opened retroactively. Merges cleanly into `next` (no file overlap with anything landed since). Complements the macOS DMG CI job from #367/#368.