### PR TITLE
feat: EV code-sign release artifacts via SSL.com eSigner CKA in CI

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,7 +1,12 @@
 name: Build & Release
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      sign:
+        description: "Code-sign artifacts (requires the eSigner secrets)"
+        type: boolean
+        default: false
   push:
     branches: [main, next]
     tags:
@@ -109,6 +114,54 @@ jobs:
           wix extension add -g WixToolset.BootstrapperApplications.wixext/5.0.2
           echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append
 
+      # ── eSigner CKA: load the EV code-signing cert ───────────────
+      # Tag builds (and manual runs with sign=true) Authenticode-sign every
+      # Windows artifact with the org's SSL.com EV cert. The private key
+      # never leaves SSL.com's cloud HSM; eSigner CKA exposes it through
+      # Windows CNG so native signtool works against a store thumbprint.
+      # When the ES_* secrets are absent this warns and the build ships
+      # unsigned, exactly as before signing existed. See docs/SIGNING.md.
+      - name: Set up eSigner CKA (EV code signing)
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.sign)
+        shell: pwsh
+        env:
+          ES_USERNAME: ${{ secrets.ES_USERNAME }}
+          ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+          ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
+          # repo variable ES_MODE=sandbox targets SSL.com's sandbox
+          # environment for pipeline testing (needs sandbox credentials)
+          ES_MODE: ${{ vars.ES_MODE || 'product' }}
+        run: |
+          if (-not $env:ES_USERNAME -or -not $env:ES_PASSWORD -or -not $env:ES_TOTP_SECRET) {
+            Write-Host "::warning::eSigner secrets (ES_USERNAME / ES_PASSWORD / ES_TOTP_SECRET) not set — artifacts will be UNSIGNED"
+            exit 0
+          }
+          $work = Join-Path $env:RUNNER_TEMP "esigner-cka"
+          New-Item -ItemType Directory -Force $work | Out-Null
+          Set-Location $work
+          Invoke-WebRequest -OutFile eSigner_CKA_Setup.zip "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.8/SSL.COM-eSigner-CKA_1.0.8.zip"
+          Expand-Archive -Force eSigner_CKA_Setup.zip
+          Move-Item -Destination "eSigner_CKA_Installer.exe" -Path "eSigner_CKA_Setup\*.exe"
+          $dir = Join-Path $env:USERPROFILE "eSignerCKA"
+          New-Item -ItemType Directory -Force $dir | Out-Null
+          Start-Process ".\eSigner_CKA_Installer.exe" -ArgumentList "/CURRENTUSER /VERYSILENT /SUPPRESSMSGBOXES /DIR=`"$dir`"" -Wait
+          # Post-install helpers from SSL.com's reference workflow; guarded
+          # because not every CKA build ships them (VC++ redists are already
+          # on the hosted runners).
+          foreach ($aux in @("$work\setup\vc_redist.x86.exe", "$work\setup\vc_redist.x64.exe")) {
+            if (Test-Path $aux) { Start-Process $aux -ArgumentList "/install /q" -Wait }
+          }
+          foreach ($aux in @("$dir\RegisterKSP.exe", "$dir\eSignerCSP.Config.exe")) {
+            if (Test-Path $aux) { & $aux | Out-Null }
+          }
+          & "$dir\eSignerCKATool.exe" config -mode $env:ES_MODE -user $env:ES_USERNAME -pass $env:ES_PASSWORD -totp $env:ES_TOTP_SECRET -key "$dir\master.key" -r
+          & "$dir\eSignerCKATool.exe" unload
+          & "$dir\eSignerCKATool.exe" load
+          $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
+          if (-not $cert) { throw "eSigner CKA loaded no code-signing certificate" }
+          Write-Host "Signing as: $($cert.Subject)  [$($cert.Thumbprint)]"
+          "CODESIGN_THUMBPRINT=$($cert.Thumbprint)" >> $env:GITHUB_ENV
+
       # ── package ──────────────────────────────────────────────────
       - name: Determine version tag
         id: meta
@@ -138,7 +191,9 @@ jobs:
       - name: Package all artifacts (zips + installers, clinical + Research)
         shell: pwsh
         env:
-          CODESIGN_THUMBPRINT: ${{ secrets.CODESIGN_THUMBPRINT }}
+          # env.CODESIGN_THUMBPRINT is exported by the eSigner CKA step above;
+          # the secret is a manual fallback for a runner with a local cert.
+          CODESIGN_THUMBPRINT: ${{ env.CODESIGN_THUMBPRINT || secrets.CODESIGN_THUMBPRINT }}
         run: |
           powershell -NoProfile -File scripts\package_artifacts.ps1 -Version "${{ steps.meta.outputs.TAG }}"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ The `dataDirectory` config key controls the root (defaults to cwd if unset). Whe
 
 - Default branch: `main`; daily work on `next`. PR feature → `next`, `next` → `main` for release.
 - Releases triggered by semver tags (e.g. `1.1.2`, `1.1.2-dev.0`, `1.1.2-rc.1`) — see [../CLAUDE.md](../CLAUDE.md) for tag format.
+- **Code signing:** tag builds Authenticode-sign the exe, MSIs, and Setup bundles with the SSL.com EV cert via eSigner CKA (cloud key — `ES_*` org secrets); absent secrets → unsigned build with a warning. Everything funnels through `installer/sign.ps1` on `CODESIGN_THUMBPRINT`. See [docs/SIGNING.md](docs/SIGNING.md).
 - CI workflows: `.github/workflows/release-build.yml` (Windows runner, builds .exe + zip on tags / manual dispatch) and `hil-tests.yml` (self-hosted Windows runner with Shelly IoT outlet power control, runs after the release build completes).
 
 ### Curating release notes (issue #348)

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,0 +1,97 @@
+# Code signing (SSL.com EV via eSigner cloud)
+
+Release artifacts are Authenticode-signed with Openwater's SSL.com **EV
+code-signing certificate**. Post-2023 CA/B Forum rules forbid EV keys from
+existing as an exportable PFX, so the private key lives in SSL.com's
+**eSigner** cloud HSM and never touches the runner. CI uses **eSigner CKA**
+(SSL.com's Cloud Key Adapter): it registers a Windows CNG key provider and
+loads the cert into `Cert:\CurrentUser\My`, so native `signtool` signs
+against a store thumbprint while each signature is actually performed in
+SSL.com's cloud.
+
+## What gets signed, and where
+
+| Artifact | Signed by |
+|---|---|
+| `Open-Motion.exe` inside the PyInstaller dist (→ both portable zips, harvested into both MSIs) | `scripts/package_artifacts.ps1` → `installer/sign.ps1` |
+| `Open-Motion.msi` / `Open-Motion-Research.msi` | `installer/build_installer.ps1` → `sign.ps1` |
+| Burn Setup bundles (engine signed detached, then the reattached bundle) | `installer/build_installer.ps1` → `sign.ps1` |
+| WinUSB driver catalogs + `OpenMotionDriver-x64.msi` | `openmotion-sdk` repo, `driver-msi.yml` (sdk#216) — the signed zip is then vendored here as `resources/OpenMotionDriver-x64.zip` |
+
+Everything funnels through `installer/sign.ps1`, which is driven by one
+environment variable: `CODESIGN_THUMBPRINT`. Unset → every signing step
+no-ops and the build ships unsigned (the pre-EV behavior). In CI the
+"Set up eSigner CKA" step of `release-build.yml` sets it after loading the
+cert; the `CODESIGN_THUMBPRINT` repo secret remains as a manual fallback
+for signing with a locally-installed cert (e.g. a self-hosted runner).
+
+**When CI signs:** tag builds, plus `workflow_dispatch` runs with the
+`sign` input checked. Pushes to `next`/`main` build unsigned — no reason
+to spend cloud signings on throwaway builds.
+
+macOS is unaffected: the DMG stays ad-hoc signed (Apple notarization is a
+separate, unrelated pipeline).
+
+## One-time setup (account + secrets)
+
+1. **Finish eSigner enrollment** on the approved EV order at ssl.com:
+   the order's certificate must be *attested into eSigner* (chosen as the
+   cloud-delivery option, not a shipped YubiKey).
+2. **Create the eSigner TOTP secret**: order → Signing Credentials →
+   eSigner authenticator QR code → copy the **text version** of the
+   secret. This is what lets CI generate the per-signature OTPs.
+3. **Malware Blocker**: eSigner's pre-signing malware scan is only
+   supported through CodeSignTool/eSigner Express. For CKA (signtool)
+   signing it must be **disabled** on the signing credential in the
+   SSL.com portal, or cloud signing requests fail.
+4. **Create the GitHub secrets** — org-level, granted to
+   `openmotion-bloodflow-app` **and** `openmotion-sdk` (the driver build
+   uses the same cert):
+
+   ```bash
+   gh secret set ES_USERNAME    --org OpenwaterHealth --visibility selected --repos "openmotion-bloodflow-app,openmotion-sdk"
+   gh secret set ES_PASSWORD    --org OpenwaterHealth --visibility selected --repos "openmotion-bloodflow-app,openmotion-sdk"
+   gh secret set ES_TOTP_SECRET --org OpenwaterHealth --visibility selected --repos "openmotion-bloodflow-app,openmotion-sdk"
+   ```
+
+   `ES_USERNAME`/`ES_PASSWORD` are the SSL.com account login; the TOTP
+   secret is from step 2. (Per-repo secrets work too if org policy is in
+   the way.)
+
+## Testing the pipeline without cutting a release
+
+- Run **Build & Release** via `workflow_dispatch` with `sign` checked —
+  signs real artifacts, uploads them as workflow artifacts, creates no
+  GitHub release.
+- For a dry run against SSL.com's **sandbox** environment instead of the
+  production cert: set repo variable `ES_MODE=sandbox` and temporarily
+  point the ES_* secrets at sandbox.ssl.com credentials. Unset when done.
+
+Verify any produced artifact:
+
+```powershell
+Get-AuthenticodeSignature .\Open-Motion-Setup-1.6.0.exe | Format-List Status, SignerCertificate
+# Status must be Valid; the signer should be the Openwater EV cert, not CN=Openwater WinUSB
+```
+
+## Driver (openmotion-sdk)
+
+`driver-msi.yml` uses the same CKA recipe to sign the four driver
+catalogs and the driver MSI, replacing the retired self-signed
+`CN=Openwater WinUSB` scheme (which required installing a private root
+cert on every user machine). After the first EV-signed driver build,
+download the `OpenMotionDriver-x64` CI artifact and commit it here as
+`resources/OpenMotionDriver-x64.zip` so the Setup bundles chain the
+EV-signed driver MSI. Details: sdk#216.
+
+## Deliberate follow-ups
+
+- **`_REQUIRE_SIGNED_UPDATES` (motion_connector.py) is still `False`.**
+  Flip it to `True` one release *after* the first signed release ships
+  and verifies, so the in-app updater starts refusing unsigned bundles.
+- **Driver: Microsoft attestation signing** (optional, later). The EV
+  cert qualifies us to register a Microsoft Partner Center hardware
+  account; attestation-signed driver packages install with no
+  TrustedPublisher step and no prompt at all.
+- eSigner billing: cloud signings are metered per the eSigner service
+  plan — check the tier if release cadence increases significantly.

--- a/installer/sign.ps1
+++ b/installer/sign.ps1
@@ -1,4 +1,10 @@
 # installer/sign.ps1 — Authenticode-sign the given files, or skip if no cert.
+#
+# CODESIGN_THUMBPRINT selects a code-signing cert already present in the
+# machine's cert store. In CI that is the SSL.com EV cert, loaded into
+# Cert:\CurrentUser\My by eSigner CKA (the key itself stays in SSL.com's
+# cloud HSM) — see the "eSigner CKA" step in release-build.yml and
+# docs/SIGNING.md.
 param([Parameter(Mandatory = $true)][string[]]$Files)
 
 $thumb = $env:CODESIGN_THUMBPRINT
@@ -7,9 +13,28 @@ if (-not $thumb) {
     return
 }
 
+# signtool is not on PATH on the GitHub runners — fall back to the newest
+# Windows Kits copy.
+$signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+if (-not $signtool) {
+    $kits = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+    $signtool = Get-ChildItem "$kits\10.0.*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+        Sort-Object { [version]$_.Directory.Parent.Name } -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $signtool) { throw "signtool.exe not found (PATH or Windows Kits)" }
+
 foreach ($f in $Files) {
     Write-Host "signing $f" -ForegroundColor Cyan
-    & signtool sign /sha1 $thumb /fd SHA256 `
-        /tr http://timestamp.digicert.com /td SHA256 $f
-    if ($LASTEXITCODE -ne 0) { throw "signtool failed for $f" }
+    # Both the eSigner cloud signing call and the timestamp server can flake
+    # transiently, so retry before failing the build.
+    $attempts = 3
+    for ($i = 1; $i -le $attempts; $i++) {
+        & $signtool sign /sha1 $thumb /fd SHA256 `
+            /tr http://ts.ssl.com /td SHA256 $f
+        if ($LASTEXITCODE -eq 0) { break }
+        if ($i -eq $attempts) { throw "signtool failed for $f after $attempts attempts" }
+        Write-Host "signtool exit $LASTEXITCODE -- retrying ($i/$attempts)" -ForegroundColor Yellow
+        Start-Sleep -Seconds 10
+    }
 }

--- a/scripts/package_artifacts.ps1
+++ b/scripts/package_artifacts.ps1
@@ -37,6 +37,14 @@ if (-not (Test-Path (Join-Path $DistDir 'Open-Motion.exe'))) {
 }
 $cfgPath = Join-Path $DistDir "_internal\config\app_config.json"
 
+# -- Authenticode-sign the app exe in the dist (no-op without a cert). One
+#    signature covers all 4 artifacts: both zips and both MSIs harvest this
+#    same dist tree. The MSIs and Setup bundles are signed separately by
+#    installer/build_installer.ps1. --
+powershell -NoProfile -File (Join-Path $root "installer\sign.ps1") `
+    -Files (Join-Path $DistDir "Open-Motion.exe")
+if ($LASTEXITCODE -ne 0) { throw "signing Open-Motion.exe failed" }
+
 # -- WiX gate: skip installers (zips still build) when the toolchain is absent --
 $buildInstallers = -not $SkipInstaller
 if ($buildInstallers -and -not (Test-WixAvailable)) {


### PR DESCRIPTION
Refs #358

## What

- **`release-build.yml`**: new *Set up eSigner CKA* step on tag builds (and `workflow_dispatch` with the new `sign` input). Installs SSL.com's Cloud Key Adapter, authenticates from new secrets `ES_USERNAME` / `ES_PASSWORD` / `ES_TOTP_SECRET`, loads the EV cert into the runner's store, and exports `CODESIGN_THUMBPRINT` for the existing signing plumbing (the old `secrets.CODESIGN_THUMBPRINT` remains as a manual local-cert fallback). Missing secrets → `::warning::` + unsigned build, byte-for-byte today's behavior.
- **`scripts/package_artifacts.ps1`**: signs `Open-Motion.exe` inside the dist before packaging — one signature covers both portable zips and both MSI harvests.
- **`installer/sign.ps1`**: resolves signtool from Windows Kits (not on PATH on hosted runners), SSL.com RFC3161 timestamp (`/tr http://ts.ssl.com`), 3-attempt retry for transient cloud/timestamp flakes. Also fixes a latent parse bomb: PowerShell 5.1 reads the BOM-less file as ANSI, and an em dash inside a string mangled into a stray quote — the script would have failed to parse the first time it ever ran with a thumbprint set.
- **`docs/SIGNING.md`**: full runbook — SSL.com portal enrollment, TOTP secret, Malware Blocker gotcha, org-secret setup, sandbox testing, verification.

## What this deliberately does not do

- `_REQUIRE_SIGNED_UPDATES` stays `False` — flip one release **after** the first signed release ships (per Ethan).
- Driver signing is the companion SDK PR (sdk#216); after its first EV-signed CI build, `resources/OpenMotionDriver-x64.zip` gets refreshed here so the Setup bundles chain an EV-signed driver MSI.
- macOS DMG untouched (notarization is a separate effort).

## Verification

- All scripts parse clean under Windows PowerShell 5.1 (`Parser::ParseFile`).
- Workflow YAML validates.
- Unsigned path exercised implicitly: with no thumbprint every signing call is the pre-existing no-op.
- End-to-end signing can only run in CI once the ES_* secrets exist — see docs/SIGNING.md for the dispatch-with-sign=true smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)