### PR TITLE
fix: force research mode on macOS so the DMG can start

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,6 +226,23 @@ def _load_app_config() -> dict:
         baseline["clinicalMode"] = clinical
         merged["clinicalMode"] = clinical
 
+    # macOS is a research-only platform: it is never validated or shipped for
+    # clinical use. This has to win over the bundled config AND the env
+    # override, because clinicalMode drives require_encrypted_db (see the
+    # MotionInterface construction below), and the SDK refuses the scan-db
+    # keystore on macOS outright — so a "clinical" macOS session cannot start
+    # at all, it can only fail later and less clearly. Forcing it here is what
+    # makes the DMG a coherent research build rather than a broken clinical
+    # one. build_macos.sh bundles config/ wholesale and has no variant flip of
+    # its own (unlike scripts/build_common.ps1), so this is the only gate.
+    if sys.platform == "darwin" and (baseline.get("clinicalMode") or merged.get("clinicalMode")):
+        logger.warning(
+            "clinicalMode requested on macOS — forcing Research. macOS builds "
+            "are research-only and are not validated for clinical use."
+        )
+        baseline["clinicalMode"] = False
+        merged["clinicalMode"] = False
+
     _APP_CONFIG_BASELINE.clear()
     _APP_CONFIG_BASELINE.update(baseline)
     logger.info(

--- a/tests/test_main_config_wiring.py
+++ b/tests/test_main_config_wiring.py
@@ -1,5 +1,7 @@
 import json
 import importlib
+import sys
+
 import pytest
 
 
@@ -15,3 +17,61 @@ def test_load_app_config_applies_local_override(tmp_path, monkeypatch):
     # baseline is stashed for the connector (value comes from the shipped
     # config file, so assert presence, not a specific value).
     assert "engineeringMode" in main._APP_CONFIG_BASELINE
+
+
+# --------------------------------------------------------------------------
+# macOS is research-only (SDK refuses the scan-db keystore on darwin)
+# --------------------------------------------------------------------------
+#
+# tmp_path is requested as a fixture so pytest materializes it during setup —
+# resolving it *after* sys.platform is faked to "darwin" makes pytest take its
+# POSIX branch and call os.getuid(), which does not exist on Windows.
+
+def _config_with(tmp_path, monkeypatch, platform, overrides):
+    monkeypatch.setenv("OPENWATER_DATA_ROOT", str(tmp_path))
+    (tmp_path / "app_config.local.json").write_text(
+        json.dumps(overrides), encoding="utf-8"
+    )
+    monkeypatch.setattr(sys, "platform", platform)
+    main = importlib.import_module("main")
+    return main, main._load_app_config()
+
+
+@pytest.mark.unit
+def test_macos_forces_research_mode(tmp_path, monkeypatch):
+    """clinicalMode drives require_encrypted_db, and the SDK refuses the
+    keystore on darwin — so a clinical macOS session cannot start at all."""
+    _main, cfg = _config_with(tmp_path, monkeypatch, "darwin", {"clinicalMode": True})
+    assert cfg["clinicalMode"] is False
+
+
+@pytest.mark.unit
+def test_macos_forces_research_mode_in_the_baseline_too(tmp_path, monkeypatch):
+    # the connector reads the baseline, so leaving it True would still hand a
+    # clinical flag to everything downstream of the merged config
+    main, _cfg = _config_with(tmp_path, monkeypatch, "darwin", {"clinicalMode": True})
+    assert main._APP_CONFIG_BASELINE["clinicalMode"] is False
+
+
+@pytest.mark.unit
+def test_macos_beats_the_clinical_env_override(tmp_path, monkeypatch):
+    """OPENMOTION_CLINICAL=1 normally wins over the config. "macOS is never
+    clinical" is absolute, so the platform gate has to win over it in turn —
+    otherwise the env var just produces a crash instead of a research build."""
+    monkeypatch.setenv("OPENMOTION_CLINICAL", "1")
+    _main, cfg = _config_with(tmp_path, monkeypatch, "darwin", {})
+    assert cfg["clinicalMode"] is False
+
+
+@pytest.mark.unit
+def test_non_macos_still_honors_clinical_mode(tmp_path, monkeypatch):
+    # the gate must not leak off darwin — Windows is the clinical platform
+    _main, cfg = _config_with(tmp_path, monkeypatch, "win32", {"clinicalMode": True})
+    assert cfg["clinicalMode"] is True
+
+
+@pytest.mark.unit
+def test_non_macos_still_honors_the_clinical_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENMOTION_CLINICAL", "1")
+    _main, cfg = _config_with(tmp_path, monkeypatch, "win32", {"clinicalMode": False})
+    assert cfg["clinicalMode"] is True


### PR DESCRIPTION
Refs #429

## What

Force `clinicalMode` off on darwin in `_load_app_config()`, after the env overrides.

## Why

The macOS DMG currently ships as a **clinical** build and cannot start.

`build_macos.sh` bundles `config/` wholesale, and the repo's `config/app_config.json` has `clinicalMode: true`. Unlike the Windows path, the macOS script never flips the variant or sets `OPENMOTION_CLINICAL` — `scripts/build_common.ps1` does that for the four Windows artifacts and has no macOS counterpart.

So `main.py:356` resolves `_clinical = True` → `main.py:361` passes `require_encrypted_db=True` → `MotionInterface` calls `db_key.set_policy(require_encryption=True)` → keystore → `EncryptionUnavailable`.

This is **pre-existing on `next`** — the current backend check rejects `keyring.backends.macOS` too, so the DMG already fails at startup. openmotion-sdk#210 doesn't cause this; it just makes the error name the real cause.

macOS is research-only for this product: never validated, never shipped for clinical use.

## Two deliberate choices

**It beats `OPENMOTION_CLINICAL=1`.** That env var normally wins over everything. "macOS is never clinical" is absolute, so the platform gate wins over it in turn — otherwise the env var trades a working research build for a crash. It logs a WARNING when it overrides something.

**It's a runtime gate, not a build-script change.** Fixing it in `build_macos.sh` would leave a hand-edited `app_config.local.json` able to create a clinical macOS session. The runtime gate closes that too, and doesn't depend on a build script staying correct.

## Testing

`tests/test_main_config_wiring.py` — 6 passed. Full unit suite: **664 passed, 1 skipped, 121 deselected**.

Five new tests: darwin forces research in both the merged config and `_APP_CONFIG_BASELINE` (the connector reads the baseline), darwin beats the env override, and two win32 counterparts proving the gate doesn't leak off macOS — `clinicalMode: true` on Windows still resolves `True`.

## Related

- openmotion-sdk#210 — refuses the keystore on macOS (the other half; that one makes the failure legible, this one removes the failure)
- #428 — macOS data-root resolution