### PR TITLE
feat: tell the operator to check sensor airflow in the over-temp toast

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -572,7 +572,8 @@ class _LivePlotSink:
                         if temp_toast_enabled:
                             connector.notify(
                                 f"Camera {side.upper()} {cam_id + 1} temperature "
-                                f"{temp_c:.1f}°C — above {threshold:.0f}°C threshold",
+                                f"{temp_c:.1f}°C — above {threshold:.0f}°C threshold. "
+                                f"Check the airflow around the sensor module.",
                                 type_="warning",
                                 duration_ms=5000,
                                 tag=f"temp_{side}_{cam_id}",

--- a/tests/test_live_plot_sink.py
+++ b/tests/test_live_plot_sink.py
@@ -296,6 +296,8 @@ def test_over_temp_fires_a_toast_not_just_a_log_line():
     assert toast["durationMs"] == 5000   # auto-dismiss, not sticky
     assert "LEFT 3" in toast["text"]
     assert "112.0" in toast["text"]
+    # The operator needs an action, not just a number.
+    assert "airflow" in toast["text"]
     # The log line is unchanged — the toast is additive.
     assert len(conn.captureLog.calls) == 1
 


### PR DESCRIPTION
## What

The mid-scan over-temperature toast stated a number and nothing else:

> Camera LEFT 3 temperature 42.1°C — above 40°C threshold

That tells the operator a camera is hot but not what to do about it. The toast now reads:

> Camera LEFT 3 temperature 42.1°C — above 40°C threshold. Check the airflow around the sensor module.

This is to get in line with **SPEC-30**.

## Scope

Copy only. Unchanged: `warning` severity, 5 s auto-dismiss, the per-camera/per-scan latch and `temp_<side>_<cam>` tag, the Research-only gate (clinical builds still get the log line without the popup), and the `captureLog` / app-log line. `components/NotificationCenter.qml` is 340 px wide with `wrapMode: Text.Wrap`, so the longer string wraps instead of clipping.

## Verification

`tests/test_live_plot_sink.py::test_over_temp_fires_a_toast_not_just_a_log_line` now also asserts the guidance is present, so the copy can't silently regress. Full module: **23 passed**.

Not exercised on hardware — no behavioral path changed, only the string.

## Noted, not addressed here

- #424 — these toasts are reported as not appearing at all during scans. If that's still live, the new copy won't be seen either.
- The camera-dropout toast (`motion_connector.py` ~5116) carries the same thermal root cause and does *not* carry this guidance.

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)