### PR TITLE
feat: warn operators not to enter PII in session notes (Refs #438)

### DIFF
--- a/components/NotesModal.qml
+++ b/components/NotesModal.qml
@@ -129,11 +129,10 @@ Item {
                 }
             }
 
-            // Clinical builds only: session notes ride along into scans.db
-            // and CSV exports, so remind the operator not to make this a
-            // PHI sink. Research builds don't get the line.
+            // Session notes ride along into scans.db and CSV exports, so
+            // remind the operator not to make this a PHI sink. Shown in
+            // every build variant — research exports leave the app too.
             Text {
-                visible: MotionInterface.appConfig.clinicalMode === true
                 text: "Do not enter any patient identifiable information in these notes."
                 color: AppTheme.textSecondary
                 font.pixelSize: 12

--- a/components/NotesModal.qml
+++ b/components/NotesModal.qml
@@ -129,6 +129,20 @@ Item {
                 }
             }
 
+            // Clinical builds only: session notes ride along into scans.db
+            // and CSV exports, so remind the operator not to make this a
+            // PHI sink. Research builds don't get the line.
+            Text {
+                visible: MotionInterface.appConfig.clinicalMode === true
+                text: "Do not enter any patient identifiable information in these notes."
+                color: AppTheme.textSecondary
+                font.pixelSize: 12
+                font.italic: true
+                wrapMode: Text.Wrap
+                horizontalAlignment: Text.AlignHCenter
+                Layout.fillWidth: true
+            }
+
         }
 
         Keys.onReleased: function(event) {


### PR DESCRIPTION
Refs #438. Relates to PRODREQ-99.

## What

Adds a short italic advisory line at the bottom of the Session Notes pane:

> *Do not enter any patient identifiable information in these notes.*

## Why

Session notes persist to `sessions.session_notes` in `scans.db` and ride along
into History → Export CSV and debug bundles, so the free-text field is an easy
accidental PHI sink. The pane previously offered no guidance about what belongs
in it.

Shown in **every build variant** — research builds write the same rows and
offer the same export, so the reminder applies there too.

## Scope

One file, `components/NotesModal.qml`: a `Text` appended to the modal's
`ColumnLayout` after the notes `TextArea`. `AppTheme.textSecondary`, 12 px,
italic, centered, wrapping.

Advisory text only — no validation, no blocking, no change to what is stored or
exported.

## Verification

Launched from source against the bench (clinical build, 1200×800) and opened
the Session Notes modal: the line renders italic and centered below the text
area, with the text area shrinking to accommodate it. No layout overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
