### PR TITLE
test: HIL suite expansion → main (path-scoped snapshot of test/test-fixes)

### DIFF
--- a/tests/Reliability_Test_Script.py
+++ b/tests/Reliability_Test_Script.py
@@ -1,0 +1,1352 @@
+"""
+Reliability Test Script — overnight life test in clinical (FDA) mode.
+
+The script runs the app exactly as configured on the host. Set the desired
+mode before launching, e.g. ``"clinicalMode": true`` in the writable
+overrides file ``%PROGRAMDATA%\\Openwater\\app_config.local.json`` (the
+packaged app's bundled config in Program Files is read-only). A module
+fixture logs the effective mode and warns when clinicalMode is off.
+"""
+
+import atexit
+import getpass
+import glob
+import json
+import logging
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import psutil
+import pyautogui
+import pygetwindow as gw
+import pytest
+from pywinauto import Desktop as UiaDesktop
+
+import shelly
+
+
+pyautogui.FAILSAFE = True
+pyautogui.PAUSE = 0.5
+
+log = logging.getLogger("hil_tests")
+
+pytestmark = pytest.mark.release
+
+
+# ─── Configuration ──────────────────────────────────────────────────
+CYCLE_COUNT          = 724       # number of (5-scan + power-cycle) cycles
+SCANS_PER_CYCLE      = 5
+SCAN_DURATION_MIN    = 10
+QUALITY_CHECK_TIMEOUT = 180     # max wait for "Good signal quality" modal
+START_RETRY_SEC      = 60       # re-click Start if no dialog after this long
+STOP_SETTLE_SEC      = 15       # extra settle after teardown completes
+# Under USB stress the app can take ~2 min to register Stop and flush;
+# observed 122 s on a stressed scan. Wait comfortably past that so the
+# next Start lands after teardown instead of falling through to the retry.
+SCAN_TEARDOWN_TIMEOUT = 240     # max wait for "Full scan ended" after Stop
+POWER_CYCLE_OFF_SEC  = 5.0
+RECONNECT_TIMEOUT    = 60
+RECONNECT_SETTLE_SEC = 30       # after CONNECTED: let sensors re-enumerate
+INTER_SCAN_PAUSE_SEC = 5
+
+# Per-scan integrity gates catch ACUTE faults — a dead sensor side, a scan
+# where a large slice of data was fabricated. A cycle tripping one is
+# recorded FAIL and the run continues. Set a threshold to 0 to disable.
+#
+# Thresholds calibrated against the 2026-06/07 campaign: on a healthy run
+# affected scans sat at 8 NaN-filled frames; on the 14-day run the p99 was
+# 84 with two outliers in the tens of thousands. 100 therefore flags the
+# genuinely broken scan without firing on ordinary repair.
+FAIL_ON_CONTACT_QUALITY = True   # any camera reporting no_signal/poor_contact
+MAX_NAN_FILLED_FRAMES   = 100    # per scan, summed across the scan summaries
+MAX_HISTO_QUEUE_FULL    = 50     # per scan, firmware histo-queue overflows
+# Mid-scan contact loss (the SDK live monitor, #364). Contact is allowed to
+# drop and come back — the monitor emits RAISED then CLEARED, and a brief
+# loss is not a scan failure. What fails a scan is contact that stays lost:
+# if any camera is still poor after CQ_RECOVERY_TIMEOUT the scan is stopped.
+CQ_RECOVERY_TIMEOUT     = 180    # s to wait for contact to come back
+CQ_RECOVERY_POLL_SEC    = 5      # tighter polling while waiting to recover
+# Optional churn gate: fail even when every loss recovered, if there were
+# more than N of them in one scan. -1 disables (the default — recovery is
+# the thing that matters). Set to 0 to fail on any loss at all.
+MAX_LIVE_CQ_RAISES      = -1     # per scan; -1 disables the gate
+
+# Per-scan gates alone do NOT catch slow degradation: over the 14-day run the
+# share of scans needing repair went 3% -> 100% while the median stayed at 28
+# frames, so every individual scan passed. The trend check below compares the
+# first and last tenth of the run and is what actually surfaces that.
+DEGRADATION_FACTOR     = 3.0     # last-decile / first-decile rate that flags
+DEGRADATION_MIN_CYCLES = 20      # below this the comparison is meaningless
+
+SCAN_DURATION_SEC = SCAN_DURATION_MIN * 60
+SLEEP             = 2
+
+# App window identification + paths. The packaged 1.4.x window is titled
+# "Open-Motion" (clinical) or "Open-Motion Research".
+APP_KEYWORDS = ("open-motion", "openmotion", "bloodflow", "openwater")
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+APP_CONFIG_PATH = PROJECT_ROOT / "config" / "app_config.json"
+
+# Fallback Start-Scan button position (relative to the app window),
+# used when UIA can't find the modal's button element.
+_START_SCAN_BUTTON_REL = (0.58, 0.78)
+
+# Fallback 'Continue' position on the mid-scan Contact Quality Notification
+# modal, measured from a 1.5.0-dev.5 clinical window.
+_CQ_CONTINUE_BUTTON_REL = (0.538, 0.699)
+
+# SDK logs one transition line per state change.
+RE_CONNECTED = re.compile(r"state \S+ -> CONNECTED")
+
+# Connector logs this once scan teardown (flush + post-processing) is done.
+RE_SCAN_ENDED = re.compile(r"Full scan ended")
+
+# The connector logs the pre-scan contact-quality verdict as a per-camera
+# table, every row at INFO — including failures. A dark camera reads
+# `no_signal`, one under the light threshold reads `poor_contact`. Nothing
+# escalates, so the only way this run can notice is to parse the table.
+RE_CQ_ROW = re.compile(r"\|\s*([LR]\d)\s*\|.*?\|\s*(ok|no_signal|poor_contact)\s*\|")
+
+# Contact loss *during* a scan is reported by the SDK's live monitor
+# (bloodflow-app#364) in a completely different format from the pre-scan
+# table above — parsing only the table misses every mid-scan event, which is
+# the case that matters most clinically.
+RE_CQ_LIVE_RAISE = re.compile(r"live CQ ([LR]\d): poor_contact RAISED \(([-\d.]+) DN\)")
+# Both edges, in order, so the run can tell "lost and came back" from
+# "still lost". The monitor CLEARs at ~2 s of good frames (#364).
+RE_CQ_LIVE_EVENT = re.compile(
+    r"live CQ ([LR]\d): poor_contact (RAISED|CLEARED) \(([-\d.]+) DN\)"
+)
+
+# Pipeline integrity. Frames the firmware never delivered get NaN-filled by
+# the timestamp-repair stage; the firmware reports a full histogram queue
+# when the host-side drain stalls. Both climb with uptime.
+RE_NAN_FILL   = re.compile(r"Scan summary:.*?(\d+) frames NaN-filled")
+RE_HISTO_FULL = re.compile(r"HISTO enqueue fail: queue full")
+
+# Sidebar Start/Stop position (relative to the app window).
+SIDEBAR_START = (0.019, 0.115)
+
+
+# ─── Module state (populated by fixtures, consumed by the report) ───
+_REPORT_SESSION_START: datetime | None = None
+_REPORT_APP_VERSION:   str | None = None
+_CYCLE_RESULTS: list[dict] = []
+# Set when the bench is no longer usable (app gone). Remaining cycles are
+# skipped rather than reported as failures they never got to attempt.
+_RUN_ABORTED: str | None = None
+
+
+class ScanFailure(Exception):
+    """A cycle failed but the bench is still usable — record FAIL, keep going.
+
+    Everything that used to call ``pytest.fail`` mid-cycle raises this
+    instead. ``pytest.fail`` aborted the entire run, which is how a single
+    smart-plug timeout at cycle 42 discarded the remaining 380 cycles.
+
+    ``metrics`` carries the failing scan's observed counters so the report
+    can show *why* alongside *how much* — without it a cycle reads
+    "FAIL: mid-scan contact loss x4" while its own count column shows 0.
+    """
+
+    def __init__(self, message: str, metrics: dict | None = None):
+        super().__init__(message)
+        self.metrics = metrics or {}
+
+
+class FatalFailure(Exception):
+    """The bench is unusable (app window gone) — record FAIL and stop."""
+
+    def __init__(self, message: str, metrics: dict | None = None):
+        super().__init__(message)
+        self.metrics = metrics or {}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Window / UIA helpers (inlined so this script has no conftest dep)
+# ═══════════════════════════════════════════════════════════════════
+# Title keywords false-positive on a File Explorer window sitting at the
+# repo folder or a browser tab with the repo open, so a matching window
+# is accepted only when its owning process is the app itself.
+_APP_PROCESS_PREFIXES = ("open-motion", "openwaterapp")
+
+
+def _is_app_window(w) -> bool:
+    """True if window ``w`` is the bloodflow app (title + owning process)."""
+    title = (w.title or "").strip().lower()
+    if not title or not any(k in title for k in APP_KEYWORDS):
+        return False
+    hwnd = getattr(w, "_hWnd", None)
+    if hwnd is None:
+        return True
+    try:
+        import ctypes
+        pid = ctypes.c_ulong()
+        ctypes.windll.user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+        if pid.value == 0:
+            return True
+        proc = psutil.Process(pid.value)
+        name = proc.name().lower()
+    except Exception:
+        return True          # PID lookup failed — fall back to title match
+    if name.startswith(_APP_PROCESS_PREFIXES):
+        return True
+    if name in ("python.exe", "pythonw.exe"):   # from-source launch
+        try:
+            return "main.py" in " ".join(proc.cmdline()).lower()
+        except Exception:
+            return False
+    return False
+
+
+def get_app_window():
+    """Return a pygetwindow Window object for the bloodflow app."""
+    for w in gw.getAllWindows():
+        if _is_app_window(w):
+            return w
+    raise RuntimeError("App window not found")
+
+
+def is_app_alive() -> bool:
+    """True if the app window still exists."""
+    for w in gw.getAllWindows():
+        if _is_app_window(w):
+            return True
+    return False
+
+
+def ensure_visible() -> bool:
+    """Bring the app window to the foreground. True if found."""
+    for w in gw.getAllWindows():
+        if _is_app_window(w):
+            try:
+                if w.isMinimized:
+                    w.restore()
+                    time.sleep(2)
+                w.activate()
+                time.sleep(1)
+            except Exception:
+                pass
+            return True
+    return False
+
+
+def require_focus() -> None:
+    """Ensure the app window is foreground; fail if it can't be found."""
+    if not ensure_visible():
+        raise RuntimeError("App window not found — cannot ensure focus")
+
+
+def move_window_on_screen() -> None:
+    """Move the app window onto the primary screen if it is off-screen."""
+    try:
+        w = get_app_window()
+        screen_w, screen_h = pyautogui.size()
+        if w.left < 0 or w.top < 0 or w.left > screen_w or w.top > screen_h:
+            log.warning(
+                f"  Window is off-screen at ({w.left}, {w.top}) — "
+                f"moving to primary display"
+            )
+            w.moveTo(50, 50)
+            time.sleep(1)
+            log.info(f"  Window moved to ({w.left}, {w.top})")
+    except Exception as e:
+        log.warning(f"  move_window_on_screen failed: {e}")
+
+
+# Exact window titles by build variant: clinical, research, legacy.
+_UIA_TITLES = ("Open-Motion", "Open-Motion Research", "OpenWater Bloodflow")
+
+
+def uia_window(retries: int = 3):
+    """Return the bloodflow app's UIA window spec."""
+    for attempt in range(retries):
+        ensure_visible()
+        desktop = UiaDesktop(backend="uia")
+        for exact in _UIA_TITLES:
+            try:
+                spec = desktop.window(title=exact)
+                if spec.exists(timeout=2):
+                    return spec
+            except Exception:
+                pass
+        for kw in APP_KEYWORDS:
+            try:
+                for win in desktop.windows(title_re=f"(?i).*{kw}.*"):
+                    title = win.window_text()
+                    if "File Explorer" in title or "Chrome" in title:
+                        continue
+                    if any(k in title.lower() for k in APP_KEYWORDS):
+                        return desktop.window(title=title)
+            except Exception:
+                continue
+        if attempt < retries - 1:
+            time.sleep(2)
+    raise RuntimeError("App window not found via UI Automation")
+
+
+def click_sidebar(rx: float, ry: float, label: str = "") -> None:
+    """Click a sidebar button using window-relative coordinates."""
+    ensure_visible()
+    w = get_app_window()
+    x = int(w.left + rx * w.width)
+    y = int(w.top + ry * w.height)
+    log.info(f"  click '{label}' rel({rx:.3f}, {ry:.3f}) abs({x}, {y})")
+    pyautogui.moveTo(x, y, duration=0.3)
+    pyautogui.click(x, y)
+    time.sleep(SLEEP)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# App config helpers (read-only — the operator sets the mode)
+# ═══════════════════════════════════════════════════════════════════
+# The packaged app layers %PROGRAMDATA%\Openwater\app_config.local.json
+# over its read-only bundled config (see utils/config_store.py). This
+# script never writes either file: put the desired mode in the overrides
+# file before starting the run.
+def _writable_root() -> Path:
+    """The app's writable data root (config overrides, logs, scan data)."""
+    env = os.environ.get("OPENWATER_DATA_ROOT")
+    if env:
+        return Path(env)
+    return Path(os.environ.get("PROGRAMDATA", r"C:\ProgramData")) / "Openwater"
+
+
+def _merged_app_config() -> dict:
+    """Best-effort view of the config the app reads: the installed exe's
+    bundled config (repo config as fallback) + writable overrides."""
+    cfg: dict = {}
+    exe = _running_app_exe_path() or _find_installed_exe()
+    if exe:
+        bundled = Path(exe).parent / "_internal" / "config" / "app_config.json"
+        try:
+            cfg.update(json.loads(bundled.read_text(encoding="utf-8")))
+        except Exception:
+            pass
+    if not cfg:
+        try:
+            cfg.update(json.loads(APP_CONFIG_PATH.read_text(encoding="utf-8")))
+        except Exception:
+            pass
+    try:
+        overrides = _writable_root() / "app_config.local.json"
+        cfg.update(json.loads(overrides.read_text(encoding="utf-8")))
+    except Exception:
+        pass
+    return cfg
+
+
+# ═══════════════════════════════════════════════════════════════════
+# App-log tailing (used to verify console reconnect after power cycle)
+# ═══════════════════════════════════════════════════════════════════
+def find_app_log() -> Path | None:
+    """Locate the log written by the app instance under test.
+
+    An installed build writes ``<writable-root>/logs/open-motion-*.log``
+    (%PROGRAMDATA%\\Openwater, or $OPENWATER_DATA_ROOT). A **portable** build
+    writes next to its own exe instead — e.g.
+    ``Documents/OpenMotion/Open-Motion-1.5.0-dev.5/Open-Motion/logs/`` — which
+    is several levels below any root below, so the old one-level
+    ``logs/open-motion-*.log`` glob missed it entirely and this fell back to
+    a stale log from an unrelated launch. The running exe's own directory is
+    therefore checked first and wins outright when it has a log.
+    """
+    exe = _running_app_exe_path()
+    if exe:
+        exe_logs = sorted(
+            Path(exe).parent.glob("logs/open-motion-*.log"),
+            key=lambda p: p.stat().st_mtime,
+        )
+        if exe_logs:
+            return exe_logs[-1]
+
+    home = Path.home()
+    roots = [
+        _writable_root(),
+        Path.cwd(),
+        PROJECT_ROOT,
+        home / "Documents" / "Open-Motion",
+        home / "Documents" / "OpenWater Bloodflow",
+        home / "Documents" / "OpenMotion",
+    ]
+    candidates: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        candidates.extend(root.glob("logs/open-motion-*.log"))
+        candidates.extend(root.glob("**/logs/open-motion-*.log"))
+        candidates.extend(root.glob("**/app-logs/ow-bloodflowapp-*.log"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def log_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def wait_for_pattern(
+    pattern: re.Pattern, log_path: Path, start_offset: int, timeout: float
+) -> str | None:
+    """Tail ``log_path`` from ``start_offset``; return first match within timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with log_path.open("r", encoding="utf-8", errors="replace") as f:
+                f.seek(start_offset)
+                for line in f:
+                    if pattern.search(line):
+                        return line.strip()
+        except OSError:
+            pass
+        time.sleep(0.5)
+    return None
+
+
+def read_log_slice(log_path: Path | None, start_offset: int) -> str:
+    """Everything written to ``log_path`` since ``start_offset``."""
+    if not log_path:
+        return ""
+    try:
+        with log_path.open("r", encoding="utf-8", errors="replace") as f:
+            f.seek(start_offset)
+            return f.read()
+    except OSError:
+        return ""
+
+
+def contact_quality_failures(slice_text: str) -> list[str]:
+    """Cameras the pre-scan contact-quality check flagged, e.g. ``["R1=no_signal"]``.
+
+    Deliberately reports every flagged camera rather than a count: a whole
+    side reading ``no_signal`` is a different fault from one marginal camera.
+    """
+    return [
+        f"{cam}={reason}"
+        for cam, reason in RE_CQ_ROW.findall(slice_text)
+        if reason != "ok"
+    ]
+
+
+def scan_metrics(
+    scan_idx: int, slice_text: str, completed: bool
+) -> dict:
+    """Observed counters for one scan, from its slice of the app log.
+
+    Built the same way whether the scan passed or failed, so a failing cycle
+    reports real numbers instead of zeros.
+    """
+    nan_filled, histo_full = integrity_counts(slice_text)
+    return {
+        "scan":             scan_idx,
+        "completed":        completed,
+        "nan_filled":       nan_filled,
+        "histo_queue_full": histo_full,
+        "cq_flagged":       contact_quality_failures(slice_text),
+        "cq_live_raises":   live_cq_raises(slice_text),
+        "cq_unresolved":    cameras_currently_poor(slice_text),
+    }
+
+
+def live_cq_raises(slice_text: str) -> list[str]:
+    """Mid-scan contact-quality RAISE events, e.g. ``["R7@1.99DN"]``.
+
+    Separate from ``contact_quality_failures`` because the two come from
+    different subsystems: the pre-scan check gates scan start, the live
+    monitor watches the scan in flight. A scan can pass one and fail the
+    other, and the run needs to notice either.
+    """
+    return [f"{cam}@{dn}DN" for cam, dn in RE_CQ_LIVE_RAISE.findall(slice_text)]
+
+
+def cameras_currently_poor(slice_text: str) -> list[str]:
+    """Cameras whose most recent live event was RAISED, i.e. still bad.
+
+    A camera that raised and later cleared is not listed — that is a
+    recovered transient, not a failure.
+    """
+    state: dict[str, str] = {}
+    for cam, edge, _dn in RE_CQ_LIVE_EVENT.findall(slice_text):
+        state[cam] = edge
+    return sorted(cam for cam, edge in state.items() if edge == "RAISED")
+
+
+def integrity_counts(slice_text: str) -> tuple[int, int]:
+    """``(frames NaN-filled, histo queue-full events)`` for one scan."""
+    nan_filled = sum(int(n) for n in RE_NAN_FILL.findall(slice_text))
+    histo_full = len(RE_HISTO_FULL.findall(slice_text))
+    return nan_filled, histo_full
+
+
+def degradation_check(results: list[dict]) -> dict:
+    """Compare the first and last tenth of the run for a worsening trend.
+
+    Slow degradation is invisible to per-scan gates — the campaign that
+    motivated this ran 380 cycles while frame repair climbed from 3% to 100%
+    of scans and every individual scan stayed under threshold. Comparing the
+    ends of the run is what makes that visible.
+    """
+    n = len(results)
+    if n < DEGRADATION_MIN_CYCLES:
+        return {"checked": False, "reason": f"only {n} cycles (need {DEGRADATION_MIN_CYCLES})"}
+
+    span = max(1, n // 10)
+    first, last = results[:span], results[-span:]
+
+    def rate(rows: list[dict], key: str) -> float:
+        return sum(r.get(key, 0) for r in rows) / len(rows)
+
+    out: dict = {"checked": True, "cycles_compared": span, "degraded": False, "metrics": {}}
+    for key in ("nan_filled", "histo_queue_full"):
+        f, l = rate(first, key), rate(last, key)
+        # A near-zero baseline is normal and healthy; treat it as 1 so the
+        # ratio reflects real growth instead of dividing by ~0.
+        ratio = l / max(f, 1.0)
+        degraded = ratio >= DEGRADATION_FACTOR and l > 1.0
+        out["metrics"][key] = {
+            "first_decile_per_cycle": round(f, 2),
+            "last_decile_per_cycle":  round(l, 2),
+            "ratio":                  round(ratio, 1),
+            "degraded":               degraded,
+        }
+        out["degraded"] = out["degraded"] or degraded
+    return out
+
+
+def _degradation_md(deg: dict) -> str:
+    """Render the degradation check as a markdown block for the report."""
+    if not deg.get("checked"):
+        return f"_Not evaluated — {deg.get('reason', 'insufficient data')}._"
+
+    rows = "\n".join(
+        f"| {key} | {m['first_decile_per_cycle']} | {m['last_decile_per_cycle']} | "
+        f"{m['ratio']}x | {'**YES**' if m['degraded'] else 'no'} |"
+        for key, m in deg["metrics"].items()
+    )
+    verdict = (
+        "**DEGRADATION DETECTED** — the run got measurably worse over time. "
+        "Per-cycle results may all be PASS; that does not mean the system was "
+        "stable across the run."
+        if deg["degraded"] else
+        "No significant trend between the start and end of the run."
+    )
+    return f"""Comparing the first and last {deg['cycles_compared']} cycle(s):
+
+| Metric | First decile / cycle | Last decile / cycle | Ratio | Degraded |
+|--------|---------------------|---------------------|-------|----------|
+{rows}
+
+{verdict}"""
+
+
+def evaluate_scan(slice_text: str, scan_ended: bool) -> list[str]:
+    """Reasons this scan should be considered failed. Empty list = pass."""
+    reasons: list[str] = []
+
+    if not scan_ended:
+        reasons.append(
+            f"no 'Full scan ended' within {SCAN_TEARDOWN_TIMEOUT}s of Stop"
+        )
+
+    if FAIL_ON_CONTACT_QUALITY:
+        flagged = contact_quality_failures(slice_text)
+        if flagged:
+            reasons.append(f"pre-scan contact quality: {', '.join(flagged)}")
+
+    # Contact still down when the scan ended — never recovered.
+    unresolved = cameras_currently_poor(slice_text)
+    if unresolved:
+        reasons.append(f"contact still poor at scan end: {', '.join(unresolved)}")
+
+    # Optional churn gate: every loss recovered, but there were too many.
+    if MAX_LIVE_CQ_RAISES >= 0:
+        raises = live_cq_raises(slice_text)
+        if len(raises) > MAX_LIVE_CQ_RAISES:
+            reasons.append(
+                f"mid-scan contact loss x{len(raises)} (limit "
+                f"{MAX_LIVE_CQ_RAISES}): {', '.join(raises[:6])}"
+                + (" …" if len(raises) > 6 else "")
+            )
+
+    nan_filled, histo_full = integrity_counts(slice_text)
+    if MAX_NAN_FILLED_FRAMES and nan_filled > MAX_NAN_FILLED_FRAMES:
+        reasons.append(
+            f"{nan_filled} frames NaN-filled (limit {MAX_NAN_FILLED_FRAMES})"
+        )
+    if MAX_HISTO_QUEUE_FULL and histo_full > MAX_HISTO_QUEUE_FULL:
+        reasons.append(
+            f"{histo_full} histo queue-full events (limit {MAX_HISTO_QUEUE_FULL})"
+        )
+    return reasons
+
+
+# ═══════════════════════════════════════════════════════════════════
+# App version resolver (independent — uses psutil + .exe metadata)
+# ═══════════════════════════════════════════════════════════════════
+def _running_app_exe_path() -> str:
+    """Path of the currently-running bloodflow process, or '' if none."""
+    for proc in psutil.process_iter(["name", "exe"]):
+        try:
+            name = (proc.info.get("name") or "").lower()
+            if name in (
+                "open-motion.exe", "open-motion_console.exe",
+                "openwaterapp.exe", "openwaterapp_console.exe",
+            ):
+                exe = proc.info.get("exe") or ""
+                if exe and os.path.exists(exe):
+                    return exe
+        except Exception:
+            continue
+    return ""
+
+
+def _find_installed_exe() -> str:
+    """Find an installed Open-Motion.exe / legacy OpenWaterApp.exe
+    (newest by mtime)."""
+    env = os.environ.get("OPENWATER_EXE", "")
+    if env and os.path.exists(env):
+        return env
+    patterns = (
+        r"C:\Program Files (x86)\Openwater\**\Open-Motion.exe",
+        r"C:\Program Files\Openwater\**\Open-Motion.exe",
+        r"C:\Users\*\Documents\OpenMotion\**\Open-Motion.exe",
+        r"C:\Users\*\Desktop\**\Open-Motion.exe",
+        r"C:\Users\*\Documents\OpenMotion\**\OpenWaterApp.exe",
+        r"C:\Users\*\Desktop\**\OpenWaterApp.exe",
+        r"C:\Program Files\**\OpenWaterApp.exe",
+        r"C:\Program Files (x86)\**\OpenWaterApp.exe",
+    )
+    matches: list[str] = []
+    for p in patterns:
+        matches.extend(glob.glob(p, recursive=True))
+    return max(matches, key=os.path.getmtime) if matches else ""
+
+
+def _registry_display_version() -> str:
+    """DisplayVersion of the installed Open-Motion app from the Windows
+    uninstall registry ('' when not found / not on Windows)."""
+    try:
+        import winreg
+    except ImportError:
+        return ""
+    for root_key in (
+        r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+    ):
+        try:
+            hive = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, root_key)
+        except OSError:
+            continue
+        with hive:
+            for i in range(winreg.QueryInfoKey(hive)[0]):
+                try:
+                    with winreg.OpenKey(hive, winreg.EnumKey(hive, i)) as k:
+                        name = str(winreg.QueryValueEx(k, "DisplayName")[0])
+                        if "open-motion" not in name.lower():
+                            continue
+                        ver = str(winreg.QueryValueEx(k, "DisplayVersion")[0]).strip()
+                        if ver:
+                            return ver
+                except OSError:
+                    continue
+    return ""
+
+
+def resolve_app_version() -> str:
+    """Resolve the version of the running/installed bloodflow app.
+    """
+    # 0. The installer's registry entry — the packaged exe itself ships
+    #    without VersionInfo metadata, so this is the most reliable source.
+    reg_version = _registry_display_version()
+    if reg_version:
+        return reg_version
+
+    exe_path = _running_app_exe_path() or _find_installed_exe()
+    if not exe_path:
+        return os.environ.get("OPENWATER_VERSION", "unknown")
+
+    # 1. ProductVersion / FileVersion from .exe metadata.
+    try:
+        ps_cmd = (
+            f"$v = (Get-Item '{exe_path}').VersionInfo; "
+            "Write-Output $v.FileVersion; "
+            "Write-Output $v.ProductVersion; "
+            "Write-Output $v.FileVersionRaw; "
+            "Write-Output $v.ProductVersionRaw"
+        )
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", ps_cmd],
+            capture_output=True, text=True, timeout=10,
+        )
+        version_re = re.compile(r"^\d+(\.\d+)+")
+        for ln in (result.stdout or "").splitlines():
+            c = ln.strip()
+            if c and version_re.match(c):
+                return c
+    except Exception:
+        pass
+
+    # 2. Walk up the path looking for a folder name with a version pattern.
+    folder_version_re = re.compile(
+        r"\d+\.\d+(?:\.\d+)*(?:[-_+][A-Za-z0-9._+-]*)?"
+    )
+    for ancestor in Path(exe_path).parents:
+        name = ancestor.name
+        if name.lower() in ("users", ""):
+            break
+        if name.lower() in ("documents", "openmotion"):
+            continue
+        m = folder_version_re.search(name)
+        if m:
+            return m.group(0)
+
+    return Path(exe_path).parent.name
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Scan lifecycle helpers
+# ═══════════════════════════════════════════════════════════════════
+def _click_start_scan_button() -> bool:
+    """Click the modal's 'Start Scan' button. UIA first, coord fallback."""
+    try:
+        for elem in uia_window().descendants(title="Start Scan", control_type="Button"):
+            r = elem.rectangle()
+            cx = (r.left + r.right) // 2
+            cy = (r.top + r.bottom) // 2
+            if r.right > r.left and r.bottom > r.top and cx > 0 and cy > 0:
+                log.info(f"  click 'Start Scan' at ({cx}, {cy})")
+                pyautogui.moveTo(cx, cy, duration=0.15)
+                time.sleep(0.15)
+                pyautogui.click(cx, cy)
+                return True
+    except Exception as e:
+        log.warning(f"  UIA Start Scan lookup failed: {e}")
+
+    w = get_app_window()
+    cx = int(w.left + _START_SCAN_BUTTON_REL[0] * w.width)
+    cy = int(w.top + _START_SCAN_BUTTON_REL[1] * w.height)
+    log.info(f"  coord-fallback 'Start Scan' at ({cx}, {cy})")
+    pyautogui.moveTo(cx, cy, duration=0.15)
+    time.sleep(0.15)
+    pyautogui.click(cx, cy)
+    return True
+
+
+def _cq_notification_visible() -> bool:
+    """True if the mid-scan Contact Quality Notification modal is up."""
+    try:
+        win = uia_window()
+        if win.descendants(title="Contact Quality Notification"):
+            return True
+        # The pre-scan modal has 'Start Scan'; only the mid-scan one pairs
+        # 'Continue' with 'Stop scan'.
+        return bool(
+            win.descendants(title="Continue", control_type="Button")
+            and win.descendants(title="Stop scan", control_type="Button")
+        )
+    except Exception:
+        return False
+
+
+def _dismiss_cq_notification(label: str = "") -> bool:
+    """Click 'Continue' on the mid-scan contact-quality modal.
+
+    The modal does not close itself when contact comes back — it switches to
+    "All contact quality issues are currently inactive. You may dismiss." and
+    waits. Left up it covers the plots and sits in front of the sidebar, so
+    the next Stop click lands on the modal instead of the sidebar button.
+
+    Only ever clicks 'Continue'. 'Stop scan' is right next to it and would
+    end the scan, so the UIA lookup is title-exact and the coordinate
+    fallback is only used when the modal is confirmed present.
+    """
+    if not _cq_notification_visible():
+        return False
+    try:
+        for elem in uia_window().descendants(title="Continue", control_type="Button"):
+            r = elem.rectangle()
+            cx, cy = (r.left + r.right) // 2, (r.top + r.bottom) // 2
+            if r.right > r.left and r.bottom > r.top and cx > 0 and cy > 0:
+                log.info(f"  {label}: clicking 'Continue' on CQ modal at ({cx}, {cy})")
+                pyautogui.moveTo(cx, cy, duration=0.15)
+                time.sleep(0.15)
+                pyautogui.click(cx, cy)
+                time.sleep(SLEEP)
+                return True
+    except Exception as e:
+        log.warning(f"  {label}: UIA Continue lookup failed: {e}")
+
+    try:
+        w = get_app_window()
+        cx = int(w.left + _CQ_CONTINUE_BUTTON_REL[0] * w.width)
+        cy = int(w.top + _CQ_CONTINUE_BUTTON_REL[1] * w.height)
+        log.info(f"  {label}: coord-fallback 'Continue' at ({cx}, {cy})")
+        pyautogui.moveTo(cx, cy, duration=0.15)
+        time.sleep(0.15)
+        pyautogui.click(cx, cy)
+        time.sleep(SLEEP)
+        return True
+    except Exception as e:
+        log.warning(f"  {label}: could not dismiss CQ modal ({e}) — continuing")
+    return False
+
+
+def _quality_dialog_visible() -> bool:
+    """True if the 'Good signal quality' dialog is up and clickable."""
+    try:
+        win = uia_window()
+        if win.descendants(title="Start Scan", control_type="Button"):
+            return True
+        for title in ("Good signal quality", "Dismiss", "Retest"):
+            if win.descendants(title=title):
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _wait_quality_then_start(
+    label: str = "", timeout: int = QUALITY_CHECK_TIMEOUT,
+    log_path: Path | None = None, scan_offset: int = 0,
+) -> None:
+    """Poll until the 'Good signal quality' dialog appears, then click Start Scan.
+
+    If the dialog hasn't shown after START_RETRY_SEC, re-click the sidebar
+    Start button: the app silently swallows a Start click that lands while
+    the previous scan is still tearing down (or right after a power cycle),
+    and without a retry that swallowed click strands the whole run. The
+    dialog appears ~8 s after an accepted Start, so a 60 s retry interval
+    can't interrupt an in-flight quality check.
+
+    The contact-quality verdict is already in the app log by the time the
+    dialog is up, so it is checked *here* — before Start Scan is clicked.
+    Checking it after the scan instead would mean sitting through a full
+    10-minute scan already known to be running on a bad sensor.
+    """
+    log.info(f"  waiting up to {timeout}s for signal quality dialog…")
+    deadline = time.time() + timeout
+    last_start_click = time.time()
+    while time.time() < deadline:
+        time.sleep(5)
+        if not is_app_alive():
+            raise FatalFailure("APP CLOSED while waiting for signal-quality dialog.")
+        if _quality_dialog_visible():
+            time.sleep(0.5)             # let modal finish animating in
+
+            if FAIL_ON_CONTACT_QUALITY:
+                flagged = contact_quality_failures(
+                    read_log_slice(log_path, scan_offset)
+                )
+                if flagged:
+                    # Dismiss the modal so the app is left idle, not mid-scan.
+                    pyautogui.press("escape")
+                    time.sleep(SLEEP)
+                    raise ScanFailure(
+                        f"{label}: contact quality: {', '.join(flagged)}"
+                    )
+
+            move_window_on_screen()
+            _click_start_scan_button()
+            time.sleep(SLEEP)
+            return
+        if time.time() - last_start_click >= START_RETRY_SEC:
+            log.warning(
+                f"  no signal-quality dialog {START_RETRY_SEC}s after Start "
+                f"— the click may have been swallowed; re-clicking Start"
+            )
+            ensure_visible()
+            click_sidebar(*SIDEBAR_START, f"{label}: Start (retry)")
+            last_start_click = time.time()
+    raise ScanFailure(f"Signal-quality dialog did not appear within {timeout}s.")
+
+
+def _stop_scan_quietly(label: str) -> None:
+    """Click Stop and dismiss any modal, so a failed scan leaves the app idle.
+
+    Best-effort: an abort path must not mask the real failure with its own.
+    """
+    try:
+        move_window_on_screen()
+        ensure_visible()
+        require_focus()
+        # If the contact-quality modal is up it covers the sidebar, and it
+        # carries its own 'Stop scan' — use that rather than clicking through.
+        if _cq_notification_visible():
+            try:
+                for elem in uia_window().descendants(
+                    title="Stop scan", control_type="Button"
+                ):
+                    r = elem.rectangle()
+                    cx, cy = (r.left + r.right) // 2, (r.top + r.bottom) // 2
+                    if r.right > r.left and r.bottom > r.top:
+                        log.info(f"  {label}: 'Stop scan' on CQ modal ({cx}, {cy})")
+                        pyautogui.moveTo(cx, cy, duration=0.15)
+                        pyautogui.click(cx, cy)
+                        time.sleep(STOP_SETTLE_SEC)
+                        pyautogui.press("escape")
+                        time.sleep(SLEEP)
+                        return
+            except Exception as e:
+                log.warning(f"  {label}: modal Stop lookup failed ({e})")
+        click_sidebar(*SIDEBAR_START, f"{label}: Stop (abort)")
+        time.sleep(STOP_SETTLE_SEC)
+        pyautogui.press("escape")
+        time.sleep(SLEEP)
+    except Exception as exc:                      # noqa: BLE001
+        log.warning(f"  {label}: abort-stop failed ({exc}) — continuing")
+
+
+def _sleep_with_alive_check(
+    label: str, seconds: int,
+    log_path: Path | None = None, scan_offset: int = 0,
+) -> None:
+    """Sleep ``seconds``, checking every 30 s that the app is still alive.
+
+    Also watches for mid-scan contact loss as it happens, so an induced or
+    genuine fault surfaces within ~30 s instead of at the end of a 10-minute
+    scan the tester already knows is bad.
+    """
+    log.info(f"  {label}: scanning for {seconds}s ({seconds // 60} min)…")
+    elapsed = 0
+    poor_since: float | None = None      # when contact was first lost
+    last_report = 0
+    while elapsed < seconds:
+        # Poll faster while contact is down so recovery is picked up promptly.
+        step = CQ_RECOVERY_POLL_SEC if poor_since is not None else 30
+        nap = min(step, seconds - elapsed)
+        time.sleep(nap)
+        elapsed += nap
+        if not is_app_alive():
+            raise FatalFailure(f"APP CLOSED during {label} after {elapsed}s.")
+
+        if log_path:
+            poor = cameras_currently_poor(read_log_slice(log_path, scan_offset))
+            if poor and poor_since is None:
+                poor_since = time.time()
+                log.warning(
+                    f"  {label}: contact lost on {', '.join(poor)} at {elapsed}s "
+                    f"— waiting up to {CQ_RECOVERY_TIMEOUT}s for recovery"
+                )
+            elif poor and poor_since is not None:
+                down = time.time() - poor_since
+                if down >= CQ_RECOVERY_TIMEOUT:
+                    log.error(
+                        f"  {label}: contact still lost on {', '.join(poor)} "
+                        f"after {down:.0f}s — stopping scan"
+                    )
+                    _stop_scan_quietly(label)
+                    raise ScanFailure(
+                        f"{label}: contact not recovered within "
+                        f"{CQ_RECOVERY_TIMEOUT}s — still poor on "
+                        f"{', '.join(poor)} at {elapsed}s"
+                    )
+            elif not poor and poor_since is not None:
+                log.info(
+                    f"  {label}: contact recovered after "
+                    f"{time.time() - poor_since:.0f}s — continuing scan"
+                )
+                poor_since = None
+                # Acknowledge the modal so the scan really is left running
+                # and the sidebar is clickable again.
+                _dismiss_cq_notification(label)
+
+        if elapsed - last_report >= 60:
+            last_report = elapsed
+            log.info(f"  {label}: {elapsed}/{seconds}s")
+
+
+def _run_single_scan(cycle_idx: int, scan_idx: int) -> dict:
+    """One scan: Start → quality check → Start Scan → 10 min → Stop.
+
+    Returns the scan's observed metrics. Raises ``ScanFailure`` if the scan
+    tripped an integrity gate, ``FatalFailure`` if the app went away.
+    """
+    label = f"cycle {cycle_idx}/{CYCLE_COUNT} scan {scan_idx}/{SCANS_PER_CYCLE}"
+    log.info(f"─── ▶ {label} ───")
+
+    # Take the offset before clicking Start so the slice covers the whole
+    # scan, including the contact-quality table the check writes on entry.
+    log_path = find_app_log()
+    scan_offset = log_size(log_path) if log_path else 0
+    if log_path:
+        log.info(f"  {label}: watching app log {log_path}")
+    else:
+        log.warning(f"  {label}: NO APP LOG FOUND — integrity will NOT be checked")
+
+    move_window_on_screen()
+    ensure_visible()
+    require_focus()
+    click_sidebar(*SIDEBAR_START, f"{label}: Start")
+
+    try:
+        _wait_quality_then_start(
+            label, log_path=log_path, scan_offset=scan_offset
+        )
+        _sleep_with_alive_check(
+            label, SCAN_DURATION_SEC, log_path=log_path, scan_offset=scan_offset
+        )
+    except (ScanFailure, FatalFailure) as exc:
+        # Attach what the log shows so far — a failing cycle must report the
+        # counts behind its own failure message, not zeros.
+        exc.metrics = scan_metrics(
+            scan_idx, read_log_slice(log_path, scan_offset), completed=False
+        )
+        raise
+
+    move_window_on_screen()
+    ensure_visible()
+    require_focus()
+    # A contact-quality modal left over from a recovered loss sits in front
+    # of the sidebar; clear it before aiming at Stop.
+    _dismiss_cq_notification(label)
+    log.info(f"  {label}: clicking Stop")
+    # Scan teardown (USB flush, pipeline post-processing, DB save) takes
+    # ~30 s after the Stop click; a Start clicked before the app logs
+    # "Full scan ended" is silently swallowed. Tail the app log so the
+    # next scan waits exactly as long as teardown actually takes.
+    stop_offset = log_size(log_path) if log_path else 0
+    click_sidebar(*SIDEBAR_START, f"{label}: Stop")
+    ended = None
+    if log_path:
+        ended = wait_for_pattern(
+            RE_SCAN_ENDED, log_path, stop_offset, SCAN_TEARDOWN_TIMEOUT
+        )
+        if ended:
+            log.info(f"  {label}: teardown complete: {ended}")
+        else:
+            log.warning(
+                f"  {label}: no 'Full scan ended' in app log within "
+                f"{SCAN_TEARDOWN_TIMEOUT}s"
+            )
+    time.sleep(STOP_SETTLE_SEC)
+    pyautogui.press("escape")              # dismiss any post-scan modal
+    time.sleep(SLEEP)
+
+    # Everything above only proves the UI was driven. Read back what the app
+    # actually recorded before calling this scan good.
+    slice_text = read_log_slice(log_path, scan_offset)
+    metrics = scan_metrics(scan_idx, slice_text, completed=bool(ended))
+    if not log_path:
+        log.warning(f"  {label}: no app log found — integrity NOT verified")
+
+    reasons = evaluate_scan(slice_text, scan_ended=bool(ended))
+    if reasons:
+        raise ScanFailure(f"{label}: " + "; ".join(reasons), metrics=metrics)
+
+    log.info(
+        f"  ✓ {label} done (NaN-filled={metrics['nan_filled']}, "
+        f"histo-full={metrics['histo_queue_full']})"
+    )
+    return metrics
+
+
+def _power_cycle_and_wait_reconnect(outlet, cycle_idx: int) -> None:
+    """Power-cycle the console; wait for the app log's CONNECTED line."""
+    log.info(f"  ⟲ cycle {cycle_idx}: power-cycling console")
+    log_path = find_app_log()
+    assert log_path, "Cannot find bloodflow app log."
+    offset = log_size(log_path)
+    outlet.power_cycle(off_time=POWER_CYCLE_OFF_SEC)
+    line = wait_for_pattern(RE_CONNECTED, log_path, offset, RECONNECT_TIMEOUT)
+    assert line, (
+        f"Console did not reconnect within {RECONNECT_TIMEOUT}s after "
+        f"cycle {cycle_idx} power cycle."
+    )
+    log.info(f"  ✓ reconnected: {line.strip()}")
+    log.info(f"  settling {RECONNECT_SETTLE_SEC}s for sensors to re-enumerate")
+    time.sleep(RECONNECT_SETTLE_SEC)
+    move_window_on_screen()
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Report writer
+# ═══════════════════════════════════════════════════════════════════
+def _write_report() -> None:
+    """Write Reliability_Test_Report_<ts>.json + .md to tests/test_logs/."""
+    global _REPORT_APP_VERSION
+    v = resolve_app_version()
+    if v and v != "unknown":
+        _REPORT_APP_VERSION = v
+    app_version = _REPORT_APP_VERSION or "unknown"
+
+    log_dir = Path(__file__).resolve().parent / "test_logs"
+    log_dir.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    cfg = _merged_app_config()
+    env = {
+        "tester":         os.environ.get("TESTER_NAME", getpass.getuser()),
+        "hostname":       socket.gethostname(),
+        "os":             f"{platform.system()} {platform.release()} ({platform.version()})",
+        "python_version": sys.version.split()[0],
+        "app_version":    app_version,
+        "clinical_mode":  cfg.get("clinicalMode"),
+        "engineering_mode": cfg.get("engineeringMode"),
+    }
+    start = _REPORT_SESSION_START
+    end   = datetime.now()
+    duration = (end - start).total_seconds() if start else 0
+    passed = sum(1 for r in _CYCLE_RESULTS if r["status"] == "PASS")
+    failed = len(_CYCLE_RESULTS) - passed
+    # Counted from observed "Full scan ended" lines, not inferred from the
+    # cycle count. The old `passed * SCANS_PER_CYCLE` reported scans that
+    # were never confirmed to have run.
+    scans_completed = sum(r.get("scans_completed", 0) for r in _CYCLE_RESULTS)
+    summary = {
+        "cycles_planned":  CYCLE_COUNT,
+        "cycles_run":      len(_CYCLE_RESULTS),
+        "cycles_passed":   passed,
+        "cycles_failed":   failed,
+        "scans_per_cycle": SCANS_PER_CYCLE,
+        "scans_planned":   len(_CYCLE_RESULTS) * SCANS_PER_CYCLE,
+        "scans_completed": scans_completed,
+        "total_nan_filled":       sum(r.get("nan_filled", 0) for r in _CYCLE_RESULTS),
+        "total_histo_queue_full": sum(r.get("histo_queue_full", 0) for r in _CYCLE_RESULTS),
+        "cycles_with_cq_flags":   sum(1 for r in _CYCLE_RESULTS if r.get("cq_flagged")),
+        "total_cq_live_raises":   sum(r.get("cq_live_raises", 0) for r in _CYCLE_RESULTS),
+        "run_aborted":            _RUN_ABORTED,
+        "degradation":            degradation_check(_CYCLE_RESULTS),
+    }
+    report = {
+        "report_title":  "OpenWater BloodFlow — Reliability Test Report",
+        "test_script":   Path(__file__).name,
+        "session_start": start.isoformat(timespec="seconds") if start else "",
+        "session_end":   end.isoformat(timespec="seconds"),
+        "duration_sec":  round(duration, 1),
+        "configuration": {
+            "cycle_count":           CYCLE_COUNT,
+            "scans_per_cycle":       SCANS_PER_CYCLE,
+            "scan_duration_min":     SCAN_DURATION_MIN,
+            "power_cycle_off_sec":   POWER_CYCLE_OFF_SEC,
+            "quality_check_timeout": QUALITY_CHECK_TIMEOUT,
+        },
+        "environment":   env,
+        "summary":       summary,
+        "cycle_results": _CYCLE_RESULTS,
+    }
+
+    json_path = log_dir / f"Reliability_Test_Report_{ts}.json"
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    rows = "\n".join(
+        f"| {r['cycle']} | {r.get('scans_completed', 0)}/{r['scans_planned']} | "
+        f"{r['scan_duration_min']} | **{r['status']}** | "
+        f"{r.get('nan_filled', 0)} | {r.get('histo_queue_full', 0)} | "
+        f"{', '.join(r.get('cq_flagged') or []) or '—'} | "
+        f"{r.get('cq_live_raises', 0)} | "
+        f"{r['finished_at']} | {r.get('failure') or '—'} |"
+        for r in _CYCLE_RESULTS
+    ) or "| _no cycles recorded_ |"
+    md = f"""\
+# {report['report_title']}
+
+**Test Script:** `{report['test_script']}`
+
+## Session
+
+- **Session Start:** {report['session_start']}
+- **Session End:**   {report['session_end']}
+- **Duration:**      {report['duration_sec']} s ({report['duration_sec'] / 3600:.2f} h)
+
+## Environment
+
+- **Tester:** {env['tester']}
+- **Hostname:** {env['hostname']}
+- **OS:** {env['os']}
+- **Python:** {env['python_version']}
+- **App version:** {env['app_version']}
+- **Clinical mode:** {env['clinical_mode']} (engineeringMode={env['engineering_mode']})
+
+## Configuration
+
+- **Cycles planned:** {CYCLE_COUNT}
+- **Scans per cycle:** {SCANS_PER_CYCLE}
+- **Scan duration:** {SCAN_DURATION_MIN} min
+- **Power cycle off-time:** {POWER_CYCLE_OFF_SEC} s
+- **Quality-check timeout:** {QUALITY_CHECK_TIMEOUT} s
+
+## Summary
+
+| Metric          | Count |
+|-----------------|-------|
+| Cycles planned  | {summary['cycles_planned']} |
+| Cycles run      | {summary['cycles_run']} |
+| Cycles passed   | {summary['cycles_passed']} |
+| Cycles failed   | {summary['cycles_failed']} |
+| Scans planned   | {summary['scans_planned']} |
+| Scans completed (observed) | {summary['scans_completed']} |
+| Cycles with pre-scan contact-quality flags | {summary['cycles_with_cq_flags']} |
+| Mid-scan contact-loss events (total) | {summary['total_cq_live_raises']} |
+| Frames NaN-filled (total) | {summary['total_nan_filled']} |
+| Histo queue-full events (total) | {summary['total_histo_queue_full']} |
+| Run aborted | {summary['run_aborted'] or 'no'} |
+
+**Scans completed** counts `Full scan ended` lines observed in the app log,
+not `cycles x scans_per_cycle`. Contact-quality flags, NaN-filled frames and
+histo queue-full events are read back from the app log per scan; a cycle
+tripping a gate is recorded FAIL and the run continues.
+
+## Degradation Trend
+
+{_degradation_md(summary['degradation'])}
+
+## Per-Cycle Results
+
+| Cycle | Scans done | Scan duration (min) | Status | NaN-filled | Histo full | CQ pre-scan | CQ mid-scan | Finished At | Failure |
+|-------|-----------|---------------------|--------|-----------|-----------|------------|------------|-------------|---------|
+{rows}
+
+## Sign-Off
+
+| Role | Name | Signature | Date |
+|------|------|-----------|------|
+| Tester | {env['tester']} | _______________ | _______________ |
+| QA Reviewer | _______________ | _______________ | _______________ |
+| Technical Lead | _______________ | _______________ | _______________ |
+
+---
+_Report generated automatically by `{Path(__file__).name}` on \
+{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}_
+"""
+    md_path = log_dir / f"Reliability_Test_Report_{ts}.md"
+    md_path.write_text(md, encoding="utf-8")
+    log.info(f"Reliability Test Report written: {json_path}")
+    log.info(f"                                 {md_path}")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════
+@pytest.fixture(scope="module", autouse=True)
+def _log_app_mode():
+    """Log the effective app mode; warn when clinicalMode is off.
+
+    The script must not write any config file (the bundled config is
+    read-only under Program Files, and import-time writes to the repo
+    config abort collection — see conftest). The operator sets the mode
+    in app_config.local.json before the run instead.
+    """
+    cfg = _merged_app_config()
+    clinical = cfg.get("clinicalMode")
+    engineering = cfg.get("engineeringMode")
+    log.info(f"App mode: clinicalMode={clinical} engineeringMode={engineering}")
+    if clinical is not True:
+        log.warning(
+            "clinicalMode is not enabled — this reliability run is meant to "
+            "exercise clinical (FDA) mode. Set \"clinicalMode\": true in "
+            f"{_writable_root() / 'app_config.local.json'} and restart."
+        )
+    yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _report_lifecycle():
+    """Snapshot start time; register the atexit report writer."""
+    global _REPORT_SESSION_START
+    _REPORT_SESSION_START = datetime.now()
+    log.info(f"Reliability report started at {_REPORT_SESSION_START}")
+    atexit.register(_write_report)
+    yield
+
+
+@pytest.fixture(scope="module")
+def outlet():
+    """Resolve the Shelly outlet; skip the module if unreachable."""
+    try:
+        out = shelly.default_outlet()
+        log.info(
+            f"  Shelly outlet: host={getattr(out, 'host', '?')} "
+            f"relay={'ON' if out.is_on() else 'OFF'}"
+        )
+    except Exception as e:
+        pytest.skip(f"Shelly outlet not reachable: {e}")
+    yield out
+    try:
+        out.on()
+    except Exception:
+        pass
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════
+class TestReliabilityTestScript:
+    """Overnight reliability test — CYCLE_COUNT cycles of
+    (SCANS_PER_CYCLE × 10-min scans + power cycle).
+
+    Cycles are independent: a failed cycle is recorded FAIL and the run moves
+    on. Only a FatalFailure (app gone) stops the run, and the remaining
+    cycles are then skipped rather than recorded as failures they never
+    attempted. The old ``@pytest.mark.incremental`` is deliberately absent —
+    with it, one failure skipped every remaining cycle.
+    """
+
+    @pytest.mark.parametrize(
+        "cycle_idx",
+        range(1, CYCLE_COUNT + 1),
+        ids=[f"cycle-{i:02d}" for i in range(1, CYCLE_COUNT + 1)],
+    )
+    def test_cycle(self, outlet, app, cycle_idx):
+        global _RUN_ABORTED
+        if _RUN_ABORTED:
+            pytest.skip(f"run aborted earlier: {_RUN_ABORTED}")
+
+        scans: list[dict] = []
+        status = "PASS"
+        failure: str | None = None
+
+        try:
+            for scan_idx in range(1, SCANS_PER_CYCLE + 1):
+                scans.append(_run_single_scan(cycle_idx, scan_idx))
+                if scan_idx < SCANS_PER_CYCLE:
+                    time.sleep(INTER_SCAN_PAUSE_SEC)
+
+            if cycle_idx < CYCLE_COUNT:
+                _power_cycle_and_wait_reconnect(outlet, cycle_idx)
+            else:
+                log.info(f"  ✓ last cycle ({cycle_idx}/{CYCLE_COUNT}) — done")
+
+        except FatalFailure as exc:
+            status, failure = "FAIL", str(exc)
+            _RUN_ABORTED = failure
+            if exc.metrics:
+                scans.append(exc.metrics)
+            log.error(f"  ✗ cycle {cycle_idx}: FATAL — {failure}")
+        except ScanFailure as exc:
+            status, failure = "FAIL", str(exc)
+            if exc.metrics:
+                scans.append(exc.metrics)
+            log.error(f"  ✗ cycle {cycle_idx}: FAIL — {failure}")
+        except Exception as exc:
+            # Bench infrastructure (e.g. a smart-plug HTTP timeout) is
+            # recoverable: record it and let the next cycle try.
+            status = "FAIL"
+            failure = f"{type(exc).__name__}: {exc}"
+            log.error(f"  ✗ cycle {cycle_idx}: FAIL — {failure}")
+
+        _CYCLE_RESULTS.append({
+            "cycle":             cycle_idx,
+            "scans_planned":     SCANS_PER_CYCLE,
+            "scans_completed":   sum(1 for s in scans if s["completed"]),
+            "scan_duration_min": SCAN_DURATION_MIN,
+            "status":            status,
+            "failure":           failure,
+            "nan_filled":        sum(s["nan_filled"] for s in scans),
+            "histo_queue_full":  sum(s["histo_queue_full"] for s in scans),
+            "cq_flagged":        sorted({c for s in scans for c in s["cq_flagged"]}),
+            "cq_live_raises":    sum(len(s["cq_live_raises"]) for s in scans),
+            "finished_at":       datetime.now().isoformat(timespec="seconds"),
+        })
+
+        if status == "FAIL":
+            pytest.fail(failure or "cycle failed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ Provides:
 
 import atexit
 import getpass
+import importlib
+import inspect
 import json
 import platform
 import socket
@@ -27,10 +29,21 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-import pyautogui
 import psutil
-import pygetwindow as gw
-from pywinauto import Desktop as UiaDesktop
+
+# The GUI-automation stack drives the HIL suite only, and pywinauto is
+# Windows-only — importing it unconditionally made conftest unimportable on
+# macOS, which took the platform-independent `unit` tests down with it. Import
+# them optionally; every consumer lives inside a HIL fixture or helper, which
+# a `unit`-marked run never reaches.
+try:
+    import pyautogui
+    import pygetwindow as gw
+    from pywinauto import Desktop as UiaDesktop
+except ImportError:  # non-Windows dev machine — HIL tests can't run here anyway
+    pyautogui = None
+    gw = None
+    UiaDesktop = None
 
 
 # ─────────────────────────────────────────────
@@ -54,13 +67,14 @@ def _qcoreapplication():
 # ─────────────────────────────────────────────
 # pyautogui defaults
 # ─────────────────────────────────────────────
-pyautogui.FAILSAFE = True
-pyautogui.PAUSE = 0.5
+if pyautogui is not None:
+    pyautogui.FAILSAFE = True
+    pyautogui.PAUSE = 0.5
 
 # ─────────────────────────────────────────────
 # Constants
 # ─────────────────────────────────────────────
-APP_KEYWORDS = ["openmotion", "bloodflow", "openwater"]
+APP_KEYWORDS = ["openmotion", "open-motion", "bloodflow", "openwater"]
 SLEEP = 2  # seconds to wait after most UI actions
 
 LOG_DIR = Path(__file__).parent / "test_logs"
@@ -115,7 +129,14 @@ _class_failures = {}
 
 
 def pytest_runtest_makereport(item, call):
-    if call.when == "call" and call.excinfo is not None:
+    # A deliberate pytest.skip() inside a test (e.g. "this bench has no
+    # left sensor") is not a failure — it must not xfail the rest of an
+    # incremental class.
+    if (
+        call.when == "call"
+        and call.excinfo is not None
+        and not call.excinfo.errisinstance(pytest.skip.Exception)
+    ):
         cls = item.cls
         if cls is not None:
             _class_failures.setdefault(cls.__name__, item.name)
@@ -314,10 +335,12 @@ def _find_exe() -> str:
 # Window helpers
 # ─────────────────────────────────────────────
 # Process names accepted as the bloodflow app. ``Open-Motion.exe`` is
-# the packaged build; ``python.exe`` / ``pythonw.exe`` covers the
+# the packaged build and ``Open-Motion_console.exe`` the console build
+# shipped alongside it; ``python.exe`` / ``pythonw.exe`` covers the
 # from-source mode (verified by also checking ``main.py`` in the
 # command line, since plenty of other things run under python.exe).
-_APP_PROCESS_NAMES = ("open-motion.exe", "python.exe", "pythonw.exe")
+_APP_PROCESS_NAMES = ("open-motion.exe", "open-motion_console.exe",
+                      "python.exe", "pythonw.exe")
 
 
 def _window_process_name(w) -> str | None:
@@ -361,7 +384,9 @@ def _is_bloodflow_window(w) -> bool:
         # rather than locking out tests on systems where the Win32
         # call is unavailable (CI containers etc).
         return any(k in title.lower() for k in APP_KEYWORDS)
-    if proc_name not in _APP_PROCESS_NAMES:
+    # Accept every packaged variant: the windowed OpenWaterApp.exe and the
+    # OpenWaterApp_console.exe console build shipped alongside it (1.2.x+).
+    if not (proc_name.startswith("openwaterapp") or proc_name in _APP_PROCESS_NAMES):
         return False
     if proc_name in ("python.exe", "pythonw.exe"):
         # In from-source mode several python.exe windows can co-exist
@@ -708,7 +733,10 @@ def app():
                     ensure_visible()
                     return True
             else:
-                if "openwater" in name:
+                # "openwater" covers the old ≤1.3.x OpenWaterApp.exe;
+                # "open-motion" covers the renamed builds, console
+                # variant included.
+                if "openwater" in name or "open-motion" in name:
                     log.info("App already running.")
                     time.sleep(SLEEP)
                     ensure_visible()
@@ -921,33 +949,173 @@ def _isolate_writable_root(request, tmp_path, monkeypatch):
 # (commits ba05bd0 + e3a017a in tests/test_clinicalmode.py).
 
 _REPORT_SESSION_START: datetime | None = None
+# Resolved at session start so we don't depend on the app process
+# still being alive when the atexit-registered _write_hil_report runs
+# (test cleanup or a crash may have killed it by then).
+_REPORT_APP_VERSION: str | None = None
+
+
+def _running_app_exe_path() -> str:
+    """Find the .exe path of the bloodflow process that's currently running.
+
+    Returns the path of the FIRST live process whose name matches
+    one of the bloodflow executable names. Falls back to '' if no
+    matching process is alive.
+
+    This is the source of truth for "which app is being tested" —
+    much more reliable than ``_find_exe()`` (which picks the newest
+    installed .exe by mtime, possibly a different install).
+    """
+    # Old (≤1.3.x) and new (Open-Motion rename on next) packaged exe names.
+    target_names = {"openwaterapp.exe", "openwaterapp_console.exe",
+                    "open-motion.exe", "open-motion_console.exe"}
+    try:
+        for proc in psutil.process_iter(["name", "exe"]):
+            try:
+                name = (proc.info.get("name") or "").lower()
+                if name in target_names:
+                    exe = proc.info.get("exe") or ""
+                    if exe and os.path.exists(exe):
+                        return exe
+            except Exception:
+                continue
+    except Exception as e:
+        log.warning(f"  _running_app_exe_path failed: {e}")
+    return ""
+
+
+def _resolve_app_version() -> str:
+    """Resolve the version of the *running* bloodflow app.
+
+    Priority — match the version of what's actually being tested,
+    NOT the source tree's git state:
+
+      0. **Find the .exe path of the currently-running OpenWaterApp
+         process** via psutil. This guarantees the version we report
+         is for the app actually under test, not the newest install
+         on disk (which is what ``_find_exe()`` would pick).
+         Falls back to ``_find_exe()`` if no process is alive (e.g.
+         resolver called before the ``app`` fixture launches it).
+      1. Embedded ``ProductVersion`` / ``FileVersion`` from the .exe
+         metadata.
+      2. Walk UP from the .exe through parent / grandparent folders
+         looking for a name that contains a version pattern. Install
+         layouts vary:
+           ``…\\OpenWaterApp-1.0.2-pre-0-g8027c14\\OpenWaterApp.exe``
+                                ^ version in parent
+           ``…\\OpenMotion-Bloodflow-1.2.0-dev.1_RUO\\OpenWaterApp\\OpenWaterApp.exe``
+                                ^ version in grandparent (with _RUO suffix)
+      3. ``version.get_version()`` from the source tree — git-describe
+         based; used only when no .exe is discoverable.
+      4. ``$OPENWATER_VERSION`` env override.
+      5. ``"unknown"``.
+    """
+    import re
+
+    version_re = re.compile(r"^\d+(\.\d+)+")
+    folder_version_re = re.compile(
+        r"\d+\.\d+(?:\.\d+)*(?:[-_+][A-Za-z0-9._+-]*)?"
+    )
+
+    # 0. Prefer the path of the actually-running process.
+    exe_path = _running_app_exe_path()
+    if exe_path:
+        log.info(f"  resolving version from running process: {exe_path}")
+    else:
+        log.info("  no running OpenWaterApp process — falling back to _find_exe()")
+        try:
+            exe_path = _find_exe()
+        except Exception as e:
+            log.warning(f"  _find_exe() failed: {e}")
+            exe_path = ""
+
+    # 1. .exe ProductVersion / FileVersion metadata.
+    try:
+        if exe_path:
+            ps_cmd = (
+                f"$v = (Get-Item '{exe_path}').VersionInfo; "
+                "Write-Output $v.FileVersion; "
+                "Write-Output $v.ProductVersion; "
+                "Write-Output $v.FileVersionRaw; "
+                "Write-Output $v.ProductVersionRaw"
+            )
+            try:
+                result = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", ps_cmd],
+                    capture_output=True, text=True, timeout=10,
+                )
+                candidates = [ln.strip() for ln in (result.stdout or "").splitlines()
+                              if ln.strip()]
+                log.info(f"  app version metadata candidates: {candidates}")
+                for c in candidates:
+                    if version_re.match(c):
+                        log.info(f"  resolved app version (from .exe): {c}")
+                        return c
+            except Exception as e:
+                log.warning(f"  PowerShell VersionInfo read failed: {e}")
+
+            # 2. Walk up from the .exe — first ancestor folder whose
+            #    name contains a version-shaped substring wins.
+            for ancestor in Path(exe_path).parents:
+                folder_name = ancestor.name
+                # Don't walk past the user's home directory layout.
+                if folder_name.lower() in ("users", "documents", "openmotion", ""):
+                    if folder_name.lower() in ("users", ""):
+                        break
+                    # OpenMotion / Documents themselves don't have a
+                    # version in them but their CHILDREN do — keep
+                    # going, just don't try to match this folder.
+                    continue
+                m = folder_version_re.search(folder_name)
+                if m:
+                    version = m.group(0)
+                    log.info(
+                        f"  resolved app version (from path '{folder_name}'): "
+                        f"{version}"
+                    )
+                    return version
+
+            # Final fallback: the immediate parent folder name, even
+            # without a version pattern — at least it tells you which
+            # install was picked.
+            parent_name = Path(exe_path).parent.name
+            log.info(f"  resolved app version (parent folder): {parent_name}")
+            return parent_name
+    except Exception as e:
+        log.warning(f"  _resolve_app_version: .exe path resolution failed: {e}")
+
+    # 3. No .exe discoverable — running from source. Use git describe.
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        import version as _project_version    # noqa: PLC0415
+        v = (_project_version.get_version() or "").strip()
+        if v:
+            log.info(f"  resolved app version (from source git describe): {v}")
+            return v
+    except Exception as e:
+        log.warning(f"  version.get_version() unavailable: {e}")
+
+    # 4. Env override / 5. unknown.
+    return os.environ.get("OPENWATER_VERSION", "unknown")
 
 
 def _report_get_app_version() -> str:
-    """Best-effort guess at the bundled bloodflow build version.
+    """Return the version of the running bloodflow app.
 
-    Reads it from the running Open-Motion.exe path (the build script
-    lays the version into the parent-directory name). Falls back to
-    ``$OPENWATER_VERSION`` if no app process is detected.
+    Resolves on each call so we always pick up the currently-running
+    process's path via ``_running_app_exe_path``. Once a live answer
+    has been resolved we cache it so a later call (after the app may
+    have been killed by test cleanup) still has the right value.
     """
-    try:
-        for proc_name in ("Open-Motion.exe",):
-            try:
-                result = subprocess.run(
-                    ["wmic", "process", "where", f"name='{proc_name}'",
-                     "get", "ExecutablePath", "/value"],
-                    capture_output=True, text=True, timeout=5,
-                )
-                for line in result.stdout.splitlines():
-                    if "ExecutablePath=" in line:
-                        path = line.split("=", 1)[1].strip()
-                        if path:
-                            return Path(path).parent.name
-            except Exception:
-                continue
-    except Exception:
-        pass
-    return os.environ.get("OPENWATER_VERSION", "unknown")
+    global _REPORT_APP_VERSION
+    v = _resolve_app_version()
+    if v and v != "unknown":
+        _REPORT_APP_VERSION = v
+    # If the live resolve failed, fall back to the last good cached
+    # value (e.g. the app died during cleanup, but it was alive earlier).
+    return v if (v and v != "unknown") else (_REPORT_APP_VERSION or "unknown")
 
 
 def _report_get_environment() -> dict:
@@ -960,6 +1128,70 @@ def _report_get_environment() -> dict:
         "python_version": sys.version.split()[0],
         "app_version":    _report_get_app_version(),
     }
+
+
+def _first_doc_or_inline_comment(obj, def_keyword: str) -> str:
+    """Return a one-line description of ``obj`` (a class or function).
+
+    Prefers the first non-empty line of the object's docstring; if there
+    is none, falls back to a trailing inline comment on the object's
+    ``class``/``def`` line, e.g. ``def test_foo(self):  # what it does``.
+    Returns "" when neither is available.
+    """
+    doc = inspect.getdoc(obj)
+    if doc:
+        for line in doc.splitlines():
+            line = line.strip()
+            if line:
+                return line
+    # Fall back to a trailing inline comment on the definition line,
+    # skipping any decorator lines that precede it.
+    for src_line in inspect.getsourcelines(obj)[0]:
+        stripped = src_line.lstrip()
+        if stripped.startswith(def_keyword):
+            if "#" in src_line:
+                comment = src_line.split("#", 1)[1].strip()
+                if comment:
+                    return comment
+            break
+    return ""
+
+
+def _resolve_test_description(module_name: str, class_name: str,
+                             test_name: str) -> str:
+    """Return a one-line description of a single test.
+
+    Resolves the test method by ``module_name``/``class_name``/``test_name``
+    (preferring an already-imported module in ``sys.modules`` so we don't
+    re-run import side effects, falling back to ``importlib``) and returns
+    its docstring's first line — or a trailing inline comment on the ``def``
+    line. If the method has neither, falls back to the enclosing class's
+    docstring/inline comment so the report still says something useful.
+    Returns "" when nothing can be resolved, so the report degrades
+    gracefully.
+    """
+    if not module_name or not test_name:
+        return ""
+    # Strip any parametrize id, e.g. ``test_scan_auto_stop[loop-1]``.
+    method_name = test_name.split("[", 1)[0]
+    try:
+        module = sys.modules.get(module_name)
+        if module is None:
+            module = importlib.import_module(module_name)
+        cls = getattr(module, class_name, None) if class_name else None
+        container = cls if cls is not None else module
+        method = getattr(container, method_name, None)
+        if method is not None:
+            desc = _first_doc_or_inline_comment(method, "def ")
+            if desc:
+                return desc
+        # No per-test description — fall back to the class-level one.
+        if cls is not None:
+            return _first_doc_or_inline_comment(cls, "class ")
+    except Exception as e:
+        log.warning(f"  test description lookup failed for "
+                    f"{module_name}.{class_name}.{test_name}: {e}")
+    return ""
 
 
 def _parse_junit_xml(xml_path: Path) -> list[dict]:
@@ -1030,6 +1262,28 @@ def _write_hil_report() -> None:
     log_dir.mkdir(exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
 
+    # Which test scripts ran this session (sorted, deduplicated).
+    test_modules = sorted({r["test_module"] for r in results if r["test_module"]})
+    # Filename slug: single script → that script's name; multiple → a
+    # generic 'suite_<N>scripts' tag so the file name stays readable.
+    if len(test_modules) == 1:
+        module_slug = test_modules[0]
+    elif len(test_modules) > 1:
+        module_slug = f"suite_{len(test_modules)}scripts"
+    else:
+        module_slug = "unknown"
+
+    # One-line description per unique test, taken from the test's docstring
+    # (or a trailing inline comment). Keyed by test id, first-seen order so
+    # the report reads in run order.
+    tests: dict[str, str] = {}
+    for r in results:
+        tid = r["test_id"]
+        if tid and tid not in tests:
+            tests[tid] = _resolve_test_description(
+                r["test_module"], r["test_class"], tid
+            )
+
     env = _report_get_environment()
     duration = (
         (datetime.now() - _REPORT_SESSION_START).total_seconds()
@@ -1048,6 +1302,8 @@ def _write_hil_report() -> None:
         "report_title": "Open-Motion — HIL Test Session Report",
         "purpose":      "Verification & validation evidence for the HIL "
                         "test suite.",
+        "test_scripts":  test_modules,
+        "tests":         tests,
         "session_start": _REPORT_SESSION_START.isoformat(timespec="seconds")
                          if _REPORT_SESSION_START else "",
         "session_end":   datetime.now().isoformat(timespec="seconds"),
@@ -1056,7 +1312,7 @@ def _write_hil_report() -> None:
         "summary":       summary,
         "test_results":  results,
     }
-    json_path = log_dir / f"HIL_Report_{ts}.json"
+    json_path = log_dir / f"HIL_Report_{module_slug}_{ts}.json"
     json_path.write_text(json.dumps(report_data, indent=2), encoding="utf-8")
 
     # ── Markdown ──
@@ -1064,6 +1320,26 @@ def _write_hil_report() -> None:
         f"# {report_data['report_title']}",
         "",
         f"**Purpose:** {report_data['purpose']}",
+        "",
+        "## Test Scripts",
+        "",
+    ]
+    if test_modules:
+        for mod in test_modules:
+            lines.append(f"- `{mod}.py`")
+    else:
+        lines.append("- _n/a_")
+    lines += [
+        "",
+        "## Tests",
+        "",
+    ]
+    if tests:
+        for tid, desc in tests.items():
+            lines.append(f"- `{tid}` — {desc or '_no description_'}")
+    else:
+        lines.append("- _n/a_")
+    lines += [
         "",
         "## Session",
         "",
@@ -1128,7 +1404,7 @@ def _write_hil_report() -> None:
         f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}_",
         "",
     ]
-    md_path = log_dir / f"HIL_Report_{ts}.md"
+    md_path = log_dir / f"HIL_Report_{module_slug}_{ts}.md"
     md_path.write_text("\n".join(lines), encoding="utf-8")
 
     log.info("HIL report written:")
@@ -1138,10 +1414,18 @@ def _write_hil_report() -> None:
 
 @pytest.fixture(scope="session", autouse=True)
 def _hil_report_session():
-    """Capture session start time and arm the atexit-registered writer.
+    """Capture session start time + app version, and arm the atexit-
+    registered report writer.
 
     Autouse + session-scope so it runs once for every pytest invocation
     that touches this conftest, with no per-test setup/teardown.
+
+    Version resolution happens lazily in ``_write_hil_report`` (NOT
+    at session start) because this fixture runs BEFORE the ``app``
+    fixture launches the bloodflow app — querying ``psutil`` at
+    session start would never find a running process, defeating the
+    "use the actually-running app's path" priority. The lazy resolver
+    runs at atexit, when the app is most likely still alive.
     """
     global _REPORT_SESSION_START
     _REPORT_SESSION_START = datetime.now()

--- a/tests/hil_helpers.py
+++ b/tests/hil_helpers.py
@@ -58,6 +58,19 @@ SENSOR_OPTIONS = [
     "Left", "Right", "Third Row", "All",
 ]
 
+# Sidebar (panel) button positions as fractions of the app window
+# (rx, ry) — used by ``conftest.click_sidebar``. These work consistently
+# across the UI test scripts without any per-machine calibration.
+# Layout below assumes non-reduced mode (Scan Settings + Check visible).
+SIDEBAR_START         = (0.019, 0.115)
+SIDEBAR_SCAN_SETTINGS = (0.019, 0.210)
+SIDEBAR_NOTES         = (0.019, 0.320)
+SIDEBAR_CHECK         = (0.019, 0.420)
+SIDEBAR_HISTORY       = (0.020, 0.820)
+SIDEBAR_SETTINGS      = (0.019, 0.920)
+# In reduced mode, Notes shifts up into the Scan Settings slot.
+SIDEBAR_NOTES_REDUCED = (0.019, 0.210)
+
 # Height of the auto-update banner (components/UpdateBanner.qml line 13:
 # ``height: visible ? 36 : 0``). When the banner is shown, every
 # coordinate below it shifts down by this amount, so coord-based clicks
@@ -714,21 +727,47 @@ def _calibrate_panel_buttons() -> dict[str, tuple[int, int]]:
         except Exception as e:
             log.warning(f"  calibrate: descendants walk failed: {e}")
 
-    # Fall back to the QML pixel layout for any label UIA didn't find.
+    # Fall back to the shared SIDEBAR_* relative coordinates for any
+    # label UIA didn't find. These are the same coordinates the other
+    # UI test scripts use directly via click_sidebar(), so the
+    # calibration cache and the direct-click path agree on positions.
+    #
+    # Clinical mode hides Scan\nSettings + Check and slides Notes up
+    # into the former Scan Settings slot — pick the right Notes coord
+    # based on the current ``clinicalMode`` config value, matching how
+    # ``panel_button_screen_pos`` handles the same case.
+    reduced = bool(read_app_config_value("clinicalMode", False))
+    notes_pos = SIDEBAR_NOTES_REDUCED if reduced else SIDEBAR_NOTES
+    label_to_sidebar = {
+        "Start":          SIDEBAR_START,
+        "Scan\nSettings": SIDEBAR_SCAN_SETTINGS,
+        "Notes":          notes_pos,
+        "Check":          SIDEBAR_CHECK,
+        "History":        SIDEBAR_HISTORY,
+        "Settings":       SIDEBAR_SETTINGS,
+    }
+    try:
+        w = get_app_window()
+    except Exception as e:
+        log.warning(f"  calibrate fallback: get_app_window failed: {e}")
+        w = None
+
     for lbl in _PANEL_BUTTON_LABELS:
         if lbl in rects:
             continue
-        pos = panel_button_screen_pos(lbl)
-        if pos is not None:
-            rects[lbl] = pos
+        rel = label_to_sidebar.get(lbl)
+        if w is not None and rel is not None:
+            cx = int(w.left + rel[0] * w.width)
+            cy = int(w.top + rel[1] * w.height)
+            rects[lbl] = (cx, cy)
             log.info(
-                f"  calibrated panel '{lbl!r}' → {pos} via QML pixel "
-                f"layout (UIA fallback)"
+                f"  calibrated panel '{lbl!r}' → ({cx}, {cy}) "
+                f"via SIDEBAR_* relative {rel} (UIA fallback)"
             )
         else:
             log.warning(
                 f"  calibrated panel '{lbl!r}' → NOT FOUND "
-                f"(UIA missed and no QML slot)"
+                f"(UIA missed and no SIDEBAR mapping)"
             )
 
     return rects

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,27 @@
+# Test dependencies for the OpenMotion BloodFlow app HIL test suite.
+#
+# Install with:
+#   pip install -r tests/requirements.txt
+#
+# Targets Python 3.10+. Versions left unpinned so a fresh checkout picks
+# up the latest stable releases; pin them in CI if reproducibility matters.
+
+# Test framework
+pytest
+
+# HTTP client — used by tests/shelly.py to drive the Shelly outlet
+requests
+
+# Process introspection — checking if the app is already running
+psutil
+
+# UI automation
+pyautogui          # mouse / keyboard input
+pygetwindow        # top-level window enumeration
+pywinauto          # UI Automation tree walking
+
+# Required by motion_connector.py (imported indirectly by test_dropped_camera_gate.py)
+PyQt6
+base58
+numpy
+pandas

--- a/tests/test_connection_redesign.py
+++ b/tests/test_connection_redesign.py
@@ -38,6 +38,7 @@ from hil_helpers import (
     RE_DISCONNECTED,
     click_panel,
     find_app_log,
+    is_app_alive,
     log_size,
     wait_for_pattern,
 )
@@ -52,8 +53,10 @@ DISCONNECT_TIMEOUT = 15
 SCAN_RUNUP_SEC     = 8    # let scan get past handshake before yanking power
 SETTLE_AFTER_SCAN  = 8    # let app return to idle after mid-scan disconnect
 RAPID_TOGGLE_COUNT = 5
-RAPID_TOGGLE_HOLD  = 2.0  # seconds held in each off/on phase; faster trips the
+RAPID_TOGGLE_HOLD  = 5.0  # seconds held in each off/on phase; faster trips the
                           # Shelly relay's own duty-cycle limits, not the app.
+SLOW_TOGGLE_EXTRA  = 25.0  # extra wait after each ON for app to reconnect
+                          # (used by test_05_toggle_with_reconnect_wait)
 
 
 # ─────────────────────────────────────────────
@@ -186,7 +189,12 @@ class TestConnectionRedesign:
         time.sleep(SLEEP)
 
     def test_04_rapid_toggle(self, outlet, app):
-        """Many fast on/off toggles → app stays sane and ends up connected."""
+        """Many fast on/off toggles → app stays sane and ends up connected.
+
+        Asserts the app window survives every toggle. If the app crashes
+        during the loop we fail loudly with the toggle count, instead of
+        hanging in the post-loop log-tail verification.
+        """
         log.info(f"Rapid toggle x{RAPID_TOGGLE_COUNT}")
         for i in range(RAPID_TOGGLE_COUNT):
             outlet.off()
@@ -194,6 +202,11 @@ class TestConnectionRedesign:
             outlet.on()
             time.sleep(RAPID_TOGGLE_HOLD)
             log.info(f"  toggle {i + 1}/{RAPID_TOGGLE_COUNT}")
+            assert is_app_alive(), (
+                f"BUG: App crashed/closed after {i + 1}/{RAPID_TOGGLE_COUNT} "
+                f"rapid power toggles (RAPID_TOGGLE_HOLD={RAPID_TOGGLE_HOLD}s). "
+                f"Application window is no longer present."
+            )
 
         # Let the dust settle, then verify the app can still complete a
         # full disconnect-reconnect cycle from this state.
@@ -211,3 +224,44 @@ class TestConnectionRedesign:
         _wait_disconnected(log_path, offset)
         offset_after_disc = log_size(log_path)
         _wait_connected(log_path, offset_after_disc)
+
+    def test_05_toggle_with_reconnect_wait(self, outlet, app):
+        """Same as test_04 but wait an extra 5s after each ON for the app
+        to log a CONNECTED transition. Verifies the app fully recovers
+        between every toggle, not just at the end of the loop.
+        """
+        log_path = find_app_log()
+        assert log_path, (
+            "could not locate the bloodflow app log under any of the "
+            "search roots in utils.find_app_log — verify the app is "
+            "actually launched and writing to app-logs/."
+        )
+
+        log.info(
+            f"Toggle x{RAPID_TOGGLE_COUNT} with "
+            f"+{SLOW_TOGGLE_EXTRA}s reconnect wait per cycle"
+        )
+        for i in range(RAPID_TOGGLE_COUNT):
+            offset = log_size(log_path)
+
+            outlet.off()
+            time.sleep(RAPID_TOGGLE_HOLD)
+            outlet.on()
+            time.sleep(RAPID_TOGGLE_HOLD)
+
+            # Wait the extra 5s for the app to reconnect, while tailing
+            # the log for the CONNECTED transition emitted by the SDK.
+            line = wait_for_pattern(
+                RE_CONNECTED, log_path, offset, SLOW_TOGGLE_EXTRA
+            )
+            assert line, (
+                f"toggle {i + 1}/{RAPID_TOGGLE_COUNT}: "
+                f"app did NOT reconnect within "
+                f"{RAPID_TOGGLE_HOLD * 2 + SLOW_TOGGLE_EXTRA}s of the toggle"
+            )
+            log.info(f"  toggle {i + 1}/{RAPID_TOGGLE_COUNT}: connected ({line})")
+
+            assert is_app_alive(), (
+                f"BUG: App crashed/closed after {i + 1}/{RAPID_TOGGLE_COUNT} "
+                f"slow power toggles. Application window is no longer present."
+            )

--- a/tests/test_happy_path_full.py
+++ b/tests/test_happy_path_full.py
@@ -1,0 +1,948 @@
+"""
+test_happy_path_full.py — exhaustive end-to-end happy-path walkthrough.
+
+Marker: ``release`` (~16-18 min wall-clock — one real 10-min laser scan
+plus a full UI sweep). Only runs on release-pattern tag pushes.
+
+What it covers
+--------------
+Where ``test_scan_flow.py`` runs the core scan once and
+``test_scan_auto_stop_bug.py`` runs the *same* scan five times, this
+script instead walks the app through **every** user-facing feature of a
+normal scanning session exactly once, asserting each one in isolation so
+a failure points at the specific feature that broke:
+
+  1.  App is up and the console + sensors are CONNECTED (READY state).
+  2.  Scan Settings modal opens.
+  3.  User/subject label is set (verified later via the output filename).
+  4.  Left sensor mask is set to ``All``.
+  5.  Right sensor mask is set to ``All``.
+  6.  Scan-duration mode switch toggles (Timed -> Free Run -> Timed).
+  7.  Scan duration is set to 10 minutes.
+  8.  Scan Settings modal closes (and is verified closed).
+  9.  Session Notes modal opens and a note is typed.
+  10. Notes modal closes.
+  11. Contact-quality Check runs and its result modal is dismissed.
+  12. Scan starts.
+  13. Scan runs the full configured duration and reports completion.
+  14. Scan output files (canonical CSV + scans.db) land on disk, and the
+      canonical CSV carries the user label from step 3.
+  15. Post-scan Session Notes modal is dismissed.
+  16. History modal opens.
+  17. The scan just captured is listed in History's table.
+  18. The scan loads into the embedded PlotViewer via "Load in viewer →".
+  19. History modal closes itself once the scan loads.
+  20. The PlotViewer is showing the loaded scan and the app survived it.
+  21. Settings modal opens.
+  22. Settings modal closes.
+  23. The app is still alive and responsive at the end of the sweep.
+
+Each numbered step is its own ``test_NN_*`` method in a single
+``@pytest.mark.incremental`` class, so the first failure short-circuits
+the rest (a broken Check shouldn't cascade into 8 misleading scan
+failures) and the HIL report lists one clearly-named line per feature.
+
+Interaction patterns are borrowed from the maintained dev-tier tests so
+this release-tier sweep stays in step with the current UI:
+  - sensor dropdowns via ``focus_combobox_by_label`` (test_scan_settings),
+    which anchors focus by the field's UIA label rather than a fragile
+    Tab count — this also fixes the old duration-Tab-walk that assumed
+    focus was still at the top of the modal after the sensors were
+    mouse-selected;
+  - History is a ListView table (HistoryModal.qml), not a ComboBox, so
+    it is read by row text and loaded with "Load in viewer →", matching
+    test_history — not the old, stale ComboBox/"View in plot →" path.
+
+Preconditions
+-------------
+- Console + both sensors connected over USB.
+- ``OPENWATER_EXE`` set or ``OPENWATER_FROM_SOURCE=1``.
+- App launched (handled by the session-scoped ``app`` fixture).
+- No Shelly outlet required — this is a pure software/UI sweep, no
+  power cycling.
+"""
+
+import re
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pyautogui
+import pytest
+
+from conftest import (
+    SLEEP,
+    log,
+    read_combobox_values,
+    require_focus,
+    uia_window,
+    wait_for_combobox,
+)
+from hil_helpers import (
+    RE_CONNECTED,
+    SENSOR_OPTIONS,
+    click_element_center,
+    click_panel,
+    dismiss_signal_quality_modal,
+    find_app_log,
+    focus_combobox_by_label,
+    force_app_config_value,
+    is_app_alive,
+    log_size,
+    read_app_config_value,
+    recalibrate_panel_buttons,
+    wait_for_pattern,
+    write_app_config_value,
+)
+
+pytestmark = pytest.mark.release
+
+# Scan Settings + Check are hidden in reduced mode; force the on-disk
+# flag false at module-import time (before the session-scoped ``app``
+# fixture launches the app) and restore it on teardown. Same pattern as
+# test_scan_flow / test_scan_settings / test_usb_disconnect_freeze.
+_INITIAL_REDUCED_MODE = force_app_config_value("reducedMode", False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_reduced_mode_on_module_teardown():
+    yield
+    write_app_config_value("reducedMode", _INITIAL_REDUCED_MODE)
+
+
+# ─────────────────────────────────────────────
+# Configuration
+# ─────────────────────────────────────────────
+SCAN_DURATION_MIN = 10
+SCAN_DURATION_SEC = SCAN_DURATION_MIN * 60
+CHECK_WAIT_SEC    = 120                       # Check completes within ~2 min
+CHECK_START_TIMEOUT_SEC = 20                  # a healthy Check logs "started" in ~1s
+SCAN_START_TIMEOUT_SEC  = 30                  # scan launch (pipeline build) can take ~10s
+SCAN_POLL_SEC     = 10
+SCAN_MAX_WAIT_SEC = SCAN_DURATION_SEC + 180   # scan + 3-min buffer
+READY_TIMEOUT_SEC = 30                        # wait for CONNECTED at start
+SENSOR_OPTION     = "All"                     # both sensors → all 16 cameras
+
+
+def _sensor_picker_enabled(combobox_index: int, timeout: float = 15.0) -> bool:
+    """True iff the sensor ComboBox at ``combobox_index`` is enabled.
+
+    A side with no sensor attached renders its whole picker grayed out
+    (verified on 1.4.0: the disabled ComboBox ignores clicks and keyboard
+    selection, so trying to set it can never verify). Callers skip the
+    selection step for a disabled side.
+    """
+    elem = wait_for_combobox(combobox_index, timeout=timeout)
+    if elem is None:
+        return False
+    try:
+        return bool(elem.is_enabled())
+    except Exception as e:
+        # Assume enabled — _select_sensor's strict verify will surface
+        # the truth with a clear expected-vs-got message.
+        log.warning(f"  is_enabled() failed for ComboBox[{combobox_index}]: {e}")
+        return True
+
+# The connector logs these bracketed markers around every Check; tailing
+# them lets test_11 confirm the Check actually ran (and fail fast with a
+# clear message if the click didn't register / the app is unresponsive)
+# instead of blindly burning the full CHECK_WAIT_SEC budget.
+RE_CHECK_STARTED = re.compile(r"Contact-quality check started")
+RE_CHECK_ENDED   = re.compile(r"Contact-quality check ended")
+
+# The connector logs the launched scan with its ACTUAL configured duration,
+# e.g. "=== Full scan started: subject=owXXXX duration=120s left=0xFF ... ===".
+# test_12 keys off this to prove both that the Start click landed AND that the
+# H:M:S duration fields were set to the intended value (backend truth, no UIA).
+RE_SCAN_STARTED = re.compile(r"Full scan started:.*?duration=(\d+)s")
+
+# The History modal's title/rows are NOT exposed via UIA on this build, but
+# the connector logs "QML: [History] opened — N scan(s)" when it opens, and
+# its footer Buttons (Export CSV / Load in viewer) DO surface in UIA. test_16
+# keys off the log; open/closed state is confirmed via those buttons.
+RE_HISTORY_OPENED = re.compile(r"\[History\] opened\D+(\d+) scan")
+
+# Shared state across the incremental steps. pytest builds a fresh class
+# instance per test method, so per-test ``self.x`` doesn't persist — keep
+# cross-step data in a module-level dict instead.
+STATE: dict = {
+    "subject_label": "",     # user label typed in step 3
+    "files_before":  set(),  # data-dir listing snapshot taken at scan start
+    "scan_seconds":  None,   # duration the app reported at completion
+    "scan_started_sec": None,  # duration the backend logged at scan start
+    "duration_hms":  f"00:{SCAN_DURATION_MIN:02d}:00",  # configured scan duration
+    "history_scan_count": None,  # scan count History logged when opened
+}
+
+# NOTE: the JSON + Markdown run report is produced by conftest's autouse
+# ``_hil_report_session`` reporter (test_logs/HIL_Report_<module>_<ts>.json
+# and .md) — the suite-wide V&V evidence mechanism. This module deliberately
+# does NOT write its own report to avoid duplicating it.
+
+
+# ─────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────
+def _resolve_data_dir() -> Path:
+    """Return the directory the app writes scan output (CSVs + scans.db) into.
+
+    The output root is ``dataDirectory`` from app_config.json when set.
+    When unset (the packaged portable build ships it empty), the app
+    defaults the root to its own install folder — the same place its
+    ``logs/`` live — so derive the root from the app log location rather
+    than guessing cwd. Scan files land in the ``data/`` child when it
+    exists (1.4.0+ layout), else directly in the root (older builds).
+    """
+    root = None
+    configured = read_app_config_value("dataDirectory", None)
+    if configured and Path(configured).is_dir():
+        root = Path(configured)
+    else:
+        log_path = find_app_log()
+        if log_path:
+            root = Path(log_path).parent.parent
+    if root is None:
+        root = Path.cwd()
+    data = root / "data"
+    return data if data.is_dir() else root
+
+
+def _dir_listing(dir_path: Path) -> set:
+    """Set of file names directly under ``dir_path`` (empty on error)."""
+    try:
+        return {p.name for p in dir_path.iterdir() if p.is_file()}
+    except OSError:
+        return set()
+
+
+def _scan_settings_open() -> bool:
+    """True iff the Scan Settings modal is up.
+
+    Detected by presence of any ComboBox in the UIA tree — the only page
+    in non-reduced mode that exposes ComboBoxes is the Scan Settings
+    modal's sensor pickers. Same fingerprint as test_scan_settings.
+    """
+    try:
+        return bool(uia_window().descendants(control_type="ComboBox"))
+    except Exception:
+        return False
+
+
+_HISTORY_BUTTON_HINTS = ("Load in viewer", "Export CSV")
+
+
+def _history_open() -> bool:
+    """True iff the History modal is open, detected by its footer Buttons.
+
+    The modal's 'Scan History' title and its scan rows are NOT exposed via
+    UIA on this build, but the footer Buttons (Export CSV / Load in viewer)
+    are — so button presence is the reliable open/closed signal. (Verified
+    live against 1.3.0_RUO.)
+    """
+    try:
+        for e in uia_window().descendants(control_type="Button"):
+            nm = (e.element_info.name or e.window_text() or "")
+            if any(h.lower() in nm.lower() for h in _HISTORY_BUTTON_HINTS):
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _click_history_button(substr: str) -> str:
+    """Pixel-click the History footer Button whose name contains ``substr``.
+
+    Substring match (case-insensitive) rather than an exact title, because
+    the real label carries an arrow and doubled spaces ("Load in viewer  →")
+    that an exact UIA title query would miss. Uses a real pixel click on the
+    button's rectangle — these QML buttons ignore the UIA InvokePattern
+    (verified: ``invoke()`` was a no-op and left History open). Returns the
+    matched name, or "" if not found.
+    """
+    try:
+        for e in uia_window().descendants(control_type="Button"):
+            nm = (e.element_info.name or e.window_text() or "")
+            if substr.lower() in nm.lower():
+                click_element_center(e, nm.strip())
+                return nm
+    except Exception:
+        pass
+    return ""
+
+
+def _open_panel_verified(label: str, is_open, what: str, tries: int = 2, settle: int = 8):
+    """Click a sidebar panel button and VERIFY the expected UI actually opened.
+
+    ``click_panel`` calibrates button coordinates via UIA with a relative-
+    ratio fallback; when the fallback is even slightly off the click can
+    land off the button and silently do nothing (the log still says
+    "click panel ..."). This wrapper closes that gap: it polls ``is_open``
+    after the click, and on a miss it recalibrates and clicks again before
+    failing loudly — so a mis-landed click surfaces at THIS step with a
+    clear message instead of cascading into a confusing later failure.
+
+    All these panel buttons are toggles, so we only re-click when the panel
+    is confirmed *not* open (never double-click an already-open modal shut).
+    """
+    for attempt in range(1, tries + 1):
+        if attempt > 1:
+            log.warning(f"  {what}: not open after attempt {attempt - 1}; recalibrating panel buttons")
+            recalibrate_panel_buttons()
+        click_panel(label)
+        deadline = time.time() + settle
+        while time.time() < deadline:
+            if is_open():
+                if attempt > 1:
+                    log.info(f"  {what} opened on retry {attempt}.")
+                return
+            time.sleep(0.5)
+    pytest.fail(
+        f"{what} did not open after {tries} '{label}' click attempt(s). The "
+        f"calibrated coordinate is landing off the button — clicks are not "
+        f"registering on the app (calibration fell back to relative ratios)."
+    )
+
+
+def _select_sensor(side: str, combobox_index: int, option: str = SENSOR_OPTION):
+    """Open a sensor dropdown by its UIA label, pick ``option``, verify it.
+
+    Anchors focus with ``focus_combobox_by_label`` (test_scan_settings)
+    rather than a Tab count, so it stands alone as its own step and does
+    not depend on where focus happened to land after the previous step.
+    """
+    require_focus()
+    label = f"{side} Sensor"
+    idx = SENSOR_OPTIONS.index(option)
+    log.info(f"  {label}: selecting '{option}' (index {idx})")
+
+    focus_combobox_by_label(label)
+    pyautogui.hotkey("alt", "down")   # open the popup
+    time.sleep(0.5)
+    pyautogui.press("home")           # jump to the first item
+    time.sleep(0.2)
+    for _ in range(idx):
+        pyautogui.press("down")
+        time.sleep(0.15)
+    pyautogui.press("return")         # confirm
+    time.sleep(SLEEP)
+
+    values = read_combobox_values()
+    assert len(values) > combobox_index, (
+        f"Expected at least {combobox_index + 1} ComboBox(es) in Scan "
+        f"Settings, found {len(values)} — Qt accessibility bridge may not "
+        f"be exposing the modal's sensor pickers on this runner."
+    )
+    actual = values[combobox_index]
+    assert actual == option, f"{side} sensor: expected '{option}', got '{actual}'"
+    log.info(f"  {side} sensor set to '{actual}'.")
+
+
+def _find_user_label_field(win):
+    """Return the User Label input Edit (carries the auto-generated 'owXXXXXX'
+    value), or None. Distinguished from the 'User Label:' caption and the
+    numeric duration Edits by its 'ow' prefix."""
+    for e in win.descendants(control_type="Edit"):
+        try:
+            t = (e.window_text() or "").strip()
+        except Exception:
+            continue
+        if t.lower().startswith("ow") and not t.isdigit():
+            return e
+    return None
+
+
+def _duration_fields(win):
+    """Return the three numeric duration Edit controls (Hours, Minutes,
+    Seconds), ordered left-to-right by x-position.
+
+    The Scan Settings duration inputs render as three small numeric Edit
+    controls (~81px wide, digit text) laid out H : M : S. The wider User
+    Label Edit (~150px) is excluded. Confirmed against the running build's
+    UIA tree; mirrors ``test_history._set_scan_duration``.
+    """
+    fields = []
+    for e in win.descendants(control_type="Edit"):
+        try:
+            r = e.rectangle()
+            if (r.right - r.left) >= 150:       # skip the wide User Label field
+                continue
+            txt = (e.window_text() or "").strip()
+            if txt.isdigit() or txt == "":
+                fields.append((r.left, e))
+        except Exception:
+            continue
+    fields.sort(key=lambda t: t[0])
+    return [e for _, e in fields]
+
+
+def _read_duration_hms(win) -> str:
+    fields = _duration_fields(win)
+    vals = [(e.window_text() or "").strip() for e in fields[:3]]
+    return ":".join(vals) if len(vals) == 3 else "?"
+
+
+def _set_duration_minutes(minutes: int):
+    """Set the scan duration to 0h:``minutes``m:0s by clicking the H/M/S
+    Edit fields directly — NOT by Tab-counting.
+
+    Tab-navigation from the sensor row proved fragile: a one-off in the
+    tab count landed the value in the Hours field (an N-hour scan instead
+    of N minutes). The three duration inputs are unambiguous UIA Edit
+    controls, so we click each by its rectangle and type into it. Verified
+    live on the 1.3.0_RUO build.
+    """
+    require_focus()
+    win = uia_window()
+    fields = _duration_fields(win)
+    assert len(fields) >= 3, (
+        f"Expected 3 numeric duration fields (H:M:S) in Scan Settings, found "
+        f"{len(fields)} — UIA may not be exposing the duration inputs."
+    )
+    for elem, value, label in ((fields[0], 0, "Hours"),
+                               (fields[1], minutes, "Minutes"),
+                               (fields[2], 0, "Seconds")):
+        click_element_center(elem, f"{label} field")
+        time.sleep(0.15)
+        pyautogui.hotkey("ctrl", "a")
+        time.sleep(0.1)
+        pyautogui.typewrite(str(value), interval=0.05)
+        time.sleep(0.15)
+    hms = _read_duration_hms(win)
+    log.info(f"  duration fields now read H:M:S = {hms}")
+
+
+def _scan_reported_duration():
+    """If the post-scan Session Notes modal is up, return the scan
+    duration in seconds parsed from its "Scan completed — duration:
+    HH:MM:SS" text; else ``None`` (0 if the modal is up but unparsable).
+
+    Same detection as ``test_scan_auto_stop_bug._check_scan_finished``.
+    """
+    import re
+    try:
+        win = uia_window()
+        found_notes = False
+        for elem in win.descendants():
+            try:
+                text = elem.window_text().strip()
+            except Exception:
+                continue
+            if "session notes" in text.lower():
+                found_notes = True
+            m = re.search(r"duration:\s*(\d{2}):(\d{2}):(\d{2})", text)
+            if m:
+                h, mi, s = int(m.group(1)), int(m.group(2)), int(m.group(3))
+                secs = h * 3600 + mi * 60 + s
+                log.info(f"  Scan finished — {text.strip()} ({secs}s)")
+                return secs
+        if found_notes:
+            log.info("  Scan finished — Session Notes visible (duration unparsed)")
+            return 0
+    except Exception as e:
+        log.warning(f"  _scan_reported_duration failed: {e}")
+    return None
+
+
+# ─────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────
+@pytest.mark.incremental
+class TestHappyPathFull:
+    """Full happy-path sweep: every scanning feature exercised once, in order."""
+
+    def test_01_app_ready(self, app):
+        """App is launched and the console + sensors are CONNECTED (READY)."""
+        assert is_app_alive(), "Bloodflow app window is not present at start."
+        log_path = find_app_log()
+        assert log_path, "could not locate the bloodflow app log."
+        # If the device is already connected we may have missed the line;
+        # tail from the top of the current log and accept either a fresh
+        # CONNECTED transition or an already-connected app.
+        line = wait_for_pattern(RE_CONNECTED, log_path, 0, READY_TIMEOUT_SEC)
+        if line:
+            log.info(f"  device connected: {line}")
+        else:
+            log.info("  no CONNECTED line seen — assuming already connected.")
+
+    def test_02_open_scan_settings(self, app):
+        """Scan Settings modal opens from the sidebar (verified + retried)."""
+        _open_panel_verified(
+            "Scan\nSettings", _scan_settings_open, "Scan Settings modal"
+        )
+        elem = wait_for_combobox(0, timeout=15)
+        assert elem is not None, (
+            "Scan Settings opened but did not expose its sensor ComboBoxes "
+            "within 15 s."
+        )
+
+    def test_03_set_user_label(self, app):
+        """Set a distinctive subject/user label by clicking the field directly.
+
+        Tab navigation to the User Label field is unreliable — the first Tab
+        sometimes lands on a button, so the typed value falls on the floor and
+        the scan keeps its auto-generated 'owXXXXXX' label (this is what made
+        run 7's output 'owUOBWIL' instead of the intended label). Click the
+        UIA Edit directly, type, and verify the field took the value.
+        """
+        win = uia_window()
+        field = _find_user_label_field(win)
+        assert field is not None, (
+            "Could not find the User Label input field (an Edit with an "
+            "'ow' value) in the Scan Settings modal."
+        )
+        STATE["subject_label"] = f"HappyPath_{datetime.now():%H%M%S}"
+        click_element_center(field, "User Label field")
+        time.sleep(0.3)
+        pyautogui.hotkey("ctrl", "a")
+        time.sleep(0.1)
+        pyautogui.press("delete")
+        time.sleep(0.1)
+        pyautogui.typewrite(STATE["subject_label"], interval=0.04)
+        time.sleep(0.3)
+
+        # Verify the field actually holds our label (app normalizes to
+        # alphanumeric-uppercase on save; compare on that form). Poll a moment
+        # for the UIA value to reflect the keystrokes.
+        def _norm(s: str) -> str:
+            return "".join(c for c in s if c.isalnum()).upper()
+
+        want = _norm(STATE["subject_label"])
+        deadline = time.time() + 3
+        got = ""
+        while time.time() < deadline:
+            fld = _find_user_label_field(win) or field
+            got = (fld.window_text() or "").strip()
+            if want in _norm(got):
+                break
+            time.sleep(0.3)
+        assert want in _norm(got), (
+            f"User Label field shows '{got}' after typing "
+            f"'{STATE['subject_label']}' — the label did not register in the "
+            f"field (the click may have missed the input)."
+        )
+        log.info(f"  user label set to '{STATE['subject_label']}' (field: '{got}').")
+
+    def test_04_select_left_sensor(self, app):
+        """Left sensor mask set to 'All' — skipped when the picker is
+        disabled (no left sensor attached to this bench)."""
+        if not _sensor_picker_enabled(0):
+            log.info("  Left sensor picker disabled — no left sensor attached.")
+            pytest.skip("Left sensor not attached (picker disabled).")
+        _select_sensor(side="Left", combobox_index=0)
+
+    def test_05_select_right_sensor(self, app):
+        """Right sensor mask set to 'All' — skipped when the picker is
+        disabled (no right sensor attached to this bench)."""
+        if not _sensor_picker_enabled(1):
+            log.info("  Right sensor picker disabled — no right sensor attached.")
+            pytest.skip("Right sensor not attached (picker disabled).")
+        _select_sensor(side="Right", combobox_index=1)
+
+    def test_06_toggle_scan_mode_switch(self, app):
+        """The Timed/Free-Run duration switch is operable.
+
+        Toggle it to Free Run and back to Timed (the mode the scan needs),
+        verifying the switch responds without closing or crashing the
+        modal. Mirrors test_scan_settings test_08/test_09, collapsed into
+        one step so the happy path leaves the switch on Timed.
+        """
+        require_focus()
+        # Anchor on an ENABLED combobox — a disabled picker (side with no
+        # sensor attached) ignores clicks and never takes focus, so the
+        # Tab walk would start from the wrong place.
+        if _sensor_picker_enabled(0):
+            focus_combobox_by_label("Left Sensor")
+            tabs_to_switch = 2            # Left -> Right ComboBox -> Switch
+        else:
+            focus_combobox_by_label("Right Sensor")
+            tabs_to_switch = 1            # Right ComboBox -> Switch
+        require_focus()
+        for _ in range(tabs_to_switch):
+            pyautogui.press("tab")
+            time.sleep(0.2)
+        time.sleep(0.3)
+        pyautogui.press("space")          # Timed -> Free Run
+        time.sleep(SLEEP)
+        pyautogui.press("space")          # Free Run -> Timed
+        time.sleep(SLEEP)
+        assert _scan_settings_open(), (
+            "Scan Settings modal disappeared while toggling the "
+            "Timed/Free-Run switch — the switch may have crashed or "
+            "closed the modal."
+        )
+
+    def test_07_set_duration(self, app):
+        """Scan duration set to 10 minutes, verified in the H:M:S fields."""
+        _set_duration_minutes(SCAN_DURATION_MIN)
+        vals = [(e.window_text() or "").strip()
+                for e in _duration_fields(uia_window())[:3]]
+        assert len(vals) == 3 and all(v.isdigit() for v in vals), (
+            f"Could not read back the three duration fields: {vals}"
+        )
+        h, m, s = (int(v) for v in vals)
+        assert (h, m, s) == (0, SCAN_DURATION_MIN, 0), (
+            f"Duration read H:M:S = {h}:{m:02d}:{s:02d}, expected "
+            f"0:{SCAN_DURATION_MIN:02d}:00 — the value landed in the wrong "
+            f"field (the hours-instead-of-minutes bug)."
+        )
+
+    def test_08_close_scan_settings(self, app):
+        """Scan Settings modal closes (Escape) — and is verified closed."""
+        require_focus()
+        pyautogui.press("escape")
+        time.sleep(SLEEP)
+        assert not _scan_settings_open(), (
+            "Scan Settings modal still exposes ComboBoxes after Escape — "
+            "the modal did not close."
+        )
+
+    def test_09_add_session_note(self, app):
+        """Session Notes modal opens and accepts a typed note."""
+        click_panel("Notes")
+        require_focus()
+        note = f"Happy-path sweep {datetime.now():%Y-%m-%d %H:%M:%S}"
+        log.info(f"  typing note: '{note}'")
+        pyautogui.typewrite(note, interval=0.03)
+        time.sleep(SLEEP)
+
+    def test_10_close_notes(self, app):
+        """Notes modal closes (Escape)."""
+        require_focus()
+        pyautogui.press("escape")
+        time.sleep(SLEEP)
+
+    def test_11_contact_quality_check(self, app):
+        """Contact-quality Check runs and its result modal is dismissed.
+
+        Fails fast if the click never actually starts a Check: the
+        connector logs "Contact-quality check started" within ~1s on a
+        healthy run, so if that line doesn't appear within
+        CHECK_START_TIMEOUT_SEC the click didn't register or the app is
+        unresponsive — a far clearer signal than burning the full
+        CHECK_WAIT_SEC and reporting only "modal never appeared".
+        """
+        log_path = find_app_log()
+        start_off = log_size(log_path) if log_path else 0
+        log.info(f"  Clicking Check, waiting up to {CHECK_WAIT_SEC}s...")
+        click_panel("Check")
+
+        # Fail fast: confirm the Check actually started via the app log.
+        if log_path:
+            started = wait_for_pattern(
+                RE_CHECK_STARTED, log_path, start_off, CHECK_START_TIMEOUT_SEC
+            )
+            assert started, (
+                f"No 'Contact-quality check started' line appeared in the "
+                f"app log within {CHECK_START_TIMEOUT_SEC}s of clicking "
+                f"Check (a healthy run logs it in ~1s). The Check button "
+                f"click did not register, or the app is unresponsive — "
+                f"check {log_path} for the last logged activity."
+            )
+            log.info(f"  Check started: {started.strip()}")
+
+        elapsed = 0
+        dismissed = False
+        while elapsed < CHECK_WAIT_SEC:
+            time.sleep(SCAN_POLL_SEC)
+            elapsed += SCAN_POLL_SEC
+            if not is_app_alive():
+                pytest.fail(f"App closed during Check after {elapsed}s.")
+            if dismiss_signal_quality_modal():
+                log.info(f"  Contact-quality modal dismissed at {elapsed}s.")
+                dismissed = True
+                break
+            if elapsed % 30 == 0:
+                log.info(f"  Check running... {elapsed}/{CHECK_WAIT_SEC}s")
+        # Final attempt in case the modal appeared as the loop exited.
+        if not dismissed:
+            dismissed = dismiss_signal_quality_modal()
+
+        # Diagnostic on timeout: did the Check at least finish? This
+        # separates "Check stalled" (started, never ended) from "modal
+        # never surfaced" (ended, but the result modal wasn't detected).
+        if not dismissed and log_path:
+            ended = wait_for_pattern(RE_CHECK_ENDED, log_path, start_off, 1)
+            log.warning(
+                f"  Check modal not dismissed after {CHECK_WAIT_SEC}s — "
+                f"'check ended' logged: {bool(ended)}. "
+                + ("Check completed but the result modal wasn't detected."
+                   if ended else
+                   "Check started but never ended — it stalled mid-run.")
+            )
+        assert dismissed, (
+            f"Contact-quality result modal never appeared within "
+            f"{CHECK_WAIT_SEC}s of clicking Check."
+        )
+
+    def test_12_start_scan(self, app):
+        """Scan starts, AND the backend confirms the configured H:M:S duration.
+
+        Verifies from the app log (backend truth, not fragile UIA) that:
+          * the Start click actually launched a scan — the connector logs
+            "Full scan started ..." only on a real click; if it's absent the
+            click landed off the button; and
+          * the duration the app is scanning with matches what the H:M:S
+            fields were set to in test_07 — the log line carries
+            ``duration=<sec>s``, so a mis-set duration is caught here rather
+            than only implied by scan length.
+
+        Start is a toggle (it becomes Stop once scanning), so this never
+        re-clicks — it fails loudly instead.
+        """
+        STATE["files_before"] = _dir_listing(_resolve_data_dir())
+        log.info(f"  data dir before scan: {len(STATE['files_before'])} files.")
+
+        log_path = find_app_log()
+        start_off = log_size(log_path) if log_path else 0
+        click_panel("Start")
+
+        if log_path:
+            line = wait_for_pattern(
+                RE_SCAN_STARTED, log_path, start_off, SCAN_START_TIMEOUT_SEC
+            )
+            assert line, (
+                f"No 'Full scan started' line appeared in the app log within "
+                f"{SCAN_START_TIMEOUT_SEC}s of clicking Start. The Start click "
+                f"did not register (landed off the button), or the scan failed "
+                f"to launch — see {log_path}."
+            )
+            m = RE_SCAN_STARTED.search(line)
+            started_sec = int(m.group(1)) if m else None
+            STATE["scan_started_sec"] = started_sec
+            log.info(f"  Full scan started (backend duration={started_sec}s).")
+            assert started_sec == SCAN_DURATION_SEC, (
+                f"Scan launched with duration={started_sec}s, but the H:M:S "
+                f"fields were configured for {SCAN_DURATION_SEC}s "
+                f"({STATE['duration_hms']}). The duration was set to the wrong "
+                f"value in Scan Settings."
+            )
+        log.info("  Scan started — monitoring for completion...")
+
+    def test_13_scan_completes(self, app):
+        """Scan runs the full 10-min duration and reports completion."""
+        elapsed = 0
+        secs = None
+        while elapsed < SCAN_MAX_WAIT_SEC:
+            time.sleep(SCAN_POLL_SEC)
+            elapsed += SCAN_POLL_SEC
+            if not is_app_alive():
+                pytest.fail(f"App closed mid-scan after {elapsed}s.")
+            secs = _scan_reported_duration()
+            if secs is not None:
+                log.info(f"  Session Notes appeared after {elapsed}s "
+                         f"(reported {secs}s).")
+                break
+            if elapsed % 60 == 0:
+                log.info(f"  {elapsed}s elapsed — scan still running...")
+
+        assert secs is not None, (
+            f"Session Notes never appeared within {SCAN_MAX_WAIT_SEC}s — "
+            f"scan may be stuck."
+        )
+        STATE["scan_seconds"] = secs
+        assert secs >= SCAN_DURATION_SEC, (
+            f"Scan ran only {secs}s ({secs // 60}m {secs % 60}s); expected "
+            f"at least {SCAN_DURATION_SEC}s ({SCAN_DURATION_MIN}m). Scan "
+            f"stopped early."
+        )
+        log.info(f"  Scan duration OK: {secs}s (>= {SCAN_DURATION_SEC}s).")
+
+    def test_14_scan_output_files(self, app):
+        """Scan output is written: a raw CSV carrying the step-3 user label
+        when ``writeRawCsv`` is enabled, and the scans.db session always
+        (with ``writeRawCsv`` off — the packaged default — the DB session
+        id carries the label instead)."""
+        data_dir = _resolve_data_dir()
+        after = _dir_listing(data_dir)
+        new = sorted(after - STATE["files_before"])
+        log.info(f"  new files in {data_dir}: {new}")
+
+        # The app normalizes User Label on save — prepends 'ow', uppercases,
+        # and strips underscores/spaces/punctuation (e.g. 'HappyPath_144243'
+        # -> 'owHAPPYPATH144243'), so compare on the alphanumeric-uppercase
+        # form of both sides rather than a raw substring. Same normalization
+        # as test_scan_settings.
+        def _norm(s: str) -> str:
+            return "".join(c for c in s if c.isalnum()).upper()
+
+        norm_label = _norm(STATE["subject_label"])
+
+        if read_app_config_value("writeRawCsv", False):
+            new_csvs = [n for n in new if n.lower().endswith(".csv")]
+            assert new_csvs, (
+                f"No new .csv appeared in {data_dir} after the scan. "
+                f"New files: {new}"
+            )
+            labelled = [
+                n for n in new_csvs if norm_label and norm_label in _norm(n)
+            ]
+            assert labelled, (
+                f"None of the new CSVs {new_csvs} carry the user label "
+                f"'{STATE['subject_label']}' (normalized '{norm_label}') set in "
+                f"step 3 — the label did not propagate to the scan output "
+                f"filename."
+            )
+            log.info(f"  scan output CSV with label: {labelled}")
+        else:
+            # CSV output is config-disabled — the scan is recorded to
+            # scans.db only. The connector logs the DB session id it saved
+            # under ("Scan notes saved to DB session '<id>'"), and the id
+            # embeds the normalized user label, so label propagation is
+            # still verified.
+            log.info("  writeRawCsv is off — verifying the DB session "
+                     "instead of a CSV.")
+            session_id = ""
+            log_path = find_app_log()
+            if log_path:
+                try:
+                    text = Path(log_path).read_text(
+                        encoding="utf-8", errors="replace"
+                    )
+                    ids = re.findall(r"DB session '([^']+)'", text)
+                    session_id = ids[-1] if ids else ""
+                except OSError:
+                    pass
+            assert session_id, (
+                "writeRawCsv is off and no 'saved to DB session' line was "
+                "found in the app log — the scan does not appear to have "
+                "been recorded."
+            )
+            assert norm_label and norm_label in _norm(session_id), (
+                f"DB session '{session_id}' does not carry the user label "
+                f"'{STATE['subject_label']}' (normalized '{norm_label}') set "
+                f"in step 3 — the label did not propagate to the scan record."
+            )
+            log.info(f"  scan recorded as DB session '{session_id}'.")
+
+        # scans.db is created once and updated in place, so check it exists
+        # and was touched recently rather than expecting it in the diff.
+        db = data_dir / "scans.db"
+        assert db.exists(), f"scans.db not found in {data_dir}."
+        age = time.time() - db.stat().st_mtime
+        assert age < SCAN_MAX_WAIT_SEC + 120, (
+            f"scans.db exists but was last modified {age:.0f}s ago — the "
+            f"scan session may not have been recorded to the database."
+        )
+        log.info(f"  scans.db present and updated {age:.0f}s ago.")
+
+    def test_15_close_post_scan_notes(self, app):
+        """Auto-opened post-scan Session Notes modal is dismissed."""
+        require_focus()
+        pyautogui.press("escape")
+        time.sleep(SLEEP)
+
+    def test_16_open_history(self, app):
+        """History opens from the sidebar.
+
+        Verified two ways (the modal's title/rows are NOT in the UIA tree
+        on this build): the connector logs '[History] opened — N scan(s)',
+        and the modal's footer Buttons (Export CSV / Load in viewer) appear
+        in UIA. We do NOT retry-click here — History is a toggle, and a
+        false-negative retry would toggle an already-open modal shut.
+        """
+        log_path = find_app_log()
+        start_off = log_size(log_path) if log_path else 0
+        click_panel("History")
+
+        if log_path:
+            line = wait_for_pattern(RE_HISTORY_OPENED, log_path, start_off, 15)
+            if line:
+                m = RE_HISTORY_OPENED.search(line)
+                STATE["history_scan_count"] = int(m.group(1)) if m else None
+                log.info(f"  {line.strip()}")
+
+        deadline = time.time() + 10
+        while time.time() < deadline and not _history_open():
+            time.sleep(0.5)
+        assert _history_open(), (
+            "History modal footer buttons (Export CSV / Load in viewer) did "
+            "not appear within 10s of clicking History — the modal did not "
+            "open (the History click may have landed off the button)."
+        )
+
+    def test_17_scan_listed(self, app):
+        """History lists at least one scan (the one just captured is recorded).
+
+        The scan count comes from the '[History] opened — N scan(s)' log line;
+        the rows themselves aren't UIA-exposed, but test_14 already proved the
+        scan's CSV + DB session were written, and it's the latest entry."""
+        n = STATE.get("history_scan_count")
+        assert n is not None and n >= 1, (
+            f"History reported {n} scans — expected at least 1. The scan just "
+            f"captured should be recorded (see the '[History] opened — N "
+            f"scan(s)' app-log line)."
+        )
+        log.info(f"  History lists {n} scan(s).")
+
+    def test_18_load_in_viewer(self, app):
+        """Select the latest scan row, then load it into the PlotViewer.
+
+        'Load in viewer' is disabled until a row is actively clicked (the
+        default highlight isn't enough — verified live). History rows are
+        NOT exposed via UIA on this build (only the footer Buttons are), so
+        the top row is selected by a click anchored to the app-window rect
+        — a last-resort calibrated coordinate (STYLE_GUIDE §6, tier 3),
+        correlated against the live modal layout. The button itself is
+        UIA-addressable and clicked by substring.
+        """
+        r = uia_window().rectangle()
+        w, h = r.right - r.left, r.bottom - r.top
+        # First data row sits ~0.22 across and ~0.275 down from the modal's
+        # top-left (the modal is a centred overlay that scales with the window).
+        row_x, row_y = int(r.left + 0.223 * w), int(r.top + 0.275 * h)
+        log.info(f"  selecting latest History row at ({row_x}, {row_y})")
+        pyautogui.click(row_x, row_y)
+        time.sleep(0.5)
+
+        # Once a row is selected the button relabels from "Load in viewer →"
+        # to 'Load "<scan-name>" →', so match on the stable "Load" prefix.
+        name = _click_history_button("Load")
+        assert name, (
+            "No 'Load ...' button found in the open History modal after "
+            "selecting a row — expected the load button next to Export CSV / "
+            "Delete (the row selection may not have registered)."
+        )
+        log.info(f"  invoked History load button '{name.strip()}'.")
+        time.sleep(SLEEP)
+
+    def test_19_history_closed_by_load(self, app):
+        """History closes itself once the scan loads (footer buttons vanish)."""
+        deadline = time.time() + 8
+        while time.time() < deadline and _history_open():
+            time.sleep(0.5)
+        assert not _history_open(), (
+            "History modal footer buttons still present after 'Load in "
+            "viewer' — expected the modal to close once the scan loaded."
+        )
+
+    def test_20_plot_loaded(self, app):
+        """The scan loaded into the PlotViewer and the app survived it."""
+        assert is_app_alive(), (
+            "App window is gone after loading the scan into the PlotViewer."
+        )
+        log.info("  PlotViewer loaded the scan; app still responsive.")
+
+    def test_21_open_settings(self, app):
+        """Settings modal opens from the sidebar gear."""
+        click_panel("Settings")
+        time.sleep(SLEEP)
+        # SettingsModal is fingerprinted by its "Time window" text /
+        # "Run Calibration" button; a ComboBox may not be present, so
+        # just assert the app survived opening it.
+        assert is_app_alive(), "App closed when opening Settings."
+
+    def test_22_close_settings(self, app):
+        """Settings modal closes (Escape)."""
+        require_focus()
+        pyautogui.press("escape")
+        time.sleep(SLEEP)
+
+    def test_23_app_still_alive(self, app):
+        """After the full sweep the app is still alive and responsive."""
+        assert is_app_alive(), (
+            "App window is gone at the end of the happy-path sweep."
+        )
+        log.info(
+            f"  Happy-path complete — scan ran {STATE['scan_seconds']}s, "
+            f"label '{STATE['subject_label']}'."
+        )

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -16,6 +16,7 @@ import pytest
 from conftest import (
     SLEEP,
     click_by_name,
+    click_sidebar,
     ensure_visible,
     log,
     read_combobox_values,
@@ -24,6 +25,9 @@ from conftest import (
 )
 from hil_helpers import (
     SENSOR_OPTIONS,
+    SIDEBAR_HISTORY,
+    SIDEBAR_SCAN_SETTINGS,
+    SIDEBAR_START,
     click_element_center,
     click_panel,
 )
@@ -52,42 +56,69 @@ _SEED_MAX_WAIT_SEC = 240
 # ─────────────────────────────────────────────
 # Seed-scan helpers (mirrors the abbreviated auto-stop-bug test)
 # ─────────────────────────────────────────────
-def _wait_for_combobox(idx: int, timeout: int = 15):
+def _wait_for_combobox(idx: int, timeout: int = 30):
     """Poll UIA up to ``timeout`` seconds for at least ``idx + 1``
-    ComboBoxes to appear in the window. Self-hosted runner sometimes
-    needs several seconds before Qt exposes modal contents through
-    the accessibility bridge, especially on the first modal of the
-    session.
+    ComboBoxes to appear in the window.
 
-    Returns the ComboBox element on success, or None on timeout.
+    Tries multiple control types because QML ComboBoxes are sometimes
+    exposed as 'ComboBox' and sometimes as 'Custom' depending on the
+    Qt accessibility bridge state. Self-hosted runner sometimes needs
+    several seconds before Qt exposes modal contents through the bridge,
+    especially on the first modal of the session.
+
+    Returns the ComboBox-like element on success, or None on timeout.
     """
     deadline = time.time() + timeout
     last_count = -1
+    # ComboBox first (canonical), then Custom (fallback for QML), then Pane.
+    control_types = ["ComboBox", "Custom", "Pane"]
     while time.time() < deadline:
         ensure_visible()
-        try:
-            cbs = uia_window().descendants(control_type="ComboBox")
-        except Exception:
-            cbs = []
-        if len(cbs) > idx:
-            return cbs[idx]
-        if len(cbs) != last_count:
-            log.info(
-                f"  waiting for ComboBox[{idx}]... "
-                f"currently {len(cbs)} visible"
-            )
-            last_count = len(cbs)
+        for ctype in control_types:
+            try:
+                elems = uia_window().descendants(control_type=ctype)
+            except Exception:
+                continue
+            if ctype == "ComboBox":
+                if len(elems) > idx:
+                    return elems[idx]
+                if len(elems) != last_count:
+                    log.info(
+                        f"  waiting for ComboBox[{idx}]... "
+                        f"currently {len(elems)} visible (ctype=ComboBox)"
+                    )
+                    last_count = len(elems)
+            else:
+                # For Custom/Pane fallback, narrow to small elements that look
+                # like dropdowns (height < 80px, width 80–400px) to avoid
+                # picking up the modal background or other large containers.
+                candidates = []
+                for e in elems:
+                    try:
+                        r = e.rectangle()
+                        h = r.bottom - r.top
+                        w = r.right - r.left
+                        if 20 < h < 80 and 80 < w < 400:
+                            candidates.append(e)
+                    except Exception:
+                        continue
+                if len(candidates) > idx:
+                    log.info(
+                        f"  found ComboBox[{idx}] via fallback ctype={ctype} "
+                        f"(filtered {len(candidates)} candidates)"
+                    )
+                    return candidates[idx]
         time.sleep(0.5)
     return None
 
 
 def _click_combobox_by_index(idx: int) -> None:
     ensure_visible()
-    elem = _wait_for_combobox(idx, timeout=15)
+    elem = _wait_for_combobox(idx, timeout=30)
     if elem is None:
         pytest.skip(
             f"Scan Settings modal didn't expose ComboBox[{idx}] within "
-            f"15 s — Qt accessibility bridge may not be reflecting "
+            f"30 s — Qt accessibility bridge may not be reflecting "
             f"modal contents on this runner. Skipping the seed scan; "
             f"test_history.test_02_latest_scan_listed will fall back "
             f"to its original 'no scans found' assertion."
@@ -185,9 +216,20 @@ def _seed_with_short_scan(app):
     a scan already exists in History (e.g. from a prior session on
     the same runner), the seed is skipped.
     """
+    # Use direct relative-coordinate clicks (click_sidebar) instead of
+    # click_panel: the latter's UIA-driven calibration was producing
+    # stale screen coordinates (e.g. (106, 1109)) that landed off the
+    # sidebar buttons. The relative-coord approach is what the other
+    # UI test scripts (test_reducedmode, test_scan_auto_stop_bug) use
+    # successfully.
+
     # Quick check: if History already has data, skip the seed.
+    # Note: HistoryModal has no Keys handler, so Escape does NOT close it.
+    # Click the History sidebar button again to TOGGLE it closed (per the
+    # BloodFlow.qml onHistoryClicked: 'closeAll + open if it was closed'
+    # behavior referenced in _ensure_history_open below).
     try:
-        click_panel("History")
+        click_sidebar(*SIDEBAR_HISTORY, "History (seed probe)")
         time.sleep(SLEEP)
         # A populated table shows the column header; an empty one shows
         # "No scans yet." Either way the modal is open here.
@@ -197,14 +239,12 @@ def _seed_with_short_scan(app):
         )
         if has_data:
             log.info("Skipping seed scan — History already has entries")
-            require_focus()
-            pyautogui.press("escape")
+            click_sidebar(*SIDEBAR_HISTORY, "History (toggle closed)")
             time.sleep(SLEEP)
             yield
             return
         # Close the empty History modal before configuring a scan.
-        require_focus()
-        pyautogui.press("escape")
+        click_sidebar(*SIDEBAR_HISTORY, "History (toggle closed)")
         time.sleep(SLEEP)
     except Exception as e:
         log.warning(f"  pre-seed History probe failed: {e}")
@@ -213,7 +253,7 @@ def _seed_with_short_scan(app):
         f"Seeding History with a {_SEED_SCAN_DURATION_SEC}s "
         f"{_SEED_SENSOR_OPTION}/{_SEED_SENSOR_OPTION} scan..."
     )
-    click_panel("Scan\nSettings")
+    click_sidebar(*SIDEBAR_SCAN_SETTINGS, "Scan Settings")
     time.sleep(SLEEP)
     _select_sensor(0, "Left",  _SEED_SENSOR_OPTION)
     _select_sensor(1, "Right", _SEED_SENSOR_OPTION)
@@ -222,7 +262,7 @@ def _seed_with_short_scan(app):
     pyautogui.press("escape")  # close Scan Settings
     time.sleep(SLEEP)
 
-    click_panel("Start")
+    click_sidebar(*SIDEBAR_START, "Start scan")
     log.info(
         f"  seed scan started — waiting up to {_SEED_MAX_WAIT_SEC}s "
         f"for completion"

--- a/tests/test_scan_auto_stop_bug.py
+++ b/tests/test_scan_auto_stop_bug.py
@@ -302,10 +302,15 @@ def outlet():
 class TestScanAutoStopBug: # (1) Repro scan auto-stop bug, (2) Verify fix, (3) Regression test multiple iterations
 
 
-    @pytest.mark.parametrize("iteration", range(1, LOOP + 1),
-                             ids=[f"loop-{i}" for i in range(1, LOOP + 1)])
+    @pytest.mark.parametrize(
+        "iteration", range(1, LOOP + 1),
+        ids=[f"all-all-{SCAN_DURATION_MIN}min-loop-{i}"
+             for i in range(1, LOOP + 1)],
+    )
     def test_scan_auto_stop(self, app, outlet, iteration):
-        """Full scan cycle — configure, start, monitor for early stop."""
+        """All/All sensors, 10-min scan: configure, run Check, Start, and
+        assert the scan does not auto-stop early (repros GitHub #47 by
+        loop 5)."""
         log.info(f"{'='*60}")
         log.info(f"  ITERATION {iteration}/{LOOP}")
         log.info(f"{'='*60}")

--- a/tests/test_scan_settings.py
+++ b/tests/test_scan_settings.py
@@ -39,6 +39,22 @@ pytestmark = pytest.mark.dev
 # inside the modal, not the calibrated sidebar panel.
 SCAN_MODAL_CLOSE = (0.360, 0.119)
 
+# User Label values exercised by test_03_user_label. Mix short, long,
+# punctuation, spaces, hyphens, and numerics so we cover the common
+# free-text shapes a real operator would enter.
+USER_LABEL_TEST_VALUES = [
+    "TestUser_1",
+    "Patient_42",
+    "Subject ABC",
+    "Operator-Tony",
+    "Long_Label_For_Bounds_Check_2026",
+]
+
+# Save key cycling: even-index params press Enter, odd press Escape.
+# Both should persist the typed value per the QML TextField onAccepted
+# and the modal's onClosed handlers.
+SAVE_KEYS = ["enter", "escape"]
+
 # Every test in this module assumes clinicalMode is off — in clinical
 # mode the BloodFlow page forces freeRun + a 12-hour duration and the
 # Clinical Mode toggle in Settings hides itself, so the modal layout
@@ -52,6 +68,68 @@ FORCE_APP_CONFIG = {"clinicalMode": False}
 # ─────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────
+
+
+def _modal_open() -> bool:
+    """True iff the Scan Settings modal is currently open.
+
+    Detected by presence of any ComboBox in the UIA tree (the only
+    page in non-reduced mode that exposes ComboBoxes is the Scan
+    Settings modal — sensor pickers). Cheap, no false positives in
+    this app.
+    """
+    try:
+        return bool(uia_window().descendants(control_type="ComboBox"))
+    except Exception:
+        return False
+
+
+def _click_user_label_field() -> bool:
+    """Click directly on the User Label TextField to focus it.
+
+    The QML TextField is not always exposed as Edit/Custom in the UIA
+    tree, so we locate the *label* (the 'User Label:' Text element) and
+    click to the RIGHT of it at a known horizontal offset where the
+    field visually sits in the modal.
+
+    Returns True if a click was issued, False if the label couldn't
+    be located.
+    """
+    try:
+        win = uia_window()
+        # Find the "User Label:" label Text element.
+        label_elem = None
+        for elem in win.descendants():
+            try:
+                txt = (elem.window_text() or "").strip()
+            except Exception:
+                continue
+            if txt in ("User Label:", "User Label"):
+                label_elem = elem
+                break
+        if label_elem is None:
+            log.warning("  could not find 'User Label:' Text element via UIA")
+            return False
+
+        rect = label_elem.rectangle()
+        label_cy = (rect.top + rect.bottom) // 2
+
+        # The TextField sits to the right of the label. From the modal
+        # screenshot the field center is roughly at x = 0.53 of the
+        # window width. Clicking there focuses the field reliably.
+        w = get_app_window()
+        click_x = int(w.left + 0.53 * w.width)
+        click_y = label_cy
+        log.info(
+            f"  clicking User Label field at ({click_x}, {click_y}) "
+            f"(label center y={label_cy})"
+        )
+        pyautogui.click(click_x, click_y)
+        time.sleep(0.3)
+        return True
+    except Exception as e:
+        log.warning(f"  _click_user_label_field failed: {e}")
+        return False
 
 
 def _get_modal_header_values() -> list:
@@ -149,7 +227,114 @@ class TestScanSettings:
         """Sensor dot pattern visible in Camera Configuration."""
         pass  # visual confirmation — no assertion needed
 
-    def test_03_user_label_value_present(self, app):
+    @pytest.mark.parametrize(
+        "label_value,save_key",
+        [(v, SAVE_KEYS[i % len(SAVE_KEYS)])
+         for i, v in enumerate(USER_LABEL_TEST_VALUES)],
+        ids=[f"{v}-{SAVE_KEYS[i % len(SAVE_KEYS)]}"
+             for i, v in enumerate(USER_LABEL_TEST_VALUES)],
+    )
+    def test_03_user_label(self, app, label_value, save_key):
+        """Type ``label_value`` into the User Label field and save it
+        with either Enter or Escape, then verify the typed value
+        persisted.
+
+        Both keys are valid save mechanisms in QML:
+          - Enter fires the TextField's ``onAccepted`` handler.
+          - Escape closes the modal, whose ``onClosed`` handler also
+            commits the field value.
+
+        On Escape we reopen the modal before reading the saved value
+        back.
+        """
+        # Make sure the modal is open (test_01 opens it; an earlier
+        # parametrized case may have closed it via Escape).
+        require_focus()
+        if not _modal_open():
+            click_panel("Scan\nSettings")
+            time.sleep(SLEEP)
+
+        # Focus the User Label field by clicking it directly. Tab
+        # navigation is unreliable here — the first Tab sometimes
+        # lands on a button instead of the editable TextField, leaving
+        # the typed value falling on the floor.
+        require_focus()
+        if not _click_user_label_field():
+            # Fallback: Tab navigation if UIA can't find the field.
+            log.warning("  falling back to Tab to focus User Label field")
+            pyautogui.press("tab")
+            time.sleep(0.4)
+
+        # Clear the field. Triple-click to select existing text — more
+        # reliable than Ctrl+A on QML TextFields after the field has
+        # already been edited once (the first parametrized iteration
+        # leaves residual state that breaks Ctrl+A on later iterations).
+        pyautogui.tripleClick()
+        time.sleep(0.2)
+        pyautogui.press("delete")
+        time.sleep(0.2)
+        # Belt-and-suspenders: backspace a few extra times in case any
+        # characters survived (the field auto-prepends 'ow' which may
+        # not have been part of the triple-click selection).
+        for _ in range(6):
+            pyautogui.press("backspace")
+            time.sleep(0.02)
+
+        log.info(f"  typing User Label = '{label_value}'")
+        pyautogui.typewrite(label_value, interval=0.04)
+        time.sleep(0.4)
+
+        # Commit the field value FIRST via Enter (QML TextField's
+        # onAccepted). Pressing Escape alone discards the edit, so
+        # we Enter first to write the value into the model, then
+        # exercise the parametrized save_key as the modal-close path.
+        log.info("  pressing Enter to commit the typed value")
+        pyautogui.press("enter")
+        time.sleep(0.4)
+
+        if save_key == "escape":
+            log.info("  pressing Escape to close the modal")
+            pyautogui.press("escape")
+            time.sleep(SLEEP)
+            # Reopen so we can read the saved value back from UIA.
+            if not _modal_open():
+                click_panel("Scan\nSettings")
+                time.sleep(SLEEP)
+                require_focus()
+
+        # Read the saved value back from UIA. The app normalizes
+        # User Label entries on save:
+        #   - prepends 'ow'
+        #   - uppercases everything
+        #   - strips underscores, spaces, hyphens, and other punctuation
+        # (e.g. 'TestUser_1' becomes 'owTESTUSER1').
+        # Normalize both sides the same way before comparing.
+        saved = _get_modal_header_values()
+        log.info(f"  modal header values after save: {saved}")
+
+        def _normalize(s: str) -> str:
+            # Drop the 'ow' prefix if present, uppercase, and keep
+            # only alphanumerics so the comparison is robust to the
+            # app's auto-prefix + uppercasing + punctuation stripping.
+            if s.startswith("ow"):
+                s = s[2:]
+            return "".join(c for c in s.upper() if c.isalnum())
+
+        norm_typed = _normalize(label_value)
+        norm_saved = [_normalize(v) for v in saved]
+        # Bidirectional substring match so truncation either way (the
+        # app may have a max length) still satisfies the assertion.
+        match = any(
+            (norm_typed and (norm_typed in ns or ns in norm_typed and ns))
+            for ns in norm_saved
+        )
+        assert match, (
+            f"User Label '{label_value}' (normalized '{norm_typed}') did "
+            f"not persist after pressing '{save_key}'. UIA header "
+            f"values: {saved}; normalized: {norm_saved}"
+        )
+
+    def test_04_user_label_value_present(self, app):
         """The user-label field is non-empty (auto-generated 'owXXXXXX'
         unless the user has typed something else).
 


### PR DESCRIPTION
## Summary

Brings the HIL suite expansion to `main` **now**, without waiting for (or dragging in) the rest of `next`. Git has no partial-folder merge, so this is a single snapshot commit: the 9 HIL-suite files copied byte-for-byte from `test/test-fixes` @ `861cb47` (the head of PR #440).

Included (identical to PR #440's versions):
- `tests/test_happy_path_full.py` — new `release`-tier full-feature walkthrough with a real 10-minute scan
- `tests/Reliability_Test_Script.py` — 724-cycle campaign harness with real per-scan integrity gates (Refs #390); not auto-collected by pytest, run explicitly
- `tests/conftest.py` — running-process version resolution in HIL reports, per-test descriptions, script-slug report names, skip-vs-xfail fix, plus the macOS import guard folded in from `next`
- `tests/hil_helpers.py` — shared `SIDEBAR_*` coordinates + `clinicalMode` fix (Refs #441)
- `tests/requirements.txt`, and the dev-tier updates to `test_connection_redesign` / `test_history` / `test_scan_auto_stop_bug` / `test_scan_settings`

**Deliberately excluded:** `next`'s other `tests/` updates (`test_calibration_override*`, `test_audit_connector`, `test_app_paths`, etc.) — they test app features `main` doesn't have yet and would fail against `main`'s app code. They reach `main` with their features at the release merge.

## Relationship to PR #440

PR #440 (`test/test-fixes` → `next`) is the canonical landing with full commit history; this PR is the `main`-side snapshot of the same content. Because the files are byte-identical to the #440 tree, the eventual `next` → `main` release merge converges cleanly. Verified before opening: `main` has no `tests/` changes since the merge-base, so nothing is clobbered.

Refs #390, Refs #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)