### PR TITLE
fix: bundle the replay sample scan in the macOS .app

### DIFF
--- a/build_macos.sh
+++ b/build_macos.sh
@@ -84,6 +84,28 @@ for folder in ("pages", "components", "assets", "models", "config"):
     if os.path.isdir(folder):
         datas.append((folder, folder))
 
+# Bundle the replay sample scan (#314) — loaded into the viewer when no device
+# is connected at boot. Located at runtime via
+# utils.resource_path.resource_path("resources", "sample_scan.csv").
+#
+# A targeted file entry rather than adding "resources" to the folder loop
+# above: that directory also holds the Windows DFU driver payload
+# (OpenMotionDriver-x64.zip), which is dead weight inside a .app.
+_SAMPLE_SCAN = os.path.join("resources", "sample_scan.csv")
+if os.path.exists(_SAMPLE_SCAN):
+    datas.append((_SAMPLE_SCAN, "resources"))
+else:
+    # Optional, so not fatal — but never silent. Dropping it here is how the
+    # runtime file goes missing, and the app can only report the absence after
+    # the fact (a warning in the boot log, no sample in the viewer). macOS is
+    # research-only (see the darwin clamp in main.py), so the offer dialog is
+    # always reachable there and a missing file is always user-visible.
+    print(
+        f"[spec] WARNING: {_SAMPLE_SCAN!r} not found in {os.getcwd()} — the "
+        "build will ship without a replay sample scan; the no-device offer "
+        "dialog will appear and then do nothing."
+    )
+
 # Ensure icon is bundled
 if os.path.exists(ICNS_FILE):
     datas.append((ICNS_FILE, "."))

--- a/openwater_macos.spec
+++ b/openwater_macos.spec
@@ -20,6 +20,28 @@ for folder in ("pages", "components", "assets", "models", "config"):
     if os.path.isdir(folder):
         datas.append((folder, folder))
 
+# Bundle the replay sample scan (#314) — loaded into the viewer when no device
+# is connected at boot. Located at runtime via
+# utils.resource_path.resource_path("resources", "sample_scan.csv").
+#
+# A targeted file entry rather than adding "resources" to the folder loop
+# above: that directory also holds the Windows DFU driver payload
+# (OpenMotionDriver-x64.zip), which is dead weight inside a .app.
+_SAMPLE_SCAN = os.path.join("resources", "sample_scan.csv")
+if os.path.exists(_SAMPLE_SCAN):
+    datas.append((_SAMPLE_SCAN, "resources"))
+else:
+    # Optional, so not fatal — but never silent. Dropping it here is how the
+    # runtime file goes missing, and the app can only report the absence after
+    # the fact (a warning in the boot log, no sample in the viewer). macOS is
+    # research-only (see the darwin clamp in main.py), so the offer dialog is
+    # always reachable there and a missing file is always user-visible.
+    print(
+        f"[spec] WARNING: {_SAMPLE_SCAN!r} not found in {os.getcwd()} — the "
+        "build will ship without a replay sample scan; the no-device offer "
+        "dialog will appear and then do nothing."
+    )
+
 # Ensure icon is bundled
 if os.path.exists(ICNS_FILE):
     datas.append((ICNS_FILE, "."))
@@ -95,8 +117,10 @@ app = BUNDLE(
     bundle_identifier="com.openwaterhealth.bloodflow",
     info_plist={
         "CFBundleDisplayName": APP_NAME,
-        "CFBundleShortVersionString": os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
-        "CFBundleVersion": os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
+        "CFBundleShortVersionString": os.environ.get("OPENMOTION_VERSION")
+            or os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
+        "CFBundleVersion": os.environ.get("OPENMOTION_VERSION")
+            or os.popen("python version.py 2>/dev/null").read().strip() or "0.0.0",
         "NSHighResolutionCapable": True,
         "LSMinimumSystemVersion": "12.0",
         "NSPrincipalClass": "NSApplication",

--- a/tests/test_pyinstaller_spec.py
+++ b/tests/test_pyinstaller_spec.py
@@ -1,4 +1,5 @@
 import ast
+import re
 from pathlib import Path
 
 import pytest
@@ -7,8 +8,50 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# build_macos.sh writes openwater_macos.spec from an inline heredoc on every
+# run, so the heredoc — not the tracked .spec — is the source of truth.
+_MACOS_HEREDOC_RE = re.compile(
+    r"cat > \"\$SPEC_FILE\" << 'SPEC_EOF'\n(.*?)\nSPEC_EOF\n", re.S
+)
+
+
+def _macos_spec_source() -> str:
+    """The macOS spec as build_macos.sh would emit it."""
+    script = (_REPO_ROOT / "build_macos.sh").read_text(encoding="utf-8")
+    match = _MACOS_HEREDOC_RE.search(script)
+    assert match, "could not find the spec heredoc in build_macos.sh"
+    return match.group(1) + "\n"
+
+
+def _bundles_sample_scan(source: str) -> bool:
+    """True when `source` declares the replay sample scan as a data file.
+
+    Structural rather than a substring match: looks for the module-level
+    ``_SAMPLE_SCAN = os.path.join("resources", "sample_scan.csv")`` binding
+    both specs use, so a spec that merely mentions the file in a comment
+    does not pass.
+    """
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "_SAMPLE_SCAN"
+            for t in node.targets
+        ):
+            continue
+        parts = [
+            a.value for a in getattr(node.value, "args", [])
+            if isinstance(a, ast.Constant) and isinstance(a.value, str)
+        ]
+        if parts == ["resources", "sample_scan.csv"]:
+            return True
+    return False
+
+
 def _hidden_imports_from_spec() -> set[str]:
-    spec_path = Path(__file__).resolve().parents[1] / "openwater.spec"
+    spec_path = _REPO_ROOT / "openwater.spec"
     tree = ast.parse(spec_path.read_text(encoding="utf-8"), filename=str(spec_path))
 
     hidden_imports: set[str] = set()
@@ -39,3 +82,33 @@ def test_pyinstaller_spec_bundles_runtime_dependency_hidden_imports():
         "crcmod",
         "base58",
     } <= _hidden_imports_from_spec()
+
+
+@pytest.mark.parametrize("spec", ["windows", "macos"])
+def test_every_spec_bundles_the_replay_sample_scan(spec):
+    """Both platform specs must ship resources/sample_scan.csv (#432).
+
+    The macOS spec listed only whole folders (pages/components/assets/models/
+    config) and never picked up `resources`, so the DMG shipped without the
+    sample. The no-device offer dialog does not gate on the file's existence,
+    so it still appeared and then silently did nothing when clicked.
+    """
+    source = (
+        (_REPO_ROOT / "openwater.spec").read_text(encoding="utf-8")
+        if spec == "windows"
+        else _macos_spec_source()
+    )
+    assert _bundles_sample_scan(source)
+
+
+def test_tracked_macos_spec_matches_build_script():
+    """The checked-in openwater_macos.spec is generated output — keep it equal
+    to the heredoc that produces it.
+
+    It is regenerated on every build, so a hand-edit to one side alone is
+    silently discarded (and a stale copy misleads anyone reading it: before
+    #432 the tracked file still predated the OPENMOTION_VERSION support added
+    in #368).
+    """
+    tracked = (_REPO_ROOT / "openwater_macos.spec").read_text(encoding="utf-8")
+    assert tracked == _macos_spec_source()


### PR DESCRIPTION
Refs #432

## Problem

On the macOS DMG the startup "No console detected — would you like to open a sample dataset?" dialog appears, but clicking **Open sample dataset** does nothing: no plot, no toast, no error.

`resources/sample_scan.csv` is never bundled into the `.app`. `openwater.spec` (Windows) has a targeted `datas` entry for it; the macOS spec that `build_macos.sh` generates from an inline heredoc listed only whole folders — `pages`, `components`, `assets`, `models`, `config` — and `resources` was not among them.

The dialog is not gated on the file existing (`_maybe_offer_sample_scan` only *logs* availability, then emits regardless), so `_load_sample_scan` stats a missing path, logs a WARNING and returns. Fail-soft by design, indistinguishable from a dead button in the UI.

This only became reachable after #430 forced research mode on darwin — before that the DMG ran as a clinical build and never offered the sample at all.

## Change

- Mirror the Windows targeted `datas` entry, plus its missing-file build warning, in the `build_macos.sh` heredoc. A per-file entry rather than adding `resources` to the folder loop, so the Windows DFU driver payload (`OpenMotionDriver-x64.zip`) is not dragged into the `.app`.
- Regenerate the tracked `openwater_macos.spec` from that heredoc. It is generated output and had **already drifted** — the checked-in copy still predated the `OPENMOTION_VERSION` support added in #368, so anyone reading it (including during review of this area) sees something the build does not emit.
- Tests in `tests/test_pyinstaller_spec.py`:
  - `test_every_spec_bundles_the_replay_sample_scan[windows|macos]` — structural (AST) check that both specs declare the sample scan, so a comment mentioning the filename cannot satisfy it.
  - `test_tracked_macos_spec_matches_build_script` — drift guard; the heredoc is the source of truth and a hand-edit to the tracked spec alone is silently discarded on the next build.

## Verification

- Both new tests fail against `origin/next` and pass here (checked by running the helpers against `git show origin/next:build_macos.sh`: pre-fix `_bundles_sample_scan` → `False`, pre-fix tracked spec ≠ heredoc).
- `python -m pytest tests/test_pyinstaller_spec.py` → 4 passed.
- `bash -n build_macos.sh` and `ast.parse(openwater_macos.spec)` both clean.
- Full `-m unit` suite: 708 passed. The 2 failures are pre-existing local noise — `test_app_config_defaults` and `test_bvi_lpf` `rglob` the repo root and pick up my gitignored `.worktrees/` and `dist/` leftovers, which their exclusion lists do not cover. Unrelated to this diff (it touches no QML and no app config) and absent on a clean CI checkout.

**Not verified on a real DMG** — I have no macOS machine here. The runtime path is unchanged and already proven by the `config/` bundle, which resolves through the same `sys._MEIPASS` → `Contents/Frameworks` symlink; but the end-to-end check (build the DMG, launch with no device, accept the offer, see traces) is worth doing before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)